### PR TITLE
feat: Phase 4.5 Deep Progression System — Phase 1 foundation

### DIFF
--- a/dashboard/server/routes/progression.ts
+++ b/dashboard/server/routes/progression.ts
@@ -1,0 +1,35 @@
+/**
+ * Progression route handler — Dashboard integration
+ *
+ * Thin adapter that integrates the monorepo's lib/progression-http module
+ * into the dashboard's HTTP server.
+ *
+ * Issue #203 — Phase 4.5 Deep Progression System (Phase 1 foundation)
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { ProgressionHandlerOptions } from '../../../lib/types/progression.js';
+import progressionHttp from '../../../lib/progression-http.js';
+
+const { handleProgressionApi } = progressionHttp as typeof import('../../../lib/progression-http.js');
+export { handleProgressionApi };
+export type { ProgressionHandlerOptions };
+
+/**
+ * Progression API route handler for the dashboard.
+ *
+ * Handles:
+ *   GET  /api/rpg/progression/summary       — Dashboard summary cards
+ *   GET  /api/rpg/progression/:agentId      — Full profile + tree state
+ *   POST /api/rpg/progression/events        — Ingest XP event (validated)
+ *   POST /api/rpg/progression/prestige      — Trigger prestige transition
+ *
+ * @returns true if the request was handled, false otherwise
+ */
+export function handleProgression(
+  req: IncomingMessage,
+  res: ServerResponse,
+  opts: ProgressionHandlerOptions,
+): boolean {
+  return handleProgressionApi(req, res, opts);
+}

--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -104,6 +104,7 @@ import { handleConversationApi } from './routes/conversation.js';
 import { handleTacticalMapControls } from './routes/tactical-map-controls.js';
 import { handleLogs } from './routes/logs.js';
 import { handleTacticalMapReplay } from './routes/tactical-map-replay.js';
+import { handleProgressionApi } from './routes/progression.js';
 
 // ─── Configuration ───────────────────────────────────────────────────────────
 // All VentureOS data paths flow through lib/paths.ts (no os.homedir() needed).
@@ -2808,6 +2809,9 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
 
   // VentureOS RPG APIs (Issue #78 — monorepo integration)
   if (handleRpgApi(req, res, { dbPath: RPG_DB_PATH })) return;
+
+  // VentureOS Progression APIs (Issue #203 — Phase 4.5)
+  if (handleProgressionApi(req, res, { dbPath: RPG_DB_PATH })) return;
 
   // VentureOS APIs
   if (req.url && req.url.startsWith('/api/ventureos-kpis')) {

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -12,6 +12,6 @@
     "isolatedModules": true,
     "resolveJsonModule": true
   },
-  "include": ["server/**/*.ts", "../lib/rpg-http.ts", "../lib/conversation-http.ts", "../lib/types/*.ts", "../lib/paths.ts", "../lib/http-types.ts", "../lib/error-handler.ts"],
+  "include": ["server/**/*.ts", "../lib/rpg-http.ts", "../lib/conversation-http.ts", "../lib/progression-http.ts", "../lib/progression-engine.ts", "../lib/progression-store.ts", "../lib/types/*.ts", "../lib/paths.ts", "../lib/http-types.ts", "../lib/error-handler.ts"],
   "exclude": ["dist", "node_modules", "tests"]
 }

--- a/docs/progression-system.md
+++ b/docs/progression-system.md
@@ -1,0 +1,143 @@
+# Phase 4.5 — Deep Progression System (Phase 1 Foundation)
+
+> Issue #203 | Roadmap #138
+
+## Overview
+
+The Deep Progression System adds persistent, meaningful progression mechanics to VentureOS agents. Phase 1 ships the foundational backbone: data persistence, a deterministic progression engine, validated API endpoints, and minimal dashboard visibility.
+
+## Architecture
+
+```
+lib/types/progression.ts     — Type contracts (profiles, events, prestige)
+lib/progression-engine.ts    — Pure-function math (XP, levels, diversification, prestige)
+lib/progression-store.ts     — SQLite persistence (ProgressionStore class)
+lib/progression-http.ts      — HTTP route handler
+dashboard/server/routes/progression.ts — Dashboard adapter
+```
+
+## Data Model
+
+### Tables
+
+| Table | Purpose |
+|-------|---------|
+| `progression_profiles` | Agent-level progression state (XP, level, prestige rank) |
+| `skill_nodes` | Skill tree node definitions (static) |
+| `skill_edges` | Prerequisite relationships between nodes |
+| `skill_unlocks` | Per-agent unlock state (reset on prestige) |
+| `xp_events` | XP ledger with source attribution and diversification metadata |
+| `prestige_records` | Prestige transition audit trail |
+
+All tables are auto-migrated on first database open (no manual migration needed).
+
+### Shared Database
+
+Progression tables live in the same SQLite database as the existing RPG system (`RPG_DB_PATH` from `lib/paths.ts`), keeping the operational footprint small.
+
+## Formulas
+
+### XP → Level
+
+```
+XP required for level N = floor(100 × (N - 1)^1.5)
+
+Level 1:   0 XP     Level 10:  ~3,162 XP
+Level 2: 100 XP     Level 20:  ~8,944 XP
+Level 5: 800 XP     Level 50: ~35,355 XP
+```
+
+### Diversification Weighting
+
+XP events are weighted by how diversely an agent earns XP across categories:
+
+| Unique categories used | Multiplier |
+|------------------------|------------|
+| 1                      | 0.5× (penalty for volume farming) |
+| 2-3                    | 0.5×-1.0× (scaling) |
+| 4-6                    | 1.0×-1.3× (bonus) |
+| 7+                     | 1.3×-1.5× (strong bonus, capped) |
+
+**Diversification Score** (0-100): Shannon entropy of category distribution, normalized by max possible entropy (log₂ of 10 categories).
+
+### XP Source Categories
+
+`mission_completion` · `code_review` · `documentation` · `bug_fix` · `deployment` · `collaboration` · `research` · `testing` · `observability` · `security`
+
+### Prestige
+
+Prestige resets current XP and level while preserving lifetime XP and incrementing rank:
+
+| From Rank | Min Level Required | Effect |
+|-----------|-------------------|--------|
+| 0 → 1    | 20                | Reset XP/level, keep lifetime XP |
+| 1 → 2    | 25                | Same |
+| N → N+1  | 20 + N×5          | Same (max rank: 10) |
+
+Skill unlocks reset on prestige. Prestige history is recorded as an audit trail.
+
+## API Endpoints
+
+### `GET /api/rpg/progression/summary`
+
+Dashboard summary cards. Returns all profiles with level/XP, today's aggregate stats, and top categories.
+
+### `GET /api/rpg/progression/:agentId`
+
+Full profile read: progression state, skill tree, unlock state, recent events, prestige history, next-level progress, and prestige eligibility.
+
+### `POST /api/rpg/progression/events`
+
+Ingest an XP event. Validates all fields, applies diversification weighting, returns the effective XP, updated profile, and level-up indicator.
+
+```json
+{
+  "agent_id": "oracle",
+  "raw_xp": 100,
+  "source_category": "mission_completion",
+  "source_description": "Completed sprint review"
+}
+```
+
+### `POST /api/rpg/progression/prestige`
+
+Trigger a prestige transition. Returns the prestige record and reset profile.
+
+```json
+{ "agent_id": "oracle" }
+```
+
+### Validation
+
+- `agent_id`: required, alphanumeric + hyphens/underscores, max 64 chars
+- `raw_xp`: required, must be a positive number
+- `source_category`: must be one of the 10 defined categories
+- `source_description`: required string, truncated to 500 chars
+- Invalid input returns `400` with `{ ok: false, error: "..." }`
+
+## Default Skill Tree
+
+5 categories × 3 tiers = 15 nodes. Each category (engineering, operations, analysis, communication, strategy) has:
+- **Tier 1**: Entry node, no prerequisites, 100 XP cost
+- **Tier 2**: Requires tier 1, 300 XP cost
+- **Tier 3**: Requires tier 2, 800 XP cost
+
+Auto-seeded on first database open.
+
+## Testing
+
+```bash
+# Unit tests (engine math)
+npx jest tests/unit/progression-engine.test.ts
+
+# Integration tests (store + HTTP)
+npx jest tests/integration/progression-store.test.ts
+npx jest tests/integration/progression-http.test.ts
+```
+
+## Out of Scope (Phase 1)
+
+- Visual skill tree authoring UI
+- Narrative/animation polish
+- Advanced balancing tools
+- Skill node unlock mutations (future phase)

--- a/lib/__tests__/progression-engine.test.ts
+++ b/lib/__tests__/progression-engine.test.ts
@@ -1,0 +1,261 @@
+/**
+ * Progression Engine — Unit Tests
+ *
+ * Tests for deterministic XP accumulation, diversification weighting,
+ * level thresholds, and prestige transition rules.
+ *
+ * Issue #203 — Phase 4.5 Deep Progression System (Phase 1 foundation)
+ */
+
+import {
+  xpForLevel,
+  levelFromXp,
+  levelProgress,
+  diversificationMultiplier,
+  diversificationScore,
+  isPrestigeEligible,
+  prestigeLevelRequirement,
+  prestigeXpRequirement,
+  isValidSourceCategory,
+  getDefaultSkillTree,
+  XP_SOURCE_CATEGORIES,
+  MAX_PRESTIGE_RANK,
+} from '../progression-engine';
+
+// ─── Level Thresholds ───────────────────────────────────────────────────────
+
+describe('xpForLevel', () => {
+  it('returns 0 for level 1', () => {
+    expect(xpForLevel(1)).toBe(0);
+  });
+
+  it('returns 0 for level 0 and negative', () => {
+    expect(xpForLevel(0)).toBe(0);
+    expect(xpForLevel(-5)).toBe(0);
+  });
+
+  it('returns 100 for level 2', () => {
+    expect(xpForLevel(2)).toBe(100);
+  });
+
+  it('is monotonically increasing', () => {
+    let prev = 0;
+    for (let i = 1; i <= 50; i++) {
+      const curr = xpForLevel(i);
+      expect(curr).toBeGreaterThanOrEqual(prev);
+      prev = curr;
+    }
+  });
+
+  it('produces expected values for sample levels', () => {
+    expect(xpForLevel(10)).toBeGreaterThan(2000);
+    expect(xpForLevel(20)).toBeGreaterThan(8000);
+    expect(xpForLevel(50)).toBeGreaterThan(30000);
+  });
+});
+
+describe('levelFromXp', () => {
+  it('returns 1 for 0 XP', () => {
+    expect(levelFromXp(0)).toBe(1);
+  });
+
+  it('returns 1 for negative XP', () => {
+    expect(levelFromXp(-100)).toBe(1);
+  });
+
+  it('returns 2 for exactly 100 XP', () => {
+    expect(levelFromXp(100)).toBe(2);
+  });
+
+  it('returns correct level for 99 XP (still level 1)', () => {
+    expect(levelFromXp(99)).toBe(1);
+  });
+
+  it('is consistent with xpForLevel', () => {
+    for (let lvl = 1; lvl <= 30; lvl++) {
+      const xp = xpForLevel(lvl);
+      expect(levelFromXp(xp)).toBe(lvl);
+    }
+  });
+
+  it('handles large XP values', () => {
+    expect(levelFromXp(1000000)).toBeGreaterThan(50);
+  });
+});
+
+describe('levelProgress', () => {
+  it('returns 0% for start of level', () => {
+    const progress = levelProgress(0);
+    expect(progress.progress_pct).toBe(0);
+  });
+
+  it('returns correct remaining XP', () => {
+    const progress = levelProgress(50);
+    expect(progress.xp_remaining).toBe(50); // Need 100 for level 2, have 50
+  });
+
+  it('returns 100% or close when about to level up', () => {
+    const threshold = xpForLevel(3);
+    const progress = levelProgress(threshold - 1);
+    expect(progress.progress_pct).toBeGreaterThan(90);
+  });
+});
+
+// ─── Diversification Weighting ──────────────────────────────────────────────
+
+describe('diversificationMultiplier', () => {
+  it('returns 1.0 for empty history', () => {
+    expect(diversificationMultiplier({})).toBe(1.0);
+  });
+
+  it('returns 0.5 for single category (volume farming penalty)', () => {
+    expect(diversificationMultiplier({ mission_completion: 50 })).toBe(0.5);
+  });
+
+  it('returns > 0.5 for 2 categories', () => {
+    const mult = diversificationMultiplier({ mission_completion: 10, code_review: 5 });
+    expect(mult).toBeGreaterThan(0.5);
+    expect(mult).toBeLessThanOrEqual(1.0);
+  });
+
+  it('returns >= 1.0 for 4+ categories (diversification bonus)', () => {
+    const mult = diversificationMultiplier({
+      mission_completion: 5,
+      code_review: 5,
+      documentation: 5,
+      bug_fix: 5,
+    });
+    expect(mult).toBeGreaterThanOrEqual(1.0);
+  });
+
+  it('returns <= 1.5 for many categories (capped)', () => {
+    const counts: Record<string, number> = {};
+    for (const cat of XP_SOURCE_CATEGORIES) {
+      counts[cat] = 3;
+    }
+    const mult = diversificationMultiplier(counts);
+    expect(mult).toBeLessThanOrEqual(1.5);
+    expect(mult).toBeGreaterThanOrEqual(1.3);
+  });
+
+  it('ignores categories with 0 count', () => {
+    const mult = diversificationMultiplier({
+      mission_completion: 10,
+      code_review: 0,
+    });
+    expect(mult).toBe(0.5); // Only 1 active category
+  });
+});
+
+describe('diversificationScore', () => {
+  it('returns 0 for empty or single category', () => {
+    expect(diversificationScore({})).toBe(0);
+    expect(diversificationScore({ mission_completion: 50 })).toBe(0);
+  });
+
+  it('returns > 0 for multiple categories', () => {
+    expect(diversificationScore({ mission_completion: 5, code_review: 5 })).toBeGreaterThan(0);
+  });
+
+  it('returns higher score for more even distribution', () => {
+    const skewed = diversificationScore({ mission_completion: 100, code_review: 1 });
+    const even = diversificationScore({ mission_completion: 50, code_review: 50 });
+    expect(even).toBeGreaterThan(skewed);
+  });
+
+  it('returns 0-100 range', () => {
+    const counts: Record<string, number> = {};
+    for (const cat of XP_SOURCE_CATEGORIES) {
+      counts[cat] = 10;
+    }
+    const score = diversificationScore(counts);
+    expect(score).toBeGreaterThanOrEqual(0);
+    expect(score).toBeLessThanOrEqual(100);
+  });
+});
+
+// ─── Prestige ───────────────────────────────────────────────────────────────
+
+describe('isPrestigeEligible', () => {
+  it('returns false at level 1', () => {
+    expect(isPrestigeEligible(1, 0, 0)).toBe(false);
+  });
+
+  it('returns true at level 20 with enough XP for rank 0→1', () => {
+    const reqXp = prestigeXpRequirement(0);
+    expect(isPrestigeEligible(20, 0, reqXp)).toBe(true);
+  });
+
+  it('requires higher level for higher ranks', () => {
+    expect(prestigeLevelRequirement(0)).toBe(20);
+    expect(prestigeLevelRequirement(1)).toBe(25);
+    expect(prestigeLevelRequirement(2)).toBe(30);
+  });
+
+  it('returns false when level is insufficient', () => {
+    expect(isPrestigeEligible(19, 0, 999999)).toBe(false);
+  });
+
+  it('returns false when lifetime XP is insufficient', () => {
+    expect(isPrestigeEligible(20, 0, 0)).toBe(false);
+  });
+});
+
+describe('MAX_PRESTIGE_RANK', () => {
+  it('is 10', () => {
+    expect(MAX_PRESTIGE_RANK).toBe(10);
+  });
+});
+
+// ─── Source Category Validation ─────────────────────────────────────────────
+
+describe('isValidSourceCategory', () => {
+  it('returns true for valid categories', () => {
+    for (const cat of XP_SOURCE_CATEGORIES) {
+      expect(isValidSourceCategory(cat)).toBe(true);
+    }
+  });
+
+  it('returns false for invalid categories', () => {
+    expect(isValidSourceCategory('invalid')).toBe(false);
+    expect(isValidSourceCategory('')).toBe(false);
+    expect(isValidSourceCategory('MISSION_COMPLETION')).toBe(false);
+  });
+});
+
+// ─── Skill Tree ─────────────────────────────────────────────────────────────
+
+describe('getDefaultSkillTree', () => {
+  it('returns 15 nodes (3 per category × 5 categories)', () => {
+    const tree = getDefaultSkillTree();
+    expect(tree.nodes).toHaveLength(15);
+  });
+
+  it('returns edges matching prerequisites', () => {
+    const tree = getDefaultSkillTree();
+    expect(tree.edges.length).toBeGreaterThan(0);
+    // Each tier 2+ node should have an edge from its prerequisite
+    for (const edge of tree.edges) {
+      const target = tree.nodes.find((n) => n.node_id === edge.to_node_id);
+      expect(target).toBeDefined();
+      expect(target!.prerequisites).toContain(edge.from_node_id);
+    }
+  });
+
+  it('has valid categories', () => {
+    const tree = getDefaultSkillTree();
+    const validCats = ['engineering', 'operations', 'analysis', 'communication', 'strategy'];
+    for (const node of tree.nodes) {
+      expect(validCats).toContain(node.category);
+    }
+  });
+
+  it('has tier 1 nodes with no prerequisites', () => {
+    const tree = getDefaultSkillTree();
+    const tier1 = tree.nodes.filter((n) => n.tier === 1);
+    expect(tier1.length).toBe(5); // One per category
+    for (const node of tier1) {
+      expect(node.prerequisites).toHaveLength(0);
+    }
+  });
+});

--- a/lib/__tests__/progression-http.test.ts
+++ b/lib/__tests__/progression-http.test.ts
@@ -1,0 +1,203 @@
+/**
+ * Progression HTTP API — Integration Tests
+ *
+ * Tests for the progression API routes: summary, profile read,
+ * XP event ingestion, prestige, and validation error paths.
+ *
+ * Issue #203 — Phase 4.5 Deep Progression System (Phase 1 foundation)
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import http from 'node:http';
+import { handleProgressionApi } from '../progression-http';
+import { ProgressionStore } from '../progression-store';
+
+function tempDbPath(): string {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prog-http-'));
+  return path.join(tmpDir, 'test-progression.db');
+}
+
+/** Simulate an HTTP request to the progression API. */
+function fakeRequest(
+  dbPathArg: string,
+  method: string,
+  url: string,
+  body?: Record<string, unknown>,
+): Promise<{ status: number; body: Record<string, unknown> }> {
+  return new Promise((resolve) => {
+    let resolvedStatus = 200;
+    let resolvedBody = '{}';
+
+    // Create a mock request
+    const req = Object.create(http.IncomingMessage.prototype) as http.IncomingMessage & {
+      _events: Record<string, Function[]>;
+      _readableState: { ended: boolean };
+    };
+    (req as any).url = url;
+    (req as any).method = method;
+    (req as any).headers = { host: 'localhost', 'content-type': 'application/json' };
+    (req as any)._events = {};
+    (req as any)._readableState = { ended: false };
+
+    // Simple event emitter
+    const listeners: Record<string, Function[]> = {};
+    req.on = ((event: string, cb: Function) => {
+      if (!listeners[event]) listeners[event] = [];
+      listeners[event].push(cb);
+      return req;
+    }) as any;
+
+    function emit(event: string, ...args: unknown[]) {
+      for (const cb of listeners[event] ?? []) {
+        cb(...args);
+      }
+    }
+
+    // Create a mock response
+    const res = {
+      writeHead(code: number, headers?: Record<string, string>) {
+        resolvedStatus = code;
+        return res;
+      },
+      end(data?: string) {
+        resolvedBody = data ?? '{}';
+        try {
+          resolve({ status: resolvedStatus, body: JSON.parse(resolvedBody) });
+        } catch {
+          resolve({ status: resolvedStatus, body: {} });
+        }
+      },
+      setHeader() {},
+      getHeader() { return undefined; },
+      write() { return true; },
+    } as unknown as http.ServerResponse;
+
+    const handled = handleProgressionApi(req, res, { dbPath: dbPathArg });
+
+    if (!handled) {
+      resolve({ status: 404, body: { error: 'not handled' } });
+      return;
+    }
+
+    // For POST requests, emit body data after handler sets up listeners
+    if (body && method === 'POST') {
+      const bodyStr = JSON.stringify(body);
+      setImmediate(() => {
+        emit('data', Buffer.from(bodyStr));
+        emit('end');
+      });
+    }
+  });
+}
+
+let dbPath: string;
+
+beforeEach(() => {
+  dbPath = tempDbPath();
+  // Initialize the store to ensure schema is created
+  const store = new ProgressionStore(dbPath);
+  store.close();
+});
+
+afterEach(() => {
+  try { fs.rmSync(path.dirname(dbPath), { recursive: true }); } catch { /* ignore */ }
+});
+
+// ─── Summary Endpoint ───────────────────────────────────────────────────────
+
+describe('GET /api/rpg/progression/summary', () => {
+  it('returns empty summary when no profiles exist', async () => {
+    const { status, body } = await fakeRequest(dbPath, 'GET', '/api/rpg/progression/summary');
+    expect(status).toBe(200);
+    expect((body as any).profiles).toEqual([]);
+    expect((body as any).total_xp_today).toBe(0);
+  });
+});
+
+// ─── Profile Endpoint ───────────────────────────────────────────────────────
+
+describe('GET /api/rpg/progression/:agentId', () => {
+  it('returns profile with skill tree for new agent', async () => {
+    const { status, body } = await fakeRequest(dbPath, 'GET', '/api/rpg/progression/oracle');
+    expect(status).toBe(200);
+    expect((body as any).profile.agent_id).toBe('oracle');
+    expect((body as any).profile.level).toBe(1);
+    expect((body as any).skill_tree.nodes.length).toBe(15);
+    expect((body as any).prestige_eligible).toBe(false);
+  });
+});
+
+// ─── XP Event Ingestion ─────────────────────────────────────────────────────
+
+describe('POST /api/rpg/progression/events', () => {
+  it('ingests a valid XP event', async () => {
+    const { status, body } = await fakeRequest(dbPath, 'POST', '/api/rpg/progression/events', {
+      agent_id: 'oracle',
+      raw_xp: 100,
+      source_category: 'mission_completion',
+      source_description: 'Completed a mission',
+    });
+    expect(status).toBe(201);
+    expect((body as any).ok).toBe(true);
+    expect((body as any).event.raw_xp).toBe(100);
+    expect((body as any).profile.current_xp).toBeGreaterThan(0);
+  });
+
+  it('rejects missing agent_id', async () => {
+    const { status, body } = await fakeRequest(dbPath, 'POST', '/api/rpg/progression/events', {
+      raw_xp: 100,
+      source_category: 'mission_completion',
+      source_description: 'Test',
+    });
+    expect(status).toBe(400);
+    expect((body as any).ok).toBe(false);
+  });
+
+  it('rejects non-positive XP', async () => {
+    const { status, body } = await fakeRequest(dbPath, 'POST', '/api/rpg/progression/events', {
+      agent_id: 'oracle',
+      raw_xp: -5,
+      source_category: 'mission_completion',
+      source_description: 'Test',
+    });
+    expect(status).toBe(400);
+    expect((body as any).ok).toBe(false);
+  });
+
+  it('rejects invalid source_category', async () => {
+    const { status, body } = await fakeRequest(dbPath, 'POST', '/api/rpg/progression/events', {
+      agent_id: 'oracle',
+      raw_xp: 50,
+      source_category: 'hacking',
+      source_description: 'Test',
+    });
+    expect(status).toBe(400);
+    expect((body as any).ok).toBe(false);
+  });
+
+  it('rejects missing source_description', async () => {
+    const { status, body } = await fakeRequest(dbPath, 'POST', '/api/rpg/progression/events', {
+      agent_id: 'oracle',
+      raw_xp: 50,
+      source_category: 'mission_completion',
+    });
+    expect(status).toBe(400);
+    expect((body as any).ok).toBe(false);
+  });
+});
+
+// ─── Route Matching ─────────────────────────────────────────────────────────
+
+describe('Route matching', () => {
+  it('does not handle unrelated paths', async () => {
+    const { status } = await fakeRequest(dbPath, 'GET', '/api/rpg/stats');
+    expect(status).toBe(404); // Not handled
+  });
+
+  it('does not handle paths outside /api/rpg/progression', async () => {
+    const { status } = await fakeRequest(dbPath, 'GET', '/api/other');
+    expect(status).toBe(404);
+  });
+});

--- a/lib/__tests__/progression-store.test.ts
+++ b/lib/__tests__/progression-store.test.ts
@@ -1,0 +1,298 @@
+/**
+ * Progression Store — Integration Tests
+ *
+ * Tests for SQLite persistence: profiles, XP ingestion with diversification,
+ * prestige transitions, and skill tree seeding.
+ *
+ * Uses a temporary in-memory or file-based database per test.
+ *
+ * Issue #203 — Phase 4.5 Deep Progression System (Phase 1 foundation)
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { ProgressionStore } from '../progression-store';
+import { xpForLevel, levelFromXp, prestigeLevelRequirement } from '../progression-engine';
+
+function tempDbPath(): string {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'prog-test-'));
+  return path.join(tmpDir, 'test-progression.db');
+}
+
+// ─── Profile Operations ─────────────────────────────────────────────────────
+
+describe('ProgressionStore — Profiles', () => {
+  let store: ProgressionStore;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = tempDbPath();
+    store = new ProgressionStore(dbPath);
+  });
+
+  afterEach(() => {
+    store.close();
+    try { fs.rmSync(path.dirname(dbPath), { recursive: true }); } catch { /* ignore */ }
+  });
+
+  it('creates a new profile with default values', () => {
+    const profile = store.getOrCreateProfile('oracle', 'Oracle');
+    expect(profile.agent_id).toBe('oracle');
+    expect(profile.display_name).toBe('Oracle');
+    expect(profile.current_xp).toBe(0);
+    expect(profile.lifetime_xp).toBe(0);
+    expect(profile.level).toBe(1);
+    expect(profile.prestige_rank).toBe(0);
+    expect(profile.diversification_score).toBe(0);
+  });
+
+  it('returns existing profile on repeated calls', () => {
+    store.getOrCreateProfile('oracle', 'Oracle');
+    const again = store.getOrCreateProfile('oracle', 'Different Name');
+    expect(again.display_name).toBe('Oracle'); // Original name preserved
+  });
+
+  it('returns null for getProfile when not found', () => {
+    expect(store.getProfile('nonexistent')).toBeNull();
+  });
+
+  it('lists all profiles sorted by level desc', () => {
+    store.getOrCreateProfile('a');
+    store.getOrCreateProfile('b');
+    const profiles = store.listProfiles();
+    expect(profiles).toHaveLength(2);
+  });
+});
+
+// ─── XP Event Ingestion ─────────────────────────────────────────────────────
+
+describe('ProgressionStore — XP Ingestion', () => {
+  let store: ProgressionStore;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = tempDbPath();
+    store = new ProgressionStore(dbPath);
+  });
+
+  afterEach(() => {
+    store.close();
+    try { fs.rmSync(path.dirname(dbPath), { recursive: true }); } catch { /* ignore */ }
+  });
+
+  it('ingests an XP event and updates profile', () => {
+    const result = store.ingestXpEvent('oracle', 50, 'mission_completion', 'Completed task');
+    expect(result.event.agent_id).toBe('oracle');
+    expect(result.event.raw_xp).toBe(50);
+    expect(result.event.source_category).toBe('mission_completion');
+    expect(result.event.effective_xp).toBeGreaterThan(0);
+    expect(result.profile.current_xp).toBeGreaterThan(0);
+    expect(result.profile.lifetime_xp).toBeGreaterThan(0);
+  });
+
+  it('applies diversification penalty for single category', () => {
+    // First event from one category
+    const r1 = store.ingestXpEvent('oracle', 100, 'mission_completion', 'Task 1');
+    // Multiplier should be 0.5 (single category penalty)
+    expect(r1.event.diversification_multiplier).toBe(0.5);
+    expect(r1.event.effective_xp).toBe(50); // 100 * 0.5
+  });
+
+  it('applies diversification bonus for diverse categories', () => {
+    // Ingest events across multiple categories first
+    store.ingestXpEvent('oracle', 100, 'mission_completion', 'Task 1');
+    store.ingestXpEvent('oracle', 100, 'code_review', 'Review 1');
+    store.ingestXpEvent('oracle', 100, 'documentation', 'Docs 1');
+    store.ingestXpEvent('oracle', 100, 'bug_fix', 'Fix 1');
+
+    // Now ingest another — should have decent multiplier
+    const result = store.ingestXpEvent('oracle', 100, 'testing', 'Test 1');
+    expect(result.event.diversification_multiplier).toBeGreaterThan(0.8);
+  });
+
+  it('detects level-up', () => {
+    // Need 100 XP for level 2. With single-cat penalty (0.5), need 200 raw.
+    // Let's use diverse categories for better multiplier.
+    store.ingestXpEvent('oracle', 30, 'mission_completion', 'Task 1');
+    store.ingestXpEvent('oracle', 30, 'code_review', 'Review 1');
+    store.ingestXpEvent('oracle', 30, 'documentation', 'Docs 1');
+    const r = store.ingestXpEvent('oracle', 200, 'bug_fix', 'Fix 1');
+
+    expect(r.profile.level).toBeGreaterThanOrEqual(2);
+    expect(r.levelUp).toBe(true);
+  });
+
+  it('rejects non-positive XP', () => {
+    expect(() => store.ingestXpEvent('oracle', 0, 'mission_completion', 'Nope')).toThrow();
+    expect(() => store.ingestXpEvent('oracle', -10, 'mission_completion', 'Nope')).toThrow();
+  });
+
+  it('rejects invalid source category', () => {
+    expect(() =>
+      store.ingestXpEvent('oracle', 50, 'invalid_category' as any, 'Nope'),
+    ).toThrow('Invalid source_category');
+  });
+
+  it('accumulates XP correctly over multiple events', () => {
+    store.ingestXpEvent('oracle', 10, 'mission_completion', 'T1');
+    store.ingestXpEvent('oracle', 10, 'code_review', 'T2');
+    store.ingestXpEvent('oracle', 10, 'documentation', 'T3');
+    store.ingestXpEvent('oracle', 10, 'bug_fix', 'T4');
+    const result = store.ingestXpEvent('oracle', 10, 'testing', 'T5');
+
+    expect(result.profile.lifetime_xp).toBeGreaterThan(0);
+    expect(result.profile.current_xp).toBe(result.profile.lifetime_xp);
+
+    // Verify events are retrievable
+    const events = store.getRecentEvents('oracle', 10);
+    expect(events).toHaveLength(5);
+  });
+
+  it('updates diversification score', () => {
+    store.ingestXpEvent('oracle', 10, 'mission_completion', 'T1');
+    store.ingestXpEvent('oracle', 10, 'code_review', 'T2');
+    store.ingestXpEvent('oracle', 10, 'documentation', 'T3');
+    store.ingestXpEvent('oracle', 10, 'bug_fix', 'T4');
+    const result = store.ingestXpEvent('oracle', 10, 'testing', 'T5');
+    expect(result.profile.diversification_score).toBeGreaterThan(0);
+  });
+});
+
+// ─── Prestige Operations ────────────────────────────────────────────────────
+
+describe('ProgressionStore — Prestige', () => {
+  let store: ProgressionStore;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = tempDbPath();
+    store = new ProgressionStore(dbPath);
+  });
+
+  afterEach(() => {
+    store.close();
+    try { fs.rmSync(path.dirname(dbPath), { recursive: true }); } catch { /* ignore */ }
+  });
+
+  it('rejects prestige for non-existent profile', () => {
+    expect(() => store.prestigeTransition('nobody')).toThrow('Profile not found');
+  });
+
+  it('rejects prestige when level is too low', () => {
+    store.getOrCreateProfile('oracle');
+    expect(() => store.prestigeTransition('oracle')).toThrow('Not eligible');
+  });
+
+  it('executes prestige transition when eligible', () => {
+    // Build up enough XP to reach level 20
+    const reqXp = xpForLevel(20);
+    // Need to ingest enough XP. Use diverse categories for good multiplier.
+    const categories = [
+      'mission_completion', 'code_review', 'documentation', 'bug_fix',
+      'deployment', 'collaboration', 'research', 'testing',
+    ] as const;
+
+    let totalEffective = 0;
+    let idx = 0;
+    while (totalEffective < reqXp + 1000) {
+      const cat = categories[idx % categories.length];
+      const result = store.ingestXpEvent('oracle', 500, cat, `Event ${idx}`);
+      totalEffective = result.profile.current_xp;
+      idx++;
+      if (idx > 200) break; // Safety
+    }
+
+    const profile = store.getProfile('oracle')!;
+    expect(profile.level).toBeGreaterThanOrEqual(20);
+
+    // Execute prestige
+    const record = store.prestigeTransition('oracle');
+    expect(record.from_rank).toBe(0);
+    expect(record.to_rank).toBe(1);
+    expect(record.xp_at_prestige).toBeGreaterThan(0);
+    expect(record.level_at_prestige).toBeGreaterThanOrEqual(20);
+
+    // Verify profile was reset
+    const after = store.getProfile('oracle')!;
+    expect(after.current_xp).toBe(0);
+    expect(after.level).toBe(1);
+    expect(after.prestige_rank).toBe(1);
+    expect(after.lifetime_xp).toBeGreaterThan(0); // Lifetime preserved
+
+    // Verify history
+    const history = store.getPrestigeHistory('oracle');
+    expect(history).toHaveLength(1);
+    expect(history[0].to_rank).toBe(1);
+  });
+});
+
+// ─── Skill Tree ─────────────────────────────────────────────────────────────
+
+describe('ProgressionStore — Skill Tree', () => {
+  let store: ProgressionStore;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = tempDbPath();
+    store = new ProgressionStore(dbPath);
+  });
+
+  afterEach(() => {
+    store.close();
+    try { fs.rmSync(path.dirname(dbPath), { recursive: true }); } catch { /* ignore */ }
+  });
+
+  it('seeds default skill tree on creation', () => {
+    const nodes = store.getSkillNodes();
+    expect(nodes).toHaveLength(15);
+    const edges = store.getSkillEdges();
+    expect(edges.length).toBeGreaterThan(0);
+  });
+
+  it('does not duplicate nodes on re-open', () => {
+    store.close();
+    const store2 = new ProgressionStore(dbPath);
+    const nodes = store2.getSkillNodes();
+    expect(nodes).toHaveLength(15);
+    store2.close();
+  });
+
+  it('returns empty unlocks for new agent', () => {
+    const unlocks = store.getUnlocks('oracle');
+    expect(unlocks).toHaveLength(0);
+  });
+});
+
+// ─── Today Stats ────────────────────────────────────────────────────────────
+
+describe('ProgressionStore — Today Stats', () => {
+  let store: ProgressionStore;
+  let dbPath: string;
+
+  beforeEach(() => {
+    dbPath = tempDbPath();
+    store = new ProgressionStore(dbPath);
+  });
+
+  afterEach(() => {
+    store.close();
+    try { fs.rmSync(path.dirname(dbPath), { recursive: true }); } catch { /* ignore */ }
+  });
+
+  it('returns zero stats when no events', () => {
+    const stats = store.getTodayEvents();
+    expect(stats.total_xp).toBe(0);
+    expect(stats.total_count).toBe(0);
+    expect(stats.top_categories).toHaveLength(0);
+  });
+
+  it('counts today events correctly', () => {
+    store.ingestXpEvent('oracle', 50, 'mission_completion', 'T1');
+    store.ingestXpEvent('oracle', 30, 'code_review', 'T2');
+    const stats = store.getTodayEvents();
+    expect(stats.total_count).toBe(2);
+    expect(stats.total_xp).toBeGreaterThan(0);
+    expect(stats.top_categories.length).toBeGreaterThan(0);
+  });
+});

--- a/lib/progression-engine.ts
+++ b/lib/progression-engine.ts
@@ -1,0 +1,222 @@
+/**
+ * Progression Engine — VentureOS Phase 4.5
+ *
+ * Deterministic progression math: XP accumulation, diversification weighting,
+ * level/rank thresholds, and prestige transition rules.
+ *
+ * All formulas are pure functions with no side effects for easy testing.
+ *
+ * Issue #203 — Phase 4.5 Deep Progression System (Phase 1 foundation)
+ */
+
+import type {
+  XpSourceCategory,
+  SkillNode,
+  SkillCategory,
+  SkillEdge,
+} from './types/progression';
+
+// ─── Level Thresholds ───────────────────────────────────────────────────────
+
+/**
+ * XP required to reach a given level (1-indexed).
+ * Uses a quadratic curve: level N requires 100 * N^1.5 cumulative XP.
+ *
+ * Level 1: 0 XP (starting level)
+ * Level 2: 100 XP
+ * Level 3: ~283 XP
+ * Level 10: ~3162 XP
+ * Level 20: ~8944 XP
+ * Level 50: ~35355 XP
+ */
+export function xpForLevel(level: number): number {
+  if (level <= 1) return 0;
+  return Math.floor(100 * Math.pow(level - 1, 1.5));
+}
+
+/**
+ * Derive the current level from cumulative XP.
+ * Scans from level 1 upward until XP is insufficient for the next level.
+ */
+export function levelFromXp(xp: number): number {
+  if (xp < 0) return 1;
+  let level = 1;
+  while (xpForLevel(level + 1) <= xp) {
+    level++;
+    // Safety cap to prevent infinite loops
+    if (level >= 999) break;
+  }
+  return level;
+}
+
+/**
+ * Progress toward the next level, as a fraction 0..1.
+ */
+export function levelProgress(xp: number): { xp_required: number; xp_remaining: number; progress_pct: number } {
+  const currentLevel = levelFromXp(xp);
+  const currentThreshold = xpForLevel(currentLevel);
+  const nextThreshold = xpForLevel(currentLevel + 1);
+  const xpRequired = nextThreshold - currentThreshold;
+  const xpIntoLevel = xp - currentThreshold;
+  const xpRemaining = nextThreshold - xp;
+  const progressPct = xpRequired > 0 ? Math.min(100, Math.round((xpIntoLevel / xpRequired) * 100)) : 100;
+  return { xp_required: xpRequired, xp_remaining: xpRemaining, progress_pct: progressPct };
+}
+
+// ─── Diversification Weighting ──────────────────────────────────────────────
+
+/**
+ * All valid XP source categories.
+ */
+export const XP_SOURCE_CATEGORIES: readonly XpSourceCategory[] = [
+  'mission_completion',
+  'code_review',
+  'documentation',
+  'bug_fix',
+  'deployment',
+  'collaboration',
+  'research',
+  'testing',
+  'observability',
+  'security',
+] as const;
+
+/**
+ * Validate that a string is a valid XP source category.
+ */
+export function isValidSourceCategory(s: string): s is XpSourceCategory {
+  return (XP_SOURCE_CATEGORIES as readonly string[]).includes(s);
+}
+
+/**
+ * Calculate diversification multiplier based on recent event distribution.
+ *
+ * The multiplier rewards agents who earn XP across diverse categories:
+ * - If all recent events come from 1 category → multiplier = 0.5 (penalty)
+ * - If events come from 2-3 categories → multiplier = 0.8-1.0 (neutral)
+ * - If events come from 4-6 categories → multiplier = 1.0-1.3 (bonus)
+ * - If events come from 7+ categories → multiplier = 1.3-1.5 (strong bonus)
+ *
+ * @param recentCategoryCounts Map of category → count for recent events
+ * @returns Multiplier to apply to raw XP (0.5 to 1.5)
+ */
+export function diversificationMultiplier(
+  recentCategoryCounts: Record<string, number>,
+): number {
+  const categories = Object.keys(recentCategoryCounts).filter(
+    (k) => (recentCategoryCounts[k] ?? 0) > 0,
+  );
+  const uniqueCount = categories.length;
+
+  if (uniqueCount <= 0) return 1.0; // No history → neutral
+  if (uniqueCount === 1) return 0.5; // Pure volume farming → penalty
+  if (uniqueCount <= 3) return 0.5 + (uniqueCount / 3) * 0.5; // 0.5 → 1.0
+  if (uniqueCount <= 6) return 1.0 + ((uniqueCount - 3) / 3) * 0.3; // 1.0 → 1.3
+  return Math.min(1.5, 1.3 + ((uniqueCount - 6) / 4) * 0.2); // 1.3 → 1.5 (capped)
+}
+
+/**
+ * Calculate a diversification score (0-100) from category counts.
+ * Uses Shannon entropy normalized by max possible entropy.
+ */
+export function diversificationScore(
+  recentCategoryCounts: Record<string, number>,
+): number {
+  const counts = Object.values(recentCategoryCounts).filter((c) => c > 0);
+  if (counts.length <= 1) return 0;
+
+  const total = counts.reduce((a, b) => a + b, 0);
+  if (total === 0) return 0;
+
+  // Shannon entropy
+  let entropy = 0;
+  for (const count of counts) {
+    const p = count / total;
+    if (p > 0) entropy -= p * Math.log2(p);
+  }
+
+  // Normalize by max entropy (log2 of number of possible categories)
+  const maxEntropy = Math.log2(XP_SOURCE_CATEGORIES.length);
+  const normalized = maxEntropy > 0 ? entropy / maxEntropy : 0;
+
+  return Math.round(normalized * 100);
+}
+
+// ─── Prestige ───────────────────────────────────────────────────────────────
+
+/**
+ * Minimum level required to prestige at each rank.
+ * Rank 0→1 requires level 20, rank 1→2 requires level 25, etc.
+ */
+export function prestigeLevelRequirement(currentRank: number): number {
+  return 20 + currentRank * 5;
+}
+
+/**
+ * Minimum lifetime XP required to prestige at each rank.
+ */
+export function prestigeXpRequirement(currentRank: number): number {
+  return xpForLevel(prestigeLevelRequirement(currentRank));
+}
+
+/**
+ * Check if an agent is eligible for prestige transition.
+ */
+export function isPrestigeEligible(
+  level: number,
+  currentRank: number,
+  lifetimeXp: number,
+): boolean {
+  const reqLevel = prestigeLevelRequirement(currentRank);
+  const reqXp = prestigeXpRequirement(currentRank);
+  return level >= reqLevel && lifetimeXp >= reqXp;
+}
+
+/**
+ * Maximum prestige rank (soft cap).
+ */
+export const MAX_PRESTIGE_RANK = 10;
+
+// ─── Default Skill Tree ────────────────────────────────────────────────────
+
+/**
+ * Default skill tree nodes for the Phase 1 foundation.
+ * Each category has 3 tiers of nodes.
+ */
+export function getDefaultSkillTree(): { nodes: SkillNode[]; edges: SkillEdge[] } {
+  const nodes: SkillNode[] = [
+    // Engineering
+    { node_id: 'eng-1', name: 'Code Foundations', description: 'Basic code contribution proficiency', category: 'engineering', xp_cost: 100, tier: 1, prerequisites: [] },
+    { node_id: 'eng-2', name: 'Architecture', description: 'System design and architecture skills', category: 'engineering', xp_cost: 300, tier: 2, prerequisites: ['eng-1'] },
+    { node_id: 'eng-3', name: 'Mastery', description: 'Engineering mastery across complex systems', category: 'engineering', xp_cost: 800, tier: 3, prerequisites: ['eng-2'] },
+
+    // Operations
+    { node_id: 'ops-1', name: 'Deployment Basics', description: 'CI/CD and deployment fundamentals', category: 'operations', xp_cost: 100, tier: 1, prerequisites: [] },
+    { node_id: 'ops-2', name: 'Reliability', description: 'SRE practices and incident response', category: 'operations', xp_cost: 300, tier: 2, prerequisites: ['ops-1'] },
+    { node_id: 'ops-3', name: 'Orchestration', description: 'Complex multi-system orchestration', category: 'operations', xp_cost: 800, tier: 3, prerequisites: ['ops-2'] },
+
+    // Analysis
+    { node_id: 'ana-1', name: 'Data Literacy', description: 'Basic data analysis and interpretation', category: 'analysis', xp_cost: 100, tier: 1, prerequisites: [] },
+    { node_id: 'ana-2', name: 'Insight Mining', description: 'Pattern recognition and deep analysis', category: 'analysis', xp_cost: 300, tier: 2, prerequisites: ['ana-1'] },
+    { node_id: 'ana-3', name: 'Predictive Models', description: 'Advanced predictive analysis capabilities', category: 'analysis', xp_cost: 800, tier: 3, prerequisites: ['ana-2'] },
+
+    // Communication
+    { node_id: 'com-1', name: 'Clear Reporting', description: 'Effective status and progress reporting', category: 'communication', xp_cost: 100, tier: 1, prerequisites: [] },
+    { node_id: 'com-2', name: 'Documentation', description: 'Comprehensive documentation authoring', category: 'communication', xp_cost: 300, tier: 2, prerequisites: ['com-1'] },
+    { node_id: 'com-3', name: 'Knowledge Synthesis', description: 'Cross-domain knowledge synthesis and teaching', category: 'communication', xp_cost: 800, tier: 3, prerequisites: ['com-2'] },
+
+    // Strategy
+    { node_id: 'str-1', name: 'Task Planning', description: 'Basic task breakdown and prioritization', category: 'strategy', xp_cost: 100, tier: 1, prerequisites: [] },
+    { node_id: 'str-2', name: 'Mission Design', description: 'Complex mission architecture and coordination', category: 'strategy', xp_cost: 300, tier: 2, prerequisites: ['str-1'] },
+    { node_id: 'str-3', name: 'Strategic Vision', description: 'Long-term strategic planning and roadmap design', category: 'strategy', xp_cost: 800, tier: 3, prerequisites: ['str-2'] },
+  ];
+
+  const edges: SkillEdge[] = [];
+  for (const node of nodes) {
+    for (const prereq of node.prerequisites) {
+      edges.push({ from_node_id: prereq, to_node_id: node.node_id });
+    }
+  }
+
+  return { nodes, edges };
+}

--- a/lib/progression-http.ts
+++ b/lib/progression-http.ts
@@ -1,0 +1,333 @@
+/**
+ * Progression HTTP Route Handler — VentureOS Phase 4.5
+ *
+ * HTTP API surface for the progression system. Integrates with the
+ * dashboard's node:http server via handleProgressionApi().
+ *
+ * Routes:
+ *   GET  /api/rpg/progression/summary       — Dashboard summary cards
+ *   GET  /api/rpg/progression/:agentId      — Full profile + tree state
+ *   POST /api/rpg/progression/events        — Ingest XP event
+ *   POST /api/rpg/progression/prestige      — Trigger prestige transition
+ *
+ * Issue #203 — Phase 4.5 Deep Progression System (Phase 1 foundation)
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type {
+  ProgressionHandlerOptions,
+  ProgressionProfileResponse,
+  ProgressionSummaryResponse,
+  IngestXpEventRequest,
+  IngestXpEventResponse,
+  PrestigeRequest,
+  PrestigeResponse,
+  ProgressionErrorResponse,
+} from './types/progression';
+import { ProgressionStore } from './progression-store';
+import { levelProgress, isPrestigeEligible, isValidSourceCategory } from './progression-engine';
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function sendJson(res: ServerResponse, status: number, body: unknown): void {
+  const json = JSON.stringify(body, null, 2);
+  res.writeHead(status, { 'content-type': 'application/json; charset=utf-8' });
+  res.end(json);
+}
+
+function parseUrl(req: IncomingMessage): URL | null {
+  if (!req.url) return null;
+  try {
+    return new URL(req.url, `http://${req.headers.host ?? 'localhost'}`);
+  } catch {
+    return null;
+  }
+}
+
+async function readBody(req: IncomingMessage, maxBytes: number = 65536): Promise<string> {
+  return new Promise<string>((resolve, reject) => {
+    let data = '';
+    let bytes = 0;
+    req.on('data', (chunk: Buffer) => {
+      bytes += chunk.length;
+      if (bytes > maxBytes) {
+        try { req.destroy(); } catch { /* ignore */ }
+        reject(new Error('Request body too large'));
+        return;
+      }
+      data += chunk.toString('utf8');
+    });
+    req.on('end', () => resolve(data));
+    req.on('error', reject);
+  });
+}
+
+function sendError(res: ServerResponse, status: number, error: string): void {
+  const body: ProgressionErrorResponse = { ok: false, error };
+  sendJson(res, status, body);
+}
+
+function openStore(dbPath: string): ProgressionStore {
+  return new ProgressionStore(dbPath);
+}
+
+// ─── Sync Route Handlers ────────────────────────────────────────────────────
+
+function handleSummary(dbPath: string, res: ServerResponse): void {
+  const store = openStore(dbPath);
+  try {
+    const profiles = store.listProfiles();
+    const todayStats = store.getTodayEvents();
+
+    const summaryProfiles = profiles.map((p) => {
+      const progress = levelProgress(p.current_xp);
+      return {
+        agent_id: p.agent_id,
+        display_name: p.display_name,
+        level: p.level,
+        current_xp: p.current_xp,
+        prestige_rank: p.prestige_rank,
+        diversification_score: p.diversification_score,
+        next_level_pct: progress.progress_pct,
+      };
+    });
+
+    const body: ProgressionSummaryResponse = {
+      profiles: summaryProfiles,
+      total_xp_today: todayStats.total_xp,
+      total_events_today: todayStats.total_count,
+      top_categories: todayStats.top_categories,
+    };
+
+    sendJson(res, 200, body);
+  } finally {
+    store.close();
+  }
+}
+
+function handleProfile(dbPath: string, res: ServerResponse, agentId: string): void {
+  const store = openStore(dbPath);
+  try {
+    const profile = store.getOrCreateProfile(agentId);
+    const unlocks = store.getUnlocks(agentId);
+    const nodes = store.getSkillNodes();
+    const edges = store.getSkillEdges();
+    const recentEvents = store.getRecentEvents(agentId, 20);
+    const prestigeHistory = store.getPrestigeHistory(agentId);
+    const progress = levelProgress(profile.current_xp);
+    const prestigeEligible = isPrestigeEligible(
+      profile.level,
+      profile.prestige_rank,
+      profile.lifetime_xp,
+    );
+
+    const body: ProgressionProfileResponse = {
+      profile,
+      unlocks,
+      skill_tree: { nodes, edges },
+      recent_events: recentEvents,
+      prestige_history: prestigeHistory,
+      next_level: progress,
+      prestige_eligible: prestigeEligible,
+    };
+
+    sendJson(res, 200, body);
+  } finally {
+    store.close();
+  }
+}
+
+// ─── Async Route Handlers ───────────────────────────────────────────────────
+
+async function handleIngestEvent(
+  dbPath: string,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  let body: IngestXpEventRequest;
+  try {
+    const raw = await readBody(req);
+    body = JSON.parse(raw) as IngestXpEventRequest;
+  } catch {
+    sendError(res, 400, 'Invalid JSON body');
+    return;
+  }
+
+  // Validate required fields
+  if (!body.agent_id || typeof body.agent_id !== 'string') {
+    sendError(res, 400, 'Missing or invalid agent_id');
+    return;
+  }
+  if (typeof body.raw_xp !== 'number' || body.raw_xp <= 0) {
+    sendError(res, 400, 'raw_xp must be a positive number');
+    return;
+  }
+  if (!body.source_category || !isValidSourceCategory(body.source_category)) {
+    sendError(res, 400, `Invalid source_category. Valid: mission_completion, code_review, documentation, bug_fix, deployment, collaboration, research, testing, observability, security`);
+    return;
+  }
+  if (!body.source_description || typeof body.source_description !== 'string') {
+    sendError(res, 400, 'Missing or invalid source_description');
+    return;
+  }
+
+  // Sanitize agent_id
+  const agentId = body.agent_id.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 64);
+  if (!agentId) {
+    sendError(res, 400, 'agent_id contains no valid characters');
+    return;
+  }
+
+  const store = openStore(dbPath);
+  try {
+    const result = store.ingestXpEvent(
+      agentId,
+      body.raw_xp,
+      body.source_category,
+      body.source_description.slice(0, 500),
+    );
+
+    const response: IngestXpEventResponse = {
+      ok: true,
+      event: result.event,
+      profile: result.profile,
+      level_up: result.levelUp,
+    };
+
+    sendJson(res, 201, response);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    sendError(res, 400, msg);
+  } finally {
+    store.close();
+  }
+}
+
+async function handlePrestige(
+  dbPath: string,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  let body: PrestigeRequest;
+  try {
+    const raw = await readBody(req);
+    body = JSON.parse(raw) as PrestigeRequest;
+  } catch {
+    sendError(res, 400, 'Invalid JSON body');
+    return;
+  }
+
+  if (!body.agent_id || typeof body.agent_id !== 'string') {
+    sendError(res, 400, 'Missing or invalid agent_id');
+    return;
+  }
+
+  const agentId = body.agent_id.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 64);
+  if (!agentId) {
+    sendError(res, 400, 'agent_id contains no valid characters');
+    return;
+  }
+
+  const store = openStore(dbPath);
+  try {
+    const record = store.prestigeTransition(agentId);
+    const profile = store.getOrCreateProfile(agentId);
+
+    const response: PrestigeResponse = {
+      ok: true,
+      record,
+      profile,
+    };
+
+    sendJson(res, 200, response);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    sendError(res, 400, msg);
+  } finally {
+    store.close();
+  }
+}
+
+// ─── Main Router ────────────────────────────────────────────────────────────
+
+/**
+ * Handle a Progression API request.
+ *
+ * Expected URL pattern: /api/rpg/progression/{subRoute}
+ *
+ * Returns `true` if the request was handled, `false` if it didn't match.
+ */
+export function handleProgressionApi(
+  req: IncomingMessage,
+  res: ServerResponse,
+  opts: ProgressionHandlerOptions,
+): boolean {
+  const url = parseUrl(req);
+  if (!url) return false;
+
+  const pathname = url.pathname;
+  if (!pathname.startsWith('/api/rpg/progression')) return false;
+
+  const subPath = pathname.slice('/api/rpg/progression'.length);
+
+  // GET /api/rpg/progression/summary
+  if (req.method === 'GET' && (subPath === '/summary' || subPath === '/summary/')) {
+    try {
+      handleSummary(opts.dbPath, res);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      sendError(res, 500, msg);
+    }
+    return true;
+  }
+
+  // POST /api/rpg/progression/events
+  if (req.method === 'POST' && (subPath === '/events' || subPath === '/events/')) {
+    handleIngestEvent(opts.dbPath, req, res).catch((err) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      sendError(res, 500, msg);
+    });
+    return true;
+  }
+
+  // POST /api/rpg/progression/prestige
+  if (req.method === 'POST' && (subPath === '/prestige' || subPath === '/prestige/')) {
+    handlePrestige(opts.dbPath, req, res).catch((err) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      sendError(res, 500, msg);
+    });
+    return true;
+  }
+
+  // GET /api/rpg/progression/:agentId
+  if (req.method === 'GET' && subPath && /^\/[a-zA-Z0-9_-]+\/?$/.test(subPath)) {
+    const agentId = subPath.replace(/^\//, '').replace(/\/$/, '');
+    try {
+      handleProfile(opts.dbPath, res, agentId);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      sendError(res, 500, msg);
+    }
+    return true;
+  }
+
+  // Method not allowed for matched paths
+  if (subPath === '/events' || subPath === '/prestige') {
+    sendJson(res, 405, { ok: false, error: 'Method not allowed' });
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Factory function to create a progression router with a fixed DB path.
+ */
+export function createProgressionRouter(dbPath: string) {
+  return {
+    handleProgressionApi: (req: IncomingMessage, res: ServerResponse) =>
+      handleProgressionApi(req, res, { dbPath }),
+  };
+}
+
+export default { handleProgressionApi, createProgressionRouter };

--- a/lib/progression-store.ts
+++ b/lib/progression-store.ts
@@ -1,0 +1,447 @@
+/**
+ * Progression Store — VentureOS Phase 4.5
+ *
+ * SQLite persistence layer for progression profiles, skill tree state,
+ * XP events, and prestige metadata.
+ *
+ * Uses better-sqlite3 for synchronous, transactional access.
+ * Schema is auto-migrated on first open.
+ *
+ * Issue #203 — Phase 4.5 Deep Progression System (Phase 1 foundation)
+ */
+
+import Database from 'better-sqlite3';
+import crypto from 'node:crypto';
+import type {
+  ProgressionProfile,
+  SkillNode,
+  SkillEdge,
+  SkillUnlock,
+  XpEvent,
+  XpSourceCategory,
+  PrestigeRecord,
+} from './types/progression';
+import {
+  levelFromXp,
+  diversificationMultiplier,
+  diversificationScore,
+  isValidSourceCategory,
+  isPrestigeEligible,
+  MAX_PRESTIGE_RANK,
+  getDefaultSkillTree,
+} from './progression-engine';
+
+// ─── Schema Migration ───────────────────────────────────────────────────────
+
+const SCHEMA_SQL = `
+-- Progression profiles: one per agent
+CREATE TABLE IF NOT EXISTS progression_profiles (
+  agent_id           TEXT PRIMARY KEY,
+  display_name       TEXT NOT NULL,
+  current_xp         INTEGER NOT NULL DEFAULT 0,
+  lifetime_xp        INTEGER NOT NULL DEFAULT 0,
+  level              INTEGER NOT NULL DEFAULT 1,
+  prestige_rank      INTEGER NOT NULL DEFAULT 0,
+  diversification_score INTEGER NOT NULL DEFAULT 0,
+  created_at         TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at         TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Skill tree nodes (static definitions)
+CREATE TABLE IF NOT EXISTS skill_nodes (
+  node_id            TEXT PRIMARY KEY,
+  name               TEXT NOT NULL,
+  description        TEXT NOT NULL DEFAULT '',
+  category           TEXT NOT NULL,
+  xp_cost            INTEGER NOT NULL DEFAULT 100,
+  tier               INTEGER NOT NULL DEFAULT 1,
+  prerequisites      TEXT NOT NULL DEFAULT '[]'
+);
+
+-- Skill tree edges (prerequisite relationships)
+CREATE TABLE IF NOT EXISTS skill_edges (
+  from_node_id       TEXT NOT NULL,
+  to_node_id         TEXT NOT NULL,
+  PRIMARY KEY (from_node_id, to_node_id),
+  FOREIGN KEY (from_node_id) REFERENCES skill_nodes(node_id),
+  FOREIGN KEY (to_node_id)   REFERENCES skill_nodes(node_id)
+);
+
+-- Skill unlock state per agent
+CREATE TABLE IF NOT EXISTS skill_unlocks (
+  agent_id                TEXT NOT NULL,
+  node_id                 TEXT NOT NULL,
+  unlocked_at             TEXT NOT NULL DEFAULT (datetime('now')),
+  prestige_rank_at_unlock INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (agent_id, node_id),
+  FOREIGN KEY (node_id) REFERENCES skill_nodes(node_id)
+);
+
+-- XP event ledger with source attribution
+CREATE TABLE IF NOT EXISTS xp_events (
+  event_id                   TEXT PRIMARY KEY,
+  agent_id                   TEXT NOT NULL,
+  raw_xp                     INTEGER NOT NULL,
+  effective_xp               INTEGER NOT NULL,
+  source_category            TEXT NOT NULL,
+  source_description         TEXT NOT NULL DEFAULT '',
+  diversification_multiplier REAL NOT NULL DEFAULT 1.0,
+  created_at                 TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Prestige transition records
+CREATE TABLE IF NOT EXISTS prestige_records (
+  id                      INTEGER PRIMARY KEY AUTOINCREMENT,
+  agent_id                TEXT NOT NULL,
+  from_rank               INTEGER NOT NULL,
+  to_rank                 INTEGER NOT NULL,
+  xp_at_prestige          INTEGER NOT NULL,
+  level_at_prestige       INTEGER NOT NULL,
+  unlocks_at_prestige     INTEGER NOT NULL DEFAULT 0,
+  lifetime_xp_at_prestige INTEGER NOT NULL,
+  created_at              TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
+-- Indices for common queries
+CREATE INDEX IF NOT EXISTS idx_xp_events_agent      ON xp_events(agent_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_xp_events_category   ON xp_events(agent_id, source_category);
+CREATE INDEX IF NOT EXISTS idx_skill_unlocks_agent   ON skill_unlocks(agent_id);
+CREATE INDEX IF NOT EXISTS idx_prestige_agent        ON prestige_records(agent_id, created_at DESC);
+`;
+
+// ─── Store Class ────────────────────────────────────────────────────────────
+
+export class ProgressionStore {
+  private db: Database.Database;
+
+  constructor(dbPath: string, opts?: { readonly?: boolean }) {
+    this.db = new Database(dbPath, {
+      readonly: opts?.readonly ?? false,
+    });
+    this.db.pragma('journal_mode = WAL');
+    this.db.pragma('foreign_keys = ON');
+
+    if (!opts?.readonly) {
+      this.migrate();
+    }
+  }
+
+  /** Run schema migration. */
+  private migrate(): void {
+    this.db.exec(SCHEMA_SQL);
+    this.seedSkillTree();
+  }
+
+  /** Seed the default skill tree if empty. */
+  private seedSkillTree(): void {
+    const count = this.db.prepare('SELECT COUNT(*) as cnt FROM skill_nodes').get() as { cnt: number };
+    if (count.cnt > 0) return;
+
+    const tree = getDefaultSkillTree();
+    const insertNode = this.db.prepare(
+      `INSERT OR IGNORE INTO skill_nodes (node_id, name, description, category, xp_cost, tier, prerequisites)
+       VALUES (?, ?, ?, ?, ?, ?, ?)`,
+    );
+    const insertEdge = this.db.prepare(
+      `INSERT OR IGNORE INTO skill_edges (from_node_id, to_node_id) VALUES (?, ?)`,
+    );
+
+    const seedTransaction = this.db.transaction(() => {
+      for (const node of tree.nodes) {
+        insertNode.run(
+          node.node_id,
+          node.name,
+          node.description,
+          node.category,
+          node.xp_cost,
+          node.tier,
+          JSON.stringify(node.prerequisites),
+        );
+      }
+      for (const edge of tree.edges) {
+        insertEdge.run(edge.from_node_id, edge.to_node_id);
+      }
+    });
+    seedTransaction();
+  }
+
+  /** Close the database connection. */
+  close(): void {
+    try {
+      this.db.close();
+    } catch {
+      // ignore close errors
+    }
+  }
+
+  // ─── Profile Operations ─────────────────────────────────────────────────
+
+  /** Get or create a progression profile for an agent. */
+  getOrCreateProfile(agentId: string, displayName?: string): ProgressionProfile {
+    const existing = this.db
+      .prepare('SELECT * FROM progression_profiles WHERE agent_id = ?')
+      .get(agentId) as ProgressionProfile | undefined;
+
+    if (existing) return existing;
+
+    const name = displayName ?? agentId;
+    this.db
+      .prepare(
+        `INSERT INTO progression_profiles (agent_id, display_name, current_xp, lifetime_xp, level, prestige_rank, diversification_score)
+         VALUES (?, ?, 0, 0, 1, 0, 0)`,
+      )
+      .run(agentId, name);
+
+    return this.db
+      .prepare('SELECT * FROM progression_profiles WHERE agent_id = ?')
+      .get(agentId) as ProgressionProfile;
+  }
+
+  /** Get a profile by agent ID (returns null if not found). */
+  getProfile(agentId: string): ProgressionProfile | null {
+    return (
+      (this.db
+        .prepare('SELECT * FROM progression_profiles WHERE agent_id = ?')
+        .get(agentId) as ProgressionProfile | undefined) ?? null
+    );
+  }
+
+  /** List all profiles. */
+  listProfiles(): ProgressionProfile[] {
+    return this.db
+      .prepare('SELECT * FROM progression_profiles ORDER BY level DESC, current_xp DESC')
+      .all() as ProgressionProfile[];
+  }
+
+  // ─── XP Event Ingestion ─────────────────────────────────────────────────
+
+  /**
+   * Ingest an XP event with diversification weighting.
+   * Returns the created event and updated profile, plus whether a level-up occurred.
+   */
+  ingestXpEvent(
+    agentId: string,
+    rawXp: number,
+    sourceCategory: XpSourceCategory,
+    sourceDescription: string,
+  ): { event: XpEvent; profile: ProgressionProfile; levelUp: boolean } {
+    if (rawXp <= 0) throw new Error('raw_xp must be positive');
+    if (!isValidSourceCategory(sourceCategory)) {
+      throw new Error(`Invalid source_category: ${sourceCategory}`);
+    }
+
+    const result = this.db.transaction(() => {
+      // Ensure profile exists
+      const profile = this.getOrCreateProfile(agentId);
+      const previousLevel = profile.level;
+
+      // Get recent category distribution (last 50 events)
+      const recentEvents = this.db
+        .prepare(
+          `SELECT source_category, COUNT(*) as cnt
+           FROM xp_events WHERE agent_id = ?
+           GROUP BY source_category
+           ORDER BY cnt DESC
+           LIMIT 50`,
+        )
+        .all(agentId) as Array<{ source_category: string; cnt: number }>;
+
+      const categoryCounts: Record<string, number> = {};
+      for (const e of recentEvents) {
+        categoryCounts[e.source_category] = e.cnt;
+      }
+      // Include the current event's category
+      categoryCounts[sourceCategory] = (categoryCounts[sourceCategory] ?? 0) + 1;
+
+      // Calculate diversification multiplier
+      const multiplier = diversificationMultiplier(categoryCounts);
+      const effectiveXp = Math.max(1, Math.round(rawXp * multiplier));
+
+      // Create the XP event
+      const eventId = crypto.randomUUID();
+      this.db
+        .prepare(
+          `INSERT INTO xp_events (event_id, agent_id, raw_xp, effective_xp, source_category, source_description, diversification_multiplier)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(eventId, agentId, rawXp, effectiveXp, sourceCategory, sourceDescription, multiplier);
+
+      // Update profile
+      const newCurrentXp = profile.current_xp + effectiveXp;
+      const newLifetimeXp = profile.lifetime_xp + effectiveXp;
+      const newLevel = levelFromXp(newCurrentXp);
+      const newDivScore = diversificationScore(categoryCounts);
+
+      this.db
+        .prepare(
+          `UPDATE progression_profiles
+           SET current_xp = ?, lifetime_xp = ?, level = ?,
+               diversification_score = ?, updated_at = datetime('now')
+           WHERE agent_id = ?`,
+        )
+        .run(newCurrentXp, newLifetimeXp, newLevel, newDivScore, agentId);
+
+      const updatedProfile = this.db
+        .prepare('SELECT * FROM progression_profiles WHERE agent_id = ?')
+        .get(agentId) as ProgressionProfile;
+
+      const event: XpEvent = {
+        event_id: eventId,
+        agent_id: agentId,
+        raw_xp: rawXp,
+        effective_xp: effectiveXp,
+        source_category: sourceCategory,
+        source_description: sourceDescription,
+        diversification_multiplier: multiplier,
+        created_at: new Date().toISOString(),
+      };
+
+      return {
+        event,
+        profile: updatedProfile,
+        levelUp: newLevel > previousLevel,
+      };
+    })();
+
+    return result;
+  }
+
+  /** Get recent XP events for an agent. */
+  getRecentEvents(agentId: string, limit: number = 20): XpEvent[] {
+    return this.db
+      .prepare(
+        `SELECT * FROM xp_events WHERE agent_id = ? ORDER BY created_at DESC LIMIT ?`,
+      )
+      .all(agentId, limit) as XpEvent[];
+  }
+
+  /** Get XP events from today for summary stats. */
+  getTodayEvents(): { total_xp: number; total_count: number; top_categories: Array<{ category: string; count: number }> } {
+    const today = new Date().toISOString().slice(0, 10);
+    const totals = this.db
+      .prepare(
+        `SELECT COALESCE(SUM(effective_xp), 0) as total_xp, COUNT(*) as total_count
+         FROM xp_events WHERE created_at >= ?`,
+      )
+      .get(today) as { total_xp: number; total_count: number };
+
+    const topCats = this.db
+      .prepare(
+        `SELECT source_category as category, COUNT(*) as count
+         FROM xp_events WHERE created_at >= ?
+         GROUP BY source_category ORDER BY count DESC LIMIT 5`,
+      )
+      .all(today) as Array<{ category: string; count: number }>;
+
+    return {
+      total_xp: totals.total_xp,
+      total_count: totals.total_count,
+      top_categories: topCats,
+    };
+  }
+
+  // ─── Skill Tree Operations ──────────────────────────────────────────────
+
+  /** Get all skill tree nodes. */
+  getSkillNodes(): SkillNode[] {
+    const rows = this.db.prepare('SELECT * FROM skill_nodes ORDER BY category, tier').all() as Array<{
+      node_id: string;
+      name: string;
+      description: string;
+      category: string;
+      xp_cost: number;
+      tier: number;
+      prerequisites: string;
+    }>;
+    return rows.map((r) => ({
+      ...r,
+      category: r.category as SkillNode['category'],
+      prerequisites: JSON.parse(r.prerequisites) as string[],
+    }));
+  }
+
+  /** Get all skill tree edges. */
+  getSkillEdges(): SkillEdge[] {
+    return this.db.prepare('SELECT * FROM skill_edges').all() as SkillEdge[];
+  }
+
+  /** Get all unlocks for an agent. */
+  getUnlocks(agentId: string): SkillUnlock[] {
+    return this.db
+      .prepare('SELECT * FROM skill_unlocks WHERE agent_id = ? ORDER BY unlocked_at')
+      .all(agentId) as SkillUnlock[];
+  }
+
+  // ─── Prestige Operations ───────────────────────────────────────────────
+
+  /** Execute a prestige transition for an agent. */
+  prestigeTransition(agentId: string): PrestigeRecord {
+    return this.db.transaction(() => {
+      const profile = this.getProfile(agentId);
+      if (!profile) throw new Error(`Profile not found: ${agentId}`);
+
+      if (profile.prestige_rank >= MAX_PRESTIGE_RANK) {
+        throw new Error(`Already at maximum prestige rank (${MAX_PRESTIGE_RANK})`);
+      }
+
+      if (!isPrestigeEligible(profile.level, profile.prestige_rank, profile.lifetime_xp)) {
+        throw new Error(
+          `Not eligible for prestige. Requires higher level and lifetime XP.`,
+        );
+      }
+
+      const unlockCount = this.db
+        .prepare('SELECT COUNT(*) as cnt FROM skill_unlocks WHERE agent_id = ?')
+        .get(agentId) as { cnt: number };
+
+      const fromRank = profile.prestige_rank;
+      const toRank = fromRank + 1;
+
+      // Record the prestige
+      this.db
+        .prepare(
+          `INSERT INTO prestige_records (agent_id, from_rank, to_rank, xp_at_prestige, level_at_prestige, unlocks_at_prestige, lifetime_xp_at_prestige)
+           VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        )
+        .run(
+          agentId,
+          fromRank,
+          toRank,
+          profile.current_xp,
+          profile.level,
+          unlockCount.cnt,
+          profile.lifetime_xp,
+        );
+
+      // Reset current XP and level, keep lifetime XP, increment prestige rank
+      this.db
+        .prepare(
+          `UPDATE progression_profiles
+           SET current_xp = 0, level = 1, prestige_rank = ?,
+               updated_at = datetime('now')
+           WHERE agent_id = ?`,
+        )
+        .run(toRank, agentId);
+
+      // Clear skill unlocks (they reset on prestige)
+      this.db.prepare('DELETE FROM skill_unlocks WHERE agent_id = ?').run(agentId);
+
+      const record = this.db
+        .prepare(
+          `SELECT * FROM prestige_records WHERE agent_id = ? ORDER BY created_at DESC LIMIT 1`,
+        )
+        .get(agentId) as PrestigeRecord;
+
+      return record;
+    })();
+  }
+
+  /** Get prestige history for an agent. */
+  getPrestigeHistory(agentId: string): PrestigeRecord[] {
+    return this.db
+      .prepare('SELECT * FROM prestige_records WHERE agent_id = ? ORDER BY created_at DESC')
+      .all(agentId) as PrestigeRecord[];
+  }
+}
+
+export default { ProgressionStore };

--- a/lib/types/progression.ts
+++ b/lib/types/progression.ts
@@ -1,0 +1,195 @@
+/**
+ * Progression System TypeScript Interfaces — VentureOS Phase 4.5
+ *
+ * Type contracts for the deep progression system: profiles, skill trees,
+ * XP events, prestige ranks, and API request/response shapes.
+ *
+ * Issue #203 — Phase 4.5 Deep Progression System (Phase 1 foundation)
+ */
+
+// ─── Progression Profiles ───────────────────────────────────────────────────
+
+/** A progression profile for an agent. */
+export interface ProgressionProfile {
+  agent_id: string;
+  display_name: string;
+  /** Current XP total (post-prestige resets). */
+  current_xp: number;
+  /** Lifetime XP accumulated across all prestige cycles. */
+  lifetime_xp: number;
+  /** Current level derived from XP thresholds. */
+  level: number;
+  /** Current prestige rank (0 = no prestige). */
+  prestige_rank: number;
+  /** Number of distinct XP source categories contributed. */
+  diversification_score: number;
+  created_at: string;
+  updated_at: string;
+}
+
+// ─── Skill Tree ─────────────────────────────────────────────────────────────
+
+/** Skill categories for grouping nodes. */
+export type SkillCategory =
+  | 'engineering'
+  | 'operations'
+  | 'analysis'
+  | 'communication'
+  | 'strategy';
+
+/** A node in the skill tree. */
+export interface SkillNode {
+  node_id: string;
+  name: string;
+  description: string;
+  category: SkillCategory;
+  /** XP cost to unlock this node. */
+  xp_cost: number;
+  /** Tier within its category (1 = entry, higher = advanced). */
+  tier: number;
+  /** Prerequisite node IDs (all must be unlocked). */
+  prerequisites: string[];
+}
+
+/** An edge in the skill tree (prerequisite relationship). */
+export interface SkillEdge {
+  from_node_id: string;
+  to_node_id: string;
+}
+
+/** An agent's unlock state for a single skill node. */
+export interface SkillUnlock {
+  agent_id: string;
+  node_id: string;
+  unlocked_at: string;
+  /** Prestige rank at time of unlock (resets on prestige). */
+  prestige_rank_at_unlock: number;
+}
+
+// ─── XP Events ──────────────────────────────────────────────────────────────
+
+/** Valid XP source categories for diversification tracking. */
+export type XpSourceCategory =
+  | 'mission_completion'
+  | 'code_review'
+  | 'documentation'
+  | 'bug_fix'
+  | 'deployment'
+  | 'collaboration'
+  | 'research'
+  | 'testing'
+  | 'observability'
+  | 'security';
+
+/** An XP event in the ledger. */
+export interface XpEvent {
+  event_id: string;
+  agent_id: string;
+  /** Raw XP amount before diversification weighting. */
+  raw_xp: number;
+  /** Effective XP after diversification weighting. */
+  effective_xp: number;
+  /** Source category for diversification tracking. */
+  source_category: XpSourceCategory;
+  /** Free-text description of what triggered the XP. */
+  source_description: string;
+  /** Diversification multiplier applied (1.0 = baseline). */
+  diversification_multiplier: number;
+  created_at: string;
+}
+
+// ─── Prestige ───────────────────────────────────────────────────────────────
+
+/** Metadata for a prestige transition. */
+export interface PrestigeRecord {
+  id: number;
+  agent_id: string;
+  /** Prestige rank transitioned FROM. */
+  from_rank: number;
+  /** Prestige rank transitioned TO. */
+  to_rank: number;
+  /** XP at the moment of prestige (before reset). */
+  xp_at_prestige: number;
+  /** Level at the moment of prestige. */
+  level_at_prestige: number;
+  /** Number of skill unlocks at prestige. */
+  unlocks_at_prestige: number;
+  /** Lifetime XP at prestige. */
+  lifetime_xp_at_prestige: number;
+  created_at: string;
+}
+
+// ─── API Request/Response Shapes ────────────────────────────────────────────
+
+/** POST /api/rpg/progression/events — ingest an XP event. */
+export interface IngestXpEventRequest {
+  agent_id: string;
+  raw_xp: number;
+  source_category: XpSourceCategory;
+  source_description: string;
+}
+
+/** Response for XP event ingestion. */
+export interface IngestXpEventResponse {
+  ok: true;
+  event: XpEvent;
+  profile: ProgressionProfile;
+  level_up: boolean;
+}
+
+/** GET /api/rpg/progression/:agentId — full profile + tree state. */
+export interface ProgressionProfileResponse {
+  profile: ProgressionProfile;
+  unlocks: SkillUnlock[];
+  skill_tree: {
+    nodes: SkillNode[];
+    edges: SkillEdge[];
+  };
+  recent_events: XpEvent[];
+  prestige_history: PrestigeRecord[];
+  next_level: {
+    xp_required: number;
+    xp_remaining: number;
+    progress_pct: number;
+  };
+  prestige_eligible: boolean;
+}
+
+/** GET /api/rpg/progression/summary — dashboard summary cards. */
+export interface ProgressionSummaryResponse {
+  profiles: Array<{
+    agent_id: string;
+    display_name: string;
+    level: number;
+    current_xp: number;
+    prestige_rank: number;
+    diversification_score: number;
+    next_level_pct: number;
+  }>;
+  total_xp_today: number;
+  total_events_today: number;
+  top_categories: Array<{ category: string; count: number }>;
+}
+
+/** POST /api/rpg/progression/prestige — trigger prestige transition. */
+export interface PrestigeRequest {
+  agent_id: string;
+}
+
+/** Response for prestige transition. */
+export interface PrestigeResponse {
+  ok: true;
+  record: PrestigeRecord;
+  profile: ProgressionProfile;
+}
+
+/** Handler options matching the existing pattern. */
+export interface ProgressionHandlerOptions {
+  dbPath: string;
+}
+
+/** Error response shape. */
+export interface ProgressionErrorResponse {
+  ok: false;
+  error: string;
+}


### PR DESCRIPTION
## Summary

Fixes #203

Implements the **Phase 4.5 Deep Progression System Phase 1 foundation** — the core progression backbone for VentureOS agents.

## What shipped

### Data Model + Persistence
- `progression_profiles`: agent XP, level, prestige rank, diversification score
- `skill_nodes`/`skill_edges`: 15-node skill tree (5 categories × 3 tiers)
- `xp_events`: XP ledger with source attribution and diversification metadata
- `prestige_records`: prestige transition audit trail
- Auto-migration on first database open (no manual steps)

### Progression Engine (`lib/progression-engine.ts`)
- Deterministic XP→level curve: `floor(100 × (N-1)^1.5)`
- Diversification weighting: 0.5× penalty for single-category farming, up to 1.5× bonus for diverse contributions
- Shannon entropy-based diversification score (0-100)
- Prestige transitions: level 20+ requirement, rank-scaled thresholds, max rank 10

### API Endpoints
| Method | Route | Description |
|--------|-------|-------------|
| GET | `/api/rpg/progression/summary` | Dashboard summary cards |
| GET | `/api/rpg/progression/:agentId` | Full profile + tree + events |
| POST | `/api/rpg/progression/events` | Validated XP event ingestion |
| POST | `/api/rpg/progression/prestige` | Prestige transition |

### Dashboard Integration
- Wired into dashboard server via `routes/progression.ts` adapter
- Follows existing RPG route pattern

### Tests (65 total, all passing)
- 36 unit tests: engine math, diversification, prestige rules, skill tree
- 20 integration tests: store persistence, XP accumulation, prestige flow
- 9 HTTP tests: API contracts, validation, error paths

### Documentation
- `docs/progression-system.md`: formulas, API contracts, migration notes

## Verification
- [x] Progression persistence schema exists and auto-migrates
- [x] XP events ingested and reflected in profile state
- [x] Diversification weighting affects outcomes (with test coverage)
- [x] Prestige transition implemented with explicit rules and tests
- [x] APIs return stable contracts and reject invalid input
- [x] Dashboard summary endpoint returns real data
- [x] Tests (65) + typecheck pass
- [x] No existing tests broken (1092 pre-existing tests still pass)