### PR TITLE
feat: Wire real interaction logging + SQLite conversation persistence

### DIFF
--- a/lib/__tests__/data-capture-integration.test.ts
+++ b/lib/__tests__/data-capture-integration.test.ts
@@ -1,0 +1,166 @@
+/**
+ * Integration test for Issues #181 + #182 — Data Capture Pipeline
+ *
+ * Verifies that:
+ * 1. When conversations are created/messaged through ConversationAPI,
+ *    they persist in SQLite and are visible via list/load.
+ * 2. Agent handoffs produce interaction_logs entries.
+ * 3. The /api/rpg/conversations/active adapter would return non-empty data.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import Database from 'better-sqlite3';
+import { SqliteConversationStore } from '../sqlite-conversation-store';
+import { InteractionLogger } from '../interaction-logger';
+import { ConversationEngine } from '../conversation-engine';
+import { ConversationAPI } from '../conversation-api';
+
+let tmpDir: string;
+let dbPath: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'data-capture-integration-'));
+  dbPath = path.join(tmpDir, 'test-rpg.db');
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('Data capture integration (#181 + #182)', () => {
+  test('conversation created via API is visible in SQLite and via list', async () => {
+    const store = new SqliteConversationStore(dbPath);
+    const engine = ConversationEngine.createWithDefaults({ store });
+    const api = new ConversationAPI(engine);
+
+    // Create a conversation
+    const state = await api.startConversation({
+      participants: ['oracle', 'atlas'],
+      metadata: { topic: 'Integration test' },
+    });
+
+    expect(state.conversationId).toBeTruthy();
+    expect(state.participants).toEqual(['oracle', 'atlas']);
+
+    // Verify it's in SQLite
+    const db = new Database(dbPath, { readonly: true });
+    const convRow = db.prepare('SELECT * FROM conversations WHERE id = ?').get(state.conversationId) as any;
+    expect(convRow).toBeTruthy();
+    expect(convRow.status).toBe('active');
+
+    // Verify it's visible via list
+    const ids = await api.listConversations();
+    expect(ids).toContain(state.conversationId);
+
+    db.close();
+    store.close();
+  });
+
+  test('interaction logger captures handoff events from ConversationAPI', async () => {
+    const store = new SqliteConversationStore(dbPath);
+    const engine = ConversationEngine.createWithDefaults({
+      store,
+      config: { enforceTurns: false },
+    });
+    const api = new ConversationAPI(engine);
+    const logger = new InteractionLogger(dbPath);
+
+    // Wire event listener (mirrors what conversation-http.ts does)
+    api.on('message', (evt: { message: any }) => {
+      const msg = evt.message;
+      if (!msg || msg.from === 'system') return;
+      const recipients = (msg.deliveredTo ?? msg.to ?? []).filter(
+        (r: string) => r !== 'user' && r !== 'system' && r !== 'broadcast',
+      );
+      if (recipients.length === 0) return;
+      logger.logHandoff({
+        from: msg.from,
+        to: recipients,
+        type: msg.payload?.type ?? 'message',
+        outcome: msg.status ?? 'success',
+        conversationId: msg.conversationId,
+        description: msg.content?.slice(0, 200),
+      });
+    });
+
+    // Create conversation and send a message
+    const state = await api.startConversation({
+      participants: ['user', 'oracle'],
+      currentTurn: 'user',
+    });
+
+    await api.sendMessage({
+      conversationId: state.conversationId,
+      from: 'user',
+      to: 'oracle',
+      content: 'What are the Q4 numbers?',
+    });
+
+    // Verify interaction was logged
+    const stats = logger.getStats();
+    expect(stats.totalLogged).toBeGreaterThanOrEqual(1);
+
+    // Verify in SQLite
+    const db = new Database(dbPath, { readonly: true });
+    const logs = db.prepare('SELECT * FROM interaction_logs').all() as any[];
+    expect(logs.length).toBeGreaterThanOrEqual(1);
+
+    const handoff = logs.find((l: any) => l.initiator_agent === 'user');
+    expect(handoff).toBeTruthy();
+    expect(handoff.recipient_agent).toBe('oracle');
+    expect(handoff.interaction_type).toBe('message');
+
+    db.close();
+    logger.close();
+    store.close();
+  });
+
+  test('full pipeline: create → message → list shows non-empty active conversations', async () => {
+    const store = new SqliteConversationStore(dbPath);
+    const engine = ConversationEngine.createWithDefaults({
+      store,
+      config: { enforceTurns: false },
+    });
+    const api = new ConversationAPI(engine);
+
+    // Simulate what happens in production
+    const conv = await api.startConversation({
+      participants: ['nexus', 'oracle', 'atlas'],
+      metadata: { topic: 'Dashboard data verification' },
+    });
+
+    await api.sendMessage({
+      conversationId: conv.conversationId,
+      from: 'nexus',
+      to: ['oracle'],
+      content: 'Generating performance report.',
+    });
+
+    // Verify list returns non-empty
+    const convIds = await api.listConversations();
+    expect(convIds.length).toBeGreaterThan(0);
+    expect(convIds).toContain(conv.conversationId);
+
+    // Verify individual conversation has messages
+    const loaded = await api.getConversation(conv.conversationId);
+    expect(loaded.messages.length).toBeGreaterThan(0);
+    expect(loaded.participants).toContain('nexus');
+    expect(loaded.participants).toContain('oracle');
+
+    // Verify SQLite has the data for dashboard adapter routes
+    const db = new Database(dbPath, { readonly: true });
+    const sqlConvs = db.prepare('SELECT * FROM conversations').all() as any[];
+    expect(sqlConvs.length).toBeGreaterThan(0);
+
+    const sqlMsgs = db.prepare('SELECT * FROM conversation_messages').all() as any[];
+    expect(sqlMsgs.length).toBeGreaterThan(0);
+
+    const sqlParts = db.prepare('SELECT * FROM conversation_participants').all() as any[];
+    expect(sqlParts.length).toBeGreaterThanOrEqual(3);
+
+    db.close();
+    store.close();
+  });
+});

--- a/lib/__tests__/interaction-logger.test.ts
+++ b/lib/__tests__/interaction-logger.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for InteractionLogger — Issue #181
+ *
+ * Validates that interaction events are correctly persisted to the
+ * SQLite interaction_logs table.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import Database from 'better-sqlite3';
+import { InteractionLogger } from '../interaction-logger';
+
+let tmpDir: string;
+let dbPath: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'interaction-logger-test-'));
+  dbPath = path.join(tmpDir, 'test-rpg.db');
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('InteractionLogger', () => {
+  test('creates interaction_logs table on first write', () => {
+    const logger = new InteractionLogger(dbPath);
+    logger.logInteraction({
+      initiatorAgent: 'oracle',
+      recipientAgent: 'atlas',
+      interactionType: 'handoff',
+      outcome: 'success',
+    });
+    logger.close();
+
+    const db = new Database(dbPath, { readonly: true });
+    const tables = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='interaction_logs'"
+    ).all();
+    expect(tables).toHaveLength(1);
+    db.close();
+  });
+
+  test('persists interaction with all fields', () => {
+    const logger = new InteractionLogger(dbPath);
+    logger.logInteraction({
+      initiatorAgent: 'nexus',
+      recipientAgent: 'sentinel',
+      interactionType: 'escalation',
+      outcome: 'success',
+      missionId: 'mission-42',
+      sessionId: 'conv-abc',
+      description: 'Escalation from nexus to sentinel',
+    });
+    logger.close();
+
+    const db = new Database(dbPath, { readonly: true });
+    const rows = db.prepare('SELECT * FROM interaction_logs').all() as any[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0].initiator_agent).toBe('nexus');
+    expect(rows[0].recipient_agent).toBe('sentinel');
+    expect(rows[0].interaction_type).toBe('escalation');
+    expect(rows[0].outcome).toBe('success');
+    expect(rows[0].mission_id).toBe('mission-42');
+    expect(rows[0].session_id).toBe('conv-abc');
+    expect(rows[0].description).toBe('Escalation from nexus to sentinel');
+    expect(rows[0].created_at).toBeTruthy();
+    db.close();
+  });
+
+  test('logHandoff writes one row per recipient', () => {
+    const logger = new InteractionLogger(dbPath);
+    logger.logHandoff({
+      from: 'oracle',
+      to: ['atlas', 'sentinel'],
+      type: 'message',
+      outcome: 'success',
+      conversationId: 'conv-xyz',
+      description: 'Multi-recipient handoff',
+    });
+    logger.close();
+
+    const db = new Database(dbPath, { readonly: true });
+    const rows = db.prepare('SELECT * FROM interaction_logs ORDER BY id').all() as any[];
+    expect(rows).toHaveLength(2);
+    expect(rows[0].initiator_agent).toBe('oracle');
+    expect(rows[0].recipient_agent).toBe('atlas');
+    expect(rows[1].initiator_agent).toBe('oracle');
+    expect(rows[1].recipient_agent).toBe('sentinel');
+    db.close();
+  });
+
+  test('logHandoff skips broadcast and empty recipients', () => {
+    const logger = new InteractionLogger(dbPath);
+    logger.logHandoff({
+      from: 'oracle',
+      to: ['broadcast', '', 'atlas'],
+      type: 'message',
+      outcome: 'success',
+    });
+    logger.close();
+
+    const db = new Database(dbPath, { readonly: true });
+    const rows = db.prepare('SELECT * FROM interaction_logs').all() as any[];
+    expect(rows).toHaveLength(1);
+    expect(rows[0].recipient_agent).toBe('atlas');
+    db.close();
+  });
+
+  test('getStats returns correct counts', () => {
+    const logger = new InteractionLogger(dbPath);
+    expect(logger.getStats().totalLogged).toBe(0);
+    expect(logger.getStats().lastWriteAt).toBeNull();
+
+    logger.logInteraction({
+      initiatorAgent: 'a',
+      recipientAgent: 'b',
+      interactionType: 'test',
+      outcome: 'success',
+    });
+
+    const stats = logger.getStats();
+    expect(stats.totalLogged).toBe(1);
+    expect(stats.lastWriteAt).toBeTruthy();
+    expect(stats.dbPath).toBe(dbPath);
+    logger.close();
+  });
+
+  test('multiple writes accumulate correctly', () => {
+    const logger = new InteractionLogger(dbPath);
+    for (let i = 0; i < 5; i++) {
+      logger.logInteraction({
+        initiatorAgent: `agent-${i}`,
+        recipientAgent: `agent-${i + 1}`,
+        interactionType: 'collaboration',
+        outcome: 'success',
+      });
+    }
+    expect(logger.getStats().totalLogged).toBe(5);
+    logger.close();
+
+    const db = new Database(dbPath, { readonly: true });
+    const count = (db.prepare('SELECT COUNT(*) as c FROM interaction_logs').get() as any).c;
+    expect(count).toBe(5);
+    db.close();
+  });
+
+  test('works with existing database that already has interaction_logs table', () => {
+    // Pre-create database with existing table (different schema variant)
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE interaction_logs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        initiator_agent TEXT NOT NULL,
+        recipient_agent TEXT NOT NULL,
+        interaction_type TEXT NOT NULL,
+        outcome TEXT NOT NULL,
+        mission_id TEXT,
+        session_id TEXT,
+        description TEXT,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+    db.prepare(
+      'INSERT INTO interaction_logs (initiator_agent, recipient_agent, interaction_type, outcome) VALUES (?, ?, ?, ?)'
+    ).run('existing', 'data', 'test', 'success');
+    db.close();
+
+    const logger = new InteractionLogger(dbPath);
+    logger.logInteraction({
+      initiatorAgent: 'new',
+      recipientAgent: 'data',
+      interactionType: 'handoff',
+      outcome: 'success',
+    });
+    logger.close();
+
+    const db2 = new Database(dbPath, { readonly: true });
+    const count = (db2.prepare('SELECT COUNT(*) as c FROM interaction_logs').get() as any).c;
+    expect(count).toBe(2);
+    db2.close();
+  });
+});

--- a/lib/__tests__/sqlite-conversation-store.test.ts
+++ b/lib/__tests__/sqlite-conversation-store.test.ts
@@ -1,0 +1,284 @@
+/**
+ * Tests for SqliteConversationStore — Issue #182
+ *
+ * Validates that conversation state is correctly persisted to and
+ * loaded from the SQLite database.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import Database from 'better-sqlite3';
+import { SqliteConversationStore } from '../sqlite-conversation-store';
+import type { ConversationState, ConversationMessage } from '../conversation-engine';
+
+let tmpDir: string;
+let dbPath: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'sqlite-conv-store-test-'));
+  dbPath = path.join(tmpDir, 'test-rpg.db');
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function makeState(overrides: Partial<ConversationState> = {}): ConversationState {
+  return {
+    conversationId: 'conv-test-1',
+    createdAt: '2026-02-17T12:00:00.000Z',
+    updatedAt: '2026-02-17T12:01:00.000Z',
+    status: 'active',
+    participants: ['oracle', 'atlas', 'sentinel'],
+    currentTurn: 'oracle',
+    tokenBudget: 10000,
+    tokensUsed: 250,
+    messageCount: 2,
+    challengeCount: 0,
+    consecutiveChallenges: 0,
+    injectionScores: [0.1, 0.05],
+    policyViolationCount: 0,
+    voiceRuleViolationCount: 0,
+    affinity: {
+      averageAffinity: 0.7,
+      lowestAffinity: 0.5,
+      lowestAffinityPair: ['oracle', 'sentinel'],
+    },
+    summaries: [],
+    messages: [
+      {
+        messageId: 'msg-1',
+        conversationId: 'conv-test-1',
+        from: 'oracle',
+        to: ['atlas'],
+        deliveredTo: ['atlas'],
+        content: 'Hello Atlas, please analyze this data.',
+        createdAt: '2026-02-17T12:00:30.000Z',
+        status: 'delivered',
+      } as ConversationMessage,
+      {
+        messageId: 'msg-2',
+        conversationId: 'conv-test-1',
+        from: 'atlas',
+        to: ['oracle'],
+        deliveredTo: ['oracle'],
+        content: 'Analysis complete. Revenue up 12%.',
+        createdAt: '2026-02-17T12:01:00.000Z',
+        payload: { type: 'analysis_result', format: 'natural_language' },
+        status: 'delivered',
+      } as ConversationMessage,
+    ],
+    metadata: { topic: 'Revenue Analysis' },
+    ...overrides,
+  };
+}
+
+describe('SqliteConversationStore', () => {
+  test('creates required tables on initialization', () => {
+    const store = new SqliteConversationStore(dbPath);
+    store.close();
+
+    const db = new Database(dbPath, { readonly: true });
+    const tables = db.prepare(
+      "SELECT name FROM sqlite_master WHERE type='table' ORDER BY name"
+    ).all() as any[];
+    const tableNames = tables.map((t: any) => t.name);
+    expect(tableNames).toContain('conversations');
+    expect(tableNames).toContain('conversation_messages');
+    expect(tableNames).toContain('conversation_participants');
+    expect(tableNames).toContain('conversation_turn_state');
+    db.close();
+  });
+
+  test('save and load roundtrip preserves state', async () => {
+    const store = new SqliteConversationStore(dbPath);
+    const state = makeState();
+
+    await store.save(state);
+    const loaded = await store.load('conv-test-1');
+
+    expect(loaded).not.toBeNull();
+    expect(loaded!.conversationId).toBe('conv-test-1');
+    expect(loaded!.status).toBe('active');
+    expect(loaded!.participants.sort()).toEqual(['atlas', 'oracle', 'sentinel']);
+    expect(loaded!.currentTurn).toBe('oracle');
+    expect(loaded!.messages).toHaveLength(2);
+    expect(loaded!.messages[0].messageId).toBe('msg-1');
+    expect(loaded!.messages[0].from).toBe('oracle');
+    expect(loaded!.messages[0].content).toBe('Hello Atlas, please analyze this data.');
+    expect(loaded!.messages[1].messageId).toBe('msg-2');
+    expect(loaded!.messages[1].content).toBe('Analysis complete. Revenue up 12%.');
+    expect(loaded!.tokenBudget).toBe(10000);
+    expect(loaded!.tokensUsed).toBe(250);
+    store.close();
+  });
+
+  test('load returns null for non-existent conversation', async () => {
+    const store = new SqliteConversationStore(dbPath);
+    const result = await store.load('nonexistent');
+    expect(result).toBeNull();
+    store.close();
+  });
+
+  test('list returns all conversation IDs', async () => {
+    const store = new SqliteConversationStore(dbPath);
+
+    await store.save(makeState({ conversationId: 'conv-a', updatedAt: '2026-02-17T12:00:00Z' }));
+    await store.save(makeState({ conversationId: 'conv-b', updatedAt: '2026-02-17T13:00:00Z' }));
+    await store.save(makeState({ conversationId: 'conv-c', updatedAt: '2026-02-17T11:00:00Z' }));
+
+    const ids = await store.list();
+    // Ordered by updated_at DESC
+    expect(ids).toEqual(['conv-b', 'conv-a', 'conv-c']);
+    store.close();
+  });
+
+  test('save upserts on conflict (update existing)', async () => {
+    const store = new SqliteConversationStore(dbPath);
+
+    const v1 = makeState({ status: 'active' });
+    await store.save(v1);
+
+    const v2 = makeState({
+      status: 'paused',
+      updatedAt: '2026-02-17T14:00:00.000Z',
+      statusReason: 'HITL pause',
+    });
+    await store.save(v2);
+
+    const loaded = await store.load('conv-test-1');
+    expect(loaded!.status).toBe('paused');
+    store.close();
+  });
+
+  test('persists to actual SQLite tables readable by raw queries', async () => {
+    const store = new SqliteConversationStore(dbPath);
+    await store.save(makeState());
+    store.close();
+
+    // Verify using raw SQL (this is what the dashboard adapter routes do)
+    const db = new Database(dbPath, { readonly: true });
+    const convRow = db.prepare('SELECT * FROM conversations WHERE id = ?').get('conv-test-1') as any;
+    expect(convRow).toBeTruthy();
+    expect(convRow.status).toBe('active');
+
+    const msgRows = db.prepare(
+      'SELECT * FROM conversation_messages WHERE conversation_id = ? ORDER BY timestamp'
+    ).all('conv-test-1') as any[];
+    expect(msgRows).toHaveLength(2);
+    expect(msgRows[0].agent).toBe('oracle');
+    expect(msgRows[1].agent).toBe('atlas');
+
+    const partRows = db.prepare(
+      'SELECT * FROM conversation_participants WHERE conversation_id = ?'
+    ).all('conv-test-1') as any[];
+    expect(partRows).toHaveLength(3);
+    const agents = partRows.map((r: any) => r.agent).sort();
+    expect(agents).toEqual(['atlas', 'oracle', 'sentinel']);
+
+    const turnRow = db.prepare(
+      'SELECT * FROM conversation_turn_state WHERE conversation_id = ?'
+    ).get('conv-test-1') as any;
+    expect(turnRow.current_speaker).toBe('oracle');
+
+    db.close();
+  });
+
+  test('preserves message metadata through roundtrip', async () => {
+    const store = new SqliteConversationStore(dbPath);
+    const state = makeState();
+    state.messages[1].payload = { type: 'analysis_result', format: 'json', data: { revenue: 12 } };
+    state.messages[1].security = {
+      injectionScore: 0.05,
+      structureValid: true,
+      structureErrors: [],
+      sanitizedModified: false,
+      redactionCount: 0,
+      rateLimitAllowed: true,
+      policyWarningCount: 0,
+      voiceViolationCount: 0,
+      hitlAction: 'allow',
+      hitlTriggered: false,
+      hitlUrgency: 'none',
+      hitlMatchedTriggerIds: [],
+    };
+
+    await store.save(state);
+    const loaded = await store.load('conv-test-1');
+
+    expect(loaded!.messages[1].payload).toEqual({ type: 'analysis_result', format: 'json', data: { revenue: 12 } });
+    expect(loaded!.messages[1].security?.injectionScore).toBe(0.05);
+    store.close();
+  });
+
+  test('works with pre-existing database tables', async () => {
+    // Pre-create with existing data (like the real RPG DB)
+    const db = new Database(dbPath);
+    db.exec(`
+      CREATE TABLE conversations (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'active',
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+        metadata TEXT DEFAULT '{}'
+      );
+      INSERT INTO conversations (id, title, status, created_at, updated_at)
+      VALUES ('existing-conv', 'Old Conversation', 'active', '2026-02-14T00:00:00Z', '2026-02-14T00:00:00Z');
+
+      CREATE TABLE conversation_messages (
+        id TEXT PRIMARY KEY,
+        conversation_id TEXT NOT NULL,
+        agent TEXT NOT NULL,
+        type TEXT DEFAULT 'fact',
+        text TEXT NOT NULL,
+        timestamp TEXT NOT NULL DEFAULT (datetime('now')),
+        injection_score REAL DEFAULT 0,
+        violations TEXT DEFAULT '[]',
+        metadata TEXT DEFAULT '{}'
+      );
+
+      CREATE TABLE conversation_participants (
+        conversation_id TEXT NOT NULL,
+        agent TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'active',
+        joined_at TEXT NOT NULL DEFAULT (datetime('now')),
+        last_active TEXT NOT NULL DEFAULT (datetime('now')),
+        PRIMARY KEY (conversation_id, agent)
+      );
+
+      CREATE TABLE conversation_turn_state (
+        conversation_id TEXT PRIMARY KEY,
+        current_speaker TEXT,
+        queue TEXT DEFAULT '[]',
+        updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+      );
+    `);
+    db.close();
+
+    const store = new SqliteConversationStore(dbPath);
+    const ids = await store.list();
+    expect(ids).toContain('existing-conv');
+
+    // Save new conversation alongside existing
+    await store.save(makeState());
+    const ids2 = await store.list();
+    expect(ids2).toContain('existing-conv');
+    expect(ids2).toContain('conv-test-1');
+    store.close();
+  });
+
+  test('empty conversation (no messages) roundtrips correctly', async () => {
+    const store = new SqliteConversationStore(dbPath);
+    const state = makeState({
+      messages: [],
+      messageCount: 0,
+    });
+    await store.save(state);
+    const loaded = await store.load(state.conversationId);
+    expect(loaded!.messages).toHaveLength(0);
+    expect(loaded!.participants.sort()).toEqual(['atlas', 'oracle', 'sentinel']);
+    store.close();
+  });
+});

--- a/lib/conversation-http.ts
+++ b/lib/conversation-http.ts
@@ -21,6 +21,8 @@ import type {
 import { ConversationEngine } from './conversation-engine';
 import { ConversationAPI } from './conversation-api';
 import { toSafeError } from './error-handler';
+import { SqliteConversationStore } from './sqlite-conversation-store';
+import { InteractionLogger } from './interaction-logger';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -104,9 +106,17 @@ async function readJsonBody(
 // ─── Singleton API Instance ─────────────────────────────────────────────────
 
 let _apiInstance: ConversationAPI | null = null;
+let _interactionLogger: InteractionLogger | null = null;
 
-function getApi(_opts: ConversationHandlerOptions): ConversationAPI {
+function getApi(opts: ConversationHandlerOptions): ConversationAPI {
   if (_apiInstance) return _apiInstance;
+
+  // Issue #182: Use SQLite-backed store when dbPath is available,
+  // so conversations are persisted in the RPG database and visible
+  // to dashboard APIs (/api/rpg/conversations/active, etc.).
+  const store = opts.dbPath
+    ? new SqliteConversationStore(opts.dbPath)
+    : undefined;
 
   const engine = ConversationEngine.createWithDefaults({
     config: {
@@ -114,8 +124,66 @@ function getApi(_opts: ConversationHandlerOptions): ConversationAPI {
         process.env.CONVERSATION_PERSIST_DIR ??
         `${process.env.HOME ?? '~'}/clawd/ventureos/runtime/conversations`,
     },
+    store,
   });
   _apiInstance = new ConversationAPI(engine);
+
+  // Issue #181: Wire interaction logging into agent handoffs.
+  // Listen to ConversationAPI events and write to interaction_logs.
+  if (opts.dbPath) {
+    _interactionLogger = new InteractionLogger(opts.dbPath);
+
+    _apiInstance.on('message', (evt: { message: any; state: any }) => {
+      const msg = evt.message;
+      if (!msg || msg.from === 'system') return;
+
+      const recipients = msg.deliveredTo ?? msg.to ?? [];
+      const agentRecipients = recipients.filter(
+        (r: string) => r !== 'user' && r !== 'system' && r !== 'broadcast',
+      );
+      if (agentRecipients.length === 0) return;
+
+      _interactionLogger!.logHandoff({
+        from: msg.from,
+        to: agentRecipients,
+        type: msg.payload?.type ?? 'message',
+        outcome: msg.status ?? 'success',
+        conversationId: msg.conversationId,
+        description: msg.content?.slice(0, 200),
+      });
+    });
+
+    _apiInstance.on('conversation_started', (evt: { state: any }) => {
+      const state = evt.state;
+      if (!state || state.participants.length < 2) return;
+
+      // Log the conversation start as a collaboration interaction
+      // between the first two participants.
+      _interactionLogger!.logHandoff({
+        from: state.participants[0],
+        to: state.participants[1],
+        type: 'conversation_start',
+        outcome: 'success',
+        conversationId: state.conversationId,
+        description: `Conversation started with ${state.participants.length} participants`,
+      });
+    });
+
+    // Minimal observability: log stats periodically (every 50 interactions)
+    const origLog = _interactionLogger.logInteraction.bind(_interactionLogger);
+    let callCount = 0;
+    const wrappedLogger = _interactionLogger;
+    _apiInstance.on('message', () => {
+      callCount++;
+      if (callCount % 50 === 0) {
+        const stats = wrappedLogger.getStats();
+        console.log(
+          `[interaction-logger] stats: total=${stats.totalLogged} lastWrite=${stats.lastWriteAt}`,
+        );
+      }
+    });
+  }
+
   return _apiInstance;
 }
 

--- a/lib/interaction-logger.ts
+++ b/lib/interaction-logger.ts
@@ -1,0 +1,147 @@
+/**
+ * Interaction Logger — VentureOS RPG Database Writer
+ *
+ * Writes real agent interaction events to the interaction_logs table
+ * in the RPG SQLite database. Designed to be wired into the
+ * ConversationEngine/ConversationAPI event flow so that agent handoffs
+ * produce observable, queryable data for the dashboard.
+ *
+ * Fixes #181 — Wire real interaction logging into agent handoffs
+ */
+
+import Database from 'better-sqlite3';
+
+export interface InteractionLogParams {
+  initiatorAgent: string;
+  recipientAgent: string;
+  interactionType: string;
+  outcome: string;
+  missionId?: string;
+  sessionId?: string;
+  description?: string;
+}
+
+export interface InteractionLoggerStats {
+  totalLogged: number;
+  lastWriteAt: string | null;
+  dbPath: string;
+}
+
+export class InteractionLogger {
+  private db: Database.Database | null = null;
+  private totalLogged = 0;
+  private lastWriteAt: string | null = null;
+  private insertStmt: Database.Statement | null = null;
+
+  constructor(private readonly dbPath: string) {}
+
+  /**
+   * Open the database connection (lazy — called on first write).
+   * Creates the interaction_logs table if it doesn't exist (safe for
+   * fresh databases).
+   */
+  private ensureDb(): Database.Database {
+    if (this.db) return this.db;
+
+    this.db = new Database(this.dbPath, { readonly: false });
+    this.db.pragma('journal_mode = WAL');
+
+    // Ensure the table exists with the schema the rest of the codebase expects.
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS interaction_logs (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        initiator_agent TEXT NOT NULL,
+        recipient_agent TEXT NOT NULL,
+        interaction_type TEXT NOT NULL,
+        outcome TEXT NOT NULL,
+        mission_id TEXT,
+        session_id TEXT,
+        description TEXT,
+        created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+      )
+    `);
+
+    this.insertStmt = this.db.prepare(`
+      INSERT INTO interaction_logs
+        (initiator_agent, recipient_agent, interaction_type, outcome,
+         mission_id, session_id, description)
+      VALUES (?, ?, ?, ?, ?, ?, ?)
+    `);
+
+    return this.db;
+  }
+
+  /**
+   * Log a single interaction event.
+   *
+   * This is the primary write path that Issue #181 adds.
+   * Called from ConversationAPI event listeners when a message
+   * is successfully delivered between agents.
+   */
+  logInteraction(params: InteractionLogParams): void {
+    this.ensureDb();
+
+    this.insertStmt!.run(
+      params.initiatorAgent,
+      params.recipientAgent,
+      params.interactionType,
+      params.outcome,
+      params.missionId ?? null,
+      params.sessionId ?? null,
+      params.description ?? null,
+    );
+
+    this.totalLogged += 1;
+    this.lastWriteAt = new Date().toISOString();
+  }
+
+  /**
+   * Log a handoff event derived from a ConversationMessage.
+   *
+   * Convenience wrapper that maps conversation-engine message fields
+   * to interaction_logs columns.
+   */
+  logHandoff(opts: {
+    from: string;
+    to: string | string[];
+    type: string;
+    outcome: 'success' | 'blocked' | 'rejected';
+    conversationId?: string;
+    description?: string;
+  }): void {
+    const recipients = Array.isArray(opts.to) ? opts.to : [opts.to];
+    for (const recipient of recipients) {
+      if (!recipient || recipient === 'broadcast') continue;
+      this.logInteraction({
+        initiatorAgent: opts.from,
+        recipientAgent: recipient,
+        interactionType: opts.type,
+        outcome: opts.outcome,
+        sessionId: opts.conversationId ?? undefined,
+        description: opts.description ?? undefined,
+      });
+    }
+  }
+
+  /** Observability: return current stats without requiring DB query. */
+  getStats(): InteractionLoggerStats {
+    return {
+      totalLogged: this.totalLogged,
+      lastWriteAt: this.lastWriteAt,
+      dbPath: this.dbPath,
+    };
+  }
+
+  /** Close the database connection. */
+  close(): void {
+    try {
+      this.db?.close();
+    } catch {
+      // ignore close errors
+    }
+    this.db = null;
+    this.insertStmt = null;
+  }
+}
+
+export default InteractionLogger;

--- a/lib/sqlite-conversation-store.ts
+++ b/lib/sqlite-conversation-store.ts
@@ -1,0 +1,290 @@
+/**
+ * SQLite Conversation Store — VentureOS Conversation Persistence
+ *
+ * Implements the ConversationStore interface using the RPG SQLite database
+ * tables (conversations, conversation_messages, conversation_participants,
+ * conversation_turn_state). This ensures that dashboard APIs backed by
+ * the ConversationEngine return real persisted data.
+ *
+ * Fixes #182 — Make Conversations API produce real persisted data for dashboard
+ */
+
+import Database from 'better-sqlite3';
+import type {
+  ConversationStore,
+  ConversationState,
+  ConversationMessage,
+  ConversationId,
+} from './conversation-engine';
+
+/**
+ * SQLite-backed conversation store that reads/writes to the RPG database.
+ *
+ * The SQLite tables have a normalized schema (conversations, conversation_messages,
+ * conversation_participants, conversation_turn_state). This store translates between
+ * the ConversationEngine's in-memory ConversationState and the relational schema.
+ */
+export class SqliteConversationStore implements ConversationStore {
+  private db: Database.Database;
+
+  constructor(dbPath: string) {
+    this.db = new Database(dbPath, { readonly: false });
+    this.db.pragma('journal_mode = WAL');
+    this.ensureTables();
+  }
+
+  /**
+   * Create tables if they don't exist. Safe for both fresh and existing DBs.
+   * The schema matches what the existing dashboard code expects.
+   */
+  private ensureTables(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS conversations (
+        id TEXT PRIMARY KEY,
+        title TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'active',
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+        metadata TEXT DEFAULT '{}'
+      );
+
+      CREATE TABLE IF NOT EXISTS conversation_messages (
+        id TEXT PRIMARY KEY,
+        conversation_id TEXT NOT NULL,
+        agent TEXT NOT NULL,
+        type TEXT DEFAULT 'fact',
+        text TEXT NOT NULL,
+        timestamp TEXT NOT NULL DEFAULT (datetime('now')),
+        injection_score REAL DEFAULT 0,
+        violations TEXT DEFAULT '[]',
+        metadata TEXT DEFAULT '{}',
+        FOREIGN KEY (conversation_id) REFERENCES conversations(id)
+      );
+
+      CREATE TABLE IF NOT EXISTS conversation_participants (
+        conversation_id TEXT NOT NULL,
+        agent TEXT NOT NULL,
+        status TEXT NOT NULL DEFAULT 'active',
+        joined_at TEXT NOT NULL DEFAULT (datetime('now')),
+        last_active TEXT NOT NULL DEFAULT (datetime('now')),
+        PRIMARY KEY (conversation_id, agent),
+        FOREIGN KEY (conversation_id) REFERENCES conversations(id)
+      );
+
+      CREATE TABLE IF NOT EXISTS conversation_turn_state (
+        conversation_id TEXT PRIMARY KEY,
+        current_speaker TEXT,
+        queue TEXT DEFAULT '[]',
+        updated_at TEXT NOT NULL DEFAULT (datetime('now')),
+        FOREIGN KEY (conversation_id) REFERENCES conversations(id)
+      );
+    `);
+  }
+
+  async load(conversationId: ConversationId): Promise<ConversationState | null> {
+    const row = this.db.prepare('SELECT * FROM conversations WHERE id = ?').get(conversationId) as any;
+    if (!row) return null;
+
+    const messages = this.db
+      .prepare('SELECT * FROM conversation_messages WHERE conversation_id = ? ORDER BY timestamp ASC')
+      .all(conversationId) as any[];
+
+    const participants = this.db
+      .prepare('SELECT * FROM conversation_participants WHERE conversation_id = ?')
+      .all(conversationId) as any[];
+
+    const turnState = this.db
+      .prepare('SELECT * FROM conversation_turn_state WHERE conversation_id = ?')
+      .get(conversationId) as any;
+
+    let metadata: Record<string, unknown> = {};
+    try {
+      metadata = JSON.parse(row.metadata || '{}');
+    } catch { /* ignore parse errors */ }
+
+    const participantIds = participants.map((p: any) => p.agent);
+    const currentTurn = turnState?.current_speaker ?? participantIds[0] ?? '';
+
+    // Reconstruct ConversationMessage[] from normalized rows
+    const convMessages: ConversationMessage[] = messages.map((m: any) => {
+      let violations: string[] = [];
+      try { violations = JSON.parse(m.violations || '[]'); } catch { /* ignore */ }
+      let msgMeta: Record<string, unknown> = {};
+      try { msgMeta = JSON.parse(m.metadata || '{}'); } catch { /* ignore */ }
+
+      return {
+        messageId: m.id,
+        conversationId,
+        from: m.agent,
+        to: msgMeta._to ? (Array.isArray(msgMeta._to) ? msgMeta._to : [msgMeta._to]) : [],
+        deliveredTo: msgMeta._deliveredTo ? (Array.isArray(msgMeta._deliveredTo) ? msgMeta._deliveredTo : [msgMeta._deliveredTo]) : [],
+        content: m.text,
+        createdAt: m.timestamp,
+        payload: msgMeta._payload as any,
+        status: (msgMeta._status as any) ?? 'delivered',
+        blockedReason: msgMeta._blockedReason as string | undefined,
+        security: msgMeta._security as any,
+        handoff: msgMeta._handoff as any,
+        mediation: msgMeta._mediation as any,
+      };
+    });
+
+    const state: ConversationState = {
+      conversationId: row.id,
+      createdAt: row.created_at,
+      updatedAt: row.updated_at,
+      status: row.status as any,
+      statusReason: metadata._statusReason as string | undefined,
+      participants: participantIds,
+      currentTurn,
+      tokenBudget: (metadata._tokenBudget as number) ?? 10_000,
+      tokensUsed: (metadata._tokensUsed as number) ?? 0,
+      messageCount: convMessages.length,
+      challengeCount: (metadata._challengeCount as number) ?? 0,
+      consecutiveChallenges: (metadata._consecutiveChallenges as number) ?? 0,
+      injectionScores: (metadata._injectionScores as number[]) ?? [],
+      policyViolationCount: (metadata._policyViolationCount as number) ?? 0,
+      voiceRuleViolationCount: (metadata._voiceRuleViolationCount as number) ?? 0,
+      affinity: (metadata._affinity as any) ?? {
+        averageAffinity: 0.5,
+        lowestAffinity: 0.5,
+        lowestAffinityPair: ['', ''],
+      },
+      summaries: (metadata._summaries as any[]) ?? [],
+      messages: convMessages,
+      metadata,
+    };
+
+    return state;
+  }
+
+  async save(state: ConversationState): Promise<void> {
+    const saveTransaction = this.db.transaction(() => {
+      // Build metadata with engine-specific fields
+      const metadata: Record<string, unknown> = {
+        ...(state.metadata ?? {}),
+        _statusReason: state.statusReason,
+        _tokenBudget: state.tokenBudget,
+        _tokensUsed: state.tokensUsed,
+        _challengeCount: state.challengeCount,
+        _consecutiveChallenges: state.consecutiveChallenges,
+        _injectionScores: state.injectionScores,
+        _policyViolationCount: state.policyViolationCount,
+        _voiceRuleViolationCount: state.voiceRuleViolationCount,
+        _affinity: state.affinity,
+        _summaries: state.summaries,
+      };
+
+      // Derive a title from metadata or conversation ID
+      const title = (state.metadata?.title as string)
+        ?? (state.metadata?.topic as string)
+        ?? `Conversation ${state.conversationId.slice(0, 12)}`;
+
+      // Upsert conversation
+      this.db.prepare(`
+        INSERT INTO conversations (id, title, status, created_at, updated_at, metadata)
+        VALUES (?, ?, ?, ?, ?, ?)
+        ON CONFLICT(id) DO UPDATE SET
+          status = excluded.status,
+          updated_at = excluded.updated_at,
+          metadata = excluded.metadata
+      `).run(
+        state.conversationId,
+        title,
+        state.status,
+        state.createdAt,
+        state.updatedAt,
+        JSON.stringify(metadata),
+      );
+
+      // Upsert participants
+      const upsertParticipant = this.db.prepare(`
+        INSERT INTO conversation_participants (conversation_id, agent, status, joined_at, last_active)
+        VALUES (?, ?, 'active', datetime('now'), datetime('now'))
+        ON CONFLICT(conversation_id, agent) DO UPDATE SET
+          last_active = datetime('now')
+      `);
+      for (const agent of state.participants) {
+        upsertParticipant.run(state.conversationId, agent);
+      }
+
+      // Upsert turn state
+      let turnQueue: string[] = [];
+      try {
+        // Remaining participants after current turn
+        const idx = state.participants.indexOf(state.currentTurn);
+        if (idx >= 0) {
+          turnQueue = [...state.participants.slice(idx + 1), ...state.participants.slice(0, idx)];
+        }
+      } catch { /* ignore */ }
+
+      this.db.prepare(`
+        INSERT INTO conversation_turn_state (conversation_id, current_speaker, queue, updated_at)
+        VALUES (?, ?, ?, datetime('now'))
+        ON CONFLICT(conversation_id) DO UPDATE SET
+          current_speaker = excluded.current_speaker,
+          queue = excluded.queue,
+          updated_at = datetime('now')
+      `).run(state.conversationId, state.currentTurn, JSON.stringify(turnQueue));
+
+      // Upsert messages (only new ones — check by ID)
+      const upsertMessage = this.db.prepare(`
+        INSERT OR IGNORE INTO conversation_messages
+          (id, conversation_id, agent, type, text, timestamp, injection_score, violations, metadata)
+        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `);
+
+      for (const msg of state.messages) {
+        const msgMeta: Record<string, unknown> = {
+          _to: msg.to,
+          _deliveredTo: msg.deliveredTo,
+          _payload: msg.payload,
+          _status: msg.status,
+          _blockedReason: msg.blockedReason,
+          _security: msg.security,
+          _handoff: msg.handoff,
+          _mediation: msg.mediation,
+        };
+
+        const violations: string[] = [];
+        if (msg.security) {
+          if (msg.security.policyWarningCount > 0) violations.push('policy');
+          if (msg.security.voiceViolationCount > 0) violations.push('voice');
+          if (msg.security.injectionScore > 0.6) violations.push('injection');
+        }
+
+        upsertMessage.run(
+          msg.messageId,
+          state.conversationId,
+          msg.from,
+          msg.payload?.type ?? 'fact',
+          msg.content,
+          msg.createdAt,
+          msg.security?.injectionScore ?? 0,
+          JSON.stringify(violations),
+          JSON.stringify(msgMeta),
+        );
+      }
+    });
+
+    saveTransaction();
+  }
+
+  async list(): Promise<ConversationId[]> {
+    const rows = this.db
+      .prepare('SELECT id FROM conversations ORDER BY updated_at DESC')
+      .all() as any[];
+    return rows.map((r: any) => r.id);
+  }
+
+  /** Close the database connection. */
+  close(): void {
+    try {
+      this.db.close();
+    } catch {
+      // ignore close errors
+    }
+  }
+}
+
+export default SqliteConversationStore;


### PR DESCRIPTION
## Summary

Fixes #181 — Wire real interaction logging into agent handoffs
Fixes #182 — Make Conversations API produce real persisted data for dashboard

## Problem

1. **Issue #181**: The `interaction_logs` table in the RPG database was only populated by test seeds (all entries prefixed with `TEST:`). No runtime code wrote to it when real agent handoffs occurred through the ConversationEngine.

2. **Issue #182**: The dashboard's `/api/rpg/conversations/active` and `/api/conversation/conversations` endpoints always returned empty because the ConversationEngine used a `FileConversationStore` pointing at an empty `runtime/conversations/` directory. Real conversation data in the SQLite DB's `conversations` table was unreachable.

## Solution

### InteractionLogger (`lib/interaction-logger.ts`) — Fixes #181
- New module that opens the RPG SQLite DB in write mode
- `logHandoff()` writes to `interaction_logs` when agent messages are delivered
- `getStats()` provides minimal observability (total count + last write timestamp)
- Wired into ConversationAPI's `'message'` and `'conversation_started'` events

### SqliteConversationStore (`lib/sqlite-conversation-store.ts`) — Fixes #182
- Implements the `ConversationStore` interface using the existing SQLite tables (`conversations`, `conversation_messages`, `conversation_participants`, `conversation_turn_state`)
- Full `save()`/`load()` roundtrip preserving all ConversationState fields
- Used by `conversation-http.ts` when `dbPath` is provided (which it always is from the dashboard server)

### Updated `conversation-http.ts`
- `getApi()` now uses `SqliteConversationStore` instead of empty `FileConversationStore`
- Event listeners wire InteractionLogger to ConversationAPI events
- Periodic stats logging (every 50 interactions) for observability

## Tests (19 new)
- `interaction-logger.test.ts` — 7 tests
- `sqlite-conversation-store.test.ts` — 9 tests
- `data-capture-integration.test.ts` — 3 integration tests

All 976 existing jest tests + 208 dashboard vitest tests pass.

## Data Flow After This PR

```
Agent handoff → ConversationEngine.sendMessage()
                    ↓
              ConversationAPI emits 'message' event
                    ↓
        ┌───────────┴───────────┐
        ↓                       ↓
SqliteConversationStore    InteractionLogger
  (conversations table)    (interaction_logs table)
        ↓                       ↓
/api/rpg/conversations/   /api/rpg/stats/:agent
  active returns data       shows real interactions
```