### PR TITLE
feat(dashboard): Observability Logs Page — multi-source viewer, live tailing, secret redaction

### DIFF
--- a/dashboard/server/middleware/auth.ts
+++ b/dashboard/server/middleware/auth.ts
@@ -21,7 +21,7 @@ const { LOG_DIR, DASHBOARD_DATA_DIR } = paths as typeof import('../../../lib/pat
  * Canonical data directory — resolves via lib/paths.ts → VENTUREOS_ROOT/dashboard/data.
  * Independent of import.meta.dirname so dev and dist modes use the same token.
  */
-const DATA_DIR: string = DASHBOARD_DATA_DIR;
+const DATA_DIR: string = DASHBOARD_DATA_DIR ?? path.join(import.meta.dirname, '..', '..', 'data');
 const TOKEN_PATH: string = path.join(DATA_DIR, '.api-token');
 const ACCESS_LOG: string = path.join(LOG_DIR, 'tactical-map-access.log');
 

--- a/dashboard/server/routes/index.ts
+++ b/dashboard/server/routes/index.ts
@@ -7,6 +7,7 @@
 export { handleKpis } from './kpis.js';
 export { handleObservations } from './observations.js';
 export { handleAgentHealth } from './agent-health.js';
+export { handleLogs } from './logs.js';
 export { handleRpg, handleRpgApi } from './rpg.js';
 export { handleConversation, handleConversationApi } from './conversation.js';
 export { handleTacticalMapControls } from './tactical-map-controls.js';

--- a/dashboard/server/routes/logs.ts
+++ b/dashboard/server/routes/logs.ts
@@ -1,21 +1,149 @@
 /**
- * Logs route handler — stub.
- * Placeholder for log viewing API endpoints (Issue #137).
+ * Logs route handlers — Issue #137: Observability Logs Page.
+ * Multi-source log reading with secret redaction, filtering, and live SSE streaming.
  */
-
+import fs from 'node:fs';
+import path from 'node:path';
 import type { IncomingMessage, ServerResponse } from 'node:http';
 
-interface LogsContext {
-  OPENCLAW_DIR: string;
-  LOG_DIR: string;
-  sendJson: (res: ServerResponse, data: unknown, status?: number) => void;
-  clampInt: (n: string | number | null, lo: number, hi: number, dflt: number) => number;
+const SECRET_PATTERNS: RegExp[] = [
+  /Bearer\s+[A-Za-z0-9\-_=.]{8,}/gi,
+  /(?:token|key|secret|password|authorization|api[_-]?key)\s*[:=]\s*["']?[A-Za-z0-9\-_=.]{16,}["']?/gi,
+  /ghp_[A-Za-z0-9]{36,}/g, /gho_[A-Za-z0-9]{36,}/g, /github_pat_[A-Za-z0-9_]{20,}/g, /npm_[A-Za-z0-9]{36,}/g,
+  /\/Users\/[a-zA-Z0-9._-]+/g, /\/home\/[a-zA-Z0-9._-]+/g,
+];
+
+export function redactSecrets(text: string): string {
+  let r = text;
+  for (const p of SECRET_PATTERNS) { p.lastIndex = 0; r = r.replace(p, (m) => m.startsWith('/Users/') || m.startsWith('/home/') ? m.split('/').slice(0,2).join('/')+'/***' : m.length>12 ? m.substring(0,8)+'***REDACTED***' : '***REDACTED***'); }
+  return r;
 }
 
-export function handleLogs(
-  _req: IncomingMessage,
-  _res: ServerResponse,
-  _ctx: LogsContext,
-): boolean {
+export interface LogSource { id: string; name: string; description: string; type: 'plaintext'|'jsonl'; path: string|null; available: boolean; }
+export interface ParsedLogEntry { timestamp: string; level: 'info'|'warn'|'error'|'debug'|'unknown'; source: string; message: string; raw: string; meta?: Record<string,string>; }
+export interface LogsDeps { OPENCLAW_DIR: string; LOG_DIR: string; sendJson: (res: ServerResponse, data: unknown, status?: number) => void; clampInt: (n: string|number|null, lo: number, hi: number, dflt: number) => number; }
+
+const ISO_TS = /^(\d{4}-\d{2}-\d{2}T[\d:.]+Z?(?:[+-]\d{2}:\d{2})?)/;
+const TAG_RE = /\[([^\]]+)\]/;
+const LVL: Record<string, ParsedLogEntry['level']> = { error:'error', err:'error', warn:'warn', warning:'warn', info:'info', debug:'debug', fatal:'error', critical:'error' };
+
+function parsePlain(line: string, src: string): ParsedLogEntry|null {
+  const t = line.trim(); if (!t) return null;
+  let ts = '', rest = t; const m = t.match(ISO_TS); if (m) { ts = m[1]; rest = t.slice(m[0].length).trim(); }
+  let tag = ''; const tm = rest.match(TAG_RE); if (tm) { tag = tm[1]; rest = rest.slice(tm[0].length).trim(); }
+  let level: ParsedLogEntry['level'] = 'info'; const low = rest.toLowerCase();
+  for (const [kw, lv] of Object.entries(LVL)) { if (low.includes(kw)) { level = lv; break; } }
+  const meta: Record<string,string> = {}; if (tag) meta.tag = tag;
+  return { timestamp: ts||new Date().toISOString(), level, source: src, message: redactSecrets(rest), raw: redactSecrets(t), meta };
+}
+
+function parseJson(line: string, src: string): ParsedLogEntry|null {
+  const t = line.trim(); if (!t) return null;
+  try {
+    const o = JSON.parse(t) as Record<string,unknown>;
+    const ts = (o.ts as string)??(o.timestamp as string)??new Date().toISOString();
+    const ev = (o.event as string)??'', detail = (o.detail as string)??'', ip = (o.ip as string)??'', method = (o.method as string)??'', p = (o.path as string)??'';
+    let level: ParsedLogEntry['level'] = 'info'; const el = ev.toLowerCase();
+    if (el.includes('fail')||el.includes('error')||el.includes('block')) level = 'error';
+    else if (el.includes('warn')||el.includes('suspicious')||el.includes('brute')) level = 'warn';
+    let msg = ev; if (method&&p) msg += ` ${method} ${p}`; if (ip) msg += ` from ${ip}`; if (detail) msg += ` — ${detail}`;
+    const meta: Record<string,string> = {}; if (ev) meta.event = ev; if (ip) meta.ip = ip; if (method) meta.method = method;
+    return { timestamp: ts, level, source: src, message: redactSecrets(msg), raw: redactSecrets(t), meta };
+  } catch { return parsePlain(t, src); }
+}
+
+function readTail(fp: string, n: number): string[] {
+  try { if (!fs.existsSync(fp)) return []; const st = fs.statSync(fp); if (st.size===0) return [];
+    if (st.size < 1024*1024) return fs.readFileSync(fp,'utf8').split('\n').filter(l=>l.trim()).slice(-n);
+    const sz = Math.min(st.size, n*500), buf = Buffer.alloc(sz), fd = fs.openSync(fp,'r');
+    try { fs.readSync(fd,buf,0,sz,st.size-sz); } finally { fs.closeSync(fd); }
+    return buf.toString('utf8').split('\n').filter(l=>l.trim()).slice(-n);
+  } catch { return []; }
+}
+
+function resolveSources(d: LogsDeps): LogSource[] {
+  const ld = path.join(d.OPENCLAW_DIR, 'logs');
+  const s: LogSource[] = [
+    { id:'gateway', name:'Gateway', description:'OpenClaw gateway stdout logs', type:'plaintext', path:path.join(ld,'gateway.log'), available:false },
+    { id:'gateway-errors', name:'Gateway Errors', description:'OpenClaw gateway stderr logs', type:'plaintext', path:path.join(ld,'gateway.err.log'), available:false },
+    { id:'access', name:'Access Log', description:'Dashboard auth/access events', type:'jsonl', path:path.join(d.LOG_DIR,'tactical-map-access.log'), available:false },
+    { id:'config-audit', name:'Config Audit', description:'Config change audit trail', type:'jsonl', path:path.join(ld,'config-audit.jsonl'), available:false },
+    { id:'commands', name:'Commands', description:'Session commands', type:'jsonl', path:path.join(ld,'commands.log'), available:false },
+    { id:'session-monitor', name:'Session Monitor', description:'Session health', type:'plaintext', path:path.join(ld,'session-monitor.log'), available:false },
+  ];
+  for (const x of s) { if (x.path) try { x.available = fs.existsSync(x.path)&&fs.statSync(x.path).size>0; } catch { x.available = false; } }
+  return s;
+}
+
+function readLogs(src: LogSource, o: { lines:number; level?:string; keyword?:string; since?:number; until?:number }): ParsedLogEntry[] {
+  if (!src.path||!src.available) return [];
+  const raw = readTail(src.path, o.lines*3);
+  const fn = src.type==='jsonl' ? (l:string)=>parseJson(l,src.id) : (l:string)=>parsePlain(l,src.id);
+  let e: ParsedLogEntry[] = []; for (const l of raw) { const x = fn(l); if (x) e.push(x); }
+  if (o.level&&o.level!=='all') e = e.filter(x=>x.level===o.level);
+  if (o.keyword) { const k = o.keyword.toLowerCase(); e = e.filter(x=>x.message.toLowerCase().includes(k)||x.raw.toLowerCase().includes(k)||Object.values(x.meta??{}).some(v=>v.toLowerCase().includes(k))); }
+  if (o.since) e = e.filter(x=>{ const t = new Date(x.timestamp).getTime(); return !Number.isNaN(t)&&t>=o.since!; });
+  if (o.until) e = e.filter(x=>{ const t = new Date(x.timestamp).getTime(); return !Number.isNaN(t)&&t<=o.until!; });
+  return e.slice(-o.lines);
+}
+
+export function handleLogs(req: IncomingMessage, res: ServerResponse, deps: LogsDeps): boolean {
+  if (!req.url||req.method!=='GET') return false;
+
+  if (req.url==='/api/logs/sources') {
+    deps.sendJson(res, { sources: resolveSources(deps).map(s=>({ id:s.id, name:s.name, description:s.description, type:s.type, available:s.available })) });
+    return true;
+  }
+
+  if (req.url.startsWith('/api/logs/read')) {
+    const p = new URL(req.url,'http://localhost').searchParams;
+    const sids = (p.get('sources')??'gateway').split(',').map(s=>s.trim());
+    const lines = deps.clampInt(p.get('lines'),10,1000,200), level = p.get('level')??'all', keyword = p.get('keyword')??'';
+    const sinceStr = p.get('since')??'', untilStr = p.get('until')??'';
+    const since = sinceStr ? new Date(sinceStr).getTime() : undefined, until = untilStr ? new Date(untilStr).getTime() : undefined;
+    const all = resolveSources(deps).filter(s=>sids.includes(s.id)&&s.available);
+    let entries: ParsedLogEntry[] = [];
+    for (const s of all) entries = entries.concat(readLogs(s, { lines, level:level!=='all'?level:undefined, keyword:keyword||undefined, since:since&&!Number.isNaN(since)?since:undefined, until:until&&!Number.isNaN(until)?until:undefined }));
+    entries.sort((a,b)=>new Date(a.timestamp).getTime()-new Date(b.timestamp).getTime());
+    entries = entries.slice(-lines);
+    deps.sendJson(res, { entries, count:entries.length, sources:sids, filters:{ level, keyword, since:sinceStr, until:untilStr } });
+    return true;
+  }
+
+  if (req.url.startsWith('/api/logs/stream')) {
+    const p = new URL(req.url,'http://localhost').searchParams;
+    const sids = (p.get('sources')??'gateway').split(',').map(s=>s.trim());
+    const level = p.get('level')??'all', keyword = (p.get('keyword')??'').toLowerCase();
+    res.writeHead(200, { 'Content-Type':'text/event-stream', 'Cache-Control':'no-cache', Connection:'keep-alive' });
+    res.write('data: '+JSON.stringify({ type:'connected', sources:sids })+'\n\n');
+    const all = resolveSources(deps).filter(s=>sids.includes(s.id)&&s.available);
+    const sizes: Record<string,number> = {};
+    for (const s of all) { if (s.path) try { sizes[s.id] = fs.statSync(s.path).size; } catch { sizes[s.id] = 0; } }
+    const watchers: fs.FSWatcher[] = [];
+    for (const s of all) { if (!s.path) continue; try { const w = fs.watch(s.path, (et)=>{
+      if (et!=='change') return; try { if (!res.writable) return;
+        const st = fs.statSync(s.path!), prev = sizes[s.id]??0; if (st.size<=prev) return;
+        const fd = fs.openSync(s.path!,'r'), buf = Buffer.alloc(st.size-prev);
+        fs.readSync(fd,buf,0,buf.length,prev); fs.closeSync(fd); sizes[s.id] = st.size;
+        const nl = buf.toString('utf8').split('\n').filter(l=>l.trim());
+        const fn2 = s.type==='jsonl' ? (l:string)=>parseJson(l,s.id) : (l:string)=>parsePlain(l,s.id);
+        for (const l of nl) { const e = fn2(l); if (!e) continue; if (level!=='all'&&e.level!==level) continue;
+          if (keyword&&!e.message.toLowerCase().includes(keyword)&&!e.raw.toLowerCase().includes(keyword)) continue;
+          res.write('data: '+JSON.stringify({ type:'log', entry:e })+'\n\n'); }
+      } catch {} }); watchers.push(w); } catch {} }
+    req.on('close', ()=>{ for (const w of watchers) try { w.close(); } catch {} });
+    return true;
+  }
+
+  if (req.url.startsWith('/api/logs?')||req.url==='/api/logs') {
+    const p = new URL(req.url,'http://localhost').searchParams;
+    const svc = p.get('service')??'gateway', n = deps.clampInt(p.get('lines'),10,1000,100);
+    const map: Record<string,string> = { openclaw:'gateway', 'agent-dashboard':'access', tailscaled:'gateway' };
+    const sid = map[svc]??'gateway', src = resolveSources(deps).find(s=>s.id===sid);
+    if (!src||!src.available) { res.writeHead(200,{'Content-Type':'text/plain'}); res.end('No logs for: '+sid); return true; }
+    res.writeHead(200,{'Content-Type':'text/plain'}); res.end(readTail(src.path!,n).map(l=>redactSecrets(l)).join('\n'));
+    return true;
+  }
+
   return false;
 }

--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -65,6 +65,7 @@ const {
   KPI_DIR,
   DASHBOARD_DATA_DIR,
   OBSERVATIONS_DIR,
+  LOG_DIR,
   RPG_ROOT,
   RPG_DB_PATH,
   ACTIVE_WORK_PATH,
@@ -95,6 +96,7 @@ import { handleAgentHealth } from './routes/agent-health.js';
 import { handleRpgApi } from './routes/rpg.js';
 import { handleConversationApi } from './routes/conversation.js';
 import { handleTacticalMapControls } from './routes/tactical-map-controls.js';
+import { handleLogs } from './routes/logs.js';
 
 // ─── Configuration ───────────────────────────────────────────────────────────
 // All VentureOS data paths flow through lib/paths.ts (no os.homedir() needed).
@@ -2902,28 +2904,11 @@ const server: Server = http.createServer(async (req: IncomingMessage, res: Serve
     sendJson(res, { avgSeconds: getAvgResponseTime() });
     return;
   }
-  if (req.url && req.url.startsWith('/api/logs?')) {
-    try {
-      const params = new URL(req.url, 'http://localhost').searchParams;
-      const allowedServices: string[] = ['openclaw', 'agent-dashboard', 'tailscaled', 'sshd', 'nginx'];
-      const service: string = params.get('service') ?? 'openclaw';
-      if (!allowedServices.includes(service)) {
-        res.writeHead(400, { 'Content-Type': 'text/plain' });
-        res.end('Invalid service name');
-        return;
-      }
-      const lineCount: number = Math.min(Math.max(parseInt(params.get('lines') ?? '100') || 100, 1), 1000);
-      const logs: string = execSync(
-        `journalctl -u ${service} --no-pager -n ${lineCount} -o short 2>/dev/null || echo "No logs available"`,
-        { encoding: 'utf8', timeout: 10000 },
-      );
-      res.writeHead(200, { 'Content-Type': 'text/plain' });
-      res.end(logs);
-    } catch {
-      res.writeHead(500, { 'Content-Type': 'text/plain' });
-      res.end('Error fetching logs');
-    }
-    return;
+  // Logs API — Issue #137: Observability Logs Page
+  try {
+    if (handleLogs(req, res, { OPENCLAW_DIR, LOG_DIR, sendJson, clampInt })) return;
+  } catch {
+    // ignore
   }
 
   // Action endpoints — use shared error handler (Issue #79) for safe responses

--- a/dashboard/tests/unit/routes/logs.test.ts
+++ b/dashboard/tests/unit/routes/logs.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { handleLogs, redactSecrets } from '../../../server/routes/logs.js';
+
+function mockReq(url: string, method = 'GET'): IncomingMessage { return { url, method, headers: {} } as unknown as IncomingMessage; }
+function mockRes() {
+  const r = { statusCode: 200, headers: {} as Record<string,string>, body: '', ended: false, writable: true,
+    writeHead(s: number, h?: Record<string,string>) { r.statusCode = s; if (h) Object.assign(r.headers, h); },
+    write(c: string) { r.body += c; return true; }, end(d?: string) { if (d) r.body += d; r.ended = true; },
+    setHeader(k: string, v: string) { r.headers[k] = v; } };
+  return r;
+}
+function json(r: ReturnType<typeof mockRes>) { return JSON.parse(r.body); }
+function sendJson(res: ServerResponse, data: unknown, status = 200) { res.writeHead(status, { 'Content-Type': 'application/json' }); res.end(JSON.stringify(data)); }
+function clampInt(n: string|number|null, lo: number, hi: number, dflt: number) { const v = parseInt(String(n)); return Number.isNaN(v) ? dflt : Math.max(lo, Math.min(hi, v)); }
+
+let tmp: string, oc: string, ld: string, deps: any;
+beforeEach(() => { tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'lt-')); oc = path.join(tmp, '.oc'); ld = path.join(tmp, 'l'); fs.mkdirSync(path.join(oc, 'logs'), { recursive: true }); fs.mkdirSync(ld, { recursive: true }); deps = { OPENCLAW_DIR: oc, LOG_DIR: ld, sendJson, clampInt }; });
+afterEach(() => { try { fs.rmSync(tmp, { recursive: true, force: true }); } catch {} });
+
+describe('redactSecrets', () => {
+  it('redacts Bearer tokens', () => { expect(redactSecrets('Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.x')).toContain('REDACTED'); });
+  it('redacts ghp tokens', () => { expect(redactSecrets('ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij')).toContain('REDACTED'); });
+  it('redacts home paths', () => { const r = redactSecrets('/Users/user1/data'); expect(r).not.toContain('user1'); expect(r).toContain('/Users/***'); });
+  it('preserves normal text', () => { expect(redactSecrets('hello world')).toBe('hello world'); });
+});
+
+describe('/api/logs/sources', () => {
+  it('returns sources', () => { const r = mockRes(); handleLogs(mockReq('/api/logs/sources'), r as any, deps); const b = json(r); expect(b.sources.length).toBeGreaterThan(0); expect(b.sources.map((s:any)=>s.id)).toContain('gateway'); });
+  it('unavailable when missing', () => { const r = mockRes(); handleLogs(mockReq('/api/logs/sources'), r as any, deps); expect(json(r).sources.every((s:any)=>!s.available)).toBe(true); });
+  it('available when file exists', () => { fs.writeFileSync(path.join(oc,'logs','gateway.log'),'line\n'); const r = mockRes(); handleLogs(mockReq('/api/logs/sources'), r as any, deps); expect(json(r).sources.find((s:any)=>s.id==='gateway').available).toBe(true); });
+});
+
+describe('/api/logs/read', () => {
+  it('returns entries', () => { fs.writeFileSync(path.join(oc,'logs','gateway.log'),'2026-02-16T10:00:00Z [gw] ok\n2026-02-16T10:00:01Z [gw] error: fail\n'); const r = mockRes(); handleLogs(mockReq('/api/logs/read?sources=gateway&lines=100'), r as any, deps); const b = json(r); expect(b.count).toBe(2); expect(b.entries[1].level).toBe('error'); });
+  it('filters level', () => { fs.writeFileSync(path.join(oc,'logs','gateway.log'),'2026-02-16T10:00:00Z ok\n2026-02-16T10:00:01Z error bad\n'); const r = mockRes(); handleLogs(mockReq('/api/logs/read?sources=gateway&level=error'), r as any, deps); expect(json(r).entries.every((e:any)=>e.level==='error')).toBe(true); });
+  it('filters keyword', () => { fs.writeFileSync(path.join(oc,'logs','gateway.log'),'2026-02-16T10:00:00Z conn open\n2026-02-16T10:00:01Z timeout\n2026-02-16T10:00:02Z conn close\n'); const r = mockRes(); handleLogs(mockReq('/api/logs/read?sources=gateway&keyword=conn'), r as any, deps); expect(json(r).entries.length).toBe(2); });
+  it('reads JSONL', () => { fs.writeFileSync(path.join(ld,'tactical-map-access.log'),'{"ts":"2026-02-16T10:00:00Z","event":"auth_failure","ip":"1.2.3.4","method":"GET","path":"/","detail":"bad"}\n'); const r = mockRes(); handleLogs(mockReq('/api/logs/read?sources=access'), r as any, deps); expect(json(r).entries[0].level).toBe('error'); });
+  it('multi-source', () => { fs.writeFileSync(path.join(oc,'logs','gateway.log'),'2026-02-16T10:00:00Z gw\n'); fs.writeFileSync(path.join(ld,'tactical-map-access.log'),'{"ts":"2026-02-16T10:00:01Z","event":"ok","ip":"","method":"","path":"","detail":""}\n'); const r = mockRes(); handleLogs(mockReq('/api/logs/read?sources=gateway,access'), r as any, deps); expect(new Set(json(r).entries.map((e:any)=>e.source)).size).toBe(2); });
+  it('redacts secrets', () => { fs.writeFileSync(path.join(oc,'logs','gateway.log'),'2026-02-16T10:00:00Z ghp_ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghij\n'); const r = mockRes(); handleLogs(mockReq('/api/logs/read?sources=gateway'), r as any, deps); expect(json(r).entries[0].message).toContain('REDACTED'); });
+  it('empty for unknown', () => { const r = mockRes(); handleLogs(mockReq('/api/logs/read?sources=xyz'), r as any, deps); expect(json(r).count).toBe(0); });
+  it('line limit', () => { const l = Array.from({length:50},(_,i)=>'2026-02-16T10:'+String(i).padStart(2,'0')+':00Z l'+i).join('\n'); fs.writeFileSync(path.join(oc,'logs','gateway.log'),l); const r = mockRes(); handleLogs(mockReq('/api/logs/read?sources=gateway&lines=10'), r as any, deps); expect(json(r).count).toBeLessThanOrEqual(10); });
+});
+
+describe('legacy /api/logs', () => {
+  it('plaintext compat', () => { fs.writeFileSync(path.join(oc,'logs','gateway.log'),'2026-02-16T10:00:00Z started\n'); const r = mockRes(); handleLogs(mockReq('/api/logs?service=openclaw&lines=50'), r as any, deps); expect(r.headers['Content-Type']).toBe('text/plain'); expect(r.body).toContain('started'); });
+  it('POST returns false', () => { expect(handleLogs(mockReq('/api/logs/sources','POST'), mockRes() as any, deps)).toBe(false); });
+});
+
+describe('/api/logs/stream', () => {
+  it('SSE headers', () => { const req = mockReq('/api/logs/stream?sources=gateway'); const ls: Record<string,Function[]> = {}; (req as any).on = (e:string, fn:Function) => { (ls[e]??=[]).push(fn); }; const r = mockRes(); handleLogs(req, r as any, deps); expect(r.headers['Content-Type']).toBe('text/event-stream'); expect(r.body).toContain('"type":"connected"'); ls['close']?.forEach(fn=>fn()); });
+});


### PR DESCRIPTION
## Summary

Implements **Issue #137**: full observability Logs page for the VentureOS dashboard.

Fixes #137

### What's New

#### API Layer (`server/routes/logs.ts` — new file, 149 lines)
- **`GET /api/logs/sources`** — discover available log sources with availability status
- **`GET /api/logs/read`** — structured multi-source log reading with level, keyword, and time filters
- **`GET /api/logs/stream`** — SSE endpoint for real-time log tailing via `fs.watch`
- **Legacy `GET /api/logs?service=X`** — backward compat (reads real files instead of `journalctl`)
- **Secret redaction** — Bearer tokens, GitHub PATs (`ghp_`, `gho_`, `github_pat_`), npm tokens, home directory paths

#### Log Sources (auto-discovered from filesystem)
| Source | Format | Description |
|--------|--------|-------------|
| `gateway` | plaintext | OpenClaw gateway stdout |
| `gateway-errors` | plaintext | Gateway stderr |
| `access` | JSONL | Dashboard auth/access events |
| `config-audit` | JSONL | Configuration change audit trail |
| `commands` | JSONL | Session commands |
| `session-monitor` | plaintext | Session health |

#### Client UI (Logs page rebuild — already merged to main)
- Source selector with availability badges
- Level filter (error/warn/info/debug) + keyword search
- Live Tail mode via SSE with pulsing indicator
- Structured display: timestamp | level badge | source | tag | message
- Copy to clipboard / Download as text
- Report Issue modal with auto-filled log context
- Stats bar + keyboard shortcut `6`

#### Infrastructure Changes
- `auth.ts`: DASHBOARD_DATA_DIR fallback for test compatibility
- `server.ts`: `handleLogs` replaces old `journalctl`-based handler (works on macOS)
- `routes/index.ts`: barrel export for `handleLogs`

### Tests
- **18 new unit tests** covering redaction, sources, read, filter, stream, legacy compat
- **181 total tests passing** (all 18 test files green)

### Security
- All log output passes through `redactSecrets()` before reaching the client
- Read-only API (no mutation endpoints)
- Auth-gated via existing middleware pipeline
- Rate-limited via existing middleware