### PR TITLE
fix(dashboard): normalize token path between dev and dist modes

### DIFF
--- a/dashboard/LOCAL-DEPLOYMENT.md
+++ b/dashboard/LOCAL-DEPLOYMENT.md
@@ -1,0 +1,75 @@
+# Dashboard — Local Deployment Runbook
+
+## Token Auth — Canonical Path
+
+```
+<VENTUREOS_ROOT>/dashboard/data/.api-token
+```
+
+Resolved via `lib/paths.ts → DASHBOARD_DATA_DIR`. Both dev (`tsx watch`) and
+dist (`node dist/…`) use the **same** path. Override: `DASHBOARD_DATA_DIR` env var.
+
+## Build: CJS/ESM Boundary
+
+`lib/*.ts` compiles to CJS (root `"type": "commonjs"`) but `dist/lib/` lives
+under `dashboard/` (`"type": "module"`). The `npm run compile` script writes
+`{ "type": "commonjs" }` to `dist/lib/package.json` to prevent Node from
+misinterpreting CJS output as ESM.
+
+## Service Management (macOS)
+
+```bash
+launchctl list com.openclaw.dashboard                          # status
+launchctl kickstart -k gui/$(id -u)/com.openclaw.dashboard     # restart
+launchctl unload ~/Library/LaunchAgents/com.openclaw.dashboard.plist  # stop
+launchctl load -w ~/Library/LaunchAgents/com.openclaw.dashboard.plist # start
+```
+
+**Logs:** `tail -f ~/Library/Logs/ventureos-dashboard.{log,err.log}`
+
+## Rebuild + Restart
+
+```bash
+cd ~/clawd/ventureos/dashboard
+npm run compile
+launchctl kickstart -k gui/$(id -u)/com.openclaw.dashboard
+```
+
+## Dev Mode
+
+```bash
+cd ~/clawd/ventureos/dashboard && npm run dev
+```
+
+Uses the **same token** as the deployed service.
+
+## Verification
+
+```bash
+./dashboard/scripts/verify-local.sh
+DASHBOARD_PORT=8002 ./dashboard/scripts/verify-local.sh
+```
+
+### Manual Checklist
+
+- [ ] Service running (`launchctl list` shows PID)
+- [ ] Only `dashboard/data/.api-token` exists (no `dist/dashboard/data/.api-token`)
+- [ ] `dist/lib/package.json` exists with `"type": "commonjs"`
+- [ ] Startup logs show `[STARTUP] DASHBOARD_DATA_DIR:` → canonical path
+- [ ] `curl http://localhost:8002/api/config` returns 401
+
+## Stale Token Cleanup
+
+```bash
+rm ~/clawd/ventureos/dashboard/dist/dashboard/data/.api-token
+```
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `DASHBOARD_PORT` | `8001` | Listen port |
+| `VENTUREOS_ROOT` | `~/clawd/ventureos` | Monorepo root |
+| `DASHBOARD_DATA_DIR` | `$VENTUREOS_ROOT/dashboard/data` | Token & data dir |
+| `DASHBOARD_API_TOKEN` | *(auto)* | Override token |
+| `OPENCLAW_DIR` | `~/.openclaw` | OpenClaw runtime |

--- a/dashboard/examples/launchd.plist
+++ b/dashboard/examples/launchd.plist
@@ -35,6 +35,8 @@
       <string>__VENTUREOS_ROOT__</string>
       <key>OPENCLAW_DIR</key>
       <string>__OPENCLAW_DIR__</string>
+      <key>DASHBOARD_DATA_DIR</key>
+      <string>__VENTUREOS_ROOT__/dashboard/data</string>
       <key>VENTUREOS_LOG_DIR</key>
       <string>__VENTUREOS_ROOT__/dashboard/logs</string>
       <key>NODE_ENV</key>

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -6,7 +6,7 @@
   "description": "OpenClaw operational dashboard — monitoring, session management, KPI tracking",
   "scripts": {
     "build": "tsc --noEmit",
-    "compile": "tsc",
+    "compile": "tsc && mkdir -p dist/lib && echo '{\"type\":\"commonjs\"}' > dist/lib/package.json",
     "dev": "tsx watch server/server.ts",
     "start": "node dist/dashboard/server/server.js",
     "test": "vitest run --config vitest.config.ts",

--- a/dashboard/scripts/install-macos.sh
+++ b/dashboard/scripts/install-macos.sh
@@ -72,6 +72,12 @@ npx tsc -p tsconfig.json --outDir dist 2>&1 || {
   echo "⚠️  TypeScript compilation had warnings (non-fatal, continuing)"
 }
 
+# Mark dist/lib/ as CommonJS — lib/*.ts sources live under the root package
+# ("type": "commonjs") but dist/lib/ lands under dashboard/ ("type": "module").
+# Without this marker, Node treats the compiled CJS as ESM and crashes.
+mkdir -p "$DASHBOARD_DIR/dist/lib"
+echo '{ "type": "commonjs" }' > "$DASHBOARD_DIR/dist/lib/package.json"
+
 if [[ ! -f "$DASHBOARD_DIR/dist/dashboard/server/server.js" ]]; then
   echo "❌ Build failed — dist/dashboard/server/server.js not found"
   exit 1

--- a/dashboard/scripts/install.sh
+++ b/dashboard/scripts/install.sh
@@ -100,6 +100,10 @@ npx tsc -p tsconfig.json --outDir dist 2>&1 || {
   echo "⚠️  TypeScript compilation had warnings (non-fatal, continuing)"
 }
 
+# Mark dist/lib/ as CommonJS — see install-macos.sh for rationale.
+mkdir -p "$DASHBOARD_DIR/dist/lib"
+echo '{ "type": "commonjs" }' > "$DASHBOARD_DIR/dist/lib/package.json"
+
 if [[ ! -f "$DASHBOARD_DIR/dist/dashboard/server/server.js" ]]; then
   echo "❌ Build failed — dist/dashboard/server/server.js not found"
   exit 1

--- a/dashboard/scripts/migrate-from-standalone.sh
+++ b/dashboard/scripts/migrate-from-standalone.sh
@@ -174,6 +174,10 @@ if ! $DRY_RUN; then
   rm -rf dist
   npx tsc -p tsconfig.json --outDir dist 2>&1
 
+  # Mark dist/lib/ as CommonJS (see install-macos.sh for rationale)
+  mkdir -p "$DASHBOARD_DIR/dist/lib"
+  echo '{ "type": "commonjs" }' > "$DASHBOARD_DIR/dist/lib/package.json"
+
   if [[ -f "$DASHBOARD_DIR/dist/dashboard/server/server.js" ]]; then
     ok "Build complete → dashboard/dist/dashboard/server/server.js"
   else

--- a/dashboard/scripts/verify-local.sh
+++ b/dashboard/scripts/verify-local.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+set -euo pipefail
+
+# ─── OpenClaw Dashboard — Local Deployment Verifier ──────────────────────────
+# Usage: ./dashboard/scripts/verify-local.sh
+#        DASHBOARD_PORT=7000 ./dashboard/scripts/verify-local.sh
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+DASHBOARD_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
+VENTUREOS_ROOT="$(cd "$DASHBOARD_DIR/.." && pwd)"
+
+PORT="${DASHBOARD_PORT:-8002}"
+CANONICAL_TOKEN="${VENTUREOS_ROOT}/dashboard/data/.api-token"
+STALE_TOKEN="${VENTUREOS_ROOT}/dashboard/dist/dashboard/data/.api-token"
+DIST_LIB_PKG="${VENTUREOS_ROOT}/dashboard/dist/lib/package.json"
+DIST_SERVER="${VENTUREOS_ROOT}/dashboard/dist/dashboard/server/server.js"
+SRC_SERVER="${VENTUREOS_ROOT}/dashboard/server/server.ts"
+
+E=0; W=0
+ok()   { echo "  ✅ $*"; }
+warn() { echo "  ⚠️  $*"; W=$((W+1)); }
+fail() { echo "  ❌ $*"; E=$((E+1)); }
+
+echo "🔍 Dashboard — Local Deployment Verifier"
+echo "========================================="
+echo ""
+
+echo "── 1. Service ──"
+if [[ "$(uname)" == "Darwin" ]]; then
+  for L in com.openclaw.dashboard com.openclaw.dashboard.monorepo; do
+    if launchctl list "$L" &>/dev/null 2>&1; then
+      P=$(launchctl list "$L" 2>/dev/null | grep '"PID"' | grep -o '[0-9]*' || echo "")
+      [[ -n "$P" && "$P" != "0" ]] && ok "$L running (PID $P)" || warn "$L loaded but not running"
+    fi
+  done
+fi
+echo ""
+
+echo "── 2. Token Path ──"
+[[ -f "$CANONICAL_TOKEN" ]] && ok "Canonical: $CANONICAL_TOKEN" || fail "Canonical token MISSING"
+[[ -f "$STALE_TOKEN" ]] && fail "DRIFT: stale dist token at $STALE_TOKEN" || ok "No stale dist token"
+echo ""
+
+echo "── 3. HTTP (port $PORT) ──"
+HC=$(curl -s -o /dev/null -w "%{http_code}" "http://localhost:${PORT}/api/config" 2>/dev/null || echo "000")
+[[ "$HC" == "200" || "$HC" == "401" ]] && ok "API reachable (HTTP $HC)" || fail "API unreachable (HTTP $HC)"
+echo ""
+
+echo "── 4. Build ──"
+[[ -f "$DIST_SERVER" ]] && ok "dist/server.js" || fail "dist/server.js MISSING"
+[[ -f "$DIST_LIB_PKG" ]] && ok "dist/lib/package.json (CJS)" || fail "dist/lib/package.json MISSING"
+if [[ -f "$DIST_SERVER" && -f "$SRC_SERVER" ]]; then
+  DM=$(stat -f "%m" "$DIST_SERVER" 2>/dev/null || stat -c "%Y" "$DIST_SERVER")
+  SM=$(stat -f "%m" "$SRC_SERVER" 2>/dev/null || stat -c "%Y" "$SRC_SERVER")
+  [[ "$SM" -gt "$DM" ]] && warn "Source newer than dist" || ok "Dist up-to-date"
+fi
+echo ""
+
+echo "══════════════════════════════════"
+[[ $E -eq 0 && $W -eq 0 ]] && echo "  ✅ All checks passed" || { [[ $E -eq 0 ]] && echo "  ⚠️  $W warning(s)" || echo "  ❌ $E error(s), $W warning(s)"; }
+echo "══════════════════════════════════"
+echo "Token:   $CANONICAL_TOKEN"
+echo "Restart: launchctl kickstart -k gui/\$(id -u)/com.openclaw.dashboard"
+echo "Rebuild: cd dashboard && npm run compile"
+exit $E

--- a/dashboard/server/middleware/auth.ts
+++ b/dashboard/server/middleware/auth.ts
@@ -15,8 +15,13 @@ import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { CookieMap } from '../types.js';
 import paths from '../../../lib/paths.js';
 
-const { LOG_DIR } = paths as typeof import('../../../lib/paths.js');
-const DATA_DIR: string = path.join(import.meta.dirname, '..', '..', 'data');
+const { LOG_DIR, DASHBOARD_DATA_DIR } = paths as typeof import('../../../lib/paths.js');
+
+/**
+ * Canonical data directory — resolves via lib/paths.ts → VENTUREOS_ROOT/dashboard/data.
+ * Independent of import.meta.dirname so dev and dist modes use the same token.
+ */
+const DATA_DIR: string = DASHBOARD_DATA_DIR;
 const TOKEN_PATH: string = path.join(DATA_DIR, '.api-token');
 const ACCESS_LOG: string = path.join(LOG_DIR, 'tactical-map-access.log');
 

--- a/dashboard/server/routes/logs.ts
+++ b/dashboard/server/routes/logs.ts
@@ -1,0 +1,21 @@
+/**
+ * Logs route handler — stub.
+ * Placeholder for log viewing API endpoints (Issue #137).
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+interface LogsContext {
+  OPENCLAW_DIR: string;
+  LOG_DIR: string;
+  sendJson: (res: ServerResponse, data: unknown, status?: number) => void;
+  clampInt: (n: string | number | null, lo: number, hi: number, dflt: number) => number;
+}
+
+export function handleLogs(
+  _req: IncomingMessage,
+  _res: ServerResponse,
+  _ctx: LogsContext,
+): boolean {
+  return false;
+}

--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -63,6 +63,7 @@ const {
   OPENCLAW_DIR,
   SHARED_CONTEXT_DIR: SHARED_CONTEXT,
   KPI_DIR,
+  DASHBOARD_DATA_DIR,
   OBSERVATIONS_DIR,
   RPG_ROOT,
   RPG_DB_PATH,
@@ -3475,6 +3476,29 @@ const server: Server = http.createServer(async (req: IncomingMessage, res: Serve
 
 export { server };
 
+// ─── Startup Diagnostics ─────────────────────────────────────────────────────
+
+function logStartupDiagnostics(): void {
+  const runtimeMode: string = import.meta.dirname.includes('/dist/')
+    ? 'dist (compiled)'
+    : 'source (tsx/dev)';
+  console.log('[STARTUP] Dashboard runtime diagnostics');
+  console.log(`[STARTUP]   mode:              ${runtimeMode}`);
+  console.log(`[STARTUP]   VENTUREOS_ROOT:    ${VENTUREOS_ROOT}`);
+  console.log(`[STARTUP]   DASHBOARD_DATA_DIR:${DASHBOARD_DATA_DIR}`);
+  console.log(`[STARTUP]   TOKEN_PATH:        ${path.join(DASHBOARD_DATA_DIR, '.api-token')}`);
+  console.log(`[STARTUP]   PORT:              ${PORT}`);
+
+  // Drift guard: warn if a stale dist-relative token exists
+  const canonical: string = path.resolve(path.join(DASHBOARD_DATA_DIR, '.api-token'));
+  const distRelative: string = path.resolve(path.join(import.meta.dirname, '..', '..', 'data', '.api-token'));
+  if (canonical !== distRelative && fs.existsSync(distRelative)) {
+    console.warn(`[STARTUP] ⚠️  DRIFT: stale token at ${distRelative}`);
+    console.warn(`[STARTUP]    Canonical: ${canonical}`);
+  }
+}
+
 server.listen(PORT, HOST, () => {
   console.log(`Dashboard: http://${HOST}:${PORT}`);
+  logStartupDiagnostics();
 });

--- a/lib/paths.ts
+++ b/lib/paths.ts
@@ -41,6 +41,10 @@ export const KPI_DIR: string =
   process.env.VENTUREOS_KPI_DIR ??
   path.join(SHARED_CONTEXT_DIR, 'kpis');
 
+/** Dashboard data directory (tokens, health history, etc.). */
+export const DASHBOARD_DATA_DIR: string =
+  process.env.DASHBOARD_DATA_DIR ?? path.join(VENTUREOS_ROOT, 'dashboard', 'data');
+
 /** Observations markdown directory. */
 export const OBSERVATIONS_DIR: string =
   process.env.OBSERVATIONS_DIR ??
@@ -74,6 +78,7 @@ export const paths = {
   openclawDir: OPENCLAW_DIR,
   sharedContextDir: SHARED_CONTEXT_DIR,
   kpiDir: KPI_DIR,
+  dashboardDataDir: DASHBOARD_DATA_DIR,
   observationsDir: OBSERVATIONS_DIR,
   logDir: LOG_DIR,
   rpgRoot: RPG_ROOT,
@@ -110,6 +115,7 @@ const defaultPathsExport = {
   OPENCLAW_DIR,
   SHARED_CONTEXT_DIR,
   KPI_DIR,
+  DASHBOARD_DATA_DIR,
   OBSERVATIONS_DIR,
   LOG_DIR,
   RPG_ROOT,


### PR DESCRIPTION
## Problem

`auth.ts` computed `DATA_DIR` relative to `import.meta.dirname`, which resolves to different directories in dev vs dist mode:
- **Dev** (`tsx watch`): `dashboard/data/.api-token`
- **Dist** (`node dist/…`): `dashboard/dist/dashboard/data/.api-token`

Two separate tokens existed, causing auth confusion when switching modes.

Additionally, the CJS/ESM module boundary between `lib/` (CJS root) and `dashboard/` (ESM) was fragile — a clean rebuild (`rm -rf dist && tsc`) would crash Node because `dist/lib/paths.js` (CJS) lived under `dashboard/` (`type: module`).

## Solution

### 1. Canonical token path via `lib/paths.ts`
- New `DASHBOARD_DATA_DIR` export: `VENTUREOS_ROOT/dashboard/data` (env-overridable)
- `auth.ts` uses `DASHBOARD_DATA_DIR` instead of `import.meta.dirname`
- Both dev and dist resolve to the same token file

### 2. CJS/ESM boundary fix
- All build scripts write `{ "type": "commonjs" }` to `dist/lib/package.json`
- `npm run compile` includes this step
- Prevents Node from misinterpreting CJS lib output as ESM

### 3. Drift detection
- Startup diagnostics log resolved paths (`[STARTUP]` prefix)
- Warns if a stale dist-relative token file exists alongside the canonical one

### 4. Operational tooling
- `verify-local.sh`: automated deployment consistency checks
- `LOCAL-DEPLOYMENT.md`: runbook with service management, rebuild, verification checklist
- `launchd.plist` template: adds `DASHBOARD_DATA_DIR` env var

### 5. Missing module fix
- Added `routes/logs.ts` stub — `server.ts` imported it but the file didn't exist

## Files Changed
- `lib/paths.ts` — add `DASHBOARD_DATA_DIR`
- `dashboard/server/middleware/auth.ts` — use canonical path
- `dashboard/server/server.ts` — startup diagnostics + drift guard
- `dashboard/server/routes/logs.ts` — stub for missing import
- `dashboard/package.json` — compile script includes CJS marker
- `dashboard/examples/launchd.plist` — add env var
- `dashboard/scripts/{install-macos,install,migrate-from-standalone}.sh` — CJS marker
- `dashboard/scripts/verify-local.sh` — new verification script
- `dashboard/LOCAL-DEPLOYMENT.md` — new runbook

## Verification
Tested on local macOS deployment (`:8002`):
- ✅ Service starts cleanly with correct `DASHBOARD_DATA_DIR`
- ✅ Auth works with canonical token
- ✅ No stale dist token after clean rebuild
- ✅ Startup diagnostics log correct paths
- ✅ `verify-local.sh` passes all checks