### PR TITLE
fix(dashboard): prevent stored XSS in feed search highlighting

### DIFF
--- a/dashboard/client/feed-search-highlight.js
+++ b/dashboard/client/feed-search-highlight.js
@@ -1,0 +1,51 @@
+(function attachFeedSearchHighlight(globalScope) {
+  function normalizeSearchTerm(term) {
+    if (typeof term !== 'string') return '';
+    return term.toLowerCase();
+  }
+
+  function renderHighlightedText(container, text, term) {
+    if (!container || typeof container.textContent === 'undefined') return false;
+
+    const sourceText = typeof text === 'string' ? text : String(text ?? '');
+    const normalizedTerm = normalizeSearchTerm(term);
+
+    container.textContent = '';
+    if (!normalizedTerm) {
+      container.textContent = sourceText;
+      return false;
+    }
+
+    const idx = sourceText.toLowerCase().indexOf(normalizedTerm);
+    if (idx === -1) {
+      container.textContent = sourceText;
+      return false;
+    }
+
+    if (idx > 0) {
+      container.appendChild(document.createTextNode(sourceText.slice(0, idx)));
+    }
+
+    const highlight = document.createElement('span');
+    highlight.className = 'search-highlight';
+    highlight.textContent = sourceText.slice(idx, idx + normalizedTerm.length);
+    container.appendChild(highlight);
+
+    const tail = sourceText.slice(idx + normalizedTerm.length);
+    if (tail) {
+      container.appendChild(document.createTextNode(tail));
+    }
+
+    return true;
+  }
+
+  const api = { normalizeSearchTerm, renderHighlightedText };
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = api;
+  }
+
+  if (globalScope) {
+    globalScope.feedSearchHighlight = api;
+  }
+})(typeof window !== 'undefined' ? window : globalThis);

--- a/dashboard/client/index.html
+++ b/dashboard/client/index.html
@@ -2277,6 +2277,7 @@ body {
 </div>
 
 <script type="module" src="/rpg/components/index.js"></script>
+<script src="/feed-search-highlight.js"></script>
 <script>
 // Authenticated fetch helper (Phase 5.1 security + P0-5 429 handling)
 // Uses an HttpOnly cookie set via /api/login. Token is never exposed to JS.
@@ -4010,21 +4011,26 @@ function applyFeedFilter() {
     const matchSession = sf === 'all' || el.dataset.session === sf;
     const matchRole = rf === 'all' || el.dataset.role === rf;
     let matchSearch = true;
-    if (feedSearchTerm) {
-      const content = el.querySelector('.feed-content');
-      if (content) {
-        const text = content.getAttribute('data-original') || content.textContent;
-        if (!content.getAttribute('data-original')) {
-          content.setAttribute('data-original', text);
-        }
+    const content = el.querySelector('.feed-content');
+
+    if (content) {
+      const text = content.getAttribute('data-original') || content.textContent || '';
+      if (!content.getAttribute('data-original')) {
+        content.setAttribute('data-original', text);
+      }
+
+      if (feedSearchTerm) {
         matchSearch = text.toLowerCase().includes(feedSearchTerm);
-        if (matchSearch && feedSearchTerm) {
-          content.innerHTML = highlightText(text, feedSearchTerm);
+        if (matchSearch) {
+          window.feedSearchHighlight?.renderHighlightedText(content, text, feedSearchTerm);
         } else {
           content.textContent = text;
         }
+      } else {
+        content.textContent = text;
       }
     }
+
     el.style.display = (matchSession && matchRole && matchSearch) ? '' : 'none';
   });
 }
@@ -4458,13 +4464,6 @@ function clearFeedSearch() {
   document.getElementById('feedSearchInput').value = '';
   feedSearchTerm = '';
   applyFeedFilter();
-}
-
-function highlightText(text, term) {
-  if (!term) return text;
-  const idx = text.toLowerCase().indexOf(term);
-  if (idx === -1) return text;
-  return text.substring(0, idx) + '<span class="search-highlight">' + text.substring(idx, idx + term.length) + '</span>' + text.substring(idx + term.length);
 }
 
 // Session comparison

--- a/tests/e2e/xss-feed-search-highlight.spec.ts
+++ b/tests/e2e/xss-feed-search-highlight.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from '@playwright/test';
+import path from 'node:path';
+
+const helperScriptPath = path.resolve(process.cwd(), 'dashboard/client/feed-search-highlight.js');
+
+const HARNESS_HTML = `<!DOCTYPE html>
+<html lang="en">
+<head><meta charset="UTF-8"><title>Feed Search Highlight Harness</title></head>
+<body>
+  <div id="root"></div>
+  <script>
+    window.__feed_highlight_xss = 0;
+  </script>
+</body>
+</html>`;
+
+async function loadHarness(page: import('@playwright/test').Page) {
+  await page.setContent(HARNESS_HTML, { waitUntil: 'domcontentloaded' });
+  await page.addScriptTag({ path: helperScriptPath });
+}
+
+const payloadCases: Array<{ name: string; payload: string; term: string }> = [
+  {
+    name: 'IMG onerror payload stays inert',
+    payload: '<img src=x onerror="window.__feed_highlight_xss = 1"> alert payload',
+    term: 'alert',
+  },
+  {
+    name: 'SCRIPT tag payload stays inert',
+    payload: '<script>window.__feed_highlight_xss = 1</script>alert payload',
+    term: 'alert',
+  },
+];
+
+test.describe('XSS: dashboard feed search highlighting', () => {
+  for (const tc of payloadCases) {
+    test(`XSS regression — ${tc.name}`, async ({ page }) => {
+      await loadHarness(page);
+
+      await page.evaluate(({ payload, term }) => {
+        const container = document.createElement('div');
+        container.id = 'feed-content';
+        document.getElementById('root')?.appendChild(container);
+
+        (window as any).feedSearchHighlight.renderHighlightedText(container, payload, term);
+      }, tc);
+
+      await page.waitForTimeout(100);
+
+      const xssCanary = await page.evaluate(() => (window as any).__feed_highlight_xss);
+      expect(xssCanary).toBe(0);
+
+      await expect(page.locator('#feed-content img')).toHaveCount(0);
+      await expect(page.locator('#feed-content script')).toHaveCount(0);
+      await expect(page.locator('#feed-content .search-highlight')).toHaveText('alert');
+      await expect(page.locator('#feed-content')).toContainText(tc.payload);
+    });
+  }
+
+  test('XSS regression — non-matching search leaves raw text intact without markup injection', async ({ page }) => {
+    await loadHarness(page);
+
+    const payload = '<svg onload="window.__feed_highlight_xss = 1"></svg>';
+
+    await page.evaluate((text) => {
+      const container = document.createElement('div');
+      container.id = 'feed-content';
+      document.getElementById('root')?.appendChild(container);
+
+      (window as any).feedSearchHighlight.renderHighlightedText(container, text, 'not-found');
+    }, payload);
+
+    await page.waitForTimeout(100);
+
+    const xssCanary = await page.evaluate(() => (window as any).__feed_highlight_xss);
+    expect(xssCanary).toBe(0);
+
+    await expect(page.locator('#feed-content svg')).toHaveCount(0);
+    await expect(page.locator('#feed-content .search-highlight')).toHaveCount(0);
+    await expect(page.locator('#feed-content')).toContainText(payload);
+  });
+});


### PR DESCRIPTION
## Summary
- replace feed search highlighting HTML string injection with safe DOM node construction
- load a dedicated `feed-search-highlight.js` helper and remove the legacy `highlightText` innerHTML path
- preserve existing UX (case-insensitive first-match highlight + reset when search is cleared)

## Security
This removes the vulnerable sink where user-controlled feed text was reinserted via `innerHTML` during search highlight rendering.

## Tests
- `npx playwright test tests/e2e/xss-feed-search-highlight.spec.ts`
- `npm run test:e2e:xss`
- `npm run test --workspace=dashboard -- tests/unit/routes/observations.test.ts tests/integration/ventureos-data.test.ts`
- `npm run build --workspace=dashboard`

## Notes
- `npm run test:dashboard` currently fails in `tests/unit/middleware/auth.test.ts` due to pre-existing auth-path module resolution issues unrelated to this change.

Fixes #144
