### PR TITLE
fix(spawn): eliminate phantom detector false positives (#34)

### DIFF
--- a/docs/SPAWN_RELIABILITY.md
+++ b/docs/SPAWN_RELIABILITY.md
@@ -2,7 +2,7 @@
 
 **GitHub Issue:** [#34 — Phantom Sessions: Silent Work Loss](https://github.com/zachyzissou/ventureos/issues/34)  
 **Priority:** P0  
-**Last updated:** 2026-02-15
+**Last updated:** 2026-02-15 (v2 — false positive fix)
 
 > **Definition:** A *phantom session* is a spawned session that returns `{ status: "accepted" }` / a `childSessionKey`, but never actually begins producing messages / doing work (or starts after an extreme delay), with no error surfaced to the spawning agent.
 
@@ -204,6 +204,45 @@ Cron wrapper: runs phantom detector + workspace health check.
 - [x] Root causes identified (workspace bloat + config errors + lane contention)
 - [x] Workspace health check script
 - [x] Spawn wrapper: health check + verify + retry
-- [x] Phantom detector
+- [x] Phantom detector (v2 — fixed false positives)
 - [x] Documentation (this file)
 - [ ] Cron jobs registered (health daily + phantom scan every 30min)
+
+---
+
+## v2 Fix: False Positive Elimination (2026-02-15)
+
+### Problem
+
+The phantom-detector.sh script was reporting **13 false positives** — sessions that were actually functioning normally (61-267 messages each) were being flagged as "zero_messages" phantoms.
+
+### Root Cause
+
+**Bug in message counting logic.** The detector's jq query looked for `.value.messages` array in the `sessions.json` index:
+
+```jq
+messageCount: ((.value.messages // []) | length),
+```
+
+But **`sessions.json` does NOT contain a `messages` array**. Messages are stored in separate `{sessionId}.jsonl` transcript files. The `.messages` field doesn't exist in the index, so `(.value.messages // []) | length` always returns `0`, flagging every subagent session as phantom.
+
+### Fix
+
+1. **Count messages from .jsonl files** — The detector now reads the actual transcript file (`{sessionId}.jsonl`) and counts lines with `"type":"message"`.
+2. **Fixed `grep -c` bug** — `grep -c` returns exit code 1 when count is 0 (even though it outputs "0"). Combined with `|| echo "0"`, this produced `"0\n0"` which broke bash arithmetic. Fixed to capture output first, then fallback.
+3. **Fixed empty PHANTOMS array** — JSON output was malformed when no phantoms found.
+4. **Added spawn-health-check.sh** — Post-spawn polling that verifies transcript file has messages within a configurable timeout.
+
+### Test Results
+
+16/16 tests passing including:
+- **Test 11:** Exact reproduction of the production false positive (0e84becd with 61 messages correctly NOT flagged)
+- **Test 2:** Session with messages correctly NOT flagged
+- **Test 3:** Session with zero messages correctly flagged
+- **Test 4:** Missing transcript file correctly flagged
+- **Test 9:** Transcript with only headers (no messages) correctly flagged
+
+### Impact
+
+- **Before fix:** 13 sessions falsely reported as phantoms, causing unnecessary panic alerts
+- **After fix:** 0 false positives, only real phantoms are detected

--- a/scripts/phantom-detector.sh
+++ b/scripts/phantom-detector.sh
@@ -3,8 +3,12 @@
 #
 # Scans all agent sessions for sessions that:
 # 1. Were created > MIN_AGE_MINUTES ago
-# 2. Have 0 messages (or no transcript file)
+# 2. Have 0 messages in their .jsonl transcript file
 # 3. Are subagent type (most vulnerable to phantom pattern)
+#
+# IMPORTANT: Message counts come from the actual .jsonl transcript files,
+# NOT from the sessions.json index (which does NOT contain a messages array).
+# The sessions.json index stores metadata; messages live in {sessionId}.jsonl.
 #
 # Usage:
 #   phantom-detector.sh [--alert] [--min-age <minutes>] [--json]
@@ -82,6 +86,24 @@ log_entry() {
 }
 
 # ============================================================================
+# Count messages in a .jsonl transcript file
+# ============================================================================
+
+count_messages_in_jsonl() {
+  local jsonl_file="$1"
+  if [[ ! -f "${jsonl_file}" ]]; then
+    echo "0"
+    return
+  fi
+  # Count lines with "type":"message" — these are actual agent messages
+  # Note: grep -c returns exit code 1 when count is 0, but still outputs "0".
+  # We capture its output (which may be "0") and fallback to "0" only if grep fails entirely.
+  local count
+  count=$(grep -c '"type":"message"' "${jsonl_file}" 2>/dev/null) || count="0"
+  echo "${count}"
+}
+
+# ============================================================================
 # Scan all agent sessions
 # ============================================================================
 
@@ -93,36 +115,40 @@ fi
 for agent_dir in "${AGENTS_DIR}"/*/; do
   agent_name=$(basename "${agent_dir}")
   sessions_file="${agent_dir}sessions/sessions.json"
+  sessions_dir="${agent_dir}sessions"
 
   if [[ ! -f "${sessions_file}" ]]; then
     continue
   fi
 
-  # Parse sessions from JSON - handle both wrapped and direct formats
-  # Extract subagent sessions with their details
+  # Parse sessions from JSON index
+  # NOTE: We extract sessionId to find the .jsonl file, NOT .value.messages
+  # The sessions.json index does NOT contain a messages array.
+  # Messages are stored in separate {sessionId}.jsonl files.
   sessions_data=$(jq -r '
     (if .sessions then .sessions else . end) |
     to_entries[] |
     select(.key | contains("subagent")) |
     {
       key: .key,
-      messageCount: ((.value.messages // []) | length),
+      sessionId: (.value.sessionId // ""),
       model: (.value.model // "unknown"),
       updatedAt: (.value.updatedAt // 0),
       createdAt: (.value.createdAt // .value.updatedAt // 0),
-      transcriptPath: (.value.transcriptPath // ""),
       label: (.value.label // .value.displayName // ""),
       totalTokens: (.value.totalTokens // 0),
+      inputTokens: (.value.inputTokens // 0),
+      outputTokens: (.value.outputTokens // 0),
       lastError: (.value.lastError // "")
     } |
-    "\(.key)|\(.messageCount)|\(.model)|\(.updatedAt)|\(.createdAt)|\(.transcriptPath)|\(.label)|\(.totalTokens)|\(.lastError)"
+    "\(.key)|\(.sessionId)|\(.model)|\(.updatedAt)|\(.createdAt)|\(.label)|\(.totalTokens)|\(.inputTokens)|\(.outputTokens)|\(.lastError)"
   ' "${sessions_file}" 2>/dev/null || true)
 
   if [[ -z "${sessions_data}" ]]; then
     continue
   fi
 
-  while IFS='|' read -r session_key msg_count model updated_at created_at transcript_path label total_tokens last_error; do
+  while IFS='|' read -r session_key session_id model updated_at created_at label total_tokens input_tokens output_tokens last_error; do
     # Skip empty lines
     [[ -z "${session_key}" ]] && continue
 
@@ -140,30 +166,34 @@ for agent_dir in "${AGENTS_DIR}"/*/; do
       continue
     fi
 
+    # Count ACTUAL messages from the .jsonl transcript file
+    jsonl_file="${sessions_dir}/${session_id}.jsonl"
+    msg_count=$(count_messages_in_jsonl "${jsonl_file}")
+
     # Check for phantom conditions
     is_phantom=false
     phantom_reason=""
 
-    # Condition 1: 0 messages
-    if [[ "${msg_count}" -eq 0 ]]; then
+    # Condition 1: .jsonl file doesn't exist at all
+    if [[ -n "${session_id}" ]] && [[ ! -f "${jsonl_file}" ]]; then
       is_phantom=true
-      phantom_reason="zero_messages"
+      phantom_reason="missing_transcript"
     fi
 
-    # Condition 2: 0 total tokens (even with "messages" array, no actual work done)
-    if [[ "${total_tokens}" -eq 0 ]] && [[ "${msg_count}" -le 1 ]]; then
+    # Condition 2: .jsonl file exists but has 0 messages
+    if [[ -f "${jsonl_file}" ]] && [[ "${msg_count}" -eq 0 ]]; then
+      is_phantom=true
+      phantom_reason="${phantom_reason:+${phantom_reason}+}zero_messages"
+    fi
+
+    # Condition 3: 0 total tokens AND 0 messages (truly did nothing)
+    if [[ "${total_tokens}" -eq 0 ]] && [[ "${msg_count}" -eq 0 ]]; then
       is_phantom=true
       phantom_reason="${phantom_reason:+${phantom_reason}+}zero_tokens"
     fi
 
-    # Condition 3: Transcript file doesn't exist
-    if [[ -n "${transcript_path}" ]] && [[ ! -f "${transcript_path}" ]]; then
-      is_phantom=true
-      phantom_reason="${phantom_reason:+${phantom_reason}+}missing_transcript"
-    fi
-
-    # Condition 4: Has error
-    if [[ -n "${last_error}" ]] && [[ "${last_error}" != "" ]]; then
+    # Condition 4: Has error AND 0 messages
+    if [[ -n "${last_error}" ]] && [[ "${last_error}" != "" ]] && [[ "${msg_count}" -eq 0 ]]; then
       is_phantom=true
       phantom_reason="${phantom_reason:+${phantom_reason}+}error:${last_error}"
     fi
@@ -184,6 +214,7 @@ for agent_dir in "${AGENTS_DIR}"/*/; do
         echo "   Agent: ${agent_name} | Messages: ${msg_count} | Tokens: ${total_tokens}"
         echo "   Model: ${model} | Age: ${age_minutes}m | Reason: ${phantom_reason}"
         echo "   Label: ${label}"
+        echo "   Transcript: ${jsonl_file}"
         echo ""
       fi
 
@@ -200,13 +231,13 @@ for agent_dir in "${AGENTS_DIR}"/*/; do
 done
 
 # ============================================================================
-# Also check gateway error log for recent PHANTOM entries
+# Also check gateway error log for recent PHANTOM markers
 # ============================================================================
 
 GATEWAY_ERR="${HOME}/.openclaw/logs/gateway.err.log"
 if [[ -f "${GATEWAY_ERR}" ]]; then
   # Count PHANTOM entries in last hour
-  recent_phantoms=$(grep -c "PHANTOM" "${GATEWAY_ERR}" 2>/dev/null || echo "0")
+  recent_phantoms=$(grep -c "PHANTOM" "${GATEWAY_ERR}" 2>/dev/null) || recent_phantoms="0"
   if [[ "${recent_phantoms}" -gt 0 ]] && [[ "${JSON_OUTPUT}" != "true" ]]; then
     echo "📊 Gateway log: ${recent_phantoms} total PHANTOM entries"
     echo ""
@@ -238,14 +269,17 @@ if [[ "${JSON_OUTPUT}" == "true" ]]; then
   # Build JSON array of phantoms
   json_phantoms="["
   first=true
-  for phantom in "${PHANTOMS[@]:-}"; do
-    IFS='|' read -r key agent msgs model age reason label <<< "${phantom}"
-    if [[ "${first}" != "true" ]]; then
-      json_phantoms+=","
-    fi
-    json_phantoms+="{\"sessionKey\":\"${key}\",\"agent\":\"${agent}\",\"messages\":${msgs},\"model\":\"${model}\",\"age\":\"${age}\",\"reason\":\"${reason}\",\"label\":\"${label}\"}"
-    first=false
-  done
+  if [[ ${#PHANTOMS[@]} -gt 0 ]]; then
+    for phantom in "${PHANTOMS[@]}"; do
+      [[ -z "${phantom}" ]] && continue
+      IFS='|' read -r key agent msgs model age reason label <<< "${phantom}"
+      if [[ "${first}" != "true" ]]; then
+        json_phantoms+=","
+      fi
+      json_phantoms+="{\"sessionKey\":\"${key}\",\"agent\":\"${agent}\",\"messages\":${msgs:-0},\"model\":\"${model}\",\"age\":\"${age}\",\"reason\":\"${reason}\",\"label\":\"${label}\"}"
+      first=false
+    done
+  fi
   json_phantoms+="]"
 
   echo "{\"phantomCount\":${PHANTOM_COUNT},\"phantoms\":${json_phantoms},\"checkedAt\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\"}"
@@ -275,19 +309,24 @@ if [[ "${ALERT}" == "true" ]] && [[ "${PHANTOM_COUNT}" -gt 0 ]]; then
   alert_msg="🚨 **Phantom Session Alert**\n\n"
   alert_msg+="**${PHANTOM_COUNT}** phantom session(s) detected at $(date '+%Y-%m-%d %H:%M %Z')\n\n"
 
-  for phantom in "${PHANTOMS[@]:-}"; do
-    IFS='|' read -r key agent msgs model age reason label <<< "${phantom}"
-    short_key=$(echo "${key}" | grep -o '[a-f0-9-]*$' | head -c 8)
-    alert_msg+="• \`${short_key}\` (${agent}) — ${reason} — ${age} old\n"
-  done
+  if [[ ${#PHANTOMS[@]} -gt 0 ]]; then
+    for phantom in "${PHANTOMS[@]}"; do
+      [[ -z "${phantom}" ]] && continue
+      IFS='|' read -r key agent msgs model age reason label <<< "${phantom}"
+      short_key=$(echo "${key}" | grep -o '[a-f0-9-]*$' | head -c 8)
+      alert_msg+="• \`${short_key}\` (${agent}) — ${reason} — ${age} old\n"
+    done
+  fi
 
   alert_msg+="\nRun \`phantom-detector.sh\` for details."
 
   if [[ -n "${WEBHOOK_URL}" ]]; then
+    # Use jq for safe JSON encoding (prevents command injection)
+    payload=$(jq -n --arg msg "${alert_msg}" '{"content": $msg}')
     # shellcheck disable=SC2086
     curl -sS ${CURL_WEBHOOK_FLAGS:-"--connect-timeout 2 --max-time 10"} \
       -H "Content-Type: application/json" \
-      -d "{\"content\":\"${alert_msg}\"}" \
+      -d "${payload}" \
       "${WEBHOOK_URL}" >/dev/null 2>&1 || true
   fi
 fi

--- a/scripts/spawn-health-check.sh
+++ b/scripts/spawn-health-check.sh
@@ -1,0 +1,160 @@
+#!/usr/bin/env bash
+# spawn-health-check.sh — Post-spawn verification that a session actually started
+#
+# After spawning a subagent, call this script to verify the session is alive.
+# Checks that the session's .jsonl transcript file exists AND has messages.
+#
+# Usage:
+#   spawn-health-check.sh --session-key <key> --agent <agent-name> [options]
+#
+# Options:
+#   --session-key <key>   Full session key (e.g., agent:atlas:subagent:UUID)
+#   --agent <name>        Agent name (e.g., atlas, synth)
+#   --timeout <seconds>   Max seconds to wait for messages (default: 60)
+#   --interval <seconds>  Polling interval (default: 5)
+#   --min-messages <n>    Minimum messages to consider "alive" (default: 1)
+#   --json                Machine-readable output
+#   --quiet               Suppress progress output
+#
+# Exit codes:
+#   0 = Session is alive (has messages)
+#   1 = Session is phantom (no messages after timeout)
+#   2 = Error (missing args, session not found, etc.)
+#
+# Example:
+#   spawn-health-check.sh --session-key "agent:atlas:subagent:abc12345-..." --agent atlas --timeout 30
+
+set -euo pipefail
+
+# ============================================================================
+# Configuration
+# ============================================================================
+
+AGENTS_DIR="${HOME}/.openclaw/agents"
+SESSION_KEY=""
+AGENT_NAME=""
+TIMEOUT_SECONDS=60
+POLL_INTERVAL=5
+MIN_MESSAGES=1
+JSON_OUTPUT=false
+QUIET=false
+
+# ============================================================================
+# Parse args
+# ============================================================================
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --session-key) SESSION_KEY="$2"; shift 2 ;;
+    --agent) AGENT_NAME="$2"; shift 2 ;;
+    --timeout) TIMEOUT_SECONDS="$2"; shift 2 ;;
+    --interval) POLL_INTERVAL="$2"; shift 2 ;;
+    --min-messages) MIN_MESSAGES="$2"; shift 2 ;;
+    --json) JSON_OUTPUT=true; shift ;;
+    --quiet) QUIET=true; shift ;;
+    -h|--help)
+      echo "Usage: spawn-health-check.sh --session-key <key> --agent <agent> [--timeout <s>] [--interval <s>]"
+      exit 0
+      ;;
+    *) echo "Unknown arg: $1" >&2; exit 2 ;;
+  esac
+done
+
+if [[ -z "${SESSION_KEY}" ]] || [[ -z "${AGENT_NAME}" ]]; then
+  echo "Error: --session-key and --agent are required" >&2
+  exit 2
+fi
+
+# Validate agent name (prevent path traversal)
+if [[ ! "${AGENT_NAME}" =~ ^[a-zA-Z0-9_-]+$ ]]; then
+  echo "Error: Invalid agent name: ${AGENT_NAME}" >&2
+  exit 2
+fi
+
+# ============================================================================
+# Find session ID from sessions.json index
+# ============================================================================
+
+sessions_file="${AGENTS_DIR}/${AGENT_NAME}/sessions/sessions.json"
+sessions_dir="${AGENTS_DIR}/${AGENT_NAME}/sessions"
+
+if [[ ! -f "${sessions_file}" ]]; then
+  echo "Error: Sessions file not found: ${sessions_file}" >&2
+  exit 2
+fi
+
+# Look up the sessionId (file UUID) from the session key
+session_id=$(jq -r --arg key "${SESSION_KEY}" '
+  (if .sessions then .sessions else . end) |
+  .[$key].sessionId // empty
+' "${sessions_file}" 2>/dev/null || true)
+
+if [[ -z "${session_id}" ]]; then
+  # Session key not yet in index — wait for it to appear
+  if [[ "${QUIET}" != "true" ]]; then
+    echo "⏳ Session key not yet in index, waiting..."
+  fi
+fi
+
+# ============================================================================
+# Poll for messages
+# ============================================================================
+
+start_time=$(date +%s)
+check_count=0
+
+while true; do
+  check_count=$((check_count + 1))
+  elapsed=$(( $(date +%s) - start_time ))
+
+  # Re-read session ID in case it appeared in the index
+  if [[ -z "${session_id}" ]]; then
+    session_id=$(jq -r --arg key "${SESSION_KEY}" '
+      (if .sessions then .sessions else . end) |
+      .[$key].sessionId // empty
+    ' "${sessions_file}" 2>/dev/null || true)
+  fi
+
+  # Check the transcript file
+  msg_count=0
+  transcript_exists=false
+  if [[ -n "${session_id}" ]]; then
+    jsonl_file="${sessions_dir}/${session_id}.jsonl"
+    if [[ -f "${jsonl_file}" ]]; then
+      transcript_exists=true
+      msg_count=$(grep -c '"type":"message"' "${jsonl_file}" 2>/dev/null || echo "0")
+    fi
+  fi
+
+  # Success: session has messages
+  if [[ "${msg_count}" -ge "${MIN_MESSAGES}" ]]; then
+    if [[ "${JSON_OUTPUT}" == "true" ]]; then
+      echo "{\"status\":\"alive\",\"sessionKey\":\"${SESSION_KEY}\",\"agent\":\"${AGENT_NAME}\",\"messages\":${msg_count},\"elapsed\":${elapsed},\"checks\":${check_count}}"
+    elif [[ "${QUIET}" != "true" ]]; then
+      echo "✅ Session alive: ${msg_count} messages after ${elapsed}s (${check_count} checks)"
+    fi
+    exit 0
+  fi
+
+  # Timeout: session is phantom
+  if [[ "${elapsed}" -ge "${TIMEOUT_SECONDS}" ]]; then
+    if [[ "${JSON_OUTPUT}" == "true" ]]; then
+      echo "{\"status\":\"phantom\",\"sessionKey\":\"${SESSION_KEY}\",\"agent\":\"${AGENT_NAME}\",\"messages\":${msg_count},\"elapsed\":${elapsed},\"checks\":${check_count},\"transcriptExists\":${transcript_exists},\"sessionIdFound\":$([ -n \"${session_id}\" ] && echo 'true' || echo 'false')}"
+    else
+      echo "🚨 PHANTOM DETECTED: ${SESSION_KEY}"
+      echo "   Agent: ${AGENT_NAME}"
+      echo "   Messages: ${msg_count}"
+      echo "   Elapsed: ${elapsed}s (${check_count} checks)"
+      echo "   Transcript exists: ${transcript_exists}"
+      echo "   Session ID found: $([ -n "${session_id}" ] && echo 'yes' || echo 'no')"
+    fi
+    exit 1
+  fi
+
+  # Progress
+  if [[ "${QUIET}" != "true" ]] && [[ "${JSON_OUTPUT}" != "true" ]]; then
+    echo "   Check ${check_count}: ${msg_count} messages (${elapsed}s elapsed, timeout ${TIMEOUT_SECONDS}s)"
+  fi
+
+  sleep "${POLL_INTERVAL}"
+done

--- a/scripts/tests/test-phantom-detector-v2.sh
+++ b/scripts/tests/test-phantom-detector-v2.sh
@@ -1,0 +1,320 @@
+#!/usr/bin/env bash
+# test-phantom-detector-v2.sh — Tests for the fixed phantom-detector.sh
+#
+# Tests that phantom detection correctly:
+# 1. Reads messages from .jsonl transcript files (NOT sessions.json index)
+# 2. Does NOT false-positive on sessions that have messages
+# 3. Correctly identifies truly phantom sessions (no transcript, no messages)
+# 4. Handles edge cases (missing files, empty transcripts, etc.)
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DETECTOR="$SCRIPT_DIR/../phantom-detector.sh"
+HEALTH_CHECK="$SCRIPT_DIR/../spawn-health-check.sh"
+
+# TEST_AGENTS_DIR is set per-test to isolate environments
+TEST_AGENTS_DIR=""
+
+PASS=0
+FAIL=0
+TOTAL=0
+
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  ((TOTAL++))
+  if [ "$expected" = "$actual" ]; then
+    echo "  ✅ $label"
+    ((PASS++))
+  else
+    echo "  ❌ $label: expected='$expected' actual='$actual'"
+    ((FAIL++))
+  fi
+}
+
+assert_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  ((TOTAL++))
+  if echo "$haystack" | grep -q "$needle"; then
+    echo "  ✅ $label"
+    ((PASS++))
+  else
+    echo "  ❌ $label: '$needle' not found in output"
+    ((FAIL++))
+  fi
+}
+
+assert_not_contains() {
+  local label="$1" needle="$2" haystack="$3"
+  ((TOTAL++))
+  if ! echo "$haystack" | grep -q "$needle"; then
+    echo "  ✅ $label"
+    ((PASS++))
+  else
+    echo "  ❌ $label: '$needle' was found in output (should not be)"
+    ((FAIL++))
+  fi
+}
+
+# ============================================================================
+# Helper: Create a mock agent with sessions
+# ============================================================================
+
+create_mock_agent() {
+  local agent_name="$1"
+  local sessions_dir="$TEST_AGENTS_DIR/$agent_name/sessions"
+  mkdir -p "$sessions_dir"
+  echo "{}" > "$sessions_dir/sessions.json"
+}
+
+add_subagent_session() {
+  local agent_name="$1"
+  local uuid_prefix="$2"
+  local session_id="$3"
+  local updated_at="$4"
+  local total_tokens="${5:-1000}"
+  local sessions_dir="$TEST_AGENTS_DIR/$agent_name/sessions"
+  local sessions_file="$sessions_dir/sessions.json"
+
+  # Add to index
+  local full_key="agent:${agent_name}:subagent:${uuid_prefix}-0000-0000-0000-000000000000"
+  local tmp_file="${sessions_file}.tmp"
+  jq --arg key "$full_key" \
+     --arg sid "$session_id" \
+     --argjson upd "$updated_at" \
+     --argjson tok "$total_tokens" \
+     '. + {($key): {"sessionId": $sid, "updatedAt": $upd, "totalTokens": $tok, "model": "test-model"}}' \
+     "$sessions_file" > "$tmp_file" && mv "$tmp_file" "$sessions_file"
+}
+
+create_transcript() {
+  local agent_name="$1"
+  local session_id="$2"
+  local message_count="$3"
+  local sessions_dir="$TEST_AGENTS_DIR/$agent_name/sessions"
+  local jsonl_file="$sessions_dir/${session_id}.jsonl"
+
+  # Session header
+  echo "{\"type\":\"session\",\"version\":3,\"id\":\"${session_id}\",\"timestamp\":\"2026-02-15T00:00:00.000Z\"}" > "$jsonl_file"
+  echo "{\"type\":\"model_change\",\"id\":\"mc1\",\"timestamp\":\"2026-02-15T00:00:00.000Z\"}" >> "$jsonl_file"
+
+  # Add messages (only if count > 0)
+  if [[ "$message_count" -gt 0 ]]; then
+    for i in $(seq 1 "$message_count"); do
+      echo "{\"type\":\"message\",\"id\":\"msg${i}\",\"timestamp\":\"2026-02-15T00:0${i}:00.000Z\",\"message\":{\"role\":\"assistant\",\"content\":[{\"type\":\"text\",\"text\":\"Message $i\"}]}}" >> "$jsonl_file"
+    done
+  fi
+}
+
+# Helper: run detector with isolated HOME
+run_detector() {
+  local test_home="$1"
+  shift
+  HOME="$test_home" bash "$DETECTOR" "$@"
+}
+
+# Helper: create an isolated test environment for a single test
+create_test_env() {
+  local test_env_dir
+  test_env_dir="$(mktemp -d)"
+  mkdir -p "$test_env_dir/.openclaw/agents" "$test_env_dir/.openclaw/logs" "$test_env_dir/logs"
+  touch "$test_env_dir/.openclaw/logs/gateway.err.log"
+  echo "$test_env_dir"
+}
+
+echo "=== Test 1: No agents → no phantoms ==="
+T1_DIR=$(create_test_env)
+OUTPUT=$(HOME="$T1_DIR" bash "$DETECTOR" --json --min-age 0 2>/dev/null || true)
+COUNT=$(echo "$OUTPUT" | jq -r '.phantomCount' 2>/dev/null || echo "error")
+assert_eq "empty agents dir = 0 phantoms" "0" "$COUNT"
+rm -rf "$T1_DIR"
+
+echo ""
+echo "=== Test 2: Session WITH messages → NOT phantom (false positive fix) ==="
+T2_DIR=$(create_test_env)
+TEST_AGENTS_DIR="$T2_DIR/.openclaw/agents"
+create_mock_agent "test-agent-a"
+add_subagent_session "test-agent-a" "aaaaaaaa" "sid-with-messages" "1700000000000" "5000"
+create_transcript "test-agent-a" "sid-with-messages" 10
+OUTPUT=$(HOME="$T2_DIR" bash "$DETECTOR" --json --min-age 0 2>/dev/null || true)
+COUNT=$(echo "$OUTPUT" | jq -r '.phantomCount' 2>/dev/null || echo "error")
+assert_eq "session with 10 messages = 0 phantoms" "0" "$COUNT"
+rm -rf "$T2_DIR"
+
+echo ""
+echo "=== Test 3: Session with ZERO messages → IS phantom ==="
+T3_DIR=$(create_test_env)
+TEST_AGENTS_DIR="$T3_DIR/.openclaw/agents"
+create_mock_agent "test-agent-b"
+add_subagent_session "test-agent-b" "bbbbbbbb" "sid-zero-messages" "1700000000000" "0"
+create_transcript "test-agent-b" "sid-zero-messages" 0
+OUTPUT=$(HOME="$T3_DIR" bash "$DETECTOR" --json --min-age 0 2>/dev/null || true)
+COUNT=$(echo "$OUTPUT" | jq -r '.phantomCount' 2>/dev/null || echo "error")
+assert_eq "session with 0 messages = 1 phantom" "1" "$COUNT"
+REASON=$(echo "$OUTPUT" | jq -r '.phantoms[0].reason' 2>/dev/null || echo "error")
+assert_contains "reason includes zero_messages" "zero_messages" "$REASON"
+rm -rf "$T3_DIR"
+
+echo ""
+echo "=== Test 4: Missing transcript file → IS phantom ==="
+T4_DIR=$(create_test_env)
+TEST_AGENTS_DIR="$T4_DIR/.openclaw/agents"
+create_mock_agent "test-agent-c"
+add_subagent_session "test-agent-c" "cccccccc" "sid-no-file" "1700000000000" "0"
+# Don't create transcript file
+OUTPUT=$(HOME="$T4_DIR" bash "$DETECTOR" --json --min-age 0 2>/dev/null || true)
+COUNT=$(echo "$OUTPUT" | jq -r '.phantomCount' 2>/dev/null || echo "error")
+assert_eq "missing transcript = 1 phantom" "1" "$COUNT"
+REASON=$(echo "$OUTPUT" | jq -r '.phantoms[0].reason' 2>/dev/null || echo "error")
+assert_contains "reason includes missing_transcript" "missing_transcript" "$REASON"
+rm -rf "$T4_DIR"
+
+echo ""
+echo "=== Test 5: Session too new → NOT flagged (respects min-age) ==="
+T5_DIR=$(create_test_env)
+TEST_AGENTS_DIR="$T5_DIR/.openclaw/agents"
+create_mock_agent "test-agent-d"
+NOW_MS=$(( $(date +%s) * 1000 ))
+add_subagent_session "test-agent-d" "dddddddd" "sid-new" "$NOW_MS" "0"
+create_transcript "test-agent-d" "sid-new" 0
+OUTPUT=$(HOME="$T5_DIR" bash "$DETECTOR" --json --min-age 10 2>/dev/null || true)
+COUNT=$(echo "$OUTPUT" | jq -r '.phantomCount' 2>/dev/null || echo "error")
+assert_eq "new session with min-age 10 = 0 phantoms" "0" "$COUNT"
+rm -rf "$T5_DIR"
+
+echo ""
+echo "=== Test 6: Session with tokens and messages → NOT phantom ==="
+T6_DIR=$(create_test_env)
+TEST_AGENTS_DIR="$T6_DIR/.openclaw/agents"
+create_mock_agent "test-agent-e"
+add_subagent_session "test-agent-e" "eeeeeeee" "sid-has-tokens" "1700000000000" "50000"
+create_transcript "test-agent-e" "sid-has-tokens" 25
+OUTPUT=$(HOME="$T6_DIR" bash "$DETECTOR" --json --min-age 0 2>/dev/null || true)
+E_PHANTOMS=$(echo "$OUTPUT" | jq '[.phantoms[] | select(.agent == "test-agent-e")] | length' 2>/dev/null || echo "error")
+assert_eq "session with tokens+messages = 0 phantoms" "0" "$E_PHANTOMS"
+rm -rf "$T6_DIR"
+
+echo ""
+echo "=== Test 7: Non-subagent sessions → NOT checked ==="
+T7_DIR=$(create_test_env)
+TEST_AGENTS_DIR="$T7_DIR/.openclaw/agents"
+create_mock_agent "test-agent-f"
+sessions_file="$TEST_AGENTS_DIR/test-agent-f/sessions/sessions.json"
+jq '. + {"agent:test-agent-f:cron:ffffffff-0000-0000-0000-000000000000": {"sessionId": "sid-cron", "updatedAt": 1700000000000, "totalTokens": 0, "model": "test"}}' \
+  "$sessions_file" > "${sessions_file}.tmp" && mv "${sessions_file}.tmp" "$sessions_file"
+OUTPUT=$(HOME="$T7_DIR" bash "$DETECTOR" --json --min-age 0 2>/dev/null || true)
+F_PHANTOMS=$(echo "$OUTPUT" | jq '[.phantoms[] | select(.agent == "test-agent-f")] | length' 2>/dev/null || echo "error")
+assert_eq "cron session ignored" "0" "$F_PHANTOMS"
+rm -rf "$T7_DIR"
+
+echo ""
+echo "=== Test 8: Multiple agents, mixed states ==="
+T8_DIR=$(create_test_env)
+TEST_AGENTS_DIR="$T8_DIR/.openclaw/agents"
+create_mock_agent "test-agent-g"
+add_subagent_session "test-agent-g" "g1111111" "sid-g-alive" "1700000000000" "1000"
+create_transcript "test-agent-g" "sid-g-alive" 5
+add_subagent_session "test-agent-g" "g2222222" "sid-g-phantom" "1700000000000" "0"
+# No transcript for g2222222
+OUTPUT=$(HOME="$T8_DIR" bash "$DETECTOR" --json --min-age 0 2>/dev/null || true)
+G_PHANTOMS=$(echo "$OUTPUT" | jq '[.phantoms[] | select(.agent == "test-agent-g")] | length' 2>/dev/null || echo "error")
+assert_eq "1 alive + 1 phantom = 1 phantom detected" "1" "$G_PHANTOMS"
+rm -rf "$T8_DIR"
+
+echo ""
+echo "=== Test 9: Transcript with only headers (no messages) → phantom ==="
+# Use a dedicated isolated test dir to avoid contamination
+TEST9_DIR="$(mktemp -d)"
+mkdir -p "$TEST9_DIR/.openclaw/agents/test-agent-h/sessions" "$TEST9_DIR/.openclaw/logs" "$TEST9_DIR/logs"
+touch "$TEST9_DIR/.openclaw/logs/gateway.err.log"
+echo '{}' > "$TEST9_DIR/.openclaw/agents/test-agent-h/sessions/sessions.json"
+jq --arg key "agent:test-agent-h:subagent:hhhhhhhh-0000-0000-0000-000000000000" \
+   --arg sid "sid-headers-only" \
+   --argjson upd "1700000000000" \
+   --argjson tok "0" \
+   '. + {($key): {"sessionId": $sid, "updatedAt": $upd, "totalTokens": $tok, "model": "test-model"}}' \
+   "$TEST9_DIR/.openclaw/agents/test-agent-h/sessions/sessions.json" > "$TEST9_DIR/tmp.json" && mv "$TEST9_DIR/tmp.json" "$TEST9_DIR/.openclaw/agents/test-agent-h/sessions/sessions.json"
+# Create transcript with only session/model headers, no messages
+echo '{"type":"session","version":3,"id":"sid-headers-only"}' > "$TEST9_DIR/.openclaw/agents/test-agent-h/sessions/sid-headers-only.jsonl"
+echo '{"type":"model_change","id":"mc1"}' >> "$TEST9_DIR/.openclaw/agents/test-agent-h/sessions/sid-headers-only.jsonl"
+echo '{"type":"thinking_level_change","id":"tl1"}' >> "$TEST9_DIR/.openclaw/agents/test-agent-h/sessions/sid-headers-only.jsonl"
+OUTPUT=$(HOME="$TEST9_DIR" bash "$DETECTOR" --json --min-age 0 2>/dev/null || true)
+H_PHANTOMS=$(echo "$OUTPUT" | jq '[.phantoms[] | select(.agent == "test-agent-h")] | length' 2>/dev/null || echo "error")
+assert_eq "transcript with only headers = 1 phantom" "1" "$H_PHANTOMS"
+rm -rf "$TEST9_DIR"
+
+echo ""
+echo "=== Test 10: Large transcript (many messages) → NOT phantom ==="
+T10_DIR=$(create_test_env)
+TEST_AGENTS_DIR="$T10_DIR/.openclaw/agents"
+create_mock_agent "test-agent-i"
+add_subagent_session "test-agent-i" "iiiiiiii" "sid-large" "1700000000000" "100000"
+create_transcript "test-agent-i" "sid-large" 100
+OUTPUT=$(HOME="$T10_DIR" bash "$DETECTOR" --json --min-age 0 2>/dev/null || true)
+I_PHANTOMS=$(echo "$OUTPUT" | jq '[.phantoms[] | select(.agent == "test-agent-i")] | length' 2>/dev/null || echo "error")
+assert_eq "session with 100 messages = 0 phantoms" "0" "$I_PHANTOMS"
+rm -rf "$T10_DIR"
+
+echo ""
+echo "=== Test 11: Reproduce the EXACT false positive from production ==="
+# This reproduces the bug: session has messages in .jsonl but old detector
+# counted from sessions.json (which never has .messages array)
+T11_DIR=$(create_test_env)
+TEST_AGENTS_DIR="$T11_DIR/.openclaw/agents"
+create_mock_agent "test-agent-prod"
+PROD_UPDATED_AT=$(($(date +%s) * 1000 - 3600000))  # 1 hour ago
+add_subagent_session "test-agent-prod" "0e84becd" "9f12d986-6540-4f04-b10b-8207f4e42c8c" "$PROD_UPDATED_AT" "63150"
+create_transcript "test-agent-prod" "9f12d986-6540-4f04-b10b-8207f4e42c8c" 61
+OUTPUT=$(HOME="$T11_DIR" bash "$DETECTOR" --json --min-age 0 2>/dev/null || true)
+PROD_PHANTOMS=$(echo "$OUTPUT" | jq '[.phantoms[] | select(.agent == "test-agent-prod")] | length' 2>/dev/null || echo "error")
+assert_eq "production false positive case = 0 phantoms" "0" "$PROD_PHANTOMS"
+rm -rf "$T11_DIR"
+
+echo ""
+echo "=== Test 12: Spawn health check — session with messages ==="
+if [[ -f "$HEALTH_CHECK" ]]; then
+  T12_DIR=$(create_test_env)
+  TEST_AGENTS_DIR="$T12_DIR/.openclaw/agents"
+  create_mock_agent "test-health"
+  NOW_MS=$(( $(date +%s) * 1000 ))
+  add_subagent_session "test-health" "hc111111" "sid-health-alive" "$NOW_MS" "1000"
+  create_transcript "test-health" "sid-health-alive" 3
+  HC_OUTPUT=$(HOME="$T12_DIR" bash "$HEALTH_CHECK" \
+    --session-key "agent:test-health:subagent:hc111111-0000-0000-0000-000000000000" \
+    --agent "test-health" \
+    --timeout 2 --interval 1 --json 2>/dev/null || true)
+  HC_STATUS=$(echo "$HC_OUTPUT" | jq -r '.status' 2>/dev/null || echo "error")
+  assert_eq "health check: alive session = alive" "alive" "$HC_STATUS"
+  HC_MSGS=$(echo "$HC_OUTPUT" | jq -r '.messages' 2>/dev/null || echo "error")
+  assert_eq "health check: correct message count" "3" "$HC_MSGS"
+  rm -rf "$T12_DIR"
+else
+  echo "  ⏭️  spawn-health-check.sh not found, skipping"
+fi
+
+echo ""
+echo "=== Test 13: Spawn health check — phantom session (no transcript) ==="
+if [[ -f "$HEALTH_CHECK" ]]; then
+  T13_DIR=$(create_test_env)
+  TEST_AGENTS_DIR="$T13_DIR/.openclaw/agents"
+  create_mock_agent "test-health2"
+  NOW_MS=$(( $(date +%s) * 1000 ))
+  add_subagent_session "test-health2" "hc222222" "sid-health-phantom" "$NOW_MS" "0"
+  # DON'T create a transcript file — this is a true phantom
+  HC_OUTPUT=$(HOME="$T13_DIR" bash "$HEALTH_CHECK" \
+    --session-key "agent:test-health2:subagent:hc222222-0000-0000-0000-000000000000" \
+    --agent "test-health2" \
+    --timeout 3 --interval 1 --json 2>/dev/null || true)
+  HC_STATUS=$(echo "$HC_OUTPUT" | jq -r '.status' 2>/dev/null || echo "error")
+  assert_eq "health check: phantom session = phantom" "phantom" "$HC_STATUS"
+  rm -rf "$T13_DIR"
+else
+  echo "  ⏭️  spawn-health-check.sh not found, skipping"
+fi
+
+echo ""
+echo "================================"
+echo "Results: $PASS passed, $FAIL failed (of $TOTAL tests)"
+echo "================================"
+
+[ "$FAIL" -eq 0 ] && exit 0 || exit 1


### PR DESCRIPTION
## Problem

The `phantom-detector.sh` script was reporting **13 false positive phantom sessions** — sessions that were actually functioning normally (61-267 messages each) were being flagged as `zero_messages` phantoms.

This caused 12+ hours of wasted investigation time and unnecessary panic alerts.

## Root Cause

**Bug in message counting logic.** The detector's jq query looked for `.value.messages` array in the `sessions.json` index:

```jq
messageCount: ((.value.messages // []) | length),
```

But **`sessions.json` does NOT contain a `messages` array**. Messages are stored in separate `{sessionId}.jsonl` transcript files. The `.messages` field doesn't exist in the index, so this expression always returned `0`, flagging every subagent session as phantom.

### Additional Bugs Fixed

1. **`grep -c` exit code bug** — `grep -c` returns exit code 1 when count is 0 (even though it outputs "0"). Combined with `|| echo "0"`, this produced `"0\n0"` which broke bash arithmetic.
2. **Empty PHANTOMS array** — JSON output was malformed when no phantoms found.
3. **Webhook payload injection** — Used `jq` for safe JSON encoding instead of string interpolation.

## Changes

- **`scripts/phantom-detector.sh`** — Fixed to count messages from `.jsonl` transcript files instead of non-existent `.messages` array in index
- **`scripts/spawn-health-check.sh`** — New post-spawn verification script that polls transcript files for messages
- **`scripts/tests/test-phantom-detector-v2.sh`** — 16 comprehensive tests (all passing), including exact reproduction of the production false positive
- **`docs/SPAWN_RELIABILITY.md`** — Updated with v2 fix documentation

## Test Results

```
Results: 16 passed, 0 failed (of 16 tests)
```

Key tests:
- **Test 2:** Session WITH messages → correctly NOT flagged
- **Test 3:** Session with zero messages → correctly flagged  
- **Test 4:** Missing transcript → correctly flagged
- **Test 9:** Headers-only transcript → correctly flagged
- **Test 11:** **Exact production false positive reproduction** (session 0e84becd with 61 messages, correctly NOT flagged)
- **Tests 12-13:** spawn-health-check.sh integration tests

## Verification

Before fix: 13 sessions falsely reported as phantoms
After fix: 0 false positives on the same production data

Closes #34