### PR TITLE
feat(dashboard): Live Data V1 — real-time telemetry SSE

### DIFF
--- a/dashboard/client/index.html
+++ b/dashboard/client/index.html
@@ -1337,8 +1337,17 @@ body {
     
     <div class="page active" id="overview">
       <div class="page-header">
-        <h1 class="page-title">Overview</h1>
-        <p class="page-subtitle">Agent activity and system performance</p>
+        <div style="display:flex;align-items:center;justify-content:space-between;">
+          <div>
+            <h1 class="page-title">Overview</h1>
+            <p class="page-subtitle">Agent activity and system performance</p>
+          </div>
+          <div id="liveIndicator" style="display:flex;align-items:center;gap:8px;padding:6px 14px;border-radius:8px;background:var(--bg-card);border:1px solid var(--border);font-size:12px;font-weight:600;color:var(--text-muted);transition:all 0.3s;">
+            <span id="liveDot" style="width:8px;height:8px;border-radius:50%;background:var(--text-muted);transition:all 0.3s;"></span>
+            <span id="liveLabel">Connecting…</span>
+            <span id="liveAge" style="font-family:'JetBrains Mono',monospace;font-size:10px;color:var(--text-muted);"></span>
+          </div>
+        </div>
       </div>
 
       <div class="grid mb-24" style="grid-template-columns: repeat(3, 1fr);">
@@ -4986,6 +4995,175 @@ setTimeout(() => {
   if (costs.perDay) calculateStreak();
   updatePageTitle();
 }, 2000);
+
+// ─── Live Telemetry SSE (Live Data V1) ──────────────────────────────────────
+let telemetrySource = null;
+let telemetryLastTs = 0;
+let telemetryReconnectTimer = null;
+
+function connectLiveTelemetry() {
+  if (telemetrySource) return;
+  
+  const dot = document.getElementById('liveDot');
+  const label = document.getElementById('liveLabel');
+  const ageEl = document.getElementById('liveAge');
+  const indicator = document.getElementById('liveIndicator');
+  
+  if (label) label.textContent = 'Connecting…';
+  if (dot) dot.style.background = 'var(--yellow)';
+  
+  telemetrySource = new EventSource('/api/live-telemetry');
+  
+  telemetrySource.onopen = () => {
+    if (dot) { dot.style.background = 'var(--green)'; dot.style.boxShadow = '0 0 8px var(--green-glow)'; dot.style.animation = 'pulse 2s ease-in-out infinite'; }
+    if (label) label.textContent = 'LIVE';
+    if (indicator) { indicator.style.borderColor = 'rgba(16,185,129,0.4)'; indicator.style.color = 'var(--green)'; }
+  };
+  
+  telemetrySource.onmessage = (event) => {
+    try {
+      const snap = JSON.parse(event.data);
+      if (snap.type !== 'telemetry') return;
+      telemetryLastTs = snap.ts;
+      applyTelemetrySnapshot(snap);
+    } catch (e) {
+      console.error('Telemetry parse error:', e);
+    }
+  };
+  
+  telemetrySource.onerror = () => {
+    if (dot) { dot.style.background = 'var(--red)'; dot.style.boxShadow = 'none'; dot.style.animation = 'none'; }
+    if (label) label.textContent = 'Disconnected';
+    if (indicator) { indicator.style.borderColor = 'rgba(239,68,68,0.3)'; indicator.style.color = 'var(--red)'; }
+    
+    if (telemetrySource) {
+      telemetrySource.close();
+      telemetrySource = null;
+    }
+    
+    // Reconnect after 5 seconds
+    if (telemetryReconnectTimer) clearTimeout(telemetryReconnectTimer);
+    telemetryReconnectTimer = setTimeout(connectLiveTelemetry, 5000);
+  };
+}
+
+function applyTelemetrySnapshot(snap) {
+  // ── System stats ──
+  if (snap.system) {
+    const cpuPct = snap.system.cpuUsage || 0;
+    const sysEl = document.getElementById('systemCpu');
+    if (sysEl) sysEl.textContent = cpuPct + '%';
+    try { updateRadialGauge('cpuCircle', cpuPct); } catch {}
+    
+    const ramPct = snap.system.memoryPercent || 0;
+    const ramEl = document.getElementById('systemRam');
+    if (ramEl) ramEl.textContent = ramPct + '%';
+    try { updateRadialGauge('ramCircle', ramPct); } catch {}
+    
+    const ramDetail = document.getElementById('systemRamDetail');
+    if (ramDetail) ramDetail.textContent = `${snap.system.memoryUsedGB} / ${snap.system.memoryTotalGB} GB`;
+    
+    const diskPct = snap.system.diskPercent || 0;
+    const diskEl = document.getElementById('systemDisk');
+    if (diskEl) diskEl.textContent = diskPct + '%';
+    try { updateRadialGauge('diskCircle', diskPct); } catch {}
+    
+    const loadEl = document.getElementById('systemLoad');
+    if (loadEl) loadEl.textContent = 'Load: ' + snap.system.loadAvg1m;
+    
+    const uptime = snap.system.uptime || 0;
+    const days = Math.floor(uptime / 86400);
+    const hours = Math.floor((uptime % 86400) / 3600);
+    const uptimeStr = days > 0 ? `${days}d ${hours}h` : hours > 0 ? `${hours}h` : `${Math.floor(uptime / 60)}m`;
+    const uptimeEl = document.getElementById('systemUptime');
+    if (uptimeEl) uptimeEl.textContent = uptimeStr;
+  }
+  
+  // ── Session counts ──
+  if (snap.sessions) {
+    const runEl = document.getElementById('runningAgents');
+    if (runEl) runEl.textContent = snap.sessions.running;
+    const totalEl = document.getElementById('totalSessions');
+    if (totalEl) totalEl.textContent = snap.sessions.total;
+    const activeEl = document.getElementById('activeSessions');
+    if (activeEl) activeEl.textContent = snap.sessions.running;
+  }
+  
+  // ── Costs ──
+  if (snap.costs) {
+    const todayEl = document.getElementById('todaySpend');
+    if (todayEl) todayEl.textContent = '$' + (snap.costs.today || 0).toFixed(2);
+  }
+  
+  // ── Usage (5h window) ──
+  if (snap.usage) {
+    const opusPct = snap.usage.opusPct || 0;
+    const ovPctEl = document.getElementById('ovSessionPct');
+    if (ovPctEl) ovPctEl.textContent = opusPct + '%';
+    
+    const sBar = document.getElementById('overviewSessionBar');
+    if (sBar) {
+      sBar.style.width = opusPct + '%';
+      sBar.style.background = opusPct < 50 ? 'var(--green)' : opusPct < 80 ? 'var(--yellow)' : 'var(--red)';
+    }
+    
+    const warnIcon = document.getElementById('overviewUsageWarn');
+    if (warnIcon) warnIcon.style.display = opusPct > 70 ? 'inline' : 'none';
+    
+    // Notification for high usage from live stream
+    if (opusPct >= 80 && !window._usageNotifiedLive) {
+      sendNotification('High Usage Warning', `5h session usage at ${opusPct}%`);
+      window._usageNotifiedLive = true;
+    } else if (opusPct < 70) {
+      window._usageNotifiedLive = false;
+    }
+  }
+  
+  // ── KPI widget ──
+  if (snap.kpi) {
+    const kpiSuccEl = document.getElementById('kpiLatestSuccess');
+    if (kpiSuccEl && snap.kpi.successRate != null) {
+      kpiSuccEl.textContent = (snap.kpi.successRate * 100).toFixed(1) + '%';
+    }
+    const kpiP95El = document.getElementById('kpiLatestP95');
+    if (kpiP95El && snap.kpi.p95LatencyS != null) {
+      kpiP95El.textContent = snap.kpi.p95LatencyS.toFixed(1) + 's';
+    }
+    const kpiDateEl = document.getElementById('kpiLatestDate');
+    if (kpiDateEl && snap.kpi.date) {
+      kpiDateEl.textContent = snap.kpi.date;
+    }
+  }
+  
+  // ── Agent activity (Mission Control team grid updates) ──
+  if (snap.agents) {
+    const busyAgentsEl = document.getElementById('mcBusyAgents');
+    if (busyAgentsEl) busyAgentsEl.textContent = snap.agents.active;
+  }
+  
+  // ── Update age display ──
+  const ageEl = document.getElementById('liveAge');
+  if (ageEl) {
+    ageEl.textContent = new Date(snap.ts).toLocaleTimeString('en', { hour:'2-digit', minute:'2-digit', second:'2-digit' });
+  }
+}
+
+// Update live age periodically
+setInterval(() => {
+  if (!telemetryLastTs) return;
+  const ageEl = document.getElementById('liveAge');
+  if (!ageEl) return;
+  const ageSec = Math.round((Date.now() - telemetryLastTs) / 1000);
+  if (ageSec > 15) {
+    ageEl.textContent = ageSec + 's ago';
+    ageEl.style.color = 'var(--yellow)';
+  } else {
+    ageEl.style.color = 'var(--text-muted)';
+  }
+}, 2000);
+
+// Start live telemetry connection
+connectLiveTelemetry();
 </script>
 </body>
 </html>

--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -50,6 +50,7 @@ import type {
   MessageContentBlock,
   CookieMap,
   VentureOSKpiResponse,
+  TelemetrySnapshot,
 } from './types.js';
 
 // Shared VentureOS libraries (Issue #79)
@@ -3152,6 +3153,108 @@ const server: Server = http.createServer(async (req: IncomingMessage, res: Serve
       const safe = toSafeError(e, { action: 'cron' });
       sendJson(res, { ok: false, error: safe.error, errorRef: safe.errorRef }, safe.status);
     }
+    return;
+  }
+
+  // ── Live Telemetry SSE (Issue #live-data-v1) ──────────────────────────────
+  if (req.url === '/api/live-telemetry') {
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    });
+
+    function buildTelemetrySnapshot(): TelemetrySnapshot {
+      const sys: SystemStats = getSystemStats();
+      const sess: SessionInfo[] = getSessionsJson();
+      const now: number = Date.now();
+      const running: number = sess.filter(
+        (s) => now - s.updatedAt < 300000 && !s.aborted,
+      ).length;
+
+      // Cost data (cached)
+      const nowMs: number = Date.now();
+      if (!costCache || nowMs - costCacheTime > 60000) {
+        costCache = getCostData();
+        costCacheTime = nowMs;
+      }
+
+      // Usage data (cached)
+      if (!usageCache || nowMs - usageCacheTime > 10000) {
+        usageCache = getUsageWindows();
+        usageCacheTime = nowMs;
+      }
+
+      // VentureOS agents
+      const vaResp: VentureOSAgentsResponse = getVentureosAgents();
+      const busyIds: string[] = Object.values(vaResp.agents ?? {})
+        .filter((a) => a.status === 'working')
+        .map((a) => a.agentId);
+
+      // KPI snapshot
+      const vKpis = getVentureOSKpis();
+      const kpiLatest = vKpis.latest;
+
+      return {
+        type: 'telemetry',
+        ts: nowMs,
+        system: {
+          cpuUsage: sys.cpu?.usage ?? 0,
+          memoryPercent: sys.memory?.percent ?? 0,
+          memoryUsedGB: sys.memory?.usedGB ?? '0.0',
+          memoryTotalGB: sys.memory?.totalGB ?? '0.0',
+          diskPercent: sys.disk?.percent ?? 0,
+          loadAvg1m: sys.loadAvg?.['1m'] ?? '0',
+          uptime: sys.uptime ?? 0,
+        },
+        agents: {
+          total: Object.keys(vaResp.agents ?? {}).length,
+          active: busyIds.length,
+          busyIds,
+        },
+        sessions: {
+          total: sess.length,
+          running,
+        },
+        costs: {
+          today: costCache?.today ?? 0,
+          week: costCache?.week ?? 0,
+        },
+        usage: {
+          opusPct: usageCache?.current?.opusPct ?? 0,
+          sonnetPct: usageCache?.current?.sonnetPct ?? 0,
+          totalCost5h: usageCache?.current?.totalCost ?? 0,
+          totalCalls5h: usageCache?.current?.totalCalls ?? 0,
+          burnTokensPerMin: usageCache?.burnRate?.tokensPerMinute ?? 0,
+          burnCostPerMin: usageCache?.burnRate?.costPerMinute ?? 0,
+        },
+        kpi: {
+          successRate: kpiLatest?.successRate ?? null,
+          p95LatencyS: kpiLatest?.p95LatencyS ?? null,
+          sloStatus: kpiLatest?.sloStatus ?? null,
+          date: kpiLatest?.date ?? null,
+        },
+      };
+    }
+
+    // Send initial snapshot immediately
+    const initial: TelemetrySnapshot = buildTelemetrySnapshot();
+    res.write(`data: ${JSON.stringify(initial)}\n\n`);
+
+    // Push updates every 5 seconds
+    const telemetryInterval: NodeJS.Timeout = setInterval(() => {
+      try {
+        const snap: TelemetrySnapshot = buildTelemetrySnapshot();
+        res.write(`data: ${JSON.stringify(snap)}\n\n`);
+      } catch {
+        // ignore
+      }
+    }, 5000);
+
+    req.on('close', () => {
+      clearInterval(telemetryInterval);
+    });
+
     return;
   }
 

--- a/dashboard/server/types.ts
+++ b/dashboard/server/types.ts
@@ -338,6 +338,48 @@ export interface LiveEvent {
   content: string;
 }
 
+/** Live telemetry snapshot pushed via SSE. */
+export interface TelemetrySnapshot {
+  type: 'telemetry';
+  ts: number;
+  system: {
+    cpuUsage: number;
+    memoryPercent: number;
+    memoryUsedGB: string;
+    memoryTotalGB: string;
+    diskPercent: number;
+    loadAvg1m: string;
+    uptime: number;
+  };
+  agents: {
+    total: number;
+    active: number;
+    busyIds: string[];
+  };
+  sessions: {
+    total: number;
+    running: number;
+  };
+  costs: {
+    today: number;
+    week: number;
+  };
+  usage: {
+    opusPct: number;
+    sonnetPct: number;
+    totalCost5h: number;
+    totalCalls5h: number;
+    burnTokensPerMin: number;
+    burnCostPerMin: number;
+  };
+  kpi: {
+    successRate: number | null;
+    p95LatencyS: number | null;
+    sloStatus: string | null;
+    date: string | null;
+  };
+}
+
 // ─── Cron Domain ─────────────────────────────────────────────────────────────
 
 /** Cron job info as returned from the API. */

--- a/dashboard/tests/integration/http-smoke.test.ts
+++ b/dashboard/tests/integration/http-smoke.test.ts
@@ -294,4 +294,58 @@ describe('Dashboard HTTP smoke tests', () => {
     expect(res.status).toBe(302);
     expect(res.headers.get('location')).toBe('/login');
   });
+
+  it('streams live telemetry via SSE with correct shape', async () => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 8000);
+
+    try {
+      const res = await fetch(`${BASE_URL}/api/live-telemetry`, {
+        headers: authHeaders(),
+        signal: controller.signal,
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toContain('text/event-stream');
+
+      // Read the initial snapshot
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      let snapshot: Record<string, unknown> | null = null;
+
+      while (!snapshot) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+
+        for (const line of buffer.split('\n')) {
+          if (line.startsWith('data: ')) {
+            try {
+              const parsed = JSON.parse(line.slice(6));
+              if (parsed.type === 'telemetry') {
+                snapshot = parsed;
+                break;
+              }
+            } catch {
+              // partial line
+            }
+          }
+        }
+      }
+
+      controller.abort();
+      expect(snapshot).not.toBeNull();
+      expect(snapshot!.type).toBe('telemetry');
+      expect(typeof (snapshot as any).ts).toBe('number');
+      expect(typeof (snapshot as any).system?.cpuUsage).toBe('number');
+      expect(typeof (snapshot as any).sessions?.total).toBe('number');
+      expect(typeof (snapshot as any).costs?.today).toBe('number');
+      expect(typeof (snapshot as any).usage?.opusPct).toBe('number');
+      expect('successRate' in ((snapshot as any).kpi ?? {})).toBe(true);
+    } finally {
+      clearTimeout(timeout);
+      controller.abort();
+    }
+  });
 });

--- a/dashboard/tests/unit/routes/live-telemetry.test.ts
+++ b/dashboard/tests/unit/routes/live-telemetry.test.ts
@@ -1,0 +1,281 @@
+/**
+ * Unit tests for /api/live-telemetry SSE endpoint.
+ * Validates that the telemetry snapshot shape is correct and the stream behaves properly.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { Server } from 'node:http';
+
+const TEST_PORT = 18700 + Math.floor(Math.random() * 200);
+const HOST = '127.0.0.1';
+const TOKEN = 'telemetry-test-token';
+const BASE_URL = `http://${HOST}:${TEST_PORT}`;
+
+let tmpRoot: string;
+let server: Server | undefined;
+
+async function waitForServer(url: string, attempts: number = 30): Promise<void> {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      const res = await fetch(url, { redirect: 'manual' });
+      if (res.status < 500) return;
+    } catch {
+      // ignore
+    }
+    await new Promise((resolve) => setTimeout(resolve, 100));
+  }
+  throw new Error('Dashboard server did not start');
+}
+
+function authHeaders(): Record<string, string> {
+  return { Authorization: `Bearer ${TOKEN}` };
+}
+
+beforeAll(async () => {
+  tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ventureos-telemetry-'));
+
+  const workspaceDir = path.join(tmpRoot, 'workspace');
+  const sharedDir = path.join(tmpRoot, 'shared');
+  const kpiDir = path.join(tmpRoot, 'kpis');
+  const obsDir = path.join(tmpRoot, 'observations');
+  const openclawDir = path.join(tmpRoot, '.openclaw');
+  const sessionsDir = path.join(openclawDir, 'agents', 'main', 'sessions');
+
+  fs.mkdirSync(kpiDir, { recursive: true });
+  fs.mkdirSync(obsDir, { recursive: true });
+  fs.mkdirSync(sharedDir, { recursive: true });
+  fs.mkdirSync(sessionsDir, { recursive: true });
+  fs.mkdirSync(workspaceDir, { recursive: true });
+
+  // Write a KPI file
+  const kpiBase = {
+    date: '2025-02-14',
+    overall: {
+      success_rate: 0.96,
+      latency_ms: { p50: 100, p95: 250, p99: 400 },
+    },
+    slo: { success_rate: 0.9, p95_latency_s: 1.0 },
+  };
+  fs.writeFileSync(path.join(kpiDir, '2025-02-14.json'), JSON.stringify(kpiBase));
+
+  // Write a session
+  const sessionEntry = {
+    label: 'Telemetry Test',
+    model: 'claude-3-opus',
+    updatedAt: Date.now(),
+    abortedLastRun: false,
+    sessionId: 'telem-sess-1',
+  };
+  fs.writeFileSync(
+    path.join(sessionsDir, 'sessions.json'),
+    JSON.stringify({ 'telem-sess-1': sessionEntry }, null, 2),
+  );
+
+  const timestamp = new Date().toISOString();
+  fs.writeFileSync(
+    path.join(sessionsDir, 'telem-sess-1.jsonl'),
+    JSON.stringify({
+      type: 'message',
+      timestamp,
+      message: {
+        role: 'assistant',
+        content: 'test',
+        model: 'claude-3-opus',
+        usage: { input: 50, output: 100, cost: { total: 0.001 } },
+      },
+    }),
+  );
+
+  fs.writeFileSync(path.join(sharedDir, 'active-work.md'), '- test\n');
+  fs.writeFileSync(path.join(sharedDir, 'priorities.md'), '- test\n');
+
+  process.env.DASHBOARD_PORT = String(TEST_PORT);
+  process.env.DASHBOARD_HOST = HOST;
+  process.env.DASHBOARD_API_TOKEN = TOKEN;
+  process.env.KPI_DIR = kpiDir;
+  process.env.OBSERVATIONS_DIR = obsDir;
+  process.env.OPENCLAW_DIR = openclawDir;
+  process.env.WORKSPACE_DIR = workspaceDir;
+  process.env.VENTUREOS_ROOT = tmpRoot;
+  process.env.VENTUREOS_SHARED_CONTEXT_DIR = sharedDir;
+  process.env.VENTUREOS_ACTIVE_WORK_PATH = path.join(sharedDir, 'active-work.md');
+  process.env.VENTUREOS_PRIORITIES_PATH = path.join(sharedDir, 'priorities.md');
+  process.env.RPG_DB_PATH = path.join(tmpRoot, 'rpg.sqlite');
+  process.env.VENTUREOS_AGENTS = 'main';
+
+  const mod = (await import('../../../server/server.js')) as {
+    server?: Server;
+    default?: { server?: Server };
+  };
+  server = mod.server ?? mod.default?.server;
+
+  await waitForServer(`${BASE_URL}/login`);
+});
+
+afterAll(async () => {
+  if (server && typeof server.close === 'function') {
+    await new Promise<void>((resolve) => server!.close(() => resolve()));
+  }
+  fs.rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+describe('/api/live-telemetry SSE endpoint', () => {
+  it('rejects unauthenticated requests', async () => {
+    const res = await fetch(`${BASE_URL}/api/live-telemetry`, { redirect: 'manual' });
+    expect(res.status).toBe(401);
+  });
+
+  it('streams telemetry snapshots with correct shape', async () => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 8000);
+
+    try {
+      const res = await fetch(`${BASE_URL}/api/live-telemetry`, {
+        headers: authHeaders(),
+        signal: controller.signal,
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.headers.get('content-type')).toContain('text/event-stream');
+      expect(res.headers.get('cache-control')).toContain('no-cache');
+
+      // Read the first snapshot from the SSE stream
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      let snapshot: Record<string, unknown> | null = null;
+
+      while (!snapshot) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+
+        // Parse SSE data lines
+        const lines = buffer.split('\n');
+        for (const line of lines) {
+          if (line.startsWith('data: ')) {
+            const jsonStr = line.slice(6).trim();
+            if (jsonStr) {
+              try {
+                const parsed = JSON.parse(jsonStr);
+                if (parsed.type === 'telemetry') {
+                  snapshot = parsed;
+                  break;
+                }
+              } catch {
+                // ignore partial lines
+              }
+            }
+          }
+        }
+      }
+
+      controller.abort();
+      expect(snapshot).not.toBeNull();
+
+      // Validate shape
+      expect(snapshot!.type).toBe('telemetry');
+      expect(typeof snapshot!.ts).toBe('number');
+
+      const system = snapshot!.system as Record<string, unknown>;
+      expect(typeof system.cpuUsage).toBe('number');
+      expect(typeof system.memoryPercent).toBe('number');
+      expect(typeof system.memoryUsedGB).toBe('string');
+      expect(typeof system.memoryTotalGB).toBe('string');
+      expect(typeof system.diskPercent).toBe('number');
+      expect(typeof system.loadAvg1m).toBe('string');
+      expect(typeof system.uptime).toBe('number');
+
+      const agents = snapshot!.agents as Record<string, unknown>;
+      expect(typeof agents.total).toBe('number');
+      expect(typeof agents.active).toBe('number');
+      expect(Array.isArray(agents.busyIds)).toBe(true);
+
+      const sessions = snapshot!.sessions as Record<string, unknown>;
+      expect(typeof sessions.total).toBe('number');
+      expect(typeof sessions.running).toBe('number');
+
+      const costs = snapshot!.costs as Record<string, unknown>;
+      expect(typeof costs.today).toBe('number');
+      expect(typeof costs.week).toBe('number');
+
+      const usage = snapshot!.usage as Record<string, unknown>;
+      expect(typeof usage.opusPct).toBe('number');
+      expect(typeof usage.sonnetPct).toBe('number');
+      expect(typeof usage.totalCost5h).toBe('number');
+
+      const kpi = snapshot!.kpi as Record<string, unknown>;
+      expect('successRate' in kpi).toBe(true);
+      expect('p95LatencyS' in kpi).toBe(true);
+      expect('sloStatus' in kpi).toBe(true);
+      expect('date' in kpi).toBe(true);
+    } finally {
+      clearTimeout(timeout);
+      controller.abort();
+    }
+  });
+
+  it('sends multiple snapshots over time', async () => {
+    const controller = new AbortController();
+    const timeout = setTimeout(() => controller.abort(), 12000);
+
+    try {
+      const res = await fetch(`${BASE_URL}/api/live-telemetry`, {
+        headers: authHeaders(),
+        signal: controller.signal,
+      });
+
+      expect(res.status).toBe(200);
+
+      const reader = res.body!.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      const snapshots: Record<string, unknown>[] = [];
+
+      const startTime = Date.now();
+      while (snapshots.length < 2 && Date.now() - startTime < 11000) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+
+        // Parse complete SSE lines
+        while (buffer.includes('\n\n')) {
+          const idx = buffer.indexOf('\n\n');
+          const chunk = buffer.slice(0, idx);
+          buffer = buffer.slice(idx + 2);
+
+          for (const line of chunk.split('\n')) {
+            if (line.startsWith('data: ')) {
+              try {
+                const parsed = JSON.parse(line.slice(6));
+                if (parsed.type === 'telemetry') {
+                  snapshots.push(parsed);
+                }
+              } catch {
+                // ignore
+              }
+            }
+          }
+        }
+      }
+
+      controller.abort();
+
+      // Should have at least the initial snapshot + one interval push
+      expect(snapshots.length).toBeGreaterThanOrEqual(2);
+
+      // Second snapshot should have a later timestamp
+      if (snapshots.length >= 2) {
+        expect((snapshots[1] as { ts: number }).ts).toBeGreaterThanOrEqual(
+          (snapshots[0] as { ts: number }).ts,
+        );
+      }
+    } finally {
+      clearTimeout(timeout);
+      controller.abort();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
Adds `/api/live-telemetry` SSE endpoint that pushes real-time system, agent, session, cost, usage, and KPI snapshots every 5 seconds.

## What's New
- **Server**: `/api/live-telemetry` SSE handler with `buildTelemetrySnapshot()` aggregating all dashboard data sources
- **Types**: `TelemetrySnapshot` interface with full type coverage
- **Client**: Auto-connecting SSE with live indicator (green dot + LIVE label), reconnect-on-error, and DOM updates for CPU, RAM, disk, load, sessions, costs, usage bars, and KPI widgets
- **Tests**: Unit tests for telemetry shape + multi-snapshot streaming, integration smoke test for SSE endpoint

## Validation
- All 126 unit tests pass
- Verified with curl: live CPU/RAM/load values change across snapshots
- Agent detection correctly identifies active agents in real-time (atlas shown as working during test)
- Telemetry pushes every 5s with genuine value changes

## How to Run
```bash
cd ventureos
DASHBOARD_PORT=8001 npx tsx dashboard/server/server.ts
# Open http://127.0.0.1:8001 and log in with the API token
# Overview page shows LIVE indicator with real-time updates
```