### PR TITLE
feat(dashboard): Task Board Kanban API — first vertical slice (#219)

### DIFF
--- a/dashboard/server/routes/index.ts
+++ b/dashboard/server/routes/index.ts
@@ -14,3 +14,4 @@ export { handleTacticalMapControls } from './tactical-map-controls.js';
 export { handleTacticalMapReplay } from './tactical-map-replay.js';
 export { handleAgentDiagnostics } from './agent-diagnostics.js';
 export { handleChangelog } from './changelog.js';
+export { handleTaskBoard } from './task-board.js';

--- a/dashboard/server/routes/task-board.ts
+++ b/dashboard/server/routes/task-board.ts
@@ -1,0 +1,318 @@
+/**
+ * Task Board (Kanban) route handlers.
+ * Issue #219 — first vertical slice.
+ *
+ * Provides CRUD + summary endpoints for task cards that flow through
+ * Backlog → Queued → Running → Done/Failed columns.
+ *
+ * Data is persisted as a single JSON file on disk (consistent with
+ * the rest of the dashboard's filesystem-based storage).
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type {
+  TaskBoardDeps,
+  TaskCard,
+  TaskStatus,
+  TaskPriority,
+  TaskBoardSummary,
+} from '../types.js';
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const VALID_STATUSES: TaskStatus[] = ['backlog', 'queued', 'running', 'done', 'failed'];
+const VALID_PRIORITIES: TaskPriority[] = ['critical', 'high', 'medium', 'low'];
+
+/** Allowed state transitions (from → to[]). */
+const TRANSITIONS: Record<TaskStatus, TaskStatus[]> = {
+  backlog: ['queued', 'done'],
+  queued: ['running', 'backlog', 'done'],
+  running: ['done', 'failed'],
+  done: ['backlog'],
+  failed: ['backlog', 'queued'],
+};
+
+// ─── Store helpers ───────────────────────────────────────────────────────────
+
+function taskFilePath(dataDir: string): string {
+  return path.join(dataDir, 'task-board.json');
+}
+
+export function loadTasks(dataDir: string): TaskCard[] {
+  try {
+    const fp = taskFilePath(dataDir);
+    if (!fs.existsSync(fp)) return [];
+    const raw = fs.readFileSync(fp, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) return parsed as TaskCard[];
+    if (parsed && Array.isArray(parsed.tasks)) return parsed.tasks as TaskCard[];
+    return [];
+  } catch {
+    return [];
+  }
+}
+
+function saveTasks(dataDir: string, tasks: TaskCard[]): void {
+  const fp = taskFilePath(dataDir);
+  const dir = path.dirname(fp);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(fp, JSON.stringify({ tasks, updatedAt: Date.now() }, null, 2));
+}
+
+// ─── Derived data ────────────────────────────────────────────────────────────
+
+export function buildSummary(tasks: TaskCard[]): TaskBoardSummary {
+  const columns: Record<TaskStatus, number> = {
+    backlog: 0,
+    queued: 0,
+    running: 0,
+    done: 0,
+    failed: 0,
+  };
+  const byAgent: Record<string, Record<TaskStatus, number>> = {};
+
+  for (const t of tasks) {
+    columns[t.status] = (columns[t.status] ?? 0) + 1;
+    const aid = t.agentId ?? '_unassigned';
+    if (!byAgent[aid]) {
+      byAgent[aid] = { backlog: 0, queued: 0, running: 0, done: 0, failed: 0 };
+    }
+    byAgent[aid][t.status] = (byAgent[aid][t.status] ?? 0) + 1;
+  }
+
+  return { updatedAt: Date.now(), columns, byAgent, total: tasks.length };
+}
+
+export function filterTasks(
+  tasks: TaskCard[],
+  opts: { status?: string | null; agentId?: string | null; priority?: string | null },
+): TaskCard[] {
+  let out = tasks;
+  if (opts.status && VALID_STATUSES.includes(opts.status as TaskStatus)) {
+    out = out.filter((t) => t.status === opts.status);
+  }
+  if (opts.agentId) {
+    out = out.filter((t) => t.agentId === opts.agentId);
+  }
+  if (opts.priority && VALID_PRIORITIES.includes(opts.priority as TaskPriority)) {
+    out = out.filter((t) => t.priority === opts.priority);
+  }
+  return out;
+}
+
+export function isValidTransition(from: TaskStatus, to: TaskStatus): boolean {
+  return (TRANSITIONS[from] ?? []).includes(to);
+}
+
+// ─── Validation helpers ──────────────────────────────────────────────────────
+
+interface CreateInput {
+  title?: string;
+  description?: string;
+  priority?: string;
+  agentId?: string | null;
+  status?: string;
+}
+
+function validateCreate(body: CreateInput): { ok: true; card: TaskCard } | { ok: false; error: string } {
+  const title = (body.title ?? '').trim();
+  if (!title) return { ok: false, error: 'title is required' };
+  if (title.length > 200) return { ok: false, error: 'title must be ≤ 200 chars' };
+
+  const description = (body.description ?? '').trim();
+  if (description.length > 2000) return { ok: false, error: 'description must be ≤ 2000 chars' };
+
+  const priority = (body.priority ?? 'medium') as TaskPriority;
+  if (!VALID_PRIORITIES.includes(priority)) {
+    return { ok: false, error: `invalid priority: ${priority}` };
+  }
+
+  const status = (body.status ?? 'backlog') as TaskStatus;
+  if (!VALID_STATUSES.includes(status)) {
+    return { ok: false, error: `invalid status: ${status}` };
+  }
+
+  const agentId = body.agentId?.trim() || null;
+
+  const card: TaskCard = {
+    id: crypto.randomUUID(),
+    agentId,
+    title,
+    description,
+    priority,
+    status,
+    createdAt: Date.now(),
+    queuedAt: status === 'queued' ? Date.now() : null,
+    startedAt: null,
+    completedAt: null,
+    resultSummary: null,
+    tokensUsed: null,
+    error: null,
+  };
+
+  return { ok: true, card };
+}
+
+// ─── Route handler ───────────────────────────────────────────────────────────
+
+export async function handleTaskBoard(
+  req: IncomingMessage,
+  res: ServerResponse,
+  deps: TaskBoardDeps,
+): Promise<boolean> {
+  const { dataDir, sendJson, readRequestBody } = deps;
+  if (!req?.url) return false;
+
+  const url = req.url;
+  const method = req.method ?? 'GET';
+
+  // ── GET /api/task-board ────────────────────────────────────────────────────
+  // Returns filtered list of cards. Query params: status, agentId, priority.
+  if (url.startsWith('/api/task-board') && !url.startsWith('/api/task-board/') && method === 'GET') {
+    const params = new URL(url, 'http://localhost').searchParams;
+    const tasks = loadTasks(dataDir);
+    const filtered = filterTasks(tasks, {
+      status: params.get('status'),
+      agentId: params.get('agentId'),
+      priority: params.get('priority'),
+    });
+    sendJson(res, { tasks: filtered, total: filtered.length });
+    return true;
+  }
+
+  // ── GET /api/task-board/summary ────────────────────────────────────────────
+  // Returns column counts + per-agent breakdown.
+  if (url === '/api/task-board/summary' && method === 'GET') {
+    const tasks = loadTasks(dataDir);
+    sendJson(res, buildSummary(tasks));
+    return true;
+  }
+
+  // ── GET /api/task-board/:id ────────────────────────────────────────────────
+  // Returns a single card by ID.
+  if (url.startsWith('/api/task-board/') && method === 'GET') {
+    const id = url.split('/api/task-board/')[1]?.split('?')[0];
+    if (!id) return false;
+    const tasks = loadTasks(dataDir);
+    const card = tasks.find((t) => t.id === id);
+    if (!card) {
+      sendJson(res, { error: 'not found' }, 404);
+      return true;
+    }
+    sendJson(res, { card });
+    return true;
+  }
+
+  // ── POST /api/task-board ───────────────────────────────────────────────────
+  // Create a new card.
+  if (url === '/api/task-board' && method === 'POST') {
+    let body: CreateInput;
+    try {
+      const raw = await readRequestBody(req, { maxBytes: 8192 });
+      body = JSON.parse(raw) as CreateInput;
+    } catch {
+      sendJson(res, { error: 'invalid JSON body' }, 400);
+      return true;
+    }
+
+    const result = validateCreate(body);
+    if (!result.ok) {
+      sendJson(res, { error: result.error }, 400);
+      return true;
+    }
+
+    const tasks = loadTasks(dataDir);
+    tasks.push(result.card);
+    saveTasks(dataDir, tasks);
+    sendJson(res, { card: result.card }, 201);
+    return true;
+  }
+
+  // ── PATCH /api/task-board/:id ──────────────────────────────────────────────
+  // Update a card (status transition, result, etc.).
+  if (url.startsWith('/api/task-board/') && method === 'PATCH') {
+    const id = url.split('/api/task-board/')[1]?.split('?')[0];
+    if (!id) return false;
+
+    let body: Record<string, unknown>;
+    try {
+      const raw = await readRequestBody(req, { maxBytes: 8192 });
+      body = JSON.parse(raw) as Record<string, unknown>;
+    } catch {
+      sendJson(res, { error: 'invalid JSON body' }, 400);
+      return true;
+    }
+
+    const tasks = loadTasks(dataDir);
+    const idx = tasks.findIndex((t) => t.id === id);
+    if (idx === -1) {
+      sendJson(res, { error: 'not found' }, 404);
+      return true;
+    }
+
+    const card = { ...tasks[idx] };
+
+    // Status transition
+    if (typeof body.status === 'string') {
+      const newStatus = body.status as TaskStatus;
+      if (!VALID_STATUSES.includes(newStatus)) {
+        sendJson(res, { error: `invalid status: ${newStatus}` }, 400);
+        return true;
+      }
+      if (!isValidTransition(card.status, newStatus)) {
+        sendJson(
+          res,
+          { error: `invalid transition: ${card.status} → ${newStatus}` },
+          400,
+        );
+        return true;
+      }
+      card.status = newStatus;
+      const now = Date.now();
+      if (newStatus === 'queued') card.queuedAt = now;
+      if (newStatus === 'running') card.startedAt = now;
+      if (newStatus === 'done' || newStatus === 'failed') card.completedAt = now;
+    }
+
+    // Mutable fields
+    if (typeof body.title === 'string') card.title = (body.title as string).slice(0, 200);
+    if (typeof body.description === 'string') card.description = (body.description as string).slice(0, 2000);
+    if (typeof body.agentId === 'string') card.agentId = body.agentId || null;
+    if (typeof body.priority === 'string' && VALID_PRIORITIES.includes(body.priority as TaskPriority)) {
+      card.priority = body.priority as TaskPriority;
+    }
+    if (typeof body.resultSummary === 'string') card.resultSummary = body.resultSummary;
+    if (typeof body.tokensUsed === 'number') card.tokensUsed = body.tokensUsed;
+    if (typeof body.error === 'string') card.error = body.error;
+
+    tasks[idx] = card;
+    saveTasks(dataDir, tasks);
+    sendJson(res, { card });
+    return true;
+  }
+
+  // ── DELETE /api/task-board/:id ─────────────────────────────────────────────
+  // Remove a card.
+  if (url.startsWith('/api/task-board/') && method === 'DELETE') {
+    const id = url.split('/api/task-board/')[1]?.split('?')[0];
+    if (!id) return false;
+
+    const tasks = loadTasks(dataDir);
+    const idx = tasks.findIndex((t) => t.id === id);
+    if (idx === -1) {
+      sendJson(res, { error: 'not found' }, 404);
+      return true;
+    }
+
+    tasks.splice(idx, 1);
+    saveTasks(dataDir, tasks);
+    sendJson(res, { ok: true });
+    return true;
+  }
+
+  return false;
+}

--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -106,6 +106,7 @@ import { handleLogs } from './routes/logs.js';
 import { handleTacticalMapReplay } from './routes/tactical-map-replay.js';
 import { handleProgressionApi } from './routes/progression.js';
 import { handleChangelog } from './routes/changelog.js';
+import { handleTaskBoard } from './routes/task-board.js';
 
 // ─── Configuration ───────────────────────────────────────────────────────────
 // All VentureOS data paths flow through lib/paths.ts (no os.homedir() needed).
@@ -3177,6 +3178,23 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
     if (handleChangelog(req, res, { ventureosRoot: VENTUREOS_ROOT, sendJson, clampInt })) return;
   } catch {
     // ignore
+  }
+
+  // Task Board (Kanban) — Issue #219
+  if (req.url && req.url.startsWith('/api/task-board')) {
+    try {
+      const handled = await handleTaskBoard(req, res, {
+        dataDir: DASHBOARD_DATA_DIR,
+        sendJson,
+        readRequestBody,
+      });
+      if (handled) return;
+    } catch (e: unknown) {
+      const safe = toSafeError(e, { route: 'task-board' });
+      slogError('dashboard', 'route_error', 'task-board error', { errorRef: safe.errorRef });
+      sendJson(res, { ok: false, error: safe.error, errorRef: safe.errorRef }, safe.status);
+      return;
+    }
   }
 
   // Action endpoints — use shared error handler (Issue #79) for safe responses

--- a/dashboard/server/types.ts
+++ b/dashboard/server/types.ts
@@ -680,3 +680,43 @@ export interface ReplaySessionListResponse {
   pageSize: number;
   page: number;
 }
+
+// ─── Task Board Domain (Issue #219) ──────────────────────────────────────────
+
+/** Valid task card statuses (Kanban columns). */
+export type TaskStatus = 'backlog' | 'queued' | 'running' | 'done' | 'failed';
+
+/** Valid task card priorities. */
+export type TaskPriority = 'critical' | 'high' | 'medium' | 'low';
+
+/** A single task board card. */
+export interface TaskCard {
+  id: string;
+  agentId: string | null;
+  title: string;
+  description: string;
+  priority: TaskPriority;
+  status: TaskStatus;
+  createdAt: number;
+  queuedAt: number | null;
+  startedAt: number | null;
+  completedAt: number | null;
+  resultSummary: string | null;
+  tokensUsed: number | null;
+  error: string | null;
+}
+
+/** Summary counts per column returned by the summary endpoint. */
+export interface TaskBoardSummary {
+  updatedAt: number;
+  columns: Record<TaskStatus, number>;
+  byAgent: Record<string, Record<TaskStatus, number>>;
+  total: number;
+}
+
+/** Dependencies injected into Task Board route handlers. */
+export interface TaskBoardDeps {
+  dataDir: string;
+  sendJson: (res: ServerResponse, data: unknown, status?: number) => void;
+  readRequestBody: (req: IncomingMessage, opts?: { maxBytes?: number }) => Promise<string>;
+}

--- a/dashboard/tests/unit/routes/task-board.test.ts
+++ b/dashboard/tests/unit/routes/task-board.test.ts
@@ -1,0 +1,535 @@
+/**
+ * Task Board (Kanban) route handler tests — Issue #219.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { mockRequest, mockResponse, parseJsonBody } from '../../helpers.js';
+import {
+  handleTaskBoard,
+  loadTasks,
+  buildSummary,
+  filterTasks,
+  isValidTransition,
+} from '../../../server/routes/task-board.js';
+import type { TaskBoardDeps, TaskCard, TaskStatus } from '../../../server/types.js';
+
+const testDataDir = path.join('/tmp', 'test-task-board-' + process.pid);
+
+function createDeps(overrides: Partial<TaskBoardDeps> = {}): TaskBoardDeps {
+  return {
+    dataDir: testDataDir,
+    sendJson: (res, data, status = 200) => {
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+    },
+    readRequestBody: async (req) => {
+      return new Promise<string>((resolve) => {
+        let body = '';
+        req.on('data', (chunk: Buffer) => {
+          body += chunk.toString();
+        });
+        req.on('end', () => resolve(body));
+        // If no data events, resolve with the body we've set up
+        setTimeout(() => resolve(body), 10);
+      });
+    },
+    ...overrides,
+  };
+}
+
+/** Helper to write a POST/PATCH request body. */
+function mockRequestWithBody(
+  opts: { url: string; method: string },
+  body: unknown,
+): ReturnType<typeof mockRequest> {
+  const req = mockRequest(opts);
+  // Simulate body by providing readRequestBody override
+  return req;
+}
+
+/** Create deps with a direct body reader (avoids stream simulation). */
+function depsWithBody(body: unknown, overrides: Partial<TaskBoardDeps> = {}): TaskBoardDeps {
+  return createDeps({
+    readRequestBody: async () => JSON.stringify(body),
+    ...overrides,
+  });
+}
+
+function seedTasks(tasks: TaskCard[]): void {
+  fs.mkdirSync(testDataDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(testDataDir, 'task-board.json'),
+    JSON.stringify({ tasks, updatedAt: Date.now() }),
+  );
+}
+
+function makeSampleCard(overrides: Partial<TaskCard> = {}): TaskCard {
+  return {
+    id: 'test-' + Math.random().toString(36).slice(2, 8),
+    agentId: 'oracle',
+    title: 'Test task',
+    description: 'A test task',
+    priority: 'medium',
+    status: 'backlog',
+    createdAt: Date.now(),
+    queuedAt: null,
+    startedAt: null,
+    completedAt: null,
+    resultSummary: null,
+    tokensUsed: null,
+    error: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  fs.mkdirSync(testDataDir, { recursive: true });
+  // Clean
+  const fp = path.join(testDataDir, 'task-board.json');
+  if (fs.existsSync(fp)) fs.unlinkSync(fp);
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(testDataDir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+// ─── Unit tests for pure functions ───────────────────────────────────────────
+
+describe('buildSummary', () => {
+  it('returns zero counts when no tasks', () => {
+    const summary = buildSummary([]);
+    expect(summary.total).toBe(0);
+    expect(summary.columns.backlog).toBe(0);
+    expect(summary.columns.running).toBe(0);
+    expect(Object.keys(summary.byAgent)).toHaveLength(0);
+  });
+
+  it('counts tasks by column', () => {
+    const tasks: TaskCard[] = [
+      makeSampleCard({ status: 'backlog' }),
+      makeSampleCard({ status: 'backlog' }),
+      makeSampleCard({ status: 'running' }),
+      makeSampleCard({ status: 'done' }),
+    ];
+    const summary = buildSummary(tasks);
+    expect(summary.total).toBe(4);
+    expect(summary.columns.backlog).toBe(2);
+    expect(summary.columns.running).toBe(1);
+    expect(summary.columns.done).toBe(1);
+    expect(summary.columns.queued).toBe(0);
+  });
+
+  it('groups by agent', () => {
+    const tasks: TaskCard[] = [
+      makeSampleCard({ agentId: 'oracle', status: 'running' }),
+      makeSampleCard({ agentId: 'sentinel', status: 'done' }),
+      makeSampleCard({ agentId: 'oracle', status: 'done' }),
+    ];
+    const summary = buildSummary(tasks);
+    expect(summary.byAgent['oracle'].running).toBe(1);
+    expect(summary.byAgent['oracle'].done).toBe(1);
+    expect(summary.byAgent['sentinel'].done).toBe(1);
+  });
+
+  it('groups unassigned tasks under _unassigned', () => {
+    const tasks: TaskCard[] = [makeSampleCard({ agentId: null, status: 'backlog' })];
+    const summary = buildSummary(tasks);
+    expect(summary.byAgent['_unassigned'].backlog).toBe(1);
+  });
+});
+
+describe('filterTasks', () => {
+  const tasks: TaskCard[] = [
+    makeSampleCard({ id: 'a', agentId: 'oracle', status: 'backlog', priority: 'high' }),
+    makeSampleCard({ id: 'b', agentId: 'sentinel', status: 'running', priority: 'low' }),
+    makeSampleCard({ id: 'c', agentId: 'oracle', status: 'running', priority: 'critical' }),
+    makeSampleCard({ id: 'd', agentId: null, status: 'done', priority: 'medium' }),
+  ];
+
+  it('returns all tasks with no filters', () => {
+    expect(filterTasks(tasks, {})).toHaveLength(4);
+  });
+
+  it('filters by status', () => {
+    const result = filterTasks(tasks, { status: 'running' });
+    expect(result).toHaveLength(2);
+    expect(result.every((t) => t.status === 'running')).toBe(true);
+  });
+
+  it('filters by agentId', () => {
+    const result = filterTasks(tasks, { agentId: 'oracle' });
+    expect(result).toHaveLength(2);
+  });
+
+  it('filters by priority', () => {
+    const result = filterTasks(tasks, { priority: 'critical' });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('c');
+  });
+
+  it('combines filters', () => {
+    const result = filterTasks(tasks, { status: 'running', agentId: 'oracle' });
+    expect(result).toHaveLength(1);
+    expect(result[0].id).toBe('c');
+  });
+
+  it('ignores invalid status', () => {
+    const result = filterTasks(tasks, { status: 'invalid' });
+    expect(result).toHaveLength(4); // no filtering applied
+  });
+});
+
+describe('isValidTransition', () => {
+  it('allows backlog → queued', () => {
+    expect(isValidTransition('backlog', 'queued')).toBe(true);
+  });
+
+  it('allows queued → running', () => {
+    expect(isValidTransition('queued', 'running')).toBe(true);
+  });
+
+  it('allows running → done', () => {
+    expect(isValidTransition('running', 'done')).toBe(true);
+  });
+
+  it('allows running → failed', () => {
+    expect(isValidTransition('running', 'failed')).toBe(true);
+  });
+
+  it('allows failed → backlog', () => {
+    expect(isValidTransition('failed', 'backlog')).toBe(true);
+  });
+
+  it('allows failed → queued', () => {
+    expect(isValidTransition('failed', 'queued')).toBe(true);
+  });
+
+  it('allows done → backlog (re-queue)', () => {
+    expect(isValidTransition('done', 'backlog')).toBe(true);
+  });
+
+  it('rejects backlog → done directly skipping queue', () => {
+    // Allowed — see TRANSITIONS: backlog can → done for manual completion
+    expect(isValidTransition('backlog', 'done')).toBe(true);
+  });
+
+  it('rejects backlog → running (must go through queued)', () => {
+    expect(isValidTransition('backlog', 'running')).toBe(false);
+  });
+
+  it('rejects done → running', () => {
+    expect(isValidTransition('done', 'running')).toBe(false);
+  });
+
+  it('rejects queued → failed', () => {
+    expect(isValidTransition('queued', 'failed')).toBe(false);
+  });
+});
+
+describe('loadTasks', () => {
+  it('returns empty array when file does not exist', () => {
+    expect(loadTasks('/tmp/nonexistent-xyz-' + Date.now())).toEqual([]);
+  });
+
+  it('loads tasks from file', () => {
+    const cards = [makeSampleCard({ id: 'x' })];
+    seedTasks(cards);
+    const loaded = loadTasks(testDataDir);
+    expect(loaded).toHaveLength(1);
+    expect(loaded[0].id).toBe('x');
+  });
+
+  it('handles corrupt JSON gracefully', () => {
+    fs.writeFileSync(path.join(testDataDir, 'task-board.json'), '{broken');
+    expect(loadTasks(testDataDir)).toEqual([]);
+  });
+});
+
+// ─── HTTP route handler tests ────────────────────────────────────────────────
+
+describe('handleTaskBoard', () => {
+  describe('GET /api/task-board', () => {
+    it('returns empty list when no tasks', async () => {
+      const res = mockResponse();
+      const handled = await handleTaskBoard(
+        mockRequest({ url: '/api/task-board' }),
+        res,
+        createDeps(),
+      );
+      expect(handled).toBe(true);
+      const body = parseJsonBody(res);
+      expect(body.tasks).toEqual([]);
+      expect(body.total).toBe(0);
+    });
+
+    it('returns all tasks', async () => {
+      seedTasks([makeSampleCard({ id: '1' }), makeSampleCard({ id: '2' })]);
+      const res = mockResponse();
+      await handleTaskBoard(mockRequest({ url: '/api/task-board' }), res, createDeps());
+      const body = parseJsonBody(res);
+      expect(body.tasks).toHaveLength(2);
+    });
+
+    it('filters by status query param', async () => {
+      seedTasks([
+        makeSampleCard({ id: '1', status: 'backlog' }),
+        makeSampleCard({ id: '2', status: 'running' }),
+      ]);
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board?status=running' }),
+        res,
+        createDeps(),
+      );
+      const body = parseJsonBody(res);
+      expect(body.tasks).toHaveLength(1);
+      expect((body.tasks as TaskCard[])[0].id).toBe('2');
+    });
+
+    it('filters by agentId query param', async () => {
+      seedTasks([
+        makeSampleCard({ id: '1', agentId: 'oracle' }),
+        makeSampleCard({ id: '2', agentId: 'sentinel' }),
+      ]);
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board?agentId=oracle' }),
+        res,
+        createDeps(),
+      );
+      const body = parseJsonBody(res);
+      expect(body.tasks).toHaveLength(1);
+    });
+  });
+
+  describe('GET /api/task-board/summary', () => {
+    it('returns summary with column counts', async () => {
+      seedTasks([
+        makeSampleCard({ status: 'backlog' }),
+        makeSampleCard({ status: 'running' }),
+        makeSampleCard({ status: 'running' }),
+      ]);
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/summary' }),
+        res,
+        createDeps(),
+      );
+      const body = parseJsonBody<{ columns: Record<string, number>; total: number }>(res);
+      expect(body.total).toBe(3);
+      expect(body.columns.backlog).toBe(1);
+      expect(body.columns.running).toBe(2);
+    });
+  });
+
+  describe('GET /api/task-board/:id', () => {
+    it('returns a single card', async () => {
+      seedTasks([makeSampleCard({ id: 'abc-123' })]);
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/abc-123' }),
+        res,
+        createDeps(),
+      );
+      const body = parseJsonBody<{ card: TaskCard }>(res);
+      expect(body.card.id).toBe('abc-123');
+    });
+
+    it('returns 404 for missing card', async () => {
+      seedTasks([]);
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/nonexistent' }),
+        res,
+        createDeps(),
+      );
+      expect(res._statusCode).toBe(404);
+    });
+  });
+
+  describe('POST /api/task-board', () => {
+    it('creates a new card', async () => {
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board', method: 'POST' }),
+        res,
+        depsWithBody({ title: 'New task', priority: 'high' }),
+      );
+      expect(res._statusCode).toBe(201);
+      const body = parseJsonBody<{ card: TaskCard }>(res);
+      expect(body.card.title).toBe('New task');
+      expect(body.card.priority).toBe('high');
+      expect(body.card.status).toBe('backlog');
+      expect(body.card.id).toBeTruthy();
+
+      // Verify persisted
+      const loaded = loadTasks(testDataDir);
+      expect(loaded).toHaveLength(1);
+      expect(loaded[0].title).toBe('New task');
+    });
+
+    it('rejects empty title', async () => {
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board', method: 'POST' }),
+        res,
+        depsWithBody({ title: '' }),
+      );
+      expect(res._statusCode).toBe(400);
+      expect(parseJsonBody(res).error).toContain('title');
+    });
+
+    it('rejects invalid priority', async () => {
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board', method: 'POST' }),
+        res,
+        depsWithBody({ title: 'Task', priority: 'invalid' }),
+      );
+      expect(res._statusCode).toBe(400);
+    });
+
+    it('defaults to medium priority and backlog status', async () => {
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board', method: 'POST' }),
+        res,
+        depsWithBody({ title: 'Simple task' }),
+      );
+      const body = parseJsonBody<{ card: TaskCard }>(res);
+      expect(body.card.priority).toBe('medium');
+      expect(body.card.status).toBe('backlog');
+    });
+  });
+
+  describe('PATCH /api/task-board/:id', () => {
+    it('updates card status with valid transition', async () => {
+      seedTasks([makeSampleCard({ id: 'card-1', status: 'backlog' })]);
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/card-1', method: 'PATCH' }),
+        res,
+        depsWithBody({ status: 'queued' }),
+      );
+      expect(res._statusCode).toBe(200);
+      const body = parseJsonBody<{ card: TaskCard }>(res);
+      expect(body.card.status).toBe('queued');
+      expect(body.card.queuedAt).toBeTruthy();
+    });
+
+    it('rejects invalid transition', async () => {
+      seedTasks([makeSampleCard({ id: 'card-1', status: 'backlog' })]);
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/card-1', method: 'PATCH' }),
+        res,
+        depsWithBody({ status: 'running' }),
+      );
+      expect(res._statusCode).toBe(400);
+      expect(parseJsonBody(res).error).toContain('invalid transition');
+    });
+
+    it('sets startedAt when transitioning to running', async () => {
+      seedTasks([makeSampleCard({ id: 'card-1', status: 'queued' })]);
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/card-1', method: 'PATCH' }),
+        res,
+        depsWithBody({ status: 'running' }),
+      );
+      const body = parseJsonBody<{ card: TaskCard }>(res);
+      expect(body.card.startedAt).toBeTruthy();
+    });
+
+    it('sets completedAt when transitioning to done', async () => {
+      seedTasks([makeSampleCard({ id: 'card-1', status: 'running' })]);
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/card-1', method: 'PATCH' }),
+        res,
+        depsWithBody({ status: 'done', resultSummary: 'completed successfully' }),
+      );
+      const body = parseJsonBody<{ card: TaskCard }>(res);
+      expect(body.card.completedAt).toBeTruthy();
+      expect(body.card.resultSummary).toBe('completed successfully');
+    });
+
+    it('returns 404 for missing card', async () => {
+      seedTasks([]);
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/nope', method: 'PATCH' }),
+        res,
+        depsWithBody({ status: 'queued' }),
+      );
+      expect(res._statusCode).toBe(404);
+    });
+
+    it('updates mutable fields', async () => {
+      seedTasks([makeSampleCard({ id: 'card-1', title: 'Old', priority: 'low' })]);
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/card-1', method: 'PATCH' }),
+        res,
+        depsWithBody({ title: 'New', priority: 'critical', agentId: 'atlas' }),
+      );
+      const body = parseJsonBody<{ card: TaskCard }>(res);
+      expect(body.card.title).toBe('New');
+      expect(body.card.priority).toBe('critical');
+      expect(body.card.agentId).toBe('atlas');
+    });
+  });
+
+  describe('DELETE /api/task-board/:id', () => {
+    it('deletes a card', async () => {
+      seedTasks([makeSampleCard({ id: 'del-1' }), makeSampleCard({ id: 'del-2' })]);
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/del-1', method: 'DELETE' }),
+        res,
+        createDeps(),
+      );
+      expect(res._statusCode).toBe(200);
+      expect(parseJsonBody(res).ok).toBe(true);
+
+      const remaining = loadTasks(testDataDir);
+      expect(remaining).toHaveLength(1);
+      expect(remaining[0].id).toBe('del-2');
+    });
+
+    it('returns 404 for missing card', async () => {
+      seedTasks([]);
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/nope', method: 'DELETE' }),
+        res,
+        createDeps(),
+      );
+      expect(res._statusCode).toBe(404);
+    });
+  });
+
+  describe('routing', () => {
+    it('returns false for non-task-board URLs', async () => {
+      const handled = await handleTaskBoard(
+        mockRequest({ url: '/api/sessions' }),
+        mockResponse(),
+        createDeps(),
+      );
+      expect(handled).toBe(false);
+    });
+
+    it('returns false when req.url is missing', async () => {
+      const req = mockRequest({});
+      (req as any).url = undefined;
+      const handled = await handleTaskBoard(req, mockResponse(), createDeps());
+      expect(handled).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

First vertical slice for **Issue #219 — Agent Task Board (Kanban)**. Adds a complete CRUD API with state-machine-enforced transitions for task cards flowing through Kanban columns.

## What This PR Does

### Backend Route (`dashboard/server/routes/task-board.ts`)
- **GET** `/api/task-board` — List cards with filtering (`?status=`, `?agentId=`, `?priority=`)
- **GET** `/api/task-board/summary` — Column counts + per-agent breakdown
- **GET** `/api/task-board/:id` — Single card detail
- **POST** `/api/task-board` — Create card (validates title, priority, status)
- **PATCH** `/api/task-board/:id` — Update card with enforced state transitions
- **DELETE** `/api/task-board/:id` — Remove card

### State Machine
```
backlog → queued → running → done
                           → failed → backlog/queued (retry)
done → backlog (re-queue)
backlog → done (manual completion)
```

### Data Model
- File-based JSON at `DASHBOARD_DATA_DIR/task-board.json` (consistent with existing dashboard patterns)
- Each card: id, agentId, title, description, priority, status, timestamps, result, tokens, error

### Tests (`dashboard/tests/unit/routes/task-board.test.ts`)
- **45 tests** covering:
  - Pure functions: `buildSummary`, `filterTasks`, `isValidTransition`, `loadTasks`
  - All HTTP endpoints: GET list/summary/detail, POST create, PATCH update, DELETE
  - Validation: empty title, invalid priority, invalid transitions, 404s, corrupt data

## Acceptance Checklist

- [x] Cards can be created via POST with title/priority/agentId
- [x] Status transitions are enforced (e.g., backlog→running is rejected)
- [x] Timestamps auto-set on transition (queuedAt, startedAt, completedAt)
- [x] Filtering works by status, agentId, and priority
- [x] Summary endpoint returns per-column and per-agent counts
- [x] Failed tasks can be retried (failed → backlog/queued)
- [x] 45 unit tests pass; full dashboard suite (370 tests) green
- [x] TypeScript compiles with zero errors
- [x] Purely additive — no existing code modified beyond wiring

## Changed Files

| File | Change |
|------|--------|
| `dashboard/server/routes/task-board.ts` | **New** — Route handler (318 lines) |
| `dashboard/tests/unit/routes/task-board.test.ts` | **New** — 45 tests (535 lines) |
| `dashboard/server/types.ts` | Added TaskCard, TaskBoardSummary, TaskBoardDeps types |
| `dashboard/server/routes/index.ts` | Added barrel export |
| `dashboard/server/server.ts` | Wired route + error handling |

## Risks

- **Low risk**: Purely additive, no existing behavior changed
- **Data file**: New `task-board.json` created on first write; directory auto-created
- **No UI yet**: This is API-only; Canvas UI is a follow-up slice

## Next Slices (not in this PR)
- Canvas Kanban drag-and-drop UI
- WebSocket real-time card state push
- Heartbeat integration for auto-pickup
- Execution metrics capture (time, tokens, cost)
