### PR TITLE
Security: ignore tactical-map-server API token file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ yarn-error.log*
 tmp/
 runtime/logs/
 dashboard/data/
+
+# Tactical map server local secret
+tactical-map-server/data/.api-token


### PR DESCRIPTION
Security hardening: ensure tactical-map-server/data/.api-token remains local-only and never gets committed again.\n\nContext: token file was previously exposed on a stale branch; token has been rotated locally and the remote branch removed. This PR only adds a .gitignore rule to prevent future tracking.