### PR TITLE
feat(progression): Phase 2 — skill unlock, annotated tree state, leaderboard (#207)

### DIFF
--- a/lib/__tests__/skill-tree-phase2.test.ts
+++ b/lib/__tests__/skill-tree-phase2.test.ts
@@ -1,0 +1,513 @@
+/**
+ * Skill Tree Phase 2 — Unit Tests
+ *
+ * Tests for skill unlock logic, annotated tree state, leaderboard,
+ * and the new HTTP endpoints added in Phase 2.
+ *
+ * Issue #207 — Phase 4.5 Phase 2: Visual Skill Tree UI & Progression Polish
+ */
+
+import { ProgressionStore } from '../progression-store';
+import { levelFromXp } from '../progression-engine';
+import type { AnnotatedSkillNode, SkillNodeStatus } from '../types/progression';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+import * as os from 'node:os';
+
+// ─── Test Helpers ───────────────────────────────────────────────────────────
+
+function tmpDbPath(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), 'vos-test-'));
+  return path.join(dir, 'test.db');
+}
+
+function createStore(): { store: ProgressionStore; dbPath: string } {
+  const dbPath = tmpDbPath();
+  const store = new ProgressionStore(dbPath);
+  return { store, dbPath };
+}
+
+/** Helper: give an agent enough XP to afford skill unlocks. */
+function giveXp(store: ProgressionStore, agentId: string, amount: number): void {
+  // Use direct ingestion with varied categories to avoid diversification penalty
+  const categories = [
+    'mission_completion', 'code_review', 'documentation', 'bug_fix',
+    'deployment', 'collaboration', 'research', 'testing',
+  ] as const;
+  const perEvent = Math.ceil(amount / categories.length);
+  for (const cat of categories) {
+    store.ingestXpEvent(agentId, perEvent, cat, `test-xp-${cat}`);
+  }
+}
+
+afterEach(() => {
+  // Cleanup is handled by OS tmp directory
+});
+
+// ─── getSkillTreeState ──────────────────────────────────────────────────────
+
+describe('getSkillTreeState', () => {
+  it('returns all nodes with correct status for a fresh agent', () => {
+    const { store } = createStore();
+    try {
+      const state = store.getSkillTreeState('agent-1');
+
+      // Should have 15 nodes (5 categories × 3 tiers)
+      expect(state.nodes.length).toBe(15);
+      expect(state.unlocked_count).toBe(0);
+
+      // Tier 1 nodes should be 'available' (no prerequisites)
+      const tier1 = state.nodes.filter((n) => n.tier === 1);
+      expect(tier1.length).toBe(5);
+      for (const node of tier1) {
+        expect(node.status).toBe('available');
+      }
+
+      // Tier 2 & 3 nodes should be 'locked' (prerequisites not met)
+      const locked = state.nodes.filter((n) => n.tier > 1);
+      expect(locked.length).toBe(10);
+      for (const node of locked) {
+        expect(node.status).toBe('locked');
+      }
+    } finally {
+      store.close();
+    }
+  });
+
+  it('marks nodes as affordable when agent has enough XP', () => {
+    const { store } = createStore();
+    try {
+      giveXp(store, 'agent-1', 2000);
+      const state = store.getSkillTreeState('agent-1');
+
+      const available = state.nodes.filter((n) => n.status === 'available');
+      // Tier 1 nodes cost 100 XP, agent has plenty
+      for (const node of available) {
+        if (node.xp_cost <= state.nodes[0].xp_cost) {
+          expect(node.affordable).toBe(true);
+        }
+      }
+    } finally {
+      store.close();
+    }
+  });
+
+  it('marks nodes as not affordable when agent lacks XP', () => {
+    const { store } = createStore();
+    try {
+      // Fresh agent with 0 XP
+      const state = store.getSkillTreeState('agent-1');
+      const available = state.nodes.filter((n) => n.status === 'available');
+      for (const node of available) {
+        expect(node.affordable).toBe(false);
+      }
+    } finally {
+      store.close();
+    }
+  });
+
+  it('returns edges matching the skill tree', () => {
+    const { store } = createStore();
+    try {
+      const state = store.getSkillTreeState('agent-1');
+      // 5 categories × 2 edges each (tier1→tier2, tier2→tier3)
+      expect(state.edges.length).toBe(10);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ─── unlockSkill ────────────────────────────────────────────────────────────
+
+describe('unlockSkill', () => {
+  it('unlocks a tier-1 skill node and deducts XP', () => {
+    const { store } = createStore();
+    try {
+      giveXp(store, 'agent-1', 2000);
+      const profileBefore = store.getOrCreateProfile('agent-1');
+      const xpBefore = profileBefore.current_xp;
+
+      const result = store.unlockSkill('agent-1', 'eng-1');
+
+      expect(result.unlock.node_id).toBe('eng-1');
+      expect(result.unlock.agent_id).toBe('agent-1');
+      expect(result.node.status).toBe('unlocked');
+      expect(result.profile.current_xp).toBe(xpBefore - 100); // eng-1 costs 100
+    } finally {
+      store.close();
+    }
+  });
+
+  it('makes tier-2 node available after tier-1 unlock', () => {
+    const { store } = createStore();
+    try {
+      giveXp(store, 'agent-1', 3000);
+      store.unlockSkill('agent-1', 'eng-1');
+
+      const state = store.getSkillTreeState('agent-1');
+      const eng2 = state.nodes.find((n) => n.node_id === 'eng-2');
+      expect(eng2).toBeDefined();
+      expect(eng2!.status).toBe('available');
+    } finally {
+      store.close();
+    }
+  });
+
+  it('allows chaining tier-1 → tier-2 → tier-3 unlocks', () => {
+    const { store } = createStore();
+    try {
+      giveXp(store, 'agent-1', 10000);
+
+      store.unlockSkill('agent-1', 'ops-1'); // 100 XP
+      store.unlockSkill('agent-1', 'ops-2'); // 300 XP
+      store.unlockSkill('agent-1', 'ops-3'); // 800 XP
+
+      const unlocks = store.getUnlocks('agent-1');
+      const nodeIds = unlocks.map((u) => u.node_id);
+      expect(nodeIds).toContain('ops-1');
+      expect(nodeIds).toContain('ops-2');
+      expect(nodeIds).toContain('ops-3');
+
+      const state = store.getSkillTreeState('agent-1');
+      expect(state.unlocked_count).toBe(3);
+    } finally {
+      store.close();
+    }
+  });
+
+  it('throws when node does not exist', () => {
+    const { store } = createStore();
+    try {
+      giveXp(store, 'agent-1', 1000);
+      expect(() => store.unlockSkill('agent-1', 'nonexistent')).toThrow(
+        'Skill node not found',
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  it('throws when skill already unlocked', () => {
+    const { store } = createStore();
+    try {
+      giveXp(store, 'agent-1', 2000);
+      store.unlockSkill('agent-1', 'eng-1');
+      expect(() => store.unlockSkill('agent-1', 'eng-1')).toThrow(
+        'Skill already unlocked',
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  it('throws when prerequisites not met', () => {
+    const { store } = createStore();
+    try {
+      giveXp(store, 'agent-1', 5000);
+      // eng-2 requires eng-1
+      expect(() => store.unlockSkill('agent-1', 'eng-2')).toThrow(
+        'Prerequisites not met',
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  it('throws when insufficient XP', () => {
+    const { store } = createStore();
+    try {
+      // Fresh agent with 0 XP
+      store.getOrCreateProfile('agent-1');
+      expect(() => store.unlockSkill('agent-1', 'eng-1')).toThrow(
+        'Insufficient XP',
+      );
+    } finally {
+      store.close();
+    }
+  });
+
+  it('recalculates level after XP deduction', () => {
+    const { store } = createStore();
+    try {
+      giveXp(store, 'agent-1', 2000);
+      const before = store.getOrCreateProfile('agent-1');
+      const levelBefore = before.level;
+
+      // Unlock a costly node that may drop level
+      store.unlockSkill('agent-1', 'eng-1');
+      const after = store.getOrCreateProfile('agent-1');
+
+      // Level should be consistent with remaining XP
+      expect(after.level).toBe(levelFromXp(after.current_xp));
+      // XP decreased, so level should be <= previous
+      expect(after.level).toBeLessThanOrEqual(levelBefore);
+    } finally {
+      store.close();
+    }
+  });
+
+  it('records prestige_rank_at_unlock correctly', () => {
+    const { store } = createStore();
+    try {
+      giveXp(store, 'agent-1', 2000);
+      const result = store.unlockSkill('agent-1', 'eng-1');
+      expect(result.unlock.prestige_rank_at_unlock).toBe(0);
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ─── getLeaderboard ─────────────────────────────────────────────────────────
+
+describe('getLeaderboard', () => {
+  it('returns empty leaderboard when no agents exist', () => {
+    const { store } = createStore();
+    try {
+      const lb = store.getLeaderboard();
+      expect(lb.entries).toEqual([]);
+      expect(lb.total_agents).toBe(0);
+    } finally {
+      store.close();
+    }
+  });
+
+  it('ranks agents by prestige → level → lifetime_xp', () => {
+    const { store } = createStore();
+    try {
+      // Agent A: more XP
+      giveXp(store, 'agent-a', 5000);
+      // Agent B: less XP
+      giveXp(store, 'agent-b', 1000);
+      // Agent C: medium XP
+      giveXp(store, 'agent-c', 3000);
+
+      const lb = store.getLeaderboard();
+      expect(lb.total_agents).toBe(3);
+      expect(lb.entries.length).toBe(3);
+
+      // Agent A should be rank 1 (highest XP/level)
+      expect(lb.entries[0].agent_id).toBe('agent-a');
+      expect(lb.entries[0].rank).toBe(1);
+
+      // Ranks should be sequential
+      expect(lb.entries.map((e) => e.rank)).toEqual([1, 2, 3]);
+    } finally {
+      store.close();
+    }
+  });
+
+  it('includes unlocked_skills count', () => {
+    const { store } = createStore();
+    try {
+      giveXp(store, 'agent-1', 5000);
+      store.unlockSkill('agent-1', 'eng-1');
+      store.unlockSkill('agent-1', 'ops-1');
+
+      const lb = store.getLeaderboard();
+      const entry = lb.entries.find((e) => e.agent_id === 'agent-1');
+      expect(entry).toBeDefined();
+      expect(entry!.unlocked_skills).toBe(2);
+    } finally {
+      store.close();
+    }
+  });
+
+  it('respects limit parameter', () => {
+    const { store } = createStore();
+    try {
+      for (let i = 0; i < 10; i++) {
+        store.getOrCreateProfile(`agent-${i}`, `Agent ${i}`);
+      }
+      const lb = store.getLeaderboard(3);
+      expect(lb.entries.length).toBe(3);
+      expect(lb.total_agents).toBe(10);
+    } finally {
+      store.close();
+    }
+  });
+
+  it('returns all required fields', () => {
+    const { store } = createStore();
+    try {
+      giveXp(store, 'agent-1', 1000);
+      const lb = store.getLeaderboard();
+      const entry = lb.entries[0];
+
+      expect(entry).toHaveProperty('rank');
+      expect(entry).toHaveProperty('agent_id');
+      expect(entry).toHaveProperty('display_name');
+      expect(entry).toHaveProperty('level');
+      expect(entry).toHaveProperty('current_xp');
+      expect(entry).toHaveProperty('lifetime_xp');
+      expect(entry).toHaveProperty('prestige_rank');
+      expect(entry).toHaveProperty('unlocked_skills');
+      expect(entry).toHaveProperty('diversification_score');
+    } finally {
+      store.close();
+    }
+  });
+});
+
+// ─── HTTP Endpoint Tests (route matching) ───────────────────────────────────
+
+describe('HTTP route integration', () => {
+  // We test the handleProgressionApi function with mock req/res
+  let httpModule: typeof import('../progression-http');
+  let dbPath: string;
+  let store: ProgressionStore;
+
+  beforeEach(() => {
+    dbPath = tmpDbPath();
+    store = new ProgressionStore(dbPath);
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    httpModule = require('../progression-http');
+  });
+
+  afterEach(() => {
+    store.close();
+  });
+
+  function mockReq(method: string, url: string, body?: string): any {
+    const listeners: Record<string, Function[]> = {};
+    const req = {
+      method,
+      url,
+      headers: { host: 'localhost:3000' },
+      on(event: string, fn: Function) {
+        if (!listeners[event]) listeners[event] = [];
+        listeners[event].push(fn);
+        // Emit data/end for POST bodies
+        if (event === 'end' && body !== undefined) {
+          setTimeout(() => {
+            for (const dataFn of (listeners['data'] || [])) {
+              dataFn(Buffer.from(body));
+            }
+            for (const endFn of (listeners['end'] || [])) {
+              endFn();
+            }
+          }, 0);
+        } else if (event === 'end' && body === undefined) {
+          setTimeout(() => {
+            for (const endFn of (listeners['end'] || [])) {
+              endFn();
+            }
+          }, 0);
+        }
+        return req;
+      },
+      destroy() {},
+    };
+    return req;
+  }
+
+  function mockRes(): any {
+    let statusCode = 0;
+    let body = '';
+    const res = {
+      writeHead(status: number, _headers?: any) {
+        statusCode = status;
+      },
+      end(data?: string) {
+        body = data || '';
+      },
+      getStatus() { return statusCode; },
+      getBody() { return body; },
+      getParsed() { return JSON.parse(body); },
+    };
+    return res;
+  }
+
+  it('GET /api/rpg/progression/skill-tree/:agentId returns annotated tree', () => {
+    const req = mockReq('GET', '/api/rpg/progression/skill-tree/agent-1');
+    const res = mockRes();
+
+    const handled = httpModule.handleProgressionApi(req, res, { dbPath });
+    expect(handled).toBe(true);
+
+    const parsed = res.getParsed();
+    expect(parsed.agent_id).toBe('agent-1');
+    expect(parsed.nodes.length).toBe(15);
+    expect(parsed.total_count).toBe(15);
+    expect(parsed.unlocked_count).toBe(0);
+  });
+
+  it('POST /api/rpg/progression/skills/unlock returns unlock result', async () => {
+    // Give XP first
+    giveXp(store, 'agent-1', 2000);
+
+    const body = JSON.stringify({ agent_id: 'agent-1', node_id: 'eng-1' });
+    const req = mockReq('POST', '/api/rpg/progression/skills/unlock', body);
+    const res = mockRes();
+
+    const handled = httpModule.handleProgressionApi(req, res, { dbPath });
+    expect(handled).toBe(true);
+
+    // Wait for async body reading
+    await new Promise((r) => setTimeout(r, 50));
+
+    const parsed = res.getParsed();
+    expect(parsed.ok).toBe(true);
+    expect(parsed.unlock.node_id).toBe('eng-1');
+    expect(parsed.node.status).toBe('unlocked');
+  });
+
+  it('GET /api/rpg/progression/leaderboard returns entries', () => {
+    giveXp(store, 'agent-1', 1000);
+
+    const req = mockReq('GET', '/api/rpg/progression/leaderboard');
+    const res = mockRes();
+
+    const handled = httpModule.handleProgressionApi(req, res, { dbPath });
+    expect(handled).toBe(true);
+
+    const parsed = res.getParsed();
+    expect(parsed.entries.length).toBe(1);
+    expect(parsed.total_agents).toBe(1);
+    expect(parsed.entries[0].agent_id).toBe('agent-1');
+  });
+
+  it('GET /api/rpg/progression/leaderboard respects ?limit=', () => {
+    for (let i = 0; i < 5; i++) {
+      store.getOrCreateProfile(`agent-${i}`);
+    }
+
+    const req = mockReq('GET', '/api/rpg/progression/leaderboard?limit=2');
+    const res = mockRes();
+
+    const handled = httpModule.handleProgressionApi(req, res, { dbPath });
+    expect(handled).toBe(true);
+
+    const parsed = res.getParsed();
+    expect(parsed.entries.length).toBe(2);
+    expect(parsed.total_agents).toBe(5);
+  });
+
+  it('POST /api/rpg/progression/skills/unlock rejects missing node_id', async () => {
+    const body = JSON.stringify({ agent_id: 'agent-1' });
+    const req = mockReq('POST', '/api/rpg/progression/skills/unlock', body);
+    const res = mockRes();
+
+    httpModule.handleProgressionApi(req, res, { dbPath });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const parsed = res.getParsed();
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toMatch(/node_id/i);
+  });
+
+  it('POST /api/rpg/progression/skills/unlock rejects insufficient XP', async () => {
+    store.getOrCreateProfile('agent-1');
+    const body = JSON.stringify({ agent_id: 'agent-1', node_id: 'eng-1' });
+    const req = mockReq('POST', '/api/rpg/progression/skills/unlock', body);
+    const res = mockRes();
+
+    httpModule.handleProgressionApi(req, res, { dbPath });
+    await new Promise((r) => setTimeout(r, 50));
+
+    const parsed = res.getParsed();
+    expect(parsed.ok).toBe(false);
+    expect(parsed.error).toMatch(/Insufficient XP/);
+  });
+});

--- a/lib/progression-http.ts
+++ b/lib/progression-http.ts
@@ -23,6 +23,10 @@ import type {
   PrestigeRequest,
   PrestigeResponse,
   ProgressionErrorResponse,
+  SkillTreeStateResponse,
+  UnlockSkillRequest,
+  UnlockSkillResponse,
+  LeaderboardResponse,
 } from './types/progression';
 import { ProgressionStore } from './progression-store';
 import { levelProgress, isPrestigeEligible, isValidSourceCategory } from './progression-engine';
@@ -248,6 +252,103 @@ async function handlePrestige(
   }
 }
 
+// ─── Phase 2 Route Handlers (#207) ──────────────────────────────────────────
+
+function handleSkillTreeState(dbPath: string, res: ServerResponse, agentId: string): void {
+  const store = openStore(dbPath);
+  try {
+    const profile = store.getOrCreateProfile(agentId);
+    const treeState = store.getSkillTreeState(agentId);
+
+    const body: SkillTreeStateResponse = {
+      agent_id: agentId,
+      current_xp: profile.current_xp,
+      nodes: treeState.nodes,
+      edges: treeState.edges,
+      unlocked_count: treeState.unlocked_count,
+      total_count: treeState.nodes.length,
+    };
+
+    sendJson(res, 200, body);
+  } finally {
+    store.close();
+  }
+}
+
+async function handleUnlockSkill(
+  dbPath: string,
+  req: IncomingMessage,
+  res: ServerResponse,
+): Promise<void> {
+  let body: UnlockSkillRequest;
+  try {
+    const raw = await readBody(req);
+    body = JSON.parse(raw) as UnlockSkillRequest;
+  } catch {
+    sendError(res, 400, 'Invalid JSON body');
+    return;
+  }
+
+  if (!body.agent_id || typeof body.agent_id !== 'string') {
+    sendError(res, 400, 'Missing or invalid agent_id');
+    return;
+  }
+  if (!body.node_id || typeof body.node_id !== 'string') {
+    sendError(res, 400, 'Missing or invalid node_id');
+    return;
+  }
+
+  const agentId = body.agent_id.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 64);
+  const nodeId = body.node_id.replace(/[^a-zA-Z0-9_-]/g, '').slice(0, 64);
+
+  if (!agentId) {
+    sendError(res, 400, 'agent_id contains no valid characters');
+    return;
+  }
+  if (!nodeId) {
+    sendError(res, 400, 'node_id contains no valid characters');
+    return;
+  }
+
+  const store = openStore(dbPath);
+  try {
+    const result = store.unlockSkill(agentId, nodeId);
+
+    const response: UnlockSkillResponse = {
+      ok: true,
+      unlock: result.unlock,
+      profile: result.profile,
+      node: result.node,
+    };
+
+    sendJson(res, 200, response);
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : String(err);
+    sendError(res, 400, msg);
+  } finally {
+    store.close();
+  }
+}
+
+function handleLeaderboard(dbPath: string, res: ServerResponse, url: URL): void {
+  const limitParam = url.searchParams.get('limit');
+  const limit = limitParam ? Math.min(100, Math.max(1, parseInt(limitParam, 10) || 50)) : 50;
+
+  const store = openStore(dbPath);
+  try {
+    const result = store.getLeaderboard(limit);
+
+    const body: LeaderboardResponse = {
+      entries: result.entries,
+      total_agents: result.total_agents,
+    };
+
+    sendJson(res, 200, body);
+  } finally {
+    store.close();
+  }
+}
+
 // ─── Main Router ────────────────────────────────────────────────────────────
 
 /**
@@ -278,6 +379,40 @@ export function handleProgressionApi(
       const msg = err instanceof Error ? err.message : String(err);
       sendError(res, 500, msg);
     }
+    return true;
+  }
+
+  // GET /api/rpg/progression/leaderboard
+  if (req.method === 'GET' && (subPath === '/leaderboard' || subPath === '/leaderboard/')) {
+    try {
+      handleLeaderboard(opts.dbPath, res, url);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      sendError(res, 500, msg);
+    }
+    return true;
+  }
+
+  // GET /api/rpg/progression/skill-tree/:agentId
+  if (req.method === 'GET' && subPath.startsWith('/skill-tree/')) {
+    const agentId = subPath.slice('/skill-tree/'.length).replace(/\/$/, '');
+    if (agentId && /^[a-zA-Z0-9_-]+$/.test(agentId)) {
+      try {
+        handleSkillTreeState(opts.dbPath, res, agentId);
+      } catch (err: unknown) {
+        const msg = err instanceof Error ? err.message : String(err);
+        sendError(res, 500, msg);
+      }
+      return true;
+    }
+  }
+
+  // POST /api/rpg/progression/skills/unlock
+  if (req.method === 'POST' && (subPath === '/skills/unlock' || subPath === '/skills/unlock/')) {
+    handleUnlockSkill(opts.dbPath, req, res).catch((err) => {
+      const msg = err instanceof Error ? err.message : String(err);
+      sendError(res, 500, msg);
+    });
     return true;
   }
 

--- a/lib/progression-store.ts
+++ b/lib/progression-store.ts
@@ -20,6 +20,9 @@ import type {
   XpEvent,
   XpSourceCategory,
   PrestigeRecord,
+  AnnotatedSkillNode,
+  SkillNodeStatus,
+  LeaderboardEntry,
 } from './types/progression';
 import {
   levelFromXp,
@@ -102,11 +105,32 @@ CREATE TABLE IF NOT EXISTS prestige_records (
   created_at              TEXT NOT NULL DEFAULT (datetime('now'))
 );
 
+
+-- Phase 2: Skill node visual layout positions
+CREATE TABLE IF NOT EXISTS skill_node_layouts (
+  node_id            TEXT PRIMARY KEY,
+  x                  REAL NOT NULL DEFAULT 0,
+  y                  REAL NOT NULL DEFAULT 0,
+  FOREIGN KEY (node_id) REFERENCES skill_nodes(node_id)
+);
+
+-- Phase 2: Progression milestones feed
+CREATE TABLE IF NOT EXISTS progression_milestones (
+  id                 TEXT PRIMARY KEY,
+  agent_id           TEXT NOT NULL,
+  type               TEXT NOT NULL,
+  title              TEXT NOT NULL,
+  description        TEXT NOT NULL DEFAULT '',
+  metadata           TEXT NOT NULL DEFAULT '{}',
+  created_at         TEXT NOT NULL DEFAULT (datetime('now'))
+);
+
 -- Indices for common queries
 CREATE INDEX IF NOT EXISTS idx_xp_events_agent      ON xp_events(agent_id, created_at DESC);
 CREATE INDEX IF NOT EXISTS idx_xp_events_category   ON xp_events(agent_id, source_category);
 CREATE INDEX IF NOT EXISTS idx_skill_unlocks_agent   ON skill_unlocks(agent_id);
 CREATE INDEX IF NOT EXISTS idx_prestige_agent        ON prestige_records(agent_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_milestones_agent      ON progression_milestones(agent_id, created_at DESC);
 `;
 
 // ─── Store Class ────────────────────────────────────────────────────────────
@@ -441,6 +465,172 @@ export class ProgressionStore {
     return this.db
       .prepare('SELECT * FROM prestige_records WHERE agent_id = ? ORDER BY created_at DESC')
       .all(agentId) as PrestigeRecord[];
+  }
+
+  // ─── Phase 2: Skill Tree State & Unlock (#207) ─────────────────────────
+
+  /**
+   * Get the annotated skill tree for an agent.
+   * Each node is tagged with its status: 'unlocked', 'available', or 'locked'.
+   * A node is 'available' when all prerequisites are unlocked.
+   */
+  getSkillTreeState(agentId: string): {
+    nodes: AnnotatedSkillNode[];
+    edges: SkillEdge[];
+    unlocked_count: number;
+  } {
+    const nodes = this.getSkillNodes();
+    const edges = this.getSkillEdges();
+    const unlocks = this.getUnlocks(agentId);
+    const profile = this.getOrCreateProfile(agentId);
+
+    const unlockedSet = new Set(unlocks.map((u) => u.node_id));
+
+    const annotated: AnnotatedSkillNode[] = nodes.map((node) => {
+      let status: SkillNodeStatus;
+      if (unlockedSet.has(node.node_id)) {
+        status = 'unlocked';
+      } else if (
+        node.prerequisites.length === 0 ||
+        node.prerequisites.every((p) => unlockedSet.has(p))
+      ) {
+        status = 'available';
+      } else {
+        status = 'locked';
+      }
+
+      return {
+        ...node,
+        status,
+        affordable: status === 'available' && profile.current_xp >= node.xp_cost,
+      };
+    });
+
+    return {
+      nodes: annotated,
+      edges,
+      unlocked_count: unlockedSet.size,
+    };
+  }
+
+  /**
+   * Unlock a skill node for an agent.
+   * Validates: node exists, not already unlocked, prerequisites met, XP sufficient.
+   * Deducts XP cost from current_xp and recalculates level.
+   */
+  unlockSkill(
+    agentId: string,
+    nodeId: string,
+  ): { unlock: SkillUnlock; profile: ProgressionProfile; node: AnnotatedSkillNode } {
+    return this.db.transaction(() => {
+      const profile = this.getOrCreateProfile(agentId);
+
+      // Validate node exists
+      const nodeRow = this.db
+        .prepare('SELECT * FROM skill_nodes WHERE node_id = ?')
+        .get(nodeId) as { node_id: string; name: string; description: string; category: string; xp_cost: number; tier: number; prerequisites: string } | undefined;
+      if (!nodeRow) throw new Error(`Skill node not found: ${nodeId}`);
+
+      const node: SkillNode = {
+        ...nodeRow,
+        category: nodeRow.category as SkillNode['category'],
+        prerequisites: JSON.parse(nodeRow.prerequisites) as string[],
+      };
+
+      // Check not already unlocked
+      const existing = this.db
+        .prepare('SELECT 1 FROM skill_unlocks WHERE agent_id = ? AND node_id = ?')
+        .get(agentId, nodeId);
+      if (existing) throw new Error(`Skill already unlocked: ${nodeId}`);
+
+      // Check prerequisites
+      if (node.prerequisites.length > 0) {
+        const unlocked = this.getUnlocks(agentId);
+        const unlockedSet = new Set(unlocked.map((u) => u.node_id));
+        const missing = node.prerequisites.filter((p) => !unlockedSet.has(p));
+        if (missing.length > 0) {
+          throw new Error(`Prerequisites not met: ${missing.join(', ')}`);
+        }
+      }
+
+      // Check XP
+      if (profile.current_xp < node.xp_cost) {
+        throw new Error(
+          `Insufficient XP: have ${profile.current_xp}, need ${node.xp_cost}`,
+        );
+      }
+
+      // Deduct XP and recalculate level
+      const newXp = profile.current_xp - node.xp_cost;
+      const newLevel = levelFromXp(newXp);
+      this.db
+        .prepare(
+          `UPDATE progression_profiles
+           SET current_xp = ?, level = ?, updated_at = datetime('now')
+           WHERE agent_id = ?`,
+        )
+        .run(newXp, newLevel, agentId);
+
+      // Insert unlock record
+      this.db
+        .prepare(
+          `INSERT INTO skill_unlocks (agent_id, node_id, prestige_rank_at_unlock)
+           VALUES (?, ?, ?)`,
+        )
+        .run(agentId, nodeId, profile.prestige_rank);
+
+      const unlock = this.db
+        .prepare(
+          'SELECT * FROM skill_unlocks WHERE agent_id = ? AND node_id = ?',
+        )
+        .get(agentId, nodeId) as SkillUnlock;
+
+      const updatedProfile = this.db
+        .prepare('SELECT * FROM progression_profiles WHERE agent_id = ?')
+        .get(agentId) as ProgressionProfile;
+
+      const annotatedNode: AnnotatedSkillNode = {
+        ...node,
+        status: 'unlocked',
+        affordable: false,
+      };
+
+      return { unlock, profile: updatedProfile, node: annotatedNode };
+    })();
+  }
+
+  /**
+   * Get leaderboard: agents ranked by composite score.
+   * Sort: prestige_rank DESC, level DESC, lifetime_xp DESC.
+   */
+  getLeaderboard(limit: number = 50): { entries: LeaderboardEntry[]; total_agents: number } {
+    const total = this.db
+      .prepare('SELECT COUNT(*) as cnt FROM progression_profiles')
+      .get() as { cnt: number };
+
+    const rows = this.db
+      .prepare(
+        `SELECT p.*,
+                (SELECT COUNT(*) FROM skill_unlocks WHERE agent_id = p.agent_id) as unlocked_skills
+         FROM progression_profiles p
+         ORDER BY p.prestige_rank DESC, p.level DESC, p.lifetime_xp DESC
+         LIMIT ?`,
+      )
+      .all(limit) as Array<ProgressionProfile & { unlocked_skills: number }>;
+
+    const entries: LeaderboardEntry[] = rows.map((r, i) => ({
+      rank: i + 1,
+      agent_id: r.agent_id,
+      display_name: r.display_name,
+      level: r.level,
+      current_xp: r.current_xp,
+      lifetime_xp: r.lifetime_xp,
+      prestige_rank: r.prestige_rank,
+      unlocked_skills: r.unlocked_skills,
+      diversification_score: r.diversification_score,
+    }));
+
+    return { entries, total_agents: total.cnt };
   }
 }
 

--- a/lib/types/progression.ts
+++ b/lib/types/progression.ts
@@ -183,6 +183,60 @@ export interface PrestigeResponse {
   profile: ProgressionProfile;
 }
 
+// ─── Phase 2: Skill Tree UI & Progression Polish (#207) ─────────────────────
+
+/** Unlock state for a single node in an annotated skill tree. */
+export type SkillNodeStatus = 'locked' | 'available' | 'unlocked';
+
+/** A skill node annotated with its current unlock state for a specific agent. */
+export interface AnnotatedSkillNode extends SkillNode {
+  status: SkillNodeStatus;
+  /** True when the agent can afford this node's XP cost (meaningful when status='available'). */
+  affordable: boolean;
+}
+
+/** GET /api/rpg/progression/skill-tree/:agentId — annotated skill tree. */
+export interface SkillTreeStateResponse {
+  agent_id: string;
+  current_xp: number;
+  nodes: AnnotatedSkillNode[];
+  edges: SkillEdge[];
+  unlocked_count: number;
+  total_count: number;
+}
+
+/** POST /api/rpg/progression/skills/unlock — unlock a skill node. */
+export interface UnlockSkillRequest {
+  agent_id: string;
+  node_id: string;
+}
+
+/** Response for skill unlock. */
+export interface UnlockSkillResponse {
+  ok: true;
+  unlock: SkillUnlock;
+  profile: ProgressionProfile;
+  node: AnnotatedSkillNode;
+}
+
+/** GET /api/rpg/progression/leaderboard — ranked agents. */
+export interface LeaderboardEntry {
+  rank: number;
+  agent_id: string;
+  display_name: string;
+  level: number;
+  current_xp: number;
+  lifetime_xp: number;
+  prestige_rank: number;
+  unlocked_skills: number;
+  diversification_score: number;
+}
+
+export interface LeaderboardResponse {
+  entries: LeaderboardEntry[];
+  total_agents: number;
+}
+
 /** Handler options matching the existing pattern. */
 export interface ProgressionHandlerOptions {
   dbPath: string;
@@ -192,4 +246,59 @@ export interface ProgressionHandlerOptions {
 export interface ProgressionErrorResponse {
   ok: false;
   error: string;
+}
+
+// ─── Phase 2 Types (Issue #207) ─────────────────────────────────────────────
+
+/** Visual position of a skill node in the tree editor. */
+export interface SkillNodeLayout {
+  node_id: string;
+  x: number;
+  y: number;
+}
+
+/** Result of skill tree graph validation. */
+export interface SkillTreeValidation {
+  valid: boolean;
+  errors: string[];
+  warnings: string[];
+}
+
+/** XP attribution breakdown by source category. */
+export interface XpAttribution {
+  source_category: string;
+  total_raw_xp: number;
+  total_effective_xp: number;
+  event_count: number;
+  avg_multiplier: number;
+}
+
+/** Prestige simulation preview (non-destructive). */
+export interface PrestigeSimulation {
+  agent_id: string;
+  current_rank: number;
+  next_rank: number;
+  eligible: boolean;
+  preview: {
+    xp_reset_from: number;
+    level_reset_from: number;
+    unlocks_lost: number;
+    lifetime_xp_kept: number;
+    level_requirement: number;
+    xp_requirement: number;
+  };
+}
+
+/** Types of progression milestones. */
+export type MilestoneType = 'level_up' | 'skill_unlock' | 'prestige' | 'diversification';
+
+/** A progression milestone event. */
+export interface ProgressionMilestone {
+  id: string;
+  agent_id: string;
+  type: MilestoneType;
+  title: string;
+  description: string;
+  created_at: string;
+  metadata?: Record<string, unknown>;
 }


### PR DESCRIPTION
## Phase 4.5 Phase 2: Visual Skill Tree UI & Progression Polish

Closes #207

### What Changed

**New Store Methods (lib/progression-store.ts)**
- `unlockSkill(agentId, nodeId)` — validates prerequisites, checks XP budget, deducts cost, records unlock, recalculates level
- `getSkillTreeState(agentId)` — returns all 15 nodes annotated with `locked`/`available`/`unlocked` status + affordability flag
- `getLeaderboard(limit)` — ranks agents by prestige → level → lifetime_xp with unlocked_skills count

**New HTTP Endpoints (lib/progression-http.ts)**
| Method | Route | Purpose |
|--------|-------|---------|
| GET | `/api/rpg/progression/skill-tree/:agentId` | Annotated tree state for rendering |
| POST | `/api/rpg/progression/skills/unlock` | Unlock a skill node (validates + deducts XP) |
| GET | `/api/rpg/progression/leaderboard?limit=` | Ranked agent leaderboard |

**New Types (lib/types/progression.ts)**
- `AnnotatedSkillNode`, `SkillNodeStatus` (`locked` | `available` | `unlocked`)
- `SkillTreeStateResponse`, `UnlockSkillRequest`, `UnlockSkillResponse`
- `LeaderboardEntry`, `LeaderboardResponse`

### Cleanup
Removed broken orphaned code after the class closing brace (leftover from prior attempt referencing non-existent types).

### Test Evidence — 24 new tests, all passing

```
PASS lib/__tests__/skill-tree-phase2.test.ts
  getSkillTreeState
    ✓ returns all nodes with correct status for a fresh agent
    ✓ marks nodes as affordable when agent has enough XP
    ✓ marks nodes as not affordable when agent lacks XP
    ✓ returns edges matching the skill tree
  unlockSkill
    ✓ unlocks a tier-1 skill node and deducts XP
    ✓ makes tier-2 node available after tier-1 unlock
    ✓ allows chaining tier-1 → tier-2 → tier-3 unlocks
    ✓ throws when node does not exist
    ✓ throws when skill already unlocked
    ✓ throws when prerequisites not met
    ✓ throws when insufficient XP
    ✓ recalculates level after XP deduction
    ✓ records prestige_rank_at_unlock correctly
  getLeaderboard
    ✓ returns empty leaderboard when no agents exist
    ✓ ranks agents by prestige → level → lifetime_xp
    ✓ includes unlocked_skills count
    ✓ respects limit parameter
    ✓ returns all required fields
  HTTP route integration
    ✓ GET /api/rpg/progression/skill-tree/:agentId returns annotated tree
    ✓ POST /api/rpg/progression/skills/unlock returns unlock result
    ✓ GET /api/rpg/progression/leaderboard returns entries
    ✓ GET /api/rpg/progression/leaderboard respects ?limit=
    ✓ POST /api/rpg/progression/skills/unlock rejects missing node_id
    ✓ POST /api/rpg/progression/skills/unlock rejects insufficient XP

Tests: 24 passed, 24 total (+ 65 existing tests still passing)
```

### Acceptance Checklist
- [x] All 24 new tests pass
- [x] All 65 existing progression tests still pass (89 total)
- [x] Pure additive changes — no existing behavior modified
- [x] Input sanitization on all HTTP endpoints (agent_id, node_id regex + length cap)
- [x] XP deduction is transactional (SQLite transaction wraps the unlock)
- [x] Level is recalculated after XP spend
- [x] Prerequisite chain enforced (tier 1 → 2 → 3)
- [x] Type exports available for future client-side consumption
- [x] No dashboard server changes (existing route adapter picks up new routes automatically)

### Residual Risks
- **Native module**: `better-sqlite3` binary in git may need `npm rebuild` on fresh clone (pre-existing issue, not introduced here)
- **Future work**: Client-side skill tree visualization (React/canvas component) not included — this PR provides the API contract only
- **Leaderboard pagination**: Current implementation uses simple LIMIT; offset-based pagination can be added later if needed