### PR TITLE
feat: integrate ConversationEngine into runtime mission lifecycle

### DIFF
--- a/lib/__tests__/mission-conversation-integration.test.ts
+++ b/lib/__tests__/mission-conversation-integration.test.ts
@@ -1,0 +1,252 @@
+/**
+ * Integration test: MissionRunner + RuntimeConversationBridge
+ *
+ * Validates end-to-end that running a mission through MissionRunner
+ * with conversation hooks produces real conversation state with messages
+ * for each lifecycle event.
+ *
+ * Fixes #184
+ */
+
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import Database from 'better-sqlite3';
+
+import { MissionRunner } from '../mission-runner';
+import { RuntimeConversationBridge, missionConversationId } from '../runtime-conversation-bridge';
+import { ConversationEngine, FileConversationStore } from '../conversation-engine';
+import { ConversationAPI } from '../conversation-api';
+import { RateLimiter } from '../rate-limiter';
+import { HITLEngine } from '../hitl';
+import { AffinityManager } from '../affinity-manager';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+async function makeTempDir(prefix: string) {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  return { dir, cleanup: () => fs.rm(dir, { recursive: true, force: true }) };
+}
+
+async function makeTempAffinityDb() {
+  const { dir, cleanup } = await makeTempDir('ventureos-intg-affdb-');
+  const dbPath = path.join(dir, 'affinity.db');
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE khala_network (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      agent_a TEXT NOT NULL, agent_b TEXT NOT NULL,
+      affinity REAL NOT NULL, seed_value REAL NOT NULL,
+      last_interaction_at TIMESTAMP, interaction_count INTEGER DEFAULT 0,
+      updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      UNIQUE(agent_a, agent_b), CHECK(agent_a < agent_b),
+      CHECK(affinity >= 0.10 AND affinity <= 0.95)
+    );
+    CREATE TABLE khala_drift_history (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      agent_a TEXT NOT NULL, agent_b TEXT NOT NULL,
+      old_affinity REAL NOT NULL, new_affinity REAL NOT NULL,
+      delta REAL NOT NULL, reason TEXT NOT NULL,
+      interaction_type TEXT, related_mission_id TEXT,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+  return { db, cleanup: async () => { db.close(); await cleanup(); } };
+}
+
+function makeNow(startIso = '2026-02-17T00:00:00.000Z') {
+  let t = Date.parse(startIso);
+  return () => {
+    const d = new Date(t);
+    t += 1000;
+    return d;
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('MissionRunner + ConversationBridge integration', () => {
+  let persistDir: string;
+  let missionStateDir: string;
+  let artifactsDir: string;
+  let cleanup: Array<() => Promise<void>>;
+  let affinityDb: Database.Database;
+  let api: ConversationAPI;
+  let bridge: RuntimeConversationBridge;
+
+  beforeEach(async () => {
+    cleanup = [];
+
+    const tmp1 = await makeTempDir('ventureos-intg-conv-');
+    persistDir = tmp1.dir;
+    cleanup.push(tmp1.cleanup);
+
+    const tmp2 = await makeTempDir('ventureos-intg-state-');
+    missionStateDir = tmp2.dir;
+    cleanup.push(tmp2.cleanup);
+
+    const tmp3 = await makeTempDir('ventureos-intg-art-');
+    artifactsDir = tmp3.dir;
+    cleanup.push(tmp3.cleanup);
+
+    const affTmp = await makeTempAffinityDb();
+    affinityDb = affTmp.db;
+    cleanup.push(affTmp.cleanup);
+
+    const rateLimiter = new RateLimiter({
+      agentPerMinute: 1000, agentPerHour: 1000,
+      conversationPerMinute: 1000, conversationPerHour: 1000,
+      burstAllowance: false,
+    });
+    const hitl = new HITLEngine();
+    const affinity = new AffinityManager({ lowAffinityThreshold: 0.1 }, affinityDb);
+
+    const engine = new ConversationEngine({
+      config: { persistDir, enforceTurns: false },
+      store: new FileConversationStore(persistDir),
+      affinityManager: affinity,
+      securityDeps: { rateLimiter, hitl },
+    });
+
+    api = new ConversationAPI(engine);
+    bridge = new RuntimeConversationBridge(api, { silent: true });
+  });
+
+  afterEach(async () => {
+    for (const fn of cleanup) await fn();
+  });
+
+  it('full mission lifecycle creates conversation with all events', async () => {
+    const now = makeNow();
+
+    const runner = new MissionRunner({
+      persistDir: missionStateDir,
+      artifactsDir,
+      now,
+      hooks: bridge,
+      agents: [
+        {
+          id: 'synth',
+          async runTask(task) {
+            return { summary: `done: ${task.title}`, artifacts: [{ name: 'output.md', content: '# Output' }] };
+          },
+        },
+      ],
+    });
+
+    const result = await runner.runFromBrief({
+      title: 'Bridge Validation Mission',
+      description: 'No special keywords to keep it simple.',
+      requirements: ['Produce output'],
+      deliverables: ['output.md'],
+    });
+
+    expect(result.mission.phase).toBe('closed');
+
+    // Verify conversation was created and contains events
+    const convId = missionConversationId(result.mission.missionId);
+    const state = await api.getConversation(convId);
+
+    expect(state).toBeTruthy();
+    expect(state.status).toBe('closed');
+    expect(state.participants).toContain('system');
+    expect(state.participants).toContain('synth');
+
+    // Should have messages for: phase transitions + task start + task complete + mission close
+    expect(state.messages.length).toBeGreaterThanOrEqual(4);
+
+    // Verify specific message types exist
+    const contents = state.messages.map(m => m.content);
+    expect(contents.some(c => c.includes('phase transition'))).toBe(true);
+    expect(contents.some(c => c.includes('Task dispatched'))).toBe(true);
+    expect(contents.some(c => c.includes('Task completed'))).toBe(true);
+    expect(contents.some(c => c.includes('Mission closed'))).toBe(true);
+
+    // Verify bridge metrics
+    const metrics = bridge.getMetrics();
+    expect(metrics.conversationsCreated).toBe(1);
+    expect(metrics.conversationsClosed).toBe(1);
+    expect(metrics.hookErrors).toBe(0);
+    expect(metrics.lastSuccessAt).toBeTruthy();
+  });
+
+  it('mission failure pauses conversation (not closes)', async () => {
+    const now = makeNow();
+
+    const runner = new MissionRunner({
+      persistDir: missionStateDir,
+      artifactsDir,
+      now,
+      hooks: bridge,
+      continueOnFailure: false,
+      agents: [
+        {
+          id: 'synth',
+          async runTask() {
+            throw new Error('Agent crashed');
+          },
+        },
+      ],
+    });
+
+    const result = await runner.runFromBrief({
+      title: 'Failing Mission',
+      description: 'This should fail.',
+      requirements: ['Will fail'],
+    });
+
+    expect(result.mission.phase).toBe('error');
+
+    const convId = missionConversationId(result.mission.missionId);
+    const state = await api.getConversation(convId);
+
+    // Conversation should be paused (not closed) so it can be resumed
+    expect(state.status).toBe('paused');
+    expect(state.messages.some(m => m.content.includes('Mission error'))).toBe(true);
+  });
+
+  it('hook failures do not break mission execution', async () => {
+    const now = makeNow();
+
+    // Create a bridge with a broken API
+    const brokenEngine = {
+      startConversation: () => { throw new Error('DB down'); },
+      getConversation: () => { throw new Error('DB down'); },
+      sendMessage: () => { throw new Error('DB down'); },
+      setStatus: () => { throw new Error('DB down'); },
+      addParticipant: () => { throw new Error('DB down'); },
+      listConversations: () => { throw new Error('DB down'); },
+      getContext: () => { throw new Error('DB down'); },
+    } as any;
+    const brokenApi = new ConversationAPI(brokenEngine);
+    const brokenBridge = new RuntimeConversationBridge(brokenApi, { silent: true });
+
+    const runner = new MissionRunner({
+      persistDir: missionStateDir,
+      artifactsDir,
+      now,
+      hooks: brokenBridge,
+      agents: [
+        {
+          id: 'synth',
+          async runTask(task) {
+            return { summary: `done: ${task.title}` };
+          },
+        },
+      ],
+    });
+
+    // Mission should succeed despite broken conversation engine
+    const result = await runner.runFromBrief({
+      title: 'Resilient Mission',
+      description: 'Should complete despite broken hooks.',
+      requirements: ['Complete successfully'],
+    });
+
+    expect(result.mission.phase).toBe('closed');
+
+    // Bridge should record hook errors
+    const metrics = brokenBridge.getMetrics();
+    expect(metrics.hookErrors).toBeGreaterThan(0);
+  });
+});

--- a/lib/__tests__/runtime-conversation-bridge.test.ts
+++ b/lib/__tests__/runtime-conversation-bridge.test.ts
@@ -1,0 +1,377 @@
+/**
+ * Tests for RuntimeConversationBridge — Issue #184
+ *
+ * Validates:
+ * - Mission lifecycle creates/closes conversations
+ * - Task dispatch/completion sends messages
+ * - Idempotency (duplicate events don't create duplicate messages)
+ * - Graceful degradation (engine errors don't propagate)
+ * - Metrics tracking
+ * - Bridge wiring into MissionRunner hooks interface
+ */
+
+import os from 'node:os';
+import path from 'node:path';
+import fs from 'node:fs/promises';
+import Database from 'better-sqlite3';
+
+import {
+  RuntimeConversationBridge,
+  missionConversationId,
+  type MissionRunnerHooks,
+  type BridgeMetrics,
+} from '../runtime-conversation-bridge';
+import { ConversationEngine, FileConversationStore } from '../conversation-engine';
+import { ConversationAPI } from '../conversation-api';
+import { RateLimiter } from '../rate-limiter';
+import { HITLEngine } from '../hitl';
+import { AffinityManager } from '../affinity-manager';
+import type {
+  MissionRecord,
+  MissionPhase,
+  MissionTask,
+  TaskRunResult,
+} from '../mission-state-machine';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+async function makeTempDir(prefix: string): Promise<{ dir: string; cleanup: () => Promise<void> }> {
+  const dir = await fs.mkdtemp(path.join(os.tmpdir(), prefix));
+  return {
+    dir,
+    cleanup: async () => {
+      await fs.rm(dir, { recursive: true, force: true });
+    },
+  };
+}
+
+async function makeTempAffinityDb(): Promise<{ db: Database.Database; cleanup: () => Promise<void> }> {
+  const { dir, cleanup } = await makeTempDir('ventureos-bridge-affdb-');
+  const dbPath = path.join(dir, 'affinity.db');
+  const db = new Database(dbPath);
+  db.exec(`
+    CREATE TABLE khala_network (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      agent_a TEXT NOT NULL, agent_b TEXT NOT NULL,
+      affinity REAL NOT NULL, seed_value REAL NOT NULL,
+      last_interaction_at TIMESTAMP, interaction_count INTEGER DEFAULT 0,
+      updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+      UNIQUE(agent_a, agent_b), CHECK(agent_a < agent_b),
+      CHECK(affinity >= 0.10 AND affinity <= 0.95)
+    );
+    CREATE TABLE khala_drift_history (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      agent_a TEXT NOT NULL, agent_b TEXT NOT NULL,
+      old_affinity REAL NOT NULL, new_affinity REAL NOT NULL,
+      delta REAL NOT NULL, reason TEXT NOT NULL,
+      interaction_type TEXT, related_mission_id TEXT,
+      created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+  return { db, cleanup: async () => { db.close(); await cleanup(); } };
+}
+
+function makeEngine(persistDir: string, affinityDb: Database.Database): ConversationEngine {
+  const rateLimiter = new RateLimiter({
+    agentPerMinute: 1000, agentPerHour: 1000,
+    conversationPerMinute: 1000, conversationPerHour: 1000,
+    burstAllowance: false,
+  });
+  const hitl = new HITLEngine();
+  const affinity = new AffinityManager({ lowAffinityThreshold: 0.1 }, affinityDb);
+
+  return new ConversationEngine({
+    config: { persistDir, enforceTurns: false },
+    store: new FileConversationStore(persistDir),
+    affinityManager: affinity,
+    securityDeps: { rateLimiter, hitl },
+  });
+}
+
+function makeMission(overrides?: Partial<MissionRecord>): MissionRecord {
+  return {
+    missionId: 'test-mission-001',
+    phase: 'brief' as MissionPhase,
+    createdAt: '2026-02-17T00:00:00.000Z',
+    updatedAt: '2026-02-17T00:00:00.000Z',
+    brief: {
+      title: 'Test Mission',
+      description: 'A test mission for bridge integration',
+      requirements: ['req1'],
+    },
+    plan: {
+      createdAt: '2026-02-17T00:00:00.000Z',
+      tasks: [
+        { taskId: 'task-1', title: 'Build it', description: 'Build the thing', role: 'synth' },
+        { taskId: 'task-2', title: 'Test it', description: 'Test the thing', role: 'verifier' },
+      ],
+    },
+    history: [{ phase: 'brief' as MissionPhase, enteredAt: '2026-02-17T00:00:00.000Z' }],
+    metrics: { createdAt: '2026-02-17T00:00:00.000Z', updatedAt: '2026-02-17T00:00:00.000Z' },
+    ...overrides,
+  };
+}
+
+function makeTaskResult(task: MissionTask, status: 'succeeded' | 'failed' = 'succeeded'): TaskRunResult {
+  return {
+    taskId: task.taskId,
+    agentId: task.role,
+    startedAt: '2026-02-17T00:01:00.000Z',
+    finishedAt: '2026-02-17T00:02:00.000Z',
+    status,
+    summary: status === 'succeeded' ? 'Done' : undefined,
+    error: status === 'failed' ? { message: 'Something went wrong' } : undefined,
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('RuntimeConversationBridge', () => {
+  let persistDir: string;
+  let persistCleanup: () => Promise<void>;
+  let affinityDb: Database.Database;
+  let affinityCleanup: () => Promise<void>;
+  let engine: ConversationEngine;
+  let api: ConversationAPI;
+  let bridge: RuntimeConversationBridge;
+
+  beforeEach(async () => {
+    const tmp = await makeTempDir('ventureos-bridge-');
+    persistDir = tmp.dir;
+    persistCleanup = tmp.cleanup;
+    const affTmp = await makeTempAffinityDb();
+    affinityDb = affTmp.db;
+    affinityCleanup = affTmp.cleanup;
+    engine = makeEngine(persistDir, affinityDb);
+    api = new ConversationAPI(engine);
+    bridge = new RuntimeConversationBridge(api, { silent: true });
+  });
+
+  afterEach(async () => {
+    await persistCleanup();
+    await affinityCleanup();
+  });
+
+  describe('missionConversationId', () => {
+    it('produces deterministic IDs', () => {
+      expect(missionConversationId('abc')).toBe('mission_abc');
+      expect(missionConversationId('abc')).toBe(missionConversationId('abc'));
+    });
+  });
+
+  describe('onMissionCreated', () => {
+    it('creates a conversation with system + derived participants', async () => {
+      const mission = makeMission();
+      await bridge.onMissionCreated(mission);
+
+      const convId = missionConversationId(mission.missionId);
+      const state = await api.getConversation(convId);
+
+      expect(state).toBeTruthy();
+      expect(state.participants).toContain('system');
+      expect(state.participants).toContain('synth');
+      expect(state.participants).toContain('verifier');
+      expect(state.status).toBe('active');
+      expect(state.metadata).toHaveProperty('missionId', mission.missionId);
+    });
+
+    it('is idempotent — reuses existing conversation on second call', async () => {
+      const mission = makeMission();
+      await bridge.onMissionCreated(mission);
+      await bridge.onMissionCreated(mission);
+
+      const metrics = bridge.getMetrics();
+      // Should only count 1 creation, 2nd is reuse
+      expect(metrics.conversationsCreated).toBe(1);
+    });
+  });
+
+  describe('onPhaseTransition', () => {
+    it('sends a phase transition message', async () => {
+      const mission = makeMission();
+      await bridge.onMissionCreated(mission);
+      await bridge.onPhaseTransition(mission, 'brief', 'plan');
+
+      const convId = missionConversationId(mission.missionId);
+      const state = await api.getConversation(convId);
+      const msgs = state.messages.filter(m => m.content.includes('phase transition'));
+      expect(msgs.length).toBe(1);
+      expect(msgs[0].content).toContain('brief → plan');
+    });
+
+    it('deduplicates identical transitions', async () => {
+      const mission = makeMission();
+      await bridge.onMissionCreated(mission);
+      await bridge.onPhaseTransition(mission, 'brief', 'plan');
+      await bridge.onPhaseTransition(mission, 'brief', 'plan');
+
+      const convId = missionConversationId(mission.missionId);
+      const state = await api.getConversation(convId);
+      const msgs = state.messages.filter(m => m.content.includes('phase transition'));
+      expect(msgs.length).toBe(1);
+    });
+  });
+
+  describe('onTaskStart', () => {
+    it('sends a task dispatch message', async () => {
+      const mission = makeMission();
+      await bridge.onMissionCreated(mission);
+
+      const task = mission.plan!.tasks[0];
+      await bridge.onTaskStart(mission, task, 'synth');
+
+      const convId = missionConversationId(mission.missionId);
+      const state = await api.getConversation(convId);
+      const msgs = state.messages.filter(m => m.content.includes('Task dispatched'));
+      expect(msgs.length).toBe(1);
+      expect(msgs[0].content).toContain('synth');
+      expect(msgs[0].content).toContain('Build it');
+    });
+  });
+
+  describe('onTaskComplete', () => {
+    it('sends a task result message for success', async () => {
+      const mission = makeMission();
+      await bridge.onMissionCreated(mission);
+
+      const task = mission.plan!.tasks[0];
+      const result = makeTaskResult(task, 'succeeded');
+      await bridge.onTaskComplete(mission, task, result);
+
+      const convId = missionConversationId(mission.missionId);
+      const state = await api.getConversation(convId);
+      const msgs = state.messages.filter(m => m.content.includes('Task completed'));
+      expect(msgs.length).toBe(1);
+      expect(msgs[0].content).toContain('succeeded');
+      expect(msgs[0].content).toContain('✓');
+    });
+
+    it('sends a task result message for failure', async () => {
+      const mission = makeMission();
+      await bridge.onMissionCreated(mission);
+
+      const task = mission.plan!.tasks[0];
+      const result = makeTaskResult(task, 'failed');
+      await bridge.onTaskComplete(mission, task, result);
+
+      const convId = missionConversationId(mission.missionId);
+      const state = await api.getConversation(convId);
+      const msgs = state.messages.filter(m => m.content.includes('Task completed'));
+      expect(msgs.length).toBe(1);
+      expect(msgs[0].content).toContain('failed');
+      expect(msgs[0].content).toContain('✗');
+    });
+  });
+
+  describe('onMissionClosed', () => {
+    it('sends closing message and closes conversation', async () => {
+      const mission = makeMission({ phase: 'closed' });
+      await bridge.onMissionCreated(mission);
+      await bridge.onMissionClosed(mission);
+
+      const convId = missionConversationId(mission.missionId);
+      const state = await api.getConversation(convId);
+      expect(state.status).toBe('closed');
+      expect(state.messages.some(m => m.content.includes('Mission closed'))).toBe(true);
+
+      const metrics = bridge.getMetrics();
+      expect(metrics.conversationsClosed).toBe(1);
+    });
+  });
+
+  describe('onMissionError', () => {
+    it('sends error message and pauses conversation', async () => {
+      const mission = makeMission({
+        phase: 'error',
+        error: {
+          atPhase: 'execute',
+          occurredAt: '2026-02-17T00:05:00.000Z',
+          message: 'Agent timed out',
+        },
+      });
+      await bridge.onMissionCreated(mission);
+      await bridge.onMissionError(mission, new Error('Agent timed out'));
+
+      const convId = missionConversationId(mission.missionId);
+      const state = await api.getConversation(convId);
+      expect(state.status).toBe('paused');
+      expect(state.messages.some(m => m.content.includes('Mission error'))).toBe(true);
+    });
+  });
+
+  describe('graceful degradation', () => {
+    it('does not throw when conversation engine fails', async () => {
+      // Create a bridge with a broken API
+      const brokenEngine = {
+        startConversation: () => { throw new Error('DB exploded'); },
+        getConversation: () => { throw new Error('DB exploded'); },
+      } as any;
+      const brokenApi = new ConversationAPI(brokenEngine);
+      const brokenBridge = new RuntimeConversationBridge(brokenApi, { silent: true });
+
+      const mission = makeMission();
+
+      // Should NOT throw
+      await expect(brokenBridge.onMissionCreated(mission)).resolves.toBeUndefined();
+
+      const metrics = brokenBridge.getMetrics();
+      expect(metrics.hookErrors).toBe(1);
+      expect(metrics.lastErrorMessage).toContain('onMissionCreated');
+    });
+  });
+
+  describe('metrics', () => {
+    it('tracks all counters correctly', async () => {
+      const mission = makeMission();
+      await bridge.onMissionCreated(mission);
+      await bridge.onPhaseTransition(mission, 'brief', 'plan');
+
+      const task = mission.plan!.tasks[0];
+      await bridge.onTaskStart(mission, task, 'synth');
+      await bridge.onTaskComplete(mission, task, makeTaskResult(task));
+
+      const closedMission = makeMission({ ...mission, phase: 'closed' });
+      await bridge.onMissionClosed(closedMission);
+
+      const metrics = bridge.getMetrics();
+      expect(metrics.conversationsCreated).toBe(1);
+      expect(metrics.conversationsClosed).toBe(1);
+      expect(metrics.messagesSent).toBeGreaterThanOrEqual(4); // phase + start + complete + close
+      expect(metrics.hookErrors).toBe(0);
+      expect(metrics.lastSuccessAt).toBeTruthy();
+    });
+  });
+
+  describe('activeConversations', () => {
+    it('tracks active conversations', async () => {
+      const mission = makeMission();
+      await bridge.onMissionCreated(mission);
+
+      const active = bridge.getActiveConversations();
+      expect(active.size).toBe(1);
+      expect(active.get(mission.missionId)).toBe(missionConversationId(mission.missionId));
+    });
+
+    it('removes conversations on close', async () => {
+      const mission = makeMission({ phase: 'closed' });
+      await bridge.onMissionCreated(mission);
+      await bridge.onMissionClosed(mission);
+
+      const active = bridge.getActiveConversations();
+      expect(active.size).toBe(0);
+    });
+  });
+
+  describe('MissionRunnerHooks interface', () => {
+    it('satisfies the MissionRunnerHooks type', () => {
+      // Type-level check: bridge implements MissionRunnerHooks
+      const hooks: MissionRunnerHooks = bridge;
+      expect(hooks.onMissionCreated).toBeDefined();
+      expect(hooks.onPhaseTransition).toBeDefined();
+      expect(hooks.onTaskStart).toBeDefined();
+      expect(hooks.onTaskComplete).toBeDefined();
+      expect(hooks.onMissionClosed).toBeDefined();
+      expect(hooks.onMissionError).toBeDefined();
+    });
+  });
+});

--- a/lib/conversation-http.ts
+++ b/lib/conversation-http.ts
@@ -23,6 +23,7 @@ import { ConversationAPI } from './conversation-api';
 import { toSafeError } from './error-handler';
 import { SqliteConversationStore } from './sqlite-conversation-store';
 import { InteractionLogger } from './interaction-logger';
+import { RuntimeConversationBridge } from './runtime-conversation-bridge';
 
 // ─── Helpers ────────────────────────────────────────────────────────────────
 
@@ -107,6 +108,7 @@ async function readJsonBody(
 
 let _apiInstance: ConversationAPI | null = null;
 let _interactionLogger: InteractionLogger | null = null;
+let _runtimeBridge: RuntimeConversationBridge | null = null;
 
 function getApi(opts: ConversationHandlerOptions): ConversationAPI {
   if (_apiInstance) return _apiInstance;
@@ -184,7 +186,39 @@ function getApi(opts: ConversationHandlerOptions): ConversationAPI {
     });
   }
 
+  // Issue #184: Create runtime conversation bridge for mission integration.
+  // This bridge is accessible via getRuntimeBridge() so MissionRunner
+  // callers can pass bridge.hooks to their config.
+  if (!_runtimeBridge) {
+    _runtimeBridge = new RuntimeConversationBridge(_apiInstance);
+  }
+
   return _apiInstance;
+}
+
+/**
+ * Get the singleton RuntimeConversationBridge instance.
+ * Returns null if getApi() hasn't been called yet (i.e., no DB path configured).
+ *
+ * Usage in MissionRunner callers:
+ *   const bridge = getRuntimeBridge();
+ *   const runner = new MissionRunner({ ..., hooks: bridge ?? undefined });
+ *
+ * Fixes #184
+ */
+export function getRuntimeBridge(): RuntimeConversationBridge | null {
+  return _runtimeBridge;
+}
+
+/**
+ * Reset the singleton instances. Primarily for testing.
+ * @internal
+ */
+export function resetSingletons(): void {
+  _apiInstance = null;
+  _interactionLogger?.close();
+  _interactionLogger = null;
+  _runtimeBridge = null;
 }
 
 // ─── Route Handlers (async) ─────────────────────────────────────────────────
@@ -383,4 +417,4 @@ export function createConversationRouter(dbPath: string) {
   };
 }
 
-export default { handleConversationApi, createConversationRouter };
+export default { handleConversationApi, createConversationRouter, getRuntimeBridge, resetSingletons };

--- a/lib/mission-runner.ts
+++ b/lib/mission-runner.ts
@@ -24,6 +24,7 @@ import {
 import { SquadCoordinator, type SquadAgent } from './squad-coordinator';
 import { GateChecks, type GateDefinition } from './gate-checks';
 import { ArtifactCollector } from './artifact-collector';
+import type { MissionRunnerHooks } from './runtime-conversation-bridge';
 
 export interface MissionRunnerConfig {
   /** Directory where mission state is persisted. */
@@ -44,6 +45,13 @@ export interface MissionRunnerConfig {
 
   /** Optional approval callback for approval gates. */
   approve?: () => Promise<boolean>;
+
+  /**
+   * Optional lifecycle hooks for runtime integration.
+   * Errors in hooks are caught and do NOT affect mission execution.
+   * Fixes #184 — ConversationEngine runtime integration.
+   */
+  hooks?: MissionRunnerHooks;
 }
 
 export interface MissionRunResult {
@@ -80,12 +88,14 @@ export class MissionRunner {
   private readonly artifacts: ArtifactCollector;
   private readonly now: () => Date;
   private readonly approve?: () => Promise<boolean>;
+  private readonly hooks?: MissionRunnerHooks;
 
   constructor(config: MissionRunnerConfig) {
     if (!config?.agents?.length) throw new Error('MissionRunner requires agents[]');
 
     this.now = config.now ?? (() => new Date());
     this.approve = config.approve;
+    this.hooks = config.hooks;
 
     this.sm = new MissionStateMachine({
       persistDir: config.persistDir,
@@ -117,12 +127,17 @@ export class MissionRunner {
 
     let mission = await this.sm.createMission(brief);
 
+    // Issue #184: Notify hooks of mission creation
+    await this.safeHook('onMissionCreated', () => this.hooks?.onMissionCreated?.(mission));
+
     try {
       mission = await this.runFromPhase(mission);
       return this.toRunResult(mission);
     } catch (err) {
       // If something threw outside of phase transitions, mark mission as failed.
       const failed = await this.sm.fail(mission, err);
+      // Issue #184: Notify hooks of mission error
+      await this.safeHook('onMissionError', () => this.hooks?.onMissionError?.(failed, err));
       return this.toRunResult(failed);
     }
   }
@@ -166,12 +181,24 @@ export class MissionRunner {
 
     if (m.phase === 'brief') {
       const plan = this.squad.createPlanFromBrief(m.brief!);
+      const prevPhase = m.phase;
       m = await this.sm.transition(m, 'plan', { plan }, 'auto-planned');
+      await this.safeHook('onPhaseTransition', () => this.hooks?.onPhaseTransition?.(m, prevPhase, 'plan'));
     }
 
     if (m.phase === 'plan') {
-      const execution = await this.squad.executePlan(m.missionId, m.brief!, m.plan!);
+      // Issue #184: Notify hooks of task dispatch/completion during execution
+      const execution = await this.squad.executePlan(m.missionId, m.brief!, m.plan!, {
+        onTaskStart: async (task, agentId) => {
+          await this.safeHook('onTaskStart', () => this.hooks?.onTaskStart?.(m, task, agentId));
+        },
+        onTaskComplete: async (task, result) => {
+          await this.safeHook('onTaskComplete', () => this.hooks?.onTaskComplete?.(m, task, result));
+        },
+      });
+      const prevPhase = m.phase;
       m = await this.sm.transition(m, 'execute', { execution }, 'executed plan');
+      await this.safeHook('onPhaseTransition', () => this.hooks?.onPhaseTransition?.(m, prevPhase, 'execute'));
     }
 
     if (m.phase === 'execute') {
@@ -191,15 +218,21 @@ export class MissionRunner {
         overall,
       };
 
+      const prevPhase = m.phase;
       m = await this.sm.transition(m, 'verify', { verification }, 'gate checks');
+      await this.safeHook('onPhaseTransition', () => this.hooks?.onPhaseTransition?.(m, prevPhase, 'verify'));
     }
 
     if (m.phase === 'verify') {
       if (m.verification?.overall === 'fail') {
-        return this.sm.fail(m, new Error('Gate checks failed'), 'gates_failed', 'execute');
+        const failed = await this.sm.fail(m, new Error('Gate checks failed'), 'gates_failed', 'execute');
+        await this.safeHook('onMissionError', () => this.hooks?.onMissionError?.(failed, new Error('Gate checks failed')));
+        return failed;
       }
       if (m.verification?.overall === 'require_approval') {
-        return this.sm.fail(m, new Error('Human approval required'), 'requires_approval', 'verify');
+        const failed = await this.sm.fail(m, new Error('Human approval required'), 'requires_approval', 'verify');
+        await this.safeHook('onMissionError', () => this.hooks?.onMissionError?.(failed, new Error('Human approval required')));
+        return failed;
       }
 
       const reports = this.generateReports(m);
@@ -220,7 +253,9 @@ export class MissionRunner {
         },
       };
 
+      const prevPhase = m.phase;
       m = await this.sm.transition(m, 'deliver', { delivery }, 'delivered artifacts');
+      await this.safeHook('onPhaseTransition', () => this.hooks?.onPhaseTransition?.(m, prevPhase, 'deliver'));
     }
 
     if (m.phase === 'deliver') {
@@ -240,9 +275,26 @@ export class MissionRunner {
         },
         'mission closed'
       );
+
+      // Issue #184: Notify hooks of mission close
+      await this.safeHook('onMissionClosed', () => this.hooks?.onMissionClosed?.(m));
     }
 
     return m;
+  }
+
+  /**
+   * Safely invoke a lifecycle hook. Errors are caught and logged
+   * so that hook failures never break mission execution.
+   * Fixes #184.
+   */
+  private async safeHook(name: string, fn: () => Promise<void> | void | undefined): Promise<void> {
+    try {
+      await fn();
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.warn(`[mission-runner] Hook ${name} error (ignored): ${msg}`);
+    }
   }
 
   private validateBrief(brief: MissionBrief) {

--- a/lib/runtime-conversation-bridge.ts
+++ b/lib/runtime-conversation-bridge.ts
@@ -1,0 +1,391 @@
+/**
+ * Runtime Conversation Bridge — VentureOS Issue #184
+ *
+ * Integrates ConversationEngine into the multi-agent runtime so that
+ * real mission orchestration events (task dispatch, handoffs, completion)
+ * flow through conversation lifecycle and persist for dashboard visibility
+ * + mediation/security context.
+ *
+ * Architecture:
+ * - Provides `MissionRunnerHooks` callback interface for MissionRunner
+ * - On mission start: creates a conversation with all squad agents
+ * - On task dispatch/completion: sends messages through conversation engine
+ * - On mission close/error: closes the conversation
+ * - All operations wrapped in try/catch for graceful degradation
+ * - Idempotent: uses deterministic conversation IDs based on mission ID
+ * - Observable: exposes metrics for ops debugging
+ *
+ * Fixes #184
+ */
+
+import { ConversationAPI, type ConversationEventMap } from './conversation-api';
+import type {
+  ConversationEngine,
+  ConversationId,
+  ConversationState,
+  ConversationMessage,
+} from './conversation-engine';
+import type {
+  MissionRecord,
+  MissionPhase,
+  MissionTask,
+  TaskRunResult,
+  MissionBrief,
+} from './mission-state-machine';
+
+// ─── Hook Interfaces ────────────────────────────────────────────────────────
+
+/**
+ * Lifecycle hooks for MissionRunner integration.
+ * All hooks are optional and async-safe. Errors in hooks do NOT
+ * propagate to the mission runner — they are caught and logged.
+ */
+export interface MissionRunnerHooks {
+  onMissionCreated?(mission: MissionRecord): Promise<void>;
+  onPhaseTransition?(mission: MissionRecord, from: MissionPhase, to: MissionPhase): Promise<void>;
+  onTaskStart?(mission: MissionRecord, task: MissionTask, agentId: string): Promise<void>;
+  onTaskComplete?(mission: MissionRecord, task: MissionTask, result: TaskRunResult): Promise<void>;
+  onMissionClosed?(mission: MissionRecord): Promise<void>;
+  onMissionError?(mission: MissionRecord, error: unknown): Promise<void>;
+}
+
+// ─── Metrics ────────────────────────────────────────────────────────────────
+
+export interface BridgeMetrics {
+  conversationsCreated: number;
+  conversationsClosed: number;
+  messagesSent: number;
+  messagesBlocked: number;
+  hookErrors: number;
+  lastSuccessAt: string | null;
+  lastErrorAt: string | null;
+  lastErrorMessage: string | null;
+}
+
+// ─── Bridge ─────────────────────────────────────────────────────────────────
+
+export interface RuntimeConversationBridgeConfig {
+  /** Log prefix for console output. Default: '[conv-bridge]' */
+  logPrefix?: string;
+  /** If true, suppress console.warn on hook errors. Default: false */
+  silent?: boolean;
+}
+
+/**
+ * Deterministic conversation ID from mission ID for idempotency.
+ * This ensures re-running or resuming a mission reuses the same conversation.
+ */
+export function missionConversationId(missionId: string): ConversationId {
+  return `mission_${missionId}`;
+}
+
+export class RuntimeConversationBridge implements MissionRunnerHooks {
+  private readonly api: ConversationAPI;
+  private readonly prefix: string;
+  private readonly silent: boolean;
+
+  // Track active mission→conversation mappings
+  private activeConversations = new Map<string, ConversationId>();
+
+  // Dedup: track messages already sent to avoid duplicates on resume
+  private sentMessageKeys = new Set<string>();
+
+  private metrics: BridgeMetrics = {
+    conversationsCreated: 0,
+    conversationsClosed: 0,
+    messagesSent: 0,
+    messagesBlocked: 0,
+    hookErrors: 0,
+    lastSuccessAt: null,
+    lastErrorAt: null,
+    lastErrorMessage: null,
+  };
+
+  constructor(
+    api: ConversationAPI,
+    config: RuntimeConversationBridgeConfig = {},
+  ) {
+    this.api = api;
+    this.prefix = config.logPrefix ?? '[conv-bridge]';
+    this.silent = config.silent ?? false;
+  }
+
+  // ─── MissionRunnerHooks Implementation ──────────────────────────────
+
+  async onMissionCreated(mission: MissionRecord): Promise<void> {
+    await this.safeExec('onMissionCreated', async () => {
+      const convId = missionConversationId(mission.missionId);
+
+      // Check if conversation already exists (idempotent on resume)
+      try {
+        const existing = await this.api.getConversation(convId);
+        if (existing) {
+          this.activeConversations.set(mission.missionId, convId);
+          this.log(`Reusing existing conversation ${convId} for mission ${mission.missionId}`);
+          return;
+        }
+      } catch {
+        // Not found — create new
+      }
+
+      // Derive participants from mission plan (if available) or brief
+      const participants = this.deriveParticipants(mission);
+
+      const state = await this.api.startConversation({
+        conversationId: convId,
+        participants: ['system', ...participants],
+        currentTurn: 'system',
+        metadata: {
+          title: `Mission: ${mission.brief?.title ?? mission.missionId}`,
+          missionId: mission.missionId,
+          source: 'runtime-bridge',
+          createdBy: 'RuntimeConversationBridge',
+        },
+      });
+
+      this.activeConversations.set(mission.missionId, state.conversationId);
+      this.metrics.conversationsCreated++;
+      this.recordSuccess();
+      this.log(`Created conversation ${state.conversationId} for mission ${mission.missionId}`);
+    });
+  }
+
+  async onPhaseTransition(
+    mission: MissionRecord,
+    from: MissionPhase,
+    to: MissionPhase,
+  ): Promise<void> {
+    await this.safeExec('onPhaseTransition', async () => {
+      const convId = this.getConvId(mission.missionId);
+      if (!convId) return;
+
+      const dedup = `phase:${mission.missionId}:${from}:${to}`;
+      if (this.sentMessageKeys.has(dedup)) return;
+
+      await this.api.sendMessage({
+        conversationId: convId,
+        from: 'system',
+        to: this.deriveParticipants(mission),
+        content: `Mission phase transition: ${from} → ${to}`,
+        overrideTurn: true,
+      });
+
+      this.sentMessageKeys.add(dedup);
+      this.metrics.messagesSent++;
+      this.recordSuccess();
+    });
+  }
+
+  async onTaskStart(
+    mission: MissionRecord,
+    task: MissionTask,
+    agentId: string,
+  ): Promise<void> {
+    await this.safeExec('onTaskStart', async () => {
+      const convId = this.getConvId(mission.missionId);
+      if (!convId) return;
+
+      const dedup = `taskstart:${mission.missionId}:${task.taskId}`;
+      if (this.sentMessageKeys.has(dedup)) return;
+
+      // Ensure agent is a participant
+      try {
+        const state = await this.api.getConversation(convId);
+        if (!state.participants.includes(agentId)) {
+          await this.api.addParticipant(convId, agentId);
+        }
+      } catch {
+        // Best-effort participant add
+      }
+
+      await this.api.sendMessage({
+        conversationId: convId,
+        from: 'system',
+        to: [agentId],
+        content: `Task dispatched to ${agentId}: ${task.title}\n\n${task.description}`,
+        payload: {
+          type: 'task_dispatch',
+          data: { taskId: task.taskId, role: task.role },
+        },
+        overrideTurn: true,
+      });
+
+      this.sentMessageKeys.add(dedup);
+      this.metrics.messagesSent++;
+      this.recordSuccess();
+    });
+  }
+
+  async onTaskComplete(
+    mission: MissionRecord,
+    task: MissionTask,
+    result: TaskRunResult,
+  ): Promise<void> {
+    await this.safeExec('onTaskComplete', async () => {
+      const convId = this.getConvId(mission.missionId);
+      if (!convId) return;
+
+      const dedup = `taskcomplete:${mission.missionId}:${task.taskId}:${result.status}`;
+      if (this.sentMessageKeys.has(dedup)) return;
+
+      const statusEmoji = result.status === 'succeeded' ? '✓' : result.status === 'failed' ? '✗' : '⊘';
+      const summary = result.summary ? `\n\nSummary: ${result.summary}` : '';
+      const errorInfo = result.error ? `\n\nError: ${result.error.message}` : '';
+
+      await this.api.sendMessage({
+        conversationId: convId,
+        from: 'system',
+        to: this.deriveParticipants(mission),
+        content: `${statusEmoji} Task completed (${result.agentId}): ${task.title} — ${result.status}${summary}${errorInfo}`,
+        payload: {
+          type: 'task_result',
+          data: {
+            taskId: task.taskId,
+            agentId: result.agentId,
+            status: result.status,
+            artifactCount: result.artifacts?.length ?? 0,
+          },
+        },
+        overrideTurn: true,
+      });
+
+      this.sentMessageKeys.add(dedup);
+      this.metrics.messagesSent++;
+      this.recordSuccess();
+    });
+  }
+
+  async onMissionClosed(mission: MissionRecord): Promise<void> {
+    await this.safeExec('onMissionClosed', async () => {
+      const convId = this.getConvId(mission.missionId);
+      if (!convId) return;
+
+      const dedup = `closed:${mission.missionId}`;
+      if (this.sentMessageKeys.has(dedup)) return;
+
+      // Send closing message
+      await this.api.sendMessage({
+        conversationId: convId,
+        from: 'system',
+        to: this.deriveParticipants(mission),
+        content: `Mission closed: ${mission.brief?.title ?? mission.missionId}. Duration: ${mission.metrics?.durationMs ?? 'unknown'}ms`,
+        payload: { type: 'mission_closed' },
+        overrideTurn: true,
+      });
+
+      // Close the conversation
+      await this.api.setStatus(convId, 'closed', 'Mission completed');
+
+      this.sentMessageKeys.add(dedup);
+      this.activeConversations.delete(mission.missionId);
+      this.metrics.conversationsClosed++;
+      this.metrics.messagesSent++;
+      this.recordSuccess();
+    });
+  }
+
+  async onMissionError(mission: MissionRecord, error: unknown): Promise<void> {
+    await this.safeExec('onMissionError', async () => {
+      const convId = this.getConvId(mission.missionId);
+      if (!convId) return;
+
+      const dedup = `error:${mission.missionId}:${mission.error?.occurredAt ?? ''}`;
+      if (this.sentMessageKeys.has(dedup)) return;
+
+      const errMsg = error instanceof Error ? error.message : String(error);
+
+      await this.api.sendMessage({
+        conversationId: convId,
+        from: 'system',
+        to: this.deriveParticipants(mission),
+        content: `⚠ Mission error at phase ${mission.error?.atPhase ?? mission.phase}: ${errMsg}`,
+        payload: {
+          type: 'mission_error',
+          data: {
+            phase: mission.error?.atPhase ?? mission.phase,
+            code: mission.error?.code,
+          },
+        },
+        overrideTurn: true,
+      });
+
+      // Pause conversation (not close — may be resumed)
+      await this.api.setStatus(convId, 'paused', `Mission error: ${errMsg}`);
+
+      this.sentMessageKeys.add(dedup);
+      this.metrics.messagesSent++;
+      this.recordSuccess();
+    });
+  }
+
+  // ─── Observability ──────────────────────────────────────────────────
+
+  getMetrics(): Readonly<BridgeMetrics> {
+    return { ...this.metrics };
+  }
+
+  getActiveConversations(): ReadonlyMap<string, ConversationId> {
+    return new Map(this.activeConversations);
+  }
+
+  // ─── Internals ──────────────────────────────────────────────────────
+
+  private getConvId(missionId: string): ConversationId | null {
+    return this.activeConversations.get(missionId) ?? null;
+  }
+
+  private deriveParticipants(mission: MissionRecord): string[] {
+    const agents = new Set<string>();
+
+    // From plan tasks
+    if (mission.plan?.tasks) {
+      for (const task of mission.plan.tasks) {
+        agents.add(task.role);
+      }
+    }
+
+    // From execution results
+    if (mission.execution?.results) {
+      for (const result of mission.execution.results) {
+        agents.add(result.agentId);
+      }
+    }
+
+    // Fallback: at least include the generic builder
+    if (agents.size === 0) {
+      agents.add('synth');
+    }
+
+    return [...agents];
+  }
+
+  /**
+   * Execute a hook safely — catch all errors so the runtime never
+   * breaks due to conversation engine failures.
+   */
+  private async safeExec(hookName: string, fn: () => Promise<void>): Promise<void> {
+    try {
+      await fn();
+    } catch (err: unknown) {
+      this.metrics.hookErrors++;
+      const msg = err instanceof Error ? err.message : String(err);
+      this.metrics.lastErrorAt = new Date().toISOString();
+      this.metrics.lastErrorMessage = `${hookName}: ${msg}`;
+      if (!this.silent) {
+        console.warn(`${this.prefix} Hook ${hookName} failed (degraded gracefully): ${msg}`);
+      }
+    }
+  }
+
+  private recordSuccess(): void {
+    this.metrics.lastSuccessAt = new Date().toISOString();
+  }
+
+  private log(msg: string): void {
+    if (!this.silent) {
+      console.log(`${this.prefix} ${msg}`);
+    }
+  }
+}
+
+export default RuntimeConversationBridge;

--- a/lib/squad-coordinator.ts
+++ b/lib/squad-coordinator.ts
@@ -40,6 +40,16 @@ export interface SquadAgent {
   runTask(task: MissionTask, ctx: AgentTaskContext): Promise<AgentTaskOutput>;
 }
 
+/**
+ * Optional task-level lifecycle hooks for runtime integration.
+ * All hooks are optional and async-safe.
+ * Fixes #184 — ConversationEngine runtime integration.
+ */
+export interface SquadExecutionHooks {
+  onTaskStart?(task: MissionTask, agentId: string): Promise<void>;
+  onTaskComplete?(task: MissionTask, result: TaskRunResult): Promise<void>;
+}
+
 export interface SquadCoordinatorConfig {
   agents: SquadAgent[];
   /** If true, keep running remaining tasks after a failure. Default: true. */
@@ -178,7 +188,7 @@ export class SquadCoordinator {
    * - If parallelize=false: runs in listed order.
    * - If parallelize=true: runs tasks whose dependencies are satisfied.
    */
-  async executePlan(missionId: string, brief: MissionBrief, plan: MissionPlan): Promise<MissionExecution> {
+  async executePlan(missionId: string, brief: MissionBrief, plan: MissionPlan, hooks?: SquadExecutionHooks): Promise<MissionExecution> {
     const startedAt = iso(this.now);
     const taskStatus: Record<string, MissionTaskStatus> = {};
     for (const t of plan.tasks) taskStatus[t.taskId] = 'pending';
@@ -231,19 +241,25 @@ export class SquadCoordinator {
     const runOne = async (task: MissionTask): Promise<void> => {
       const agent = this.agentsById.get(task.role);
       if (!agent) {
-        taskStatus[task.taskId] = 'failed';
-        results.push({
+        const failResult: TaskRunResult = {
           taskId: task.taskId,
           agentId: task.role,
           startedAt: iso(this.now),
           finishedAt: iso(this.now),
           status: 'failed',
           error: { message: `No agent registered for role: ${task.role}` },
-        });
+        };
+        taskStatus[task.taskId] = 'failed';
+        results.push(failResult);
+        // Issue #184: Notify hooks of task failure
+        try { await hooks?.onTaskComplete?.(task, failResult); } catch { /* hook error ignored */ }
         markSkippedDependents(task.taskId);
         if (!this.continueOnFailure) throw new Error(`Task failed: ${task.title} (no agent for ${task.role})`);
         return;
       }
+
+      // Issue #184: Notify hooks of task start
+      try { await hooks?.onTaskStart?.(task, agent.id); } catch { /* hook error ignored */ }
 
       taskStatus[task.taskId] = 'running';
       const started = iso(this.now);
@@ -251,7 +267,7 @@ export class SquadCoordinator {
         const out = await agent.runTask(task, ctx);
         const finished = iso(this.now);
         taskStatus[task.taskId] = 'succeeded';
-        results.push({
+        const successResult: TaskRunResult = {
           taskId: task.taskId,
           agentId: agent.id,
           startedAt: started,
@@ -259,18 +275,24 @@ export class SquadCoordinator {
           status: 'succeeded',
           summary: out?.summary,
           artifacts: out?.artifacts,
-        });
+        };
+        results.push(successResult);
+        // Issue #184: Notify hooks of task completion
+        try { await hooks?.onTaskComplete?.(task, successResult); } catch { /* hook error ignored */ }
       } catch (err: any) {
         const finished = iso(this.now);
         taskStatus[task.taskId] = 'failed';
-        results.push({
+        const failResult: TaskRunResult = {
           taskId: task.taskId,
           agentId: agent.id,
           startedAt: started,
           finishedAt: finished,
           status: 'failed',
           error: { message: String(err?.message ?? err ?? 'Unknown error'), name: err?.name },
-        });
+        };
+        results.push(failResult);
+        // Issue #184: Notify hooks of task failure
+        try { await hooks?.onTaskComplete?.(task, failResult); } catch { /* hook error ignored */ }
         markSkippedDependents(task.taskId);
         if (!this.continueOnFailure) throw err;
       }


### PR DESCRIPTION
## Summary

Integrates the ConversationEngine into the multi-agent runtime so that real mission orchestration events (task dispatch, handoffs, phase transitions, completion) flow through conversation lifecycle and persist for dashboard visibility + mediation/security context.

## What Changed

### New: `lib/runtime-conversation-bridge.ts`
- **RuntimeConversationBridge** implements the `MissionRunnerHooks` interface
- On mission start → creates a conversation with all squad participants
- On task dispatch/completion → sends messages through the ConversationEngine
- On mission close → closes the conversation
- On mission error → pauses the conversation (resumable on retry)
- **Idempotent**: deterministic conversation IDs (`mission_<missionId>`)
- **Duplicate protection**: sent-message-key tracking prevents double-sends on resume
- **Graceful degradation**: all hooks wrapped in try/catch — engine errors never break mission execution
- **Observable**: `BridgeMetrics` exposes counts, failures, and timestamps

### Modified: `lib/mission-runner.ts`
- Added optional `hooks: MissionRunnerHooks` to `MissionRunnerConfig`
- Fires hooks at: mission create, phase transitions, mission close, mission error
- Passes `SquadExecutionHooks` to `executePlan()` for task-level events
- All hook calls wrapped in `safeHook()` — errors logged but never propagate

### Modified: `lib/squad-coordinator.ts`
- Added optional `SquadExecutionHooks` parameter to `executePlan()`
- Fires `onTaskStart` before each task and `onTaskComplete` after
- Hook errors caught inline — never affect task execution flow

### Modified: `lib/conversation-http.ts`
- Creates RuntimeConversationBridge singleton alongside the ConversationAPI
- Exports `getRuntimeBridge()` so MissionRunner callers can wire hooks
- Exports `resetSingletons()` for testing

## Tests (18 new, 999 existing all pass)

### `lib/__tests__/runtime-conversation-bridge.test.ts` (15 tests)
- Conversation creation, phase transitions, task events, close, error
- Idempotency, deduplication, graceful degradation, metrics tracking
- Type-level MissionRunnerHooks conformance check

### `lib/__tests__/mission-conversation-integration.test.ts` (3 tests)
- End-to-end: MissionRunner + Bridge → conversation with full lifecycle events
- Mission failure → conversation paused (not closed)
- Hook failure → mission still completes successfully (graceful degradation)

## Architecture

```
MissionRunner ──hooks──> RuntimeConversationBridge ──> ConversationAPI ──> ConversationEngine
     │                                                      │
     └── SquadCoordinator ──hooks──────────────────────────┘
                                                            │
                                                    SqliteConversationStore
                                                            │
                                                     Dashboard APIs
```

## How to Use

```typescript
import { getRuntimeBridge } from './lib/conversation-http';

// Initialize the conversation HTTP layer first (sets up singleton)
handleConversationApi(req, res, { dbPath: RPG_DB_PATH });

// Then wire bridge hooks into MissionRunner
const bridge = getRuntimeBridge();
const runner = new MissionRunner({
  agents: [...],
  hooks: bridge ?? undefined,
});
```

Fixes #184