### PR TITLE
fix: native module platform validation prevents ELF-on-Darwin regression

### DIFF
--- a/dashboard/scripts/install-macos.sh
+++ b/dashboard/scripts/install-macos.sh
@@ -62,6 +62,11 @@ echo "📦 Installing dependencies & compiling TypeScript…"
 cd "$VENTUREOS_ROOT"
 npm install --workspace=dashboard --include=dev 2>/dev/null || npm install
 
+# Validate native modules match this platform (fixes ELF-on-Darwin regression)
+if [[ -x "$VENTUREOS_ROOT/scripts/ensure-native-modules.sh" ]]; then
+  "$VENTUREOS_ROOT/scripts/ensure-native-modules.sh"
+fi
+
 cd "$DASHBOARD_DIR"
 npx tsc -p tsconfig.json --outDir dist 2>&1 || {
   echo "⚠️  TypeScript compilation had warnings (non-fatal, continuing)"

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dashboard"
   ],
   "scripts": {
+    "postinstall": "bash scripts/ensure-native-modules.sh",
     "test": "jest --runInBand && npm run test --workspace=dashboard",
     "test:dashboard": "npm run test --workspace=dashboard",
     "test:dashboard:coverage": "npm run test:coverage --workspace=dashboard",

--- a/scripts/ensure-native-modules.sh
+++ b/scripts/ensure-native-modules.sh
@@ -1,0 +1,113 @@
+#!/bin/bash
+set -euo pipefail
+
+# ─── ensure-native-modules.sh ────────────────────────────────────────────────
+# Validates that native Node.js addons match the current platform/architecture.
+# Rebuilds mismatched modules automatically.
+#
+# Problem: npm install skips native module rebuild when the package version
+# matches, even if the binary was compiled for a different platform (e.g., a
+# Linux ELF binary on macOS arm64). This causes runtime dlopen() failures.
+#
+# Usage:
+#   ./scripts/ensure-native-modules.sh           # auto-detect and fix
+#   ./scripts/ensure-native-modules.sh --check   # check only (exit 1 if bad)
+#
+# Called from:
+#   - npm postinstall hook (package.json)
+#   - dashboard/scripts/install-macos.sh
+# ──────────────────────────────────────────────────────────────────────────────
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+CHECK_ONLY=false
+if [[ "${1:-}" == "--check" ]]; then
+  CHECK_ONLY=true
+fi
+
+# ─── Platform detection ──────────────────────────────────────────────────────
+
+CURRENT_OS="$(uname -s)"   # Darwin, Linux
+CURRENT_ARCH="$(uname -m)" # arm64, x86_64
+
+case "$CURRENT_OS" in
+  Darwin) EXPECTED_FORMAT="Mach-O" ;;
+  Linux)  EXPECTED_FORMAT="ELF" ;;
+  *)      echo "⚠️  Unknown OS: $CURRENT_OS — skipping native module check"; exit 0 ;;
+esac
+
+echo "🔍 Checking native modules for $CURRENT_OS/$CURRENT_ARCH (expect $EXPECTED_FORMAT)"
+
+# ─── Check better-sqlite3 ────────────────────────────────────────────────────
+
+SQLITE_BINARY="$REPO_ROOT/node_modules/better-sqlite3/build/Release/better_sqlite3.node"
+NEEDS_REBUILD=false
+
+if [[ ! -f "$SQLITE_BINARY" ]]; then
+  echo "⚠️  better-sqlite3 binary not found — needs build"
+  NEEDS_REBUILD=true
+else
+  BINARY_INFO="$(file "$SQLITE_BINARY" 2>/dev/null || echo "unknown")"
+
+  if echo "$BINARY_INFO" | grep -q "$EXPECTED_FORMAT"; then
+    # Format matches — also check architecture on macOS
+    if [[ "$CURRENT_OS" == "Darwin" && "$CURRENT_ARCH" == "arm64" ]]; then
+      if echo "$BINARY_INFO" | grep -q "arm64"; then
+        echo "✅ better-sqlite3: Mach-O arm64 — correct"
+      else
+        echo "❌ better-sqlite3: Mach-O but wrong arch (expected arm64)"
+        echo "   Found: $BINARY_INFO"
+        NEEDS_REBUILD=true
+      fi
+    elif [[ "$CURRENT_OS" == "Darwin" && "$CURRENT_ARCH" == "x86_64" ]]; then
+      if echo "$BINARY_INFO" | grep -q "x86_64"; then
+        echo "✅ better-sqlite3: Mach-O x86_64 — correct"
+      else
+        echo "❌ better-sqlite3: Mach-O but wrong arch (expected x86_64)"
+        echo "   Found: $BINARY_INFO"
+        NEEDS_REBUILD=true
+      fi
+    else
+      echo "✅ better-sqlite3: $EXPECTED_FORMAT format — correct"
+    fi
+  else
+    echo "❌ better-sqlite3: wrong binary format"
+    echo "   Expected: $EXPECTED_FORMAT ($CURRENT_OS/$CURRENT_ARCH)"
+    echo "   Found:    $BINARY_INFO"
+    NEEDS_REBUILD=true
+  fi
+fi
+
+# ─── Rebuild if needed ───────────────────────────────────────────────────────
+
+if $NEEDS_REBUILD; then
+  if $CHECK_ONLY; then
+    echo ""
+    echo "💡 Fix: cd $(basename "$REPO_ROOT") && npm rebuild better-sqlite3"
+    exit 1
+  fi
+
+  echo ""
+  echo "🔧 Rebuilding better-sqlite3 for $CURRENT_OS/$CURRENT_ARCH…"
+  cd "$REPO_ROOT"
+  npm rebuild better-sqlite3
+
+  # Verify rebuild succeeded
+  if [[ -f "$SQLITE_BINARY" ]]; then
+    VERIFY_INFO="$(file "$SQLITE_BINARY" 2>/dev/null || echo "unknown")"
+    if echo "$VERIFY_INFO" | grep -q "$EXPECTED_FORMAT"; then
+      echo "✅ Rebuild successful: $VERIFY_INFO"
+    else
+      echo "❌ Rebuild failed — binary still wrong format"
+      echo "   Got: $VERIFY_INFO"
+      exit 1
+    fi
+  else
+    echo "❌ Rebuild failed — binary not found"
+    exit 1
+  fi
+else
+  echo ""
+  echo "✅ All native modules match current platform"
+fi


### PR DESCRIPTION
## Problem

RPG endpoints (`/api/rpg/stats`, `/api/rpg/khala-network`, `/api/rpg/tactical-overlay/*`) return 503 after dashboard restart because `better-sqlite3`'s native addon is an ELF x86-64 binary on a macOS arm64 host.

**Root cause:** `npm install` skips native module rebuild when the package version matches, even if the binary was compiled for a different platform. Once a Linux ELF binary lands in `node_modules/` (from CI, Docker, or cross-platform sync), it persists indefinitely — every restart fails with `dlopen` mismatch.

## Solution

### `scripts/ensure-native-modules.sh`
Platform-aware validation script that:
- Checks `better-sqlite3.node` binary format matches current OS/arch
- Auto-rebuilds via `npm rebuild` if mismatched
- Supports `--check` mode for CI (exits 1 without fixing)

### Integration points
- **`postinstall` hook** in root `package.json` — runs after every `npm install`
- **`install-macos.sh`** — validates before launchd service startup

## Verification

| Endpoint | Before | After |
|----------|--------|-------|
| `/api/rpg/tactical-overlay/echo` | 503 | 200 |
| `/api/rpg/stats` | 503 | 200 |
| `/api/rpg/khala-network` | 503 | 200 |

Binary check:
```
Before: ELF 64-bit LSB shared object, x86-64 (Linux)
After:  Mach-O 64-bit bundle arm64 (macOS)
```

Refs: Issue #78