### PR TITLE
fix(dashboard): prevent stored XSS in feed search highlighting

### DIFF
--- a/dashboard/client/assets/feed-search-highlight.js
+++ b/dashboard/client/assets/feed-search-highlight.js
@@ -1,14 +1,31 @@
 (function attachFeedSearchHighlight(globalScope) {
   function normalizeSearchTerm(term) {
     if (typeof term !== 'string') return '';
-    return term.toLowerCase();
+    return term;
+  }
+
+  function escapeRegex(value) {
+    return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  }
+
+  function findMatch(text, term) {
+    if (!term) return null;
+
+    const regex = new RegExp(escapeRegex(term), 'iu');
+    const match = regex.exec(text);
+    if (!match || typeof match.index !== 'number') return null;
+
+    return {
+      index: match.index,
+      value: match[0],
+    };
   }
 
   function renderHighlightedText(container, text, term) {
     if (!container || typeof container.textContent === 'undefined') return false;
 
     const sourceText = typeof text === 'string' ? text : String(text ?? '');
-    const normalizedTerm = normalizeSearchTerm(term);
+    const normalizedTerm = normalizeSearchTerm(typeof term === 'string' ? term : String(term ?? ''));
 
     container.textContent = '';
     if (!normalizedTerm) {
@@ -16,22 +33,22 @@
       return false;
     }
 
-    const idx = sourceText.toLowerCase().indexOf(normalizedTerm);
-    if (idx === -1) {
+    const found = findMatch(sourceText, normalizedTerm);
+    if (!found) {
       container.textContent = sourceText;
       return false;
     }
 
-    if (idx > 0) {
-      container.appendChild(document.createTextNode(sourceText.slice(0, idx)));
+    if (found.index > 0) {
+      container.appendChild(document.createTextNode(sourceText.slice(0, found.index)));
     }
 
     const highlight = document.createElement('span');
     highlight.className = 'search-highlight';
-    highlight.textContent = sourceText.slice(idx, idx + normalizedTerm.length);
+    highlight.textContent = found.value;
     container.appendChild(highlight);
 
-    const tail = sourceText.slice(idx + normalizedTerm.length);
+    const tail = sourceText.slice(found.index + found.value.length);
     if (tail) {
       container.appendChild(document.createTextNode(tail));
     }

--- a/dashboard/client/index.html
+++ b/dashboard/client/index.html
@@ -2277,7 +2277,7 @@ body {
 </div>
 
 <script type="module" src="/rpg/components/index.js"></script>
-<script src="/feed-search-highlight.js"></script>
+<script src="/assets/feed-search-highlight.js"></script>
 <script>
 // Authenticated fetch helper (Phase 5.1 security + P0-5 429 handling)
 // Uses an HttpOnly cookie set via /api/login. Token is never exposed to JS.

--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -109,6 +109,7 @@ const scrapeScript: string = path.join(WORKSPACE_DIR, 'scripts', 'scrape-claude-
 // Client HTML paths — served from client/ directory
 const htmlPath: string = path.join(import.meta.dirname, '..', 'client', 'index.html');
 const loginHtmlPath: string = path.join(import.meta.dirname, '..', 'client', 'login.html');
+const clientAssetsDir: string = path.join(import.meta.dirname, '..', 'client', 'assets');
 
 const VENTUREOS_AGENTS: string[] = (
   process.env.VENTUREOS_AGENTS ?? 'oracle,atlas,sentinel,verifier,archivist,synth'
@@ -3221,6 +3222,9 @@ const server: Server = http.createServer(async (req: IncomingMessage, res: Serve
 
     return;
   }
+
+  // Serve dashboard client static assets
+  if (tryServeStatic(req, res, { urlPrefix: '/assets/', rootDir: clientAssetsDir })) return;
 
   // Serve Tactical Map static files
   const TACTICAL_MAP_DIST: string = path.join(

--- a/tests/e2e/xss-feed-search-highlight.spec.ts
+++ b/tests/e2e/xss-feed-search-highlight.spec.ts
@@ -1,13 +1,17 @@
 import { test, expect } from '@playwright/test';
+import fs from 'node:fs';
 import path from 'node:path';
 
-const helperScriptPath = path.resolve(process.cwd(), 'dashboard/client/feed-search-highlight.js');
+const helperScriptPath = path.resolve(process.cwd(), 'dashboard/client/assets/feed-search-highlight.js');
+const helperScript = fs.readFileSync(helperScriptPath, 'utf8');
+const APP_ORIGIN = 'http://feed-highlight.test';
 
 const HARNESS_HTML = `<!DOCTYPE html>
 <html lang="en">
 <head><meta charset="UTF-8"><title>Feed Search Highlight Harness</title></head>
 <body>
   <div id="root"></div>
+  <script src="/assets/feed-search-highlight.js"></script>
   <script>
     window.__feed_highlight_xss = 0;
   </script>
@@ -15,8 +19,31 @@ const HARNESS_HTML = `<!DOCTYPE html>
 </html>`;
 
 async function loadHarness(page: import('@playwright/test').Page) {
-  await page.setContent(HARNESS_HTML, { waitUntil: 'domcontentloaded' });
-  await page.addScriptTag({ path: helperScriptPath });
+  await page.route(`${APP_ORIGIN}/**`, async (route) => {
+    const url = new URL(route.request().url());
+
+    if (url.pathname === '/' || url.pathname === '/index.html') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/html; charset=utf-8',
+        body: HARNESS_HTML,
+      });
+      return;
+    }
+
+    if (url.pathname === '/assets/feed-search-highlight.js') {
+      await route.fulfill({
+        status: 200,
+        contentType: 'text/javascript; charset=utf-8',
+        body: helperScript,
+      });
+      return;
+    }
+
+    await route.fulfill({ status: 404, body: 'not found' });
+  });
+
+  await page.goto(`${APP_ORIGIN}/`, { waitUntil: 'domcontentloaded' });
 }
 
 const payloadCases: Array<{ name: string; payload: string; term: string }> = [


### PR DESCRIPTION
## Summary
- remove the dashboard feed search highlighting XSS sink by replacing HTML-string highlighting with safe DOM node construction
- add `dashboard/client/assets/feed-search-highlight.js` and render highlights via text nodes + `<span class="search-highlight">`
- preserve current UX: case-insensitive search, first-match highlight, reset to plain text when filters clear
- serve dashboard static assets under `/assets/` so the helper loads in production

## Security impact
This fixes stored XSS in dashboard feed search highlighting by eliminating `innerHTML` writes from user-controlled feed content during highlight rendering.

## Tests
- `npx playwright test tests/e2e/xss-feed-search-highlight.spec.ts`
- `npm run test:e2e:xss`
- `npm run test --workspace=dashboard -- tests/unit/routes/observations.test.ts tests/integration/ventureos-data.test.ts`
- `npm run test:dashboard`
- `npm run build --workspace=dashboard`

## Notes
- `npm test` in repo root still fails in unrelated Jest suites due local `better-sqlite3` binary load issues; dashboard + XSS-focused suites pass.

Fixes #144
