### PR TITLE
fix: include client assets in dist on compile & install

### DIFF
--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -6,7 +6,7 @@
   "description": "OpenClaw operational dashboard — monitoring, session management, KPI tracking",
   "scripts": {
     "build": "tsc --noEmit",
-    "compile": "tsc && mkdir -p dist/lib && echo '{\"type\":\"commonjs\"}' > dist/lib/package.json",
+    "compile": "tsc && mkdir -p dist/lib && echo '{\"type\":\"commonjs\"}' > dist/lib/package.json && mkdir -p dist/dashboard/client && cp -R client/* dist/dashboard/client/",
     "dev": "tsx watch server/server.ts",
     "start": "node dist/dashboard/server/server.js",
     "test": "vitest run --config vitest.config.ts",

--- a/dashboard/scripts/install-macos.sh
+++ b/dashboard/scripts/install-macos.sh
@@ -78,6 +78,11 @@ npx tsc -p tsconfig.json --outDir dist 2>&1 || {
 mkdir -p "$DASHBOARD_DIR/dist/lib"
 echo '{ "type": "commonjs" }' > "$DASHBOARD_DIR/dist/lib/package.json"
 
+# Copy static client assets (HTML, CSS, images) into dist so the compiled
+# server can resolve them via import.meta.dirname (see Issue #178).
+mkdir -p "$DASHBOARD_DIR/dist/dashboard/client"
+cp -R "$DASHBOARD_DIR/client/"* "$DASHBOARD_DIR/dist/dashboard/client/"
+
 if [[ ! -f "$DASHBOARD_DIR/dist/dashboard/server/server.js" ]]; then
   echo "❌ Build failed — dist/dashboard/server/server.js not found"
   exit 1

--- a/dashboard/scripts/install.sh
+++ b/dashboard/scripts/install.sh
@@ -104,6 +104,11 @@ npx tsc -p tsconfig.json --outDir dist 2>&1 || {
 mkdir -p "$DASHBOARD_DIR/dist/lib"
 echo '{ "type": "commonjs" }' > "$DASHBOARD_DIR/dist/lib/package.json"
 
+# Copy static client assets (HTML, CSS, images) into dist so the compiled
+# server can resolve them via import.meta.dirname (see Issue #178).
+mkdir -p "$DASHBOARD_DIR/dist/dashboard/client"
+cp -R "$DASHBOARD_DIR/client/"* "$DASHBOARD_DIR/dist/dashboard/client/"
+
 if [[ ! -f "$DASHBOARD_DIR/dist/dashboard/server/server.js" ]]; then
   echo "❌ Build failed — dist/dashboard/server/server.js not found"
   exit 1

--- a/dashboard/scripts/verify-local.sh
+++ b/dashboard/scripts/verify-local.sh
@@ -49,6 +49,10 @@ echo ""
 echo "── 4. Build ──"
 [[ -f "$DIST_SERVER" ]] && ok "dist/server.js" || fail "dist/server.js MISSING"
 [[ -f "$DIST_LIB_PKG" ]] && ok "dist/lib/package.json (CJS)" || fail "dist/lib/package.json MISSING"
+DIST_LOGIN="${VENTUREOS_ROOT}/dashboard/dist/dashboard/client/login.html"
+DIST_INDEX="${VENTUREOS_ROOT}/dashboard/dist/dashboard/client/index.html"
+[[ -f "$DIST_LOGIN" ]] && ok "dist/client/login.html" || fail "dist/client/login.html MISSING — run: npm run compile"
+[[ -f "$DIST_INDEX" ]] && ok "dist/client/index.html" || fail "dist/client/index.html MISSING — run: npm run compile"
 if [[ -f "$DIST_SERVER" && -f "$SRC_SERVER" ]]; then
   DM=$(stat -f "%m" "$DIST_SERVER" 2>/dev/null || stat -c "%Y" "$DIST_SERVER")
   SM=$(stat -f "%m" "$SRC_SERVER" 2>/dev/null || stat -c "%Y" "$SRC_SERVER")

--- a/dashboard/tests/unit/dist-client-assets.test.ts
+++ b/dashboard/tests/unit/dist-client-assets.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Verify that the compile script copies client assets into dist.
+ *
+ * Bug context (Issue #178):
+ *   The compiled server resolves login.html and index.html relative to
+ *   import.meta.dirname (i.e. dist/dashboard/server/) via `../client/`.
+ *   TypeScript only emits .ts → .js; static HTML/CSS assets must be
+ *   copied explicitly by the compile script.
+ *
+ * This test runs `npm run compile` then asserts the critical client
+ * files exist under dist/dashboard/client/.
+ */
+import { describe, it, expect, beforeAll } from 'vitest';
+import { execSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+
+const DASHBOARD_DIR = path.resolve(__dirname, '../..');
+
+describe('compile produces client assets in dist', () => {
+  beforeAll(() => {
+    // Clean dist to prove compile recreates it
+    const distClient = path.join(DASHBOARD_DIR, 'dist', 'dashboard', 'client');
+    fs.rmSync(distClient, { recursive: true, force: true });
+
+    execSync('npm run compile', { cwd: DASHBOARD_DIR, stdio: 'pipe' });
+  }, 30_000);
+
+  it('dist/dashboard/client/login.html exists', () => {
+    const p = path.join(DASHBOARD_DIR, 'dist', 'dashboard', 'client', 'login.html');
+    expect(fs.existsSync(p)).toBe(true);
+  });
+
+  it('dist/dashboard/client/index.html exists', () => {
+    const p = path.join(DASHBOARD_DIR, 'dist', 'dashboard', 'client', 'index.html');
+    expect(fs.existsSync(p)).toBe(true);
+  });
+
+  it('dist/dashboard/client/assets/ directory exists', () => {
+    const p = path.join(DASHBOARD_DIR, 'dist', 'dashboard', 'client', 'assets');
+    expect(fs.existsSync(p)).toBe(true);
+    expect(fs.statSync(p).isDirectory()).toBe(true);
+  });
+});


### PR DESCRIPTION
## Bug

`GET /login` returned **500** `"Error loading login page"` on local deploys (launchd running dist server).

### Root Cause

`tsc` only emits `.ts → .js`. The static client files (`login.html`, `index.html`, `assets/`) were never copied to `dist/dashboard/client/`.

The compiled server resolves HTML paths via:
```ts
const loginHtmlPath = path.join(import.meta.dirname, '..', 'client', 'login.html');
```
At runtime in dist, `import.meta.dirname` → `dist/dashboard/server/`, so `../client/` → `dist/dashboard/client/` — which didn't exist.

The **Dockerfile** already had this copy step; local deploy paths (`npm run compile`, `install-macos.sh`, `install.sh`) did not.

## Fix

| File | Change |
|------|--------|
| `dashboard/package.json` | `compile` script now copies `client/*` → `dist/dashboard/client/` |
| `scripts/install-macos.sh` | Same copy step after `tsc` |
| `scripts/install.sh` | Same copy step after `tsc` |
| `scripts/verify-local.sh` | Added `dist/client/login.html` + `index.html` existence checks |
| `tests/unit/dist-client-assets.test.ts` | Vitest: cleans dist/client, runs compile, asserts files exist |

## Validation

```
# Before fix:
curl -s -o /dev/null -w '%{http_code}' http://localhost:8002/login
# → 500

# After fix (npm run compile + restart):
curl -s -o /dev/null -w '%{http_code}' http://localhost:8002/login
# → 200

# verify-local.sh now includes:
✅ dist/client/login.html
✅ dist/client/index.html

# vitest:
✓ tests/unit/dist-client-assets.test.ts (3 tests) 771ms
```