### PR TITLE
fix(rpg): align PsionicStatSnapshot type and queries with actual DB schema

### DIFF
--- a/lib/__tests__/rpg-http.test.ts
+++ b/lib/__tests__/rpg-http.test.ts
@@ -48,14 +48,26 @@ beforeAll((done) => {
   db = new Database(dbPath);
   db.exec(`
     CREATE TABLE psionic_stats (
-      snapshot_date TEXT NOT NULL,
-      claims_with_citations INTEGER DEFAULT 0,
-      total_claims INTEGER DEFAULT 0,
-      knowledge_gaps INTEGER DEFAULT 0,
-      cross_domain_links INTEGER DEFAULT 0,
-      source_count INTEGER DEFAULT 0,
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      agent_id TEXT NOT NULL,
+      snapshot_date DATE NOT NULL,
+      psionic_mastery INTEGER DEFAULT 0,
+      energy INTEGER DEFAULT 0,
+      shields INTEGER DEFAULT 0,
+      warp_technology INTEGER DEFAULT 0,
+      psi_reach INTEGER DEFAULT 0,
+      memory_count INTEGER DEFAULT 0,
+      unique_domains INTEGER DEFAULT 0,
+      canonical_edits INTEGER DEFAULT 0,
+      p95_latency_s REAL DEFAULT 0,
       mttr_minutes REAL DEFAULT 0,
-      freshness_hours REAL DEFAULT 0
+      acceptance_rate REAL DEFAULT 0,
+      success_rate REAL DEFAULT 0,
+      approval_accuracy REAL DEFAULT 0,
+      tasks_completed INTEGER DEFAULT 0,
+      warp_tech_inputs TEXT,
+      calculated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      UNIQUE(agent_id, snapshot_date)
     );
 
     CREATE TABLE interaction_logs (
@@ -79,8 +91,8 @@ beforeAll((done) => {
   `);
 
   // Seed data
-  db.prepare(`INSERT INTO psionic_stats VALUES ('2026-02-15', 4, 8, 1, 1, 3, 20.0, 10.0)`).run();
-  db.prepare(`INSERT INTO psionic_stats VALUES ('2026-02-14', 9, 10, 3, 2, 5, 12.5, 4.0)`).run();
+  db.prepare(`INSERT INTO psionic_stats (agent_id, snapshot_date, psionic_mastery, energy, shields, warp_technology, psi_reach, memory_count, unique_domains, canonical_edits, p95_latency_s, mttr_minutes, acceptance_rate, success_rate, approval_accuracy, tasks_completed) VALUES ('atlas', '2026-02-15', 72, 85, 60, 45, 55, 120, 8, 15, 1.2, 20.0, 0.85, 0.92, 0.88, 42)`).run();
+  db.prepare(`INSERT INTO psionic_stats (agent_id, snapshot_date, psionic_mastery, energy, shields, warp_technology, psi_reach, memory_count, unique_domains, canonical_edits, p95_latency_s, mttr_minutes, acceptance_rate, success_rate, approval_accuracy, tasks_completed) VALUES ('atlas', '2026-02-14', 68, 80, 58, 42, 50, 110, 7, 12, 1.5, 12.5, 0.82, 0.90, 0.85, 38)`).run();
   db.prepare(`INSERT INTO interaction_logs VALUES ('2026-02-14 12:00:00', 'atlas', 'deploy_success', 1200)`).run();
   db.prepare(`INSERT INTO interaction_logs VALUES ('2026-02-14 13:00:00', 'sentinel', 'escalation_true', 50)`).run();
   db.prepare(`INSERT INTO interaction_logs VALUES ('2026-02-15 09:00:00', 'oracle', 'verify', 900)`).run();
@@ -132,9 +144,11 @@ describe('RPG HTTP API', () => {
       const { status, body } = await fetch('/api/rpg/stats');
       expect(status).toBe(200);
       expect(body.stats).toBeDefined();
-      expect(body.stats.total_claims).toBe(8);
-      expect(body.stats.claims_with_citations).toBe(4);
-      expect(body.stats.citation_rate).toBe(0.5);
+      expect(body.stats.psionic_mastery).toBe(72);
+      expect(body.stats.energy).toBe(85);
+      expect(body.stats.shields).toBe(60);
+      expect(body.stats.warp_technology).toBe(45);
+      expect(body.stats.mttr_minutes).toBe(20.0);
       expect(body.snapshots).toHaveLength(2);
       expect(body.snapshots[0].snapshot_date).toBe('2026-02-15');
     });

--- a/lib/rpg-http.ts
+++ b/lib/rpg-http.ts
@@ -53,9 +53,12 @@ function parseUrl(req: IncomingMessage): URL | null {
 
 function queryPsionicStats(db: Database.Database): PsionicStatSnapshot[] {
   const stmt = db.prepare(
-    `SELECT snapshot_date, claims_with_citations, total_claims,
-            knowledge_gaps, cross_domain_links, source_count,
-            mttr_minutes, freshness_hours
+    `SELECT snapshot_date, agent_id,
+            psionic_mastery, energy, shields, warp_technology, psi_reach,
+            memory_count, unique_domains, canonical_edits,
+            p95_latency_s, mttr_minutes,
+            acceptance_rate, success_rate, approval_accuracy,
+            tasks_completed, warp_tech_inputs
      FROM psionic_stats ORDER BY snapshot_date DESC`,
   );
   return stmt.all() as PsionicStatSnapshot[];
@@ -170,17 +173,20 @@ function handleStats(
     const latest = snapshots[0];
     const stats: Record<string, number> = {};
     if (latest) {
-      stats['claims_with_citations'] = latest.claims_with_citations;
-      stats['total_claims'] = latest.total_claims;
-      stats['knowledge_gaps'] = latest.knowledge_gaps;
-      stats['cross_domain_links'] = latest.cross_domain_links;
-      stats['source_count'] = latest.source_count;
+      stats['psionic_mastery'] = latest.psionic_mastery;
+      stats['energy'] = latest.energy;
+      stats['shields'] = latest.shields;
+      stats['warp_technology'] = latest.warp_technology;
+      stats['psi_reach'] = latest.psi_reach;
+      stats['memory_count'] = latest.memory_count;
+      stats['unique_domains'] = latest.unique_domains;
+      stats['canonical_edits'] = latest.canonical_edits;
+      stats['p95_latency_s'] = latest.p95_latency_s;
       stats['mttr_minutes'] = latest.mttr_minutes;
-      stats['freshness_hours'] = latest.freshness_hours;
-      if (latest.total_claims > 0) {
-        stats['citation_rate'] =
-          Math.round((latest.claims_with_citations / latest.total_claims) * 100) / 100;
-      }
+      stats['acceptance_rate'] = latest.acceptance_rate;
+      stats['success_rate'] = latest.success_rate;
+      stats['approval_accuracy'] = latest.approval_accuracy;
+      stats['tasks_completed'] = latest.tasks_completed;
     }
     const body: RpgStatsResponse = { stats, snapshots };
     sendJson(res, 200, body);
@@ -247,10 +253,11 @@ function handleTacticalOverlay(
   const latest = snapshots[0];
   const stats: Record<string, number> = {};
   if (latest) {
-    stats['claims_with_citations'] = latest.claims_with_citations;
-    stats['total_claims'] = latest.total_claims;
-    stats['knowledge_gaps'] = latest.knowledge_gaps;
-    stats['cross_domain_links'] = latest.cross_domain_links;
+    stats['psionic_mastery'] = latest.psionic_mastery;
+    stats['energy'] = latest.energy;
+    stats['shields'] = latest.shields;
+    stats['warp_technology'] = latest.warp_technology;
+    stats['psi_reach'] = latest.psi_reach;
   }
 
   const edges = queryKhalaNetwork(db);

--- a/lib/types/rpg.ts
+++ b/lib/types/rpg.ts
@@ -12,13 +12,22 @@
 /** A single snapshot row from the psionic_stats table. */
 export interface PsionicStatSnapshot {
   snapshot_date: string;
-  claims_with_citations: number;
-  total_claims: number;
-  knowledge_gaps: number;
-  cross_domain_links: number;
-  source_count: number;
+  agent_id: string;
+  psionic_mastery: number;
+  energy: number;
+  shields: number;
+  warp_technology: number;
+  psi_reach: number;
+  memory_count: number;
+  unique_domains: number;
+  canonical_edits: number;
+  p95_latency_s: number;
   mttr_minutes: number;
-  freshness_hours: number;
+  acceptance_rate: number;
+  success_rate: number;
+  approval_accuracy: number;
+  tasks_completed: number;
+  warp_tech_inputs: string | null;
 }
 
 /** GET /api/rpg/stats response. */


### PR DESCRIPTION
## Problem

The `psionic_stats` table uses columns like `psionic_mastery`, `energy`, `shields`, `warp_technology`, `psi_reach`, etc. However, `lib/rpg-http.ts` was querying non-existent columns (`claims_with_citations`, `total_claims`, `knowledge_gaps`, `cross_domain_links`, `source_count`, `freshness_hours`), causing 500 errors on all RPG API endpoints.

Additionally, the `better-sqlite3` native module had been built for Linux x86-64 (ELF) instead of macOS arm64 (Mach-O), causing the initial 503 "RPG database unavailable" errors.

## Root Causes

1. **Native module mismatch**: `better_sqlite3.node` was an ELF x86-64 binary on a Darwin arm64 host → rebuilt via `npx node-gyp rebuild`
2. **Schema mismatch**: `PsionicStatSnapshot` interface and SQL queries referenced columns that don't exist in the actual database schema

## Changes

- `lib/types/rpg.ts` — `PsionicStatSnapshot` interface now matches the real `psionic_stats` table schema
- `lib/rpg-http.ts` — `queryPsionicStats`, `handleStats`, `handleTacticalOverlay` updated to use actual DB columns
- `lib/__tests__/rpg-http.test.ts` — test schema and assertions aligned with real schema

## Verification

- All 11 `rpg-http.test.ts` tests pass
- `/api/rpg/tactical-overlay/echo` → HTTP 200 with real agent data
- `/api/rpg/stats` → HTTP 200 with psionic stat fields
- `/api/rpg/khala-network` → HTTP 200 with network edges

## Follow-ups

- `lib/__tests__/sql-injection.test.ts` and `lib/__tests__/kpi-registry.test.ts` still reference old column names in their isolated in-memory schemas (self-contained, don't affect runtime)