### PR TITLE
feat(207): Phase 2 follow-up – skill tree engine, store & HTTP v2 endpoints

### DIFF
--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -105,6 +105,7 @@ import { handleTacticalMapControls } from './routes/tactical-map-controls.js';
 import { handleLogs } from './routes/logs.js';
 import { handleTacticalMapReplay } from './routes/tactical-map-replay.js';
 import { handleProgressionApi } from './routes/progression.js';
+import { handleProgressionV2Api } from '../../lib/progression-http-v2.js';
 import { handleChangelog } from './routes/changelog.js';
 import { handleTaskBoard } from './routes/task-board.js';
 
@@ -2811,6 +2812,9 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
 
   // VentureOS RPG APIs (Issue #78 — monorepo integration)
   if (handleRpgApi(req, res, { dbPath: RPG_DB_PATH })) return;
+
+  // VentureOS Progression V2 APIs (Issue #207 — Phase 4.5 Phase 2)
+  if (handleProgressionV2Api(req, res, { dbPath: RPG_DB_PATH })) return;
 
   // VentureOS Progression APIs (Issue #203 — Phase 4.5)
   if (handleProgressionApi(req, res, { dbPath: RPG_DB_PATH })) return;

--- a/docs/RPG_SYSTEM.md
+++ b/docs/RPG_SYSTEM.md
@@ -1952,3 +1952,29 @@ The RPG system ships features at AI-native velocity (Phase 4 Track 1-2 delivered
 **Current Priority:** Phase 5 P0 Remediation Tier 1 (Security Foundation, Synth + Oracle + Atlas, started 03:57 CST)
 
 **"My life for Aiur! En Taro Adun! Through the Khala, we are eternal!"**
+
+---
+
+## Phase 4.5 Phase 2: Visual Skill Tree UI & Progression Polish (Issue #207)
+
+### New API Endpoints (prefix: `/api/rpg/progression/`)
+- `GET /tree` — Full tree + layouts + validation
+- `GET /tree/state/:agentId` — Tree with per-agent node states
+- `POST /tree/nodes` / `DELETE /tree/nodes` — CRUD skill nodes
+- `POST /tree/layouts` — Save node positions
+- `GET /tree/validate` — Validate tree graph
+- `GET /tree/export` / `POST /tree/import` — Export/import JSON
+- `GET /attribution/:agentId` / `GET /attribution` — XP attribution
+- `GET /simulate/:agentId` — Prestige simulation
+- `GET /milestones` — Milestones feed
+- `POST /unlock` — Unlock skill (deducts XP)
+- `GET /history/:agentId` — XP history
+
+### Engine Functions
+- `detectCycles()` — DFS-based cycle detection for skill tree graph
+- `findOrphanNodes()` — Identify disconnected tier>1 nodes
+- `validateSkillTree()` — Full graph validation (cycles, orphans, costs, refs)
+- `getNodeState()` — Per-node state machine (locked/unlockable/unlocked/maxed)
+- `simulatePrestige()` — Non-destructive prestige preview
+
+### Schema: `skill_node_layouts`, `progression_milestones`

--- a/lib/__tests__/progression-engine-v2.test.ts
+++ b/lib/__tests__/progression-engine-v2.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Phase 2 Engine Tests — Issue #207
+ */
+import {
+  detectCycles,
+  findOrphanNodes,
+  validateSkillTree,
+  getNodeState,
+  simulatePrestige,
+  getDefaultSkillTree,
+  type SkillNodeState,
+} from '../progression-engine';
+
+describe('detectCycles', () => {
+  it('returns empty for acyclic graph', () => {
+    const edges = [
+      { from_node_id: 'a', to_node_id: 'b' },
+      { from_node_id: 'b', to_node_id: 'c' },
+    ];
+    expect(detectCycles(edges)).toEqual([]);
+  });
+
+  it('detects a simple cycle', () => {
+    const edges = [
+      { from_node_id: 'a', to_node_id: 'b' },
+      { from_node_id: 'b', to_node_id: 'c' },
+      { from_node_id: 'c', to_node_id: 'a' },
+    ];
+    const cycle = detectCycles(edges);
+    expect(cycle.length).toBeGreaterThan(0);
+  });
+
+  it('returns empty for empty graph', () => {
+    expect(detectCycles([])).toEqual([]);
+  });
+
+  it('detects self-loop', () => {
+    const edges = [{ from_node_id: 'a', to_node_id: 'a' }];
+    const cycle = detectCycles(edges);
+    expect(cycle.length).toBeGreaterThan(0);
+  });
+});
+
+describe('findOrphanNodes', () => {
+  it('returns empty when all nodes are connected', () => {
+    const nodes = [
+      { node_id: 'a', tier: 1, prerequisites: [] },
+      { node_id: 'b', tier: 2, prerequisites: ['a'] },
+    ];
+    const edges = [{ from_node_id: 'a', to_node_id: 'b' }];
+    expect(findOrphanNodes(nodes, edges)).toEqual([]);
+  });
+
+  it('ignores tier-1 nodes', () => {
+    const nodes = [{ node_id: 'a', tier: 1, prerequisites: [] }];
+    const edges: Array<{ from_node_id: string; to_node_id: string }> = [];
+    const orphans = findOrphanNodes(nodes, edges);
+    expect(orphans).toEqual([]);
+  });
+
+  it('finds tier-2+ nodes with no connections or prerequisites', () => {
+    const nodes = [
+      { node_id: 'a', tier: 1, prerequisites: [] },
+      { node_id: 'b', tier: 2, prerequisites: [] },
+    ];
+    const edges = [{ from_node_id: 'x', to_node_id: 'y' }]; // unrelated
+    expect(findOrphanNodes(nodes, edges)).toContain('b');
+  });
+});
+
+describe('validateSkillTree', () => {
+  it('validates the default tree as valid', () => {
+    const tree = getDefaultSkillTree();
+    const result = validateSkillTree(tree.nodes, tree.edges);
+    expect(result.valid).toBe(true);
+    expect(result.errors).toEqual([]);
+  });
+
+  it('reports missing prerequisite references', () => {
+    const nodes = [{ node_id: 'a', name: 'A', tier: 1, xp_cost: 100, prerequisites: ['nonexistent'] }];
+    const edges: Array<{ from_node_id: string; to_node_id: string }> = [];
+    const result = validateSkillTree(nodes, edges);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e: string) => e.includes('nonexistent'))).toBe(true);
+  });
+
+  it('reports non-positive XP cost', () => {
+    const nodes = [{ node_id: 'a', name: 'A', tier: 1, xp_cost: 0, prerequisites: [] }];
+    const result = validateSkillTree(nodes, []);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e: string) => e.includes('non-positive'))).toBe(true);
+  });
+
+  it('warns on very high XP cost', () => {
+    const nodes = [{ node_id: 'a', name: 'A', tier: 1, xp_cost: 200000, prerequisites: [] }];
+    const result = validateSkillTree(nodes, []);
+    expect(result.valid).toBe(true); // warnings don't invalidate
+    expect(result.warnings.some((w: string) => w.includes('very high'))).toBe(true);
+  });
+
+  it('reports cycles', () => {
+    const nodes = [
+      { node_id: 'a', name: 'A', tier: 1, xp_cost: 100, prerequisites: ['b'] },
+      { node_id: 'b', name: 'B', tier: 1, xp_cost: 100, prerequisites: ['a'] },
+    ];
+    const edges = [
+      { from_node_id: 'a', to_node_id: 'b' },
+      { from_node_id: 'b', to_node_id: 'a' },
+    ];
+    const result = validateSkillTree(nodes, edges);
+    expect(result.valid).toBe(false);
+    expect(result.errors.some((e: string) => e.includes('Cycle'))).toBe(true);
+  });
+});
+
+describe('getNodeState', () => {
+  it('returns "unlocked" for unlocked nodes', () => {
+    expect(getNodeState('a', { prerequisites: [], tier: 1 }, new Set(['a']))).toBe('unlocked');
+  });
+
+  it('returns "unlockable" for tier-1 nodes with no prereqs', () => {
+    expect(getNodeState('a', { prerequisites: [], tier: 1 }, new Set())).toBe('unlockable');
+  });
+
+  it('returns "unlockable" when all prereqs are met', () => {
+    expect(getNodeState('b', { prerequisites: ['a'], tier: 2 }, new Set(['a']))).toBe('unlockable');
+  });
+
+  it('returns "locked" when prereqs are not met', () => {
+    expect(getNodeState('b', { prerequisites: ['a'], tier: 2 }, new Set())).toBe('locked');
+  });
+
+  it('returns "locked" for tier-2 node with no prereqs defined but no connections', () => {
+    expect(getNodeState('b', { prerequisites: [], tier: 2 }, new Set())).toBe('locked');
+  });
+});
+
+describe('simulatePrestige', () => {
+  it('shows ineligible for low-level agent', () => {
+    const result = simulatePrestige({ current_xp: 50, lifetime_xp: 50, level: 2, prestige_rank: 0 }, 0);
+    expect(result.eligible).toBe(false);
+  });
+
+  it('shows eligible for high-level agent', () => {
+    const result = simulatePrestige({ current_xp: 100000, lifetime_xp: 100000, level: 25, prestige_rank: 0 }, 5);
+    expect(result.eligible).toBe(true);
+    expect(result.next_rank).toBe(1);
+    expect(result.preview.unlocks_lost).toBe(5);
+  });
+
+  it('provides correct level and XP requirements', () => {
+    const result = simulatePrestige({ current_xp: 0, lifetime_xp: 0, level: 1, prestige_rank: 0 }, 0);
+    expect(result.preview.level_requirement).toBe(20);
+  });
+});

--- a/lib/__tests__/progression-http-v2.test.ts
+++ b/lib/__tests__/progression-http-v2.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Phase 2 HTTP Route Tests — Issue #207
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { IncomingMessage, ServerResponse } from 'node:http';
+import { handleProgressionV2Api } from '../progression-http-v2';
+import { ProgressionStore } from '../progression-store';
+
+const dbPath = path.join(__dirname, '__test_http_v2.db');
+let store: ProgressionStore;
+
+function createMockReq(method: string, url: string, body?: string): IncomingMessage {
+  const { PassThrough } = require('node:stream');
+  const req = new PassThrough() as any;
+  req.method = method;
+  req.url = url;
+  if (body) { setTimeout(() => { req.write(body); req.end(); }, 5); }
+  else { setTimeout(() => req.end(), 5); }
+  return req as IncomingMessage;
+}
+
+function createMockRes(): { res: ServerResponse; getResult: () => Promise<{ status: number; body: any }> } {
+  const { PassThrough } = require('node:stream');
+  const res = new PassThrough() as any;
+  let status = 0;
+  let data = '';
+  res.writeHead = (s: number) => { status = s; };
+  res.end = (d?: string) => { data = d ?? ''; };
+  return {
+    res: res as ServerResponse,
+    getResult: () => new Promise((resolve) => {
+      setTimeout(() => resolve({ status, body: data ? JSON.parse(data) : null }), 100);
+    }),
+  };
+}
+
+async function callRoute(method: string, url: string, body?: string) {
+  const req = createMockReq(method, url, body);
+  const { res, getResult } = createMockRes();
+  handleProgressionV2Api(req, res, { dbPath });
+  return getResult();
+}
+
+beforeEach(() => {
+  try { fs.unlinkSync(dbPath); } catch {}
+  store = new ProgressionStore(dbPath);
+});
+
+afterEach(() => {
+  store.close();
+  try { fs.unlinkSync(dbPath); } catch {}
+});
+
+describe('GET /api/rpg/progression/tree', () => {
+  it('returns tree with nodes and validation', async () => {
+    const { status, body } = await callRoute('GET', '/api/rpg/progression/tree');
+    expect(status).toBe(200);
+    expect(body.nodes.length).toBe(15);
+    expect(body.validation.valid).toBe(true);
+  });
+});
+
+describe('GET /api/rpg/progression/tree/state/:agentId', () => {
+  it('returns tree with node states for agent', async () => {
+    store.getOrCreateProfile('oracle');
+    const { status, body } = await callRoute('GET', '/api/rpg/progression/tree/state/oracle');
+    expect(status).toBe(200);
+    expect(body.agent_id).toBe('oracle');
+    expect(body.nodes[0].state).toBeDefined();
+  });
+});
+
+describe('POST /api/rpg/progression/tree/nodes', () => {
+  it('creates a new node', async () => {
+    const { status, body } = await callRoute('POST', '/api/rpg/progression/tree/nodes',
+      JSON.stringify({ node_id: 'test-1', name: 'Test', category: 'engineering', xp_cost: 100, tier: 1, prerequisites: [] }));
+    expect(status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.node.node_id).toBe('test-1');
+  });
+
+  it('rejects missing fields', async () => {
+    const { status } = await callRoute('POST', '/api/rpg/progression/tree/nodes',
+      JSON.stringify({ name: 'Test' }));
+    expect(status).toBe(400);
+  });
+});
+
+describe('GET /api/rpg/progression/tree/validate', () => {
+  it('returns validation result', async () => {
+    const { status, body } = await callRoute('GET', '/api/rpg/progression/tree/validate');
+    expect(status).toBe(200);
+    expect(body.valid).toBe(true);
+  });
+});
+
+describe('POST /api/rpg/progression/tree/layouts', () => {
+  it('saves layouts', async () => {
+    const { status, body } = await callRoute('POST', '/api/rpg/progression/tree/layouts',
+      JSON.stringify({ layouts: [{ node_id: 'eng-1', x: 100, y: 200 }] }));
+    expect(status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.saved).toBe(1);
+  });
+});
+
+describe('GET /api/rpg/progression/tree/export', () => {
+  it('exports tree definition', async () => {
+    const { status, body } = await callRoute('GET', '/api/rpg/progression/tree/export');
+    expect(status).toBe(200);
+    expect(body.nodes.length).toBe(15);
+    expect(body.edges.length).toBe(10);
+  });
+});
+
+describe('POST /api/rpg/progression/tree/import', () => {
+  it('imports a tree definition', async () => {
+    const { status: exStatus, body: exportBody } = await callRoute('GET', '/api/rpg/progression/tree/export');
+    expect(exStatus).toBe(200);
+    const { status, body } = await callRoute('POST', '/api/rpg/progression/tree/import',
+      JSON.stringify(exportBody));
+    expect(status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.imported).toBe(15);
+  });
+});
+
+describe('GET /api/rpg/progression/attribution/:agentId', () => {
+  it('returns XP attribution for agent', async () => {
+    store.getOrCreateProfile('oracle');
+    store.ingestXpEvent('oracle', 50, 'code_review', 'test');
+    const { status, body } = await callRoute('GET', '/api/rpg/progression/attribution/oracle');
+    expect(status).toBe(200);
+    expect(body.agent_id).toBe('oracle');
+  });
+});
+
+describe('GET /api/rpg/progression/attribution', () => {
+  it('returns global attribution', async () => {
+    store.getOrCreateProfile('oracle');
+    store.ingestXpEvent('oracle', 50, 'code_review', 'test');
+    const { status, body } = await callRoute('GET', '/api/rpg/progression/attribution');
+    expect(status).toBe(200);
+    expect(body.attribution).toBeDefined();
+  });
+});
+
+describe('GET /api/rpg/progression/simulate/:agentId', () => {
+  it('returns prestige simulation', async () => {
+    store.getOrCreateProfile('oracle');
+    const { status, body } = await callRoute('GET', '/api/rpg/progression/simulate/oracle');
+    expect(status).toBe(200);
+    expect(body.eligible).toBe(false);
+  });
+
+  it('returns 404 for unknown agent', async () => {
+    const { status } = await callRoute('GET', '/api/rpg/progression/simulate/unknown');
+    expect(status).toBe(404);
+  });
+});
+
+describe('GET /api/rpg/progression/milestones', () => {
+  it('returns milestones list', async () => {
+    store.recordMilestone('oracle', 'level_up', 'Level 5', 'desc');
+    const { status, body } = await callRoute('GET', '/api/rpg/progression/milestones');
+    expect(status).toBe(200);
+    expect(body.milestones.length).toBe(1);
+  });
+});
+
+describe('POST /api/rpg/progression/unlock', () => {
+  it('unlocks a skill and deducts XP', async () => {
+    store.getOrCreateProfile('oracle');
+    store.ingestXpEvent('oracle', 200, 'code_review', 'test');
+    store.ingestXpEvent('oracle', 200, 'bug_fix', 'test');
+    const { status, body } = await callRoute('POST', '/api/rpg/progression/unlock',
+      JSON.stringify({ agent_id: 'oracle', node_id: 'eng-1' }));
+    expect(status).toBe(200);
+    expect(body.ok).toBe(true);
+    expect(body.unlock.node_id).toBe('eng-1');
+  });
+
+  it('rejects missing fields', async () => {
+    const { status } = await callRoute('POST', '/api/rpg/progression/unlock',
+      JSON.stringify({ agent_id: 'oracle' }));
+    expect(status).toBe(400);
+  });
+});
+
+describe('GET /api/rpg/progression/history/:agentId', () => {
+  it('returns XP history', async () => {
+    store.getOrCreateProfile('oracle');
+    store.ingestXpEvent('oracle', 50, 'code_review', 'test');
+    const { status, body } = await callRoute('GET', '/api/rpg/progression/history/oracle');
+    expect(status).toBe(200);
+    expect(body.agent_id).toBe('oracle');
+  });
+});
+
+describe('Route matching', () => {
+  it('returns false for non-matching routes', async () => {
+    const req = createMockReq('GET', '/api/other/path');
+    const { res } = createMockRes();
+    const handled = handleProgressionV2Api(req, res, { dbPath });
+    expect(handled).toBe(false);
+  });
+
+  it('v1 routes still fall through (not captured by v2)', async () => {
+    const req = createMockReq('GET', '/api/rpg/progression/summary');
+    const { res } = createMockRes();
+    const handled = handleProgressionV2Api(req, res, { dbPath });
+    expect(handled).toBe(false);
+  });
+});

--- a/lib/__tests__/progression-store-v2.test.ts
+++ b/lib/__tests__/progression-store-v2.test.ts
@@ -1,0 +1,228 @@
+/**
+ * Phase 2 Store Tests — Issue #207
+ */
+import fs from 'node:fs';
+import path from 'node:path';
+import { ProgressionStore } from '../progression-store';
+
+const dbPath = path.join(__dirname, '__test_store_v2.db');
+let store: ProgressionStore;
+
+beforeEach(() => {
+  try { fs.unlinkSync(dbPath); } catch {}
+  store = new ProgressionStore(dbPath);
+});
+
+afterEach(() => {
+  store.close();
+  try { fs.unlinkSync(dbPath); } catch {}
+});
+
+describe('upsertSkillNode', () => {
+  it('creates a new node', () => {
+    const node = store.upsertSkillNode('test-1', 'Test Node', 'desc', 'engineering', 150, 1, []);
+    expect(node.node_id).toBe('test-1');
+    expect(node.name).toBe('Test Node');
+    expect(node.xp_cost).toBe(150);
+  });
+
+  it('updates an existing node', () => {
+    store.upsertSkillNode('eng-1', 'Updated', 'new desc', 'engineering', 200, 1, []);
+    const nodes = store.getSkillNodes();
+    const eng1 = nodes.find(n => n.node_id === 'eng-1');
+    expect(eng1?.name).toBe('Updated');
+    expect(eng1?.xp_cost).toBe(200);
+  });
+
+  it('creates edges for prerequisites', () => {
+    store.upsertSkillNode('test-1', 'Test', 'desc', 'engineering', 100, 2, ['eng-1']);
+    const edges = store.getSkillEdges();
+    expect(edges.some(e => e.from_node_id === 'eng-1' && e.to_node_id === 'test-1')).toBe(true);
+  });
+});
+
+describe('deleteSkillNode', () => {
+  it('deletes a leaf node', () => {
+    store.upsertSkillNode('leaf-1', 'Leaf', 'desc', 'engineering', 100, 1, []);
+    expect(store.deleteSkillNode('leaf-1')).toBe(true);
+  });
+
+  it('refuses to delete a node with dependents', () => {
+    expect(() => store.deleteSkillNode('eng-1')).toThrow(/prerequisite/i);
+  });
+
+  it('returns false for non-existent node', () => {
+    expect(store.deleteSkillNode('nope')).toBe(false);
+  });
+});
+
+describe('validateTree', () => {
+  it('validates the default tree as valid', () => {
+    const result = store.validateTree();
+    expect(result.valid).toBe(true);
+  });
+});
+
+describe('saveNodeLayouts / getNodeLayouts', () => {
+  it('saves and retrieves layouts', () => {
+    store.saveNodeLayouts([{ node_id: 'eng-1', x: 100, y: 200 }]);
+    const layouts = store.getNodeLayouts();
+    expect(layouts.length).toBe(1);
+    expect(layouts[0].x).toBe(100);
+    expect(layouts[0].y).toBe(200);
+  });
+
+  it('upserts on duplicate node_id', () => {
+    store.saveNodeLayouts([{ node_id: 'eng-1', x: 100, y: 200 }]);
+    store.saveNodeLayouts([{ node_id: 'eng-1', x: 300, y: 400 }]);
+    const layouts = store.getNodeLayouts();
+    expect(layouts.length).toBe(1);
+    expect(layouts[0].x).toBe(300);
+  });
+});
+
+describe('exportTree / importTree', () => {
+  it('round-trips the tree', () => {
+    const exported = store.exportTree();
+    expect(exported.nodes.length).toBe(15);
+    expect(exported.edges.length).toBe(10);
+    store.importTree(exported);
+    const re = store.exportTree();
+    expect(re.nodes.length).toBe(15);
+    expect(re.edges.length).toBe(10);
+  });
+});
+
+describe('getXpAttribution', () => {
+  it('returns attribution breakdown after events', () => {
+    store.getOrCreateProfile('oracle');
+    store.ingestXpEvent('oracle', 50, 'code_review', 'test');
+    store.ingestXpEvent('oracle', 30, 'bug_fix', 'test');
+    const attr = store.getXpAttribution('oracle');
+    expect(attr.length).toBe(2);
+    expect(attr.some((a: any) => a.source_category === 'code_review')).toBe(true);
+  });
+
+  it('returns empty for agent with no events', () => {
+    expect(store.getXpAttribution('nobody')).toEqual([]);
+  });
+});
+
+describe('getGlobalXpAttribution', () => {
+  it('aggregates across agents', () => {
+    store.getOrCreateProfile('oracle');
+    store.getOrCreateProfile('echo');
+    store.ingestXpEvent('oracle', 50, 'code_review', 'test');
+    store.ingestXpEvent('echo', 30, 'code_review', 'test');
+    const attr = store.getGlobalXpAttribution();
+    expect(attr.length).toBeGreaterThan(0);
+    const cr = attr.find((a: any) => a.source_category === 'code_review');
+    expect(cr!.event_count).toBe(2);
+  });
+});
+
+describe('getXpHistory', () => {
+  it('returns daily aggregation', () => {
+    store.getOrCreateProfile('oracle');
+    store.ingestXpEvent('oracle', 50, 'code_review', 'test');
+    const history = store.getXpHistory('oracle', 7);
+    expect(history.length).toBeGreaterThanOrEqual(1);
+    expect(history[0].total_xp).toBeGreaterThan(0);
+  });
+});
+
+describe('recordMilestone / getRecentMilestones', () => {
+  it('records and retrieves milestones', () => {
+    const ms = store.recordMilestone('oracle', 'level_up', 'Level 5!', 'Oracle reached level 5');
+    expect(ms.id).toBeDefined();
+    expect(ms.type).toBe('level_up');
+    const recent = store.getRecentMilestones();
+    expect(recent.length).toBe(1);
+    expect(recent[0].title).toBe('Level 5!');
+  });
+
+  it('respects limit', () => {
+    for (let i = 0; i < 5; i++) store.recordMilestone('oracle', 'level_up', `Level ${i}`, 'desc');
+    expect(store.getRecentMilestones(3).length).toBe(3);
+  });
+});
+
+describe('unlockSkill (enhanced with milestones)', () => {
+  it('unlocks a tier-1 skill, deducts XP, and records milestone', () => {
+    store.getOrCreateProfile('oracle');
+    // Give enough XP
+    store.ingestXpEvent('oracle', 200, 'code_review', 'test');
+    store.ingestXpEvent('oracle', 200, 'bug_fix', 'test');
+    const result = store.unlockSkill('oracle', 'eng-1');
+    expect(result.unlock.node_id).toBe('eng-1');
+    const profile = store.getProfile('oracle')!;
+    // XP should be reduced by eng-1 cost (100)
+    expect(profile.current_xp).toBeLessThan(400);
+    // Milestone should be recorded
+    const milestones = store.getRecentMilestones();
+    expect(milestones.some((m: any) => m.type === 'skill_unlock' && (m.title.includes('eng-1') || m.title.includes('Code Foundations')))).toBe(true);
+  });
+
+  it('rejects unlock if prerequisite not met', () => {
+    store.getOrCreateProfile('oracle');
+    store.ingestXpEvent('oracle', 500, 'code_review', 'test');
+    store.ingestXpEvent('oracle', 500, 'bug_fix', 'test');
+    expect(() => store.unlockSkill('oracle', 'eng-2')).toThrow(/[Pp]rerequisite/);
+  });
+
+  it('rejects unlock if insufficient XP', () => {
+    store.getOrCreateProfile('oracle');
+    store.ingestXpEvent('oracle', 10, 'code_review', 'test');
+    store.ingestXpEvent('oracle', 10, 'bug_fix', 'test');
+    expect(() => store.unlockSkill('oracle', 'eng-1')).toThrow(/[Ii]nsufficient/);
+  });
+
+  it('rejects double unlock', () => {
+    store.getOrCreateProfile('oracle');
+    store.ingestXpEvent('oracle', 500, 'code_review', 'test');
+    store.ingestXpEvent('oracle', 500, 'bug_fix', 'test');
+    store.unlockSkill('oracle', 'eng-1');
+    expect(() => store.unlockSkill('oracle', 'eng-1')).toThrow(/[Aa]lready/);
+  });
+});
+
+describe('Phase 1 API contract preservation', () => {
+  it('getOrCreateProfile still works', () => {
+    const profile = store.getOrCreateProfile('oracle', 'Oracle');
+    expect(profile.agent_id).toBe('oracle');
+    expect(profile.level).toBe(1);
+  });
+
+  it('ingestXpEvent still works', () => {
+    store.getOrCreateProfile('oracle');
+    const result = store.ingestXpEvent('oracle', 50, 'code_review', 'Test');
+    expect(result.event.raw_xp).toBe(50);
+  });
+
+  it('getSkillNodes returns 15 default nodes', () => {
+    expect(store.getSkillNodes().length).toBe(15);
+  });
+
+  it('getSkillEdges returns 10 default edges', () => {
+    expect(store.getSkillEdges().length).toBe(10);
+  });
+
+  it('listProfiles works', () => {
+    store.getOrCreateProfile('oracle');
+    expect(store.listProfiles().length).toBe(1);
+  });
+
+  it('getSkillTreeState still works (from PR #229)', () => {
+    store.getOrCreateProfile('oracle');
+    const state = store.getSkillTreeState('oracle');
+    expect(state.nodes.length).toBe(15);
+    expect(state.unlocked_count).toBe(0);
+  });
+
+  it('getLeaderboard still works (from PR #229)', () => {
+    store.getOrCreateProfile('oracle');
+    const lb = store.getLeaderboard();
+    expect(lb.entries.length).toBe(1);
+    expect(lb.total_agents).toBe(1);
+  });
+});

--- a/lib/progression-engine.ts
+++ b/lib/progression-engine.ts
@@ -220,3 +220,115 @@ export function getDefaultSkillTree(): { nodes: SkillNode[]; edges: SkillEdge[] 
 
   return { nodes, edges };
 }
+
+// ─── Phase 2: Graph Validation & Simulation (Issue #207) ────────────────────
+
+export function detectCycles(edges: Array<{ from_node_id: string; to_node_id: string }>): string[] {
+  const adj = new Map<string, string[]>();
+  const allNodes = new Set<string>();
+  for (const e of edges) {
+    allNodes.add(e.from_node_id);
+    allNodes.add(e.to_node_id);
+    if (!adj.has(e.from_node_id)) adj.set(e.from_node_id, []);
+    adj.get(e.from_node_id)!.push(e.to_node_id);
+  }
+  const white = new Set(allNodes);
+  const gray = new Set<string>();
+  const parent = new Map<string, string>();
+  for (const start of allNodes) {
+    if (!white.has(start)) continue;
+    const stack: string[] = [start];
+    while (stack.length > 0) {
+      const node = stack[stack.length - 1]!;
+      if (white.has(node)) {
+        white.delete(node);
+        gray.add(node);
+        for (const neighbor of adj.get(node) ?? []) {
+          if (gray.has(neighbor)) {
+            const cycle = [neighbor, node];
+            let cur = node;
+            while (cur !== neighbor && parent.has(cur)) { cur = parent.get(cur)!; cycle.push(cur); }
+            return cycle.reverse();
+          }
+          if (white.has(neighbor)) { parent.set(neighbor, node); stack.push(neighbor); }
+        }
+      } else {
+        stack.pop();
+        gray.delete(node);
+      }
+    }
+  }
+  return [];
+}
+
+export function findOrphanNodes(
+  nodes: Array<{ node_id: string; tier: number; prerequisites: string[] }>,
+  edges: Array<{ from_node_id: string; to_node_id: string }>,
+): string[] {
+  const connected = new Set<string>();
+  for (const e of edges) { connected.add(e.from_node_id); connected.add(e.to_node_id); }
+  return nodes.filter(n => n.tier > 1 && !connected.has(n.node_id) && n.prerequisites.length === 0).map(n => n.node_id);
+}
+
+export function validateSkillTree(
+  nodes: Array<{ node_id: string; name: string; tier: number; xp_cost: number; prerequisites: string[] }>,
+  edges: Array<{ from_node_id: string; to_node_id: string }>,
+): { valid: boolean; errors: string[]; warnings: string[] } {
+  const errors: string[] = [];
+  const warnings: string[] = [];
+  const nodeIds = new Set(nodes.map(n => n.node_id));
+  if (nodeIds.size !== nodes.length) errors.push('Duplicate node IDs detected');
+  for (const node of nodes) {
+    for (const prereq of node.prerequisites) {
+      if (!nodeIds.has(prereq)) errors.push('Node "' + node.node_id + '" references unknown prerequisite "' + prereq + '"');
+    }
+  }
+  for (const edge of edges) {
+    if (!nodeIds.has(edge.from_node_id)) errors.push('Edge references unknown node "' + edge.from_node_id + '"');
+    if (!nodeIds.has(edge.to_node_id)) errors.push('Edge references unknown node "' + edge.to_node_id + '"');
+  }
+  const cycle = detectCycles(edges);
+  if (cycle.length > 0) errors.push('Cycle detected: ' + cycle.join(' -> '));
+  const orphans = findOrphanNodes(nodes, edges);
+  if (orphans.length > 0) warnings.push('Orphan nodes (tier>1, no connections): ' + orphans.join(', '));
+  for (const node of nodes) {
+    if (node.xp_cost <= 0) errors.push('Node "' + node.node_id + '" has non-positive XP cost (' + node.xp_cost + ')');
+    if (node.xp_cost > 100000) warnings.push('Node "' + node.node_id + '" has very high XP cost (' + node.xp_cost + ')');
+  }
+  return { valid: errors.length === 0, errors, warnings };
+}
+
+export type SkillNodeState = 'locked' | 'unlockable' | 'unlocked' | 'maxed';
+
+export function getNodeState(
+  nodeId: string,
+  node: { prerequisites: string[]; tier: number },
+  unlockedIds: Set<string>,
+): SkillNodeState {
+  if (unlockedIds.has(nodeId)) return 'unlocked';
+  if (node.tier === 1 && node.prerequisites.length === 0) return 'unlockable';
+  if (node.prerequisites.length > 0 && node.prerequisites.every(p => unlockedIds.has(p))) return 'unlockable';
+  return 'locked';
+}
+
+export function simulatePrestige(
+  profile: { current_xp: number; lifetime_xp: number; level: number; prestige_rank: number },
+  unlockCount: number,
+) {
+  const nextRank = profile.prestige_rank + 1;
+  const levelReq = prestigeLevelRequirement(profile.prestige_rank);
+  const xpReq = prestigeXpRequirement(profile.prestige_rank);
+  const eligible = nextRank <= MAX_PRESTIGE_RANK && isPrestigeEligible(profile.level, profile.prestige_rank, profile.lifetime_xp);
+  return {
+    eligible,
+    next_rank: nextRank,
+    preview: {
+      xp_reset_from: profile.current_xp,
+      level_reset_from: profile.level,
+      unlocks_lost: unlockCount,
+      lifetime_xp_kept: profile.lifetime_xp,
+      level_requirement: levelReq,
+      xp_requirement: xpReq,
+    },
+  };
+}

--- a/lib/progression-http-v2.ts
+++ b/lib/progression-http-v2.ts
@@ -1,0 +1,190 @@
+/**
+ * Progression HTTP V2 Routes — VentureOS Phase 4.5 Phase 2
+ *
+ * Handles skill tree CRUD, XP attribution, prestige simulation,
+ * milestones, and skill unlock endpoints.
+ *
+ * Issue #207 — Phase 4.5 Phase 2: Visual Skill Tree UI & Progression Polish
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { ProgressionStore } from './progression-store';
+import { getNodeState, simulatePrestige } from './progression-engine';
+import type { ProgressionHandlerOptions } from './types/progression';
+
+const PREFIX = '/api/rpg/progression';
+
+function json(res: ServerResponse, status: number, body: unknown): void {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(body));
+}
+
+function readBody(req: IncomingMessage): Promise<string> {
+  return new Promise((resolve, reject) => {
+    let data = '';
+    req.on('data', (chunk: Buffer) => { data += chunk.toString(); });
+    req.on('end', () => resolve(data));
+    req.on('error', reject);
+  });
+}
+
+export function handleProgressionV2Api(
+  req: IncomingMessage,
+  res: ServerResponse,
+  opts: ProgressionHandlerOptions,
+): boolean {
+  const url = req.url ?? '';
+  const method = req.method ?? 'GET';
+
+  if (!url.startsWith(PREFIX + '/')) return false;
+  const path = url.slice(PREFIX.length);
+
+  // Route matching — only handle Phase 2 paths
+  const treeMatch = path === '/tree' && method === 'GET';
+  const treeStateMatch = path.startsWith('/tree/state/') && method === 'GET';
+  const treeNodesPost = path === '/tree/nodes' && method === 'POST';
+  const treeNodesDelete = path === '/tree/nodes' && method === 'DELETE';
+  const treeLayoutsPost = path === '/tree/layouts' && method === 'POST';
+  const treeValidate = path === '/tree/validate' && method === 'GET';
+  const treeExport = path === '/tree/export' && method === 'GET';
+  const treeImportPost = path === '/tree/import' && method === 'POST';
+  const attrAgent = path.startsWith('/attribution/') && method === 'GET';
+  const attrGlobal = path === '/attribution' && method === 'GET';
+  const simMatch = path.startsWith('/simulate/') && method === 'GET';
+  const milestonesGet = path === '/milestones' && method === 'GET';
+  const unlockPost = path === '/unlock' && method === 'POST';
+  const historyMatch = path.startsWith('/history/') && method === 'GET';
+
+  const isV2Route = treeMatch || treeStateMatch || treeNodesPost || treeNodesDelete ||
+    treeLayoutsPost || treeValidate || treeExport || treeImportPost ||
+    attrAgent || attrGlobal || simMatch || milestonesGet || unlockPost || historyMatch;
+
+  if (!isV2Route) return false;
+
+  // Handle async routes
+  (async () => {
+    let store: ProgressionStore | null = null;
+    try {
+      store = new ProgressionStore(opts.dbPath);
+
+      // GET /tree — full tree + layouts + validation
+      if (treeMatch) {
+        const nodes = store.getSkillNodes();
+        const edges = store.getSkillEdges();
+        const layouts = store.getNodeLayouts();
+        const validation = store.validateTree();
+        return json(res, 200, { nodes, edges, layouts, validation });
+      }
+
+      // GET /tree/state/:agentId — tree with node states
+      if (treeStateMatch) {
+        const agentId = path.slice('/tree/state/'.length);
+        const nodes = store.getSkillNodes();
+        const edges = store.getSkillEdges();
+        const layouts = store.getNodeLayouts();
+        const unlocks = store.getUnlocks(agentId);
+        const unlockedIds = new Set(unlocks.map(u => u.node_id));
+        const annotated = nodes.map(n => ({
+          ...n,
+          state: getNodeState(n.node_id, n, unlockedIds),
+        }));
+        return json(res, 200, { nodes: annotated, edges, layouts, agent_id: agentId });
+      }
+
+      // POST /tree/nodes — upsert skill node
+      if (treeNodesPost) {
+        const body = JSON.parse(await readBody(req));
+        const { node_id, name, description, category, xp_cost, tier, prerequisites } = body;
+        if (!node_id || !name || !category) return json(res, 400, { ok: false, error: 'Missing required fields: node_id, name, category' });
+        const node = store.upsertSkillNode(node_id, name, description ?? '', category, xp_cost ?? 100, tier ?? 1, prerequisites ?? []);
+        return json(res, 200, { ok: true, node });
+      }
+
+      // DELETE /tree/nodes — delete skill node
+      if (treeNodesDelete) {
+        const body = JSON.parse(await readBody(req));
+        if (!body.node_id) return json(res, 400, { ok: false, error: 'Missing node_id' });
+        const deleted = store.deleteSkillNode(body.node_id);
+        return json(res, 200, { ok: true, deleted });
+      }
+
+      // POST /tree/layouts — save node positions
+      if (treeLayoutsPost) {
+        const body = JSON.parse(await readBody(req));
+        if (!body.layouts || !Array.isArray(body.layouts)) return json(res, 400, { ok: false, error: 'Missing layouts array' });
+        store.saveNodeLayouts(body.layouts);
+        return json(res, 200, { ok: true, saved: body.layouts.length });
+      }
+
+      // GET /tree/validate — validate tree
+      if (treeValidate) {
+        const validation = store.validateTree();
+        return json(res, 200, validation);
+      }
+
+      // GET /tree/export — export tree
+      if (treeExport) {
+        const tree = store.exportTree();
+        return json(res, 200, tree);
+      }
+
+      // POST /tree/import — import tree
+      if (treeImportPost) {
+        const body = JSON.parse(await readBody(req));
+        if (!body.nodes || !body.edges) return json(res, 400, { ok: false, error: 'Missing nodes or edges' });
+        store.importTree(body);
+        return json(res, 200, { ok: true, imported: body.nodes.length });
+      }
+
+      // GET /attribution/:agentId — agent XP attribution
+      if (attrAgent) {
+        const agentId = path.slice('/attribution/'.length);
+        const attribution = store.getXpAttribution(agentId);
+        return json(res, 200, { agent_id: agentId, attribution });
+      }
+
+      // GET /attribution — global XP attribution
+      if (attrGlobal) {
+        const attribution = store.getGlobalXpAttribution();
+        return json(res, 200, { attribution });
+      }
+
+      // GET /simulate/:agentId — prestige simulation
+      if (simMatch) {
+        const agentId = path.slice('/simulate/'.length);
+        const profile = store.getProfile(agentId);
+        if (!profile) return json(res, 404, { ok: false, error: 'Profile not found' });
+        const unlocks = store.getUnlocks(agentId);
+        const sim = simulatePrestige(profile, unlocks.length);
+        return json(res, 200, { agent_id: agentId, ...sim });
+      }
+
+      // GET /milestones — recent milestones
+      if (milestonesGet) {
+        const milestones = store.getRecentMilestones();
+        return json(res, 200, { milestones });
+      }
+
+      // POST /unlock — unlock a skill (uses V1 unlockSkill which returns rich result)
+      if (unlockPost) {
+        const body = JSON.parse(await readBody(req));
+        if (!body.agent_id || !body.node_id) return json(res, 400, { ok: false, error: 'Missing agent_id or node_id' });
+        const result = store.unlockSkill(body.agent_id, body.node_id);
+        return json(res, 200, { ok: true, unlock: result.unlock });
+      }
+
+      // GET /history/:agentId — XP history
+      if (historyMatch) {
+        const agentId = path.slice('/history/'.length);
+        const history = store.getXpHistory(agentId);
+        return json(res, 200, { agent_id: agentId, history });
+      }
+    } catch (err: any) {
+      json(res, err.message?.includes('not found') ? 404 : 400, { ok: false, error: err.message ?? 'Unknown error' });
+    } finally {
+      store?.close();
+    }
+  })();
+
+  return true;
+}

--- a/lib/progression-store.ts
+++ b/lib/progression-store.ts
@@ -23,6 +23,11 @@ import type {
   AnnotatedSkillNode,
   SkillNodeStatus,
   LeaderboardEntry,
+  XpAttribution,
+  SkillNodeLayout,
+  SkillTreeValidation,
+  ProgressionMilestone,
+  MilestoneType,
 } from './types/progression';
 import {
   levelFromXp,
@@ -32,6 +37,7 @@ import {
   isPrestigeEligible,
   MAX_PRESTIGE_RANK,
   getDefaultSkillTree,
+  validateSkillTree,
 } from './progression-engine';
 
 // ─── Schema Migration ───────────────────────────────────────────────────────
@@ -585,6 +591,15 @@ export class ProgressionStore {
         )
         .get(agentId, nodeId) as SkillUnlock;
 
+      // Record milestone for the unlock
+      this.recordMilestone(
+        agentId,
+        'skill_unlock',
+        `Unlocked: ${node.name}`,
+        `${profile.display_name} unlocked "${node.name}" for ${node.xp_cost} XP`,
+        { node_id: nodeId, xp_cost: node.xp_cost },
+      );
+
       const updatedProfile = this.db
         .prepare('SELECT * FROM progression_profiles WHERE agent_id = ?')
         .get(agentId) as ProgressionProfile;
@@ -631,6 +646,122 @@ export class ProgressionStore {
     }));
 
     return { entries, total_agents: total.cnt };
+  }
+
+  // ─── Phase 2: Admin CRUD, Attribution, Milestones (Issue #207) ────────
+
+  /** Upsert a skill node and rebuild its prerequisite edges. */
+  upsertSkillNode(nodeId: string, name: string, description: string, category: string, xpCost: number, tier: number, prerequisites: string[]): SkillNode {
+    this.db.prepare(
+      `INSERT INTO skill_nodes (node_id, name, description, category, xp_cost, tier, prerequisites)
+       VALUES (?, ?, ?, ?, ?, ?, ?)
+       ON CONFLICT(node_id) DO UPDATE SET name=excluded.name, description=excluded.description,
+         category=excluded.category, xp_cost=excluded.xp_cost, tier=excluded.tier, prerequisites=excluded.prerequisites`
+    ).run(nodeId, name, description, category, xpCost, tier, JSON.stringify(prerequisites));
+    this.db.prepare('DELETE FROM skill_edges WHERE to_node_id = ?').run(nodeId);
+    const ins = this.db.prepare('INSERT OR IGNORE INTO skill_edges (from_node_id, to_node_id) VALUES (?, ?)');
+    for (const p of prerequisites) ins.run(p, nodeId);
+    const row = this.db.prepare('SELECT * FROM skill_nodes WHERE node_id = ?').get(nodeId) as any;
+    return { ...row, category: row.category as SkillNode['category'], prerequisites: JSON.parse(row.prerequisites) as string[] };
+  }
+
+  /** Delete a skill node. Refuses if other nodes depend on it. */
+  deleteSkillNode(nodeId: string): boolean {
+    return this.db.transaction(() => {
+      const deps = this.db.prepare('SELECT to_node_id FROM skill_edges WHERE from_node_id = ?').all(nodeId) as Array<{ to_node_id: string }>;
+      if (deps.length > 0) throw new Error(`Cannot delete "${nodeId}": prerequisite for ${deps.map((d: any) => d.to_node_id).join(', ')}`);
+      this.db.prepare('DELETE FROM skill_edges WHERE to_node_id = ?').run(nodeId);
+      this.db.prepare('DELETE FROM skill_node_layouts WHERE node_id = ?').run(nodeId);
+      this.db.prepare('DELETE FROM skill_unlocks WHERE node_id = ?').run(nodeId);
+      return this.db.prepare('DELETE FROM skill_nodes WHERE node_id = ?').run(nodeId).changes > 0;
+    })();
+  }
+
+  /** Validate the skill tree graph (cycles, orphans, bad refs, costs). */
+  validateTree(): SkillTreeValidation {
+    return validateSkillTree(this.getSkillNodes(), this.getSkillEdges());
+  }
+
+  /** Get visual layout positions for all nodes. */
+  getNodeLayouts(): SkillNodeLayout[] {
+    return this.db.prepare('SELECT * FROM skill_node_layouts').all() as SkillNodeLayout[];
+  }
+
+  /** Save/upsert visual layout positions. */
+  saveNodeLayouts(layouts: SkillNodeLayout[]): void {
+    const upsert = this.db.prepare(
+      'INSERT INTO skill_node_layouts (node_id, x, y) VALUES (?, ?, ?) ON CONFLICT(node_id) DO UPDATE SET x=excluded.x, y=excluded.y'
+    );
+    this.db.transaction(() => { for (const l of layouts) upsert.run(l.node_id, l.x, l.y); })();
+  }
+
+  /** Export full tree definition with optional layout positions. */
+  exportTree(): { nodes: Array<SkillNode & { x?: number; y?: number }>; edges: SkillEdge[] } {
+    const nodes = this.getSkillNodes();
+    const edges = this.getSkillEdges();
+    const layoutMap = new Map(this.getNodeLayouts().map((l: SkillNodeLayout) => [l.node_id, l]));
+    return {
+      nodes: nodes.map((n: SkillNode) => { const l = layoutMap.get(n.node_id); return l ? { ...n, x: l.x, y: l.y } : n; }),
+      edges,
+    };
+  }
+
+  /** Import a tree definition, replacing existing nodes/edges/layouts. */
+  importTree(def: { nodes: Array<SkillNode & { x?: number; y?: number }>; edges: SkillEdge[] }): void {
+    this.db.transaction(() => {
+      this.db.prepare('DELETE FROM skill_node_layouts').run();
+      this.db.prepare('DELETE FROM skill_edges').run();
+      this.db.prepare('DELETE FROM skill_nodes').run();
+      const insN = this.db.prepare('INSERT INTO skill_nodes (node_id,name,description,category,xp_cost,tier,prerequisites) VALUES (?,?,?,?,?,?,?)');
+      const insE = this.db.prepare('INSERT INTO skill_edges (from_node_id,to_node_id) VALUES (?,?)');
+      const insL = this.db.prepare('INSERT INTO skill_node_layouts (node_id,x,y) VALUES (?,?,?)');
+      for (const n of def.nodes) {
+        insN.run(n.node_id, n.name, n.description, n.category, n.xp_cost, n.tier, JSON.stringify(n.prerequisites));
+        if (n.x != null && n.y != null) insL.run(n.node_id, n.x, n.y);
+      }
+      for (const e of def.edges) insE.run(e.from_node_id, e.to_node_id);
+    })();
+  }
+
+  /** XP attribution breakdown by source category for a single agent. */
+  getXpAttribution(agentId: string): XpAttribution[] {
+    return this.db.prepare(
+      `SELECT source_category, SUM(raw_xp) as total_raw_xp, SUM(effective_xp) as total_effective_xp,
+              COUNT(*) as event_count, AVG(diversification_multiplier) as avg_multiplier
+       FROM xp_events WHERE agent_id = ? GROUP BY source_category ORDER BY total_effective_xp DESC`
+    ).all(agentId) as XpAttribution[];
+  }
+
+  /** Global XP attribution breakdown across all agents. */
+  getGlobalXpAttribution(): XpAttribution[] {
+    return this.db.prepare(
+      `SELECT source_category, SUM(raw_xp) as total_raw_xp, SUM(effective_xp) as total_effective_xp,
+              COUNT(*) as event_count, AVG(diversification_multiplier) as avg_multiplier
+       FROM xp_events GROUP BY source_category ORDER BY total_effective_xp DESC`
+    ).all() as XpAttribution[];
+  }
+
+  /** Daily XP aggregation for an agent over the given number of days. */
+  getXpHistory(agentId: string, days: number = 30): Array<{ date: string; total_xp: number; event_count: number }> {
+    return this.db.prepare(
+      `SELECT DATE(created_at) as date, SUM(effective_xp) as total_xp, COUNT(*) as event_count
+       FROM xp_events WHERE agent_id = ? AND created_at >= datetime('now', ? || ' days')
+       GROUP BY DATE(created_at) ORDER BY date`
+    ).all(agentId, -days) as any[];
+  }
+
+  /** Record a progression milestone event. */
+  recordMilestone(agentId: string, type: MilestoneType, title: string, description: string, metadata?: Record<string, unknown>): ProgressionMilestone {
+    const id = crypto.randomUUID();
+    this.db.prepare(
+      'INSERT INTO progression_milestones (id, agent_id, type, title, description, metadata) VALUES (?, ?, ?, ?, ?, ?)'
+    ).run(id, agentId, type, title, description, JSON.stringify(metadata ?? {}));
+    return this.db.prepare('SELECT * FROM progression_milestones WHERE id = ?').get(id) as ProgressionMilestone;
+  }
+
+  /** Get recent milestones across all agents. */
+  getRecentMilestones(limit: number = 20): ProgressionMilestone[] {
+    return this.db.prepare('SELECT * FROM progression_milestones ORDER BY created_at DESC LIMIT ?').all(limit) as ProgressionMilestone[];
   }
 }
 


### PR DESCRIPTION
## Summary

Clean follow-up to PR #229 (Phase 2 foundation, now merged to `main`).
Extracts the **net-new** work from conflicting PR #234 onto a fresh branch with no merge conflicts.

### What was already merged in PR #229
- Core skill tree schema, tables, and seed data
- `unlockSkill` / `getSkillTree` / `allocateXp` / `getPrestigeStatus` / `performPrestige`
- Phase 2 HTTP endpoints (original set)
- 24 tests in `skill-tree-phase2.test.ts`

### What this follow-up adds (net-new from #234)

**Engine** (`progression-engine.ts`):
- `detectCycles` – DAG cycle detection for prerequisite graphs
- `findOrphanNodes` – identify unreachable skill nodes
- `validateSkillTree` – full tree integrity validation
- `getNodeState` – compute unlock/progress state per node
- `simulatePrestige` – preview prestige reset effects
- Milestone recording integrated into `unlockSkill` flow

**Store** (`progression-store.ts`):
- `upsertSkillNode` / `deleteSkillNode` – skill definition CRUD
- `validateTree` – persistence-aware tree validation
- `getLayouts` / `saveLayout` – dashboard layout persistence
- `exportTree` / `importTree` – JSON export/import of full trees
- `getXpAttribution` – XP breakdown by source
- `recordMilestone` / `getMilestones` – milestone tracking

**HTTP v2** (`progression-http-v2.ts` – 14 new endpoints):
- Skill node CRUD, tree validation, layout management
- XP attribution, milestone tracking, prestige simulation
- Tree export/import, orphan detection

**Tests**: 65 new tests across 3 suites (engine-v2, store-v2, http-v2)
All **1,179 existing tests pass** (53 suites). 1 pre-existing unrelated failure in `conversation-body-limits.test.ts`.

### Relationship to #234
This PR **supersedes** #234. It cherry-picks only the net-new, non-conflicting work from that branch onto latest `main`. PR #234 can be closed once this merges.

Refs: #207