### PR TITLE
feat(observations): Phase 3 — Reflector Agent GC + Prompt Cache (#232)

### DIFF
--- a/lib/__tests__/observation-cache.test.ts
+++ b/lib/__tests__/observation-cache.test.ts
@@ -1,0 +1,223 @@
+/**
+ * Tests for ObservationCache — Issue #232 (Phase 3)
+ *
+ * Validates prompt cache behavior: token-bounded loading, priority ordering,
+ * prompt block formatting, invalidation, and budget checking.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { ObservationStore } from '../observation-store';
+import { ObservationCache } from '../observation-cache';
+import type { Observation } from '../types/observation';
+
+let tmpDir: string;
+let dbPath: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'obs-cache-test-'));
+  dbPath = path.join(tmpDir, 'test-obs.db');
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function makeObs(overrides: Partial<Observation> = {}): Observation {
+  return {
+    id: `obs-${Math.random().toString(36).slice(2, 10)}`,
+    createdAt: '2026-02-18T00:00:00.000Z',
+    category: 'fact',
+    content: 'Test observation content',
+    source: { agentId: 'oracle', conversationId: 'conv-1' },
+    status: 'processed',
+    priority: 'medium',
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function insertProcessedObs(store: ObservationStore, overrides: Partial<Observation> = {}): Observation {
+  const obs = makeObs(overrides);
+  store.insert(obs);
+  return obs;
+}
+
+describe('ObservationCache', () => {
+  test('loads active observations from store', () => {
+    const store = new ObservationStore(dbPath);
+    insertProcessedObs(store, { id: 'obs-1', content: 'Active observation 1' });
+    insertProcessedObs(store, { id: 'obs-2', content: 'Active observation 2' });
+
+    const cache = new ObservationCache(store, 'oracle');
+    const snapshot = cache.getSnapshot();
+
+    expect(snapshot.observations).toHaveLength(2);
+    expect(snapshot.generation).toBe(1);
+    expect(snapshot.totalTokens).toBeGreaterThan(0);
+    store.close();
+  });
+
+  test('excludes reflected (soft-deleted) observations', () => {
+    const store = new ObservationStore(dbPath);
+    insertProcessedObs(store, { id: 'obs-active', content: 'Active' });
+    insertProcessedObs(store, { id: 'obs-reflected', content: 'Reflected' });
+
+    // Soft-delete one
+    store.markReflected(['obs-reflected'], '2026-02-18T12:00:00Z');
+
+    const cache = new ObservationCache(store, 'oracle');
+    const snapshot = cache.getSnapshot();
+
+    expect(snapshot.observations).toHaveLength(1);
+    expect(snapshot.observations[0].id).toBe('obs-active');
+    store.close();
+  });
+
+  test('orders observations by priority then recency', () => {
+    const store = new ObservationStore(dbPath);
+    insertProcessedObs(store, { id: 'obs-info', priority: 'info', createdAt: '2026-02-18T03:00:00Z' });
+    insertProcessedObs(store, { id: 'obs-high', priority: 'high', createdAt: '2026-02-18T01:00:00Z' });
+    insertProcessedObs(store, { id: 'obs-med-old', priority: 'medium', createdAt: '2026-02-18T01:00:00Z' });
+    insertProcessedObs(store, { id: 'obs-med-new', priority: 'medium', createdAt: '2026-02-18T02:00:00Z' });
+
+    const cache = new ObservationCache(store, 'oracle');
+    const obs = cache.getObservations();
+
+    expect(obs[0].id).toBe('obs-high');
+    expect(obs[1].id).toBe('obs-med-new');
+    expect(obs[2].id).toBe('obs-med-old');
+    expect(obs[3].id).toBe('obs-info');
+    store.close();
+  });
+
+  test('trims observations to token budget', () => {
+    const store = new ObservationStore(dbPath);
+    // Each observation has ~25 chars / 4 ≈ 7 tokens
+    for (let i = 0; i < 20; i++) {
+      insertProcessedObs(store, {
+        id: `obs-${i}`,
+        content: `Observation number ${i} with some extra text to pad tokens`,
+        priority: 'medium',
+      });
+    }
+
+    // Very small budget — should trim
+    const cache = new ObservationCache(store, 'oracle', { maxTokenBudget: 50 });
+    const snapshot = cache.getSnapshot();
+
+    expect(snapshot.observations.length).toBeLessThan(20);
+    expect(snapshot.totalTokens).toBeLessThanOrEqual(50 + 20); // Allow slight overshoot for last included
+    store.close();
+  });
+
+  test('invalidate forces rebuild on next access', () => {
+    const store = new ObservationStore(dbPath);
+    insertProcessedObs(store, { id: 'obs-1' });
+
+    const cache = new ObservationCache(store, 'oracle');
+    const snap1 = cache.getSnapshot();
+    expect(snap1.generation).toBe(1);
+
+    cache.invalidate();
+    const snap2 = cache.getSnapshot();
+    expect(snap2.generation).toBe(2);
+    store.close();
+  });
+
+  test('does not rebuild when not dirty', () => {
+    const store = new ObservationStore(dbPath);
+    insertProcessedObs(store, { id: 'obs-1' });
+
+    const cache = new ObservationCache(store, 'oracle');
+    const snap1 = cache.getSnapshot();
+    const snap2 = cache.getSnapshot();
+    expect(snap1.generation).toBe(snap2.generation);
+    store.close();
+  });
+
+  test('exceedsBudget reports correctly', () => {
+    const store = new ObservationStore(dbPath);
+    // ~50 chars → ~13 tokens at 4 chars/token
+    insertProcessedObs(store, { id: 'obs-1', content: 'This is a test observation with some words in it.' });
+
+    const cache = new ObservationCache(store, 'oracle', { maxTokenBudget: 10 });
+    expect(cache.exceedsBudget()).toBe(true);
+
+    const cache2 = new ObservationCache(store, 'oracle', { maxTokenBudget: 100 });
+    expect(cache2.exceedsBudget()).toBe(false);
+    store.close();
+  });
+
+  test('getPromptBlock formats observations by priority group', () => {
+    const store = new ObservationStore(dbPath);
+    insertProcessedObs(store, { id: 'obs-h', priority: 'high', content: 'Critical deadline tomorrow' });
+    insertProcessedObs(store, { id: 'obs-m', priority: 'medium', content: 'User prefers dark mode' });
+    insertProcessedObs(store, { id: 'obs-i', priority: 'info', content: 'Weather was nice today' });
+
+    const cache = new ObservationCache(store, 'oracle');
+    const block = cache.getPromptBlock();
+
+    expect(block.count).toBe(3);
+    expect(block.tokens).toBeGreaterThan(0);
+    expect(block.text).toContain('## Active Observations');
+    expect(block.text).toContain('🔴 High Priority');
+    expect(block.text).toContain('Critical deadline tomorrow');
+    expect(block.text).toContain('🟡 Medium Priority');
+    expect(block.text).toContain('User prefers dark mode');
+    expect(block.text).toContain('🟢 Info');
+    expect(block.text).toContain('Weather was nice today');
+    store.close();
+  });
+
+  test('getPromptBlock includes referenced dates', () => {
+    const store = new ObservationStore(dbPath);
+    insertProcessedObs(store, {
+      id: 'obs-date',
+      priority: 'high',
+      content: 'Meeting scheduled',
+      referencedDate: '2026-03-01',
+    });
+
+    const cache = new ObservationCache(store, 'oracle');
+    const block = cache.getPromptBlock();
+
+    expect(block.text).toContain('[ref: 2026-03-01]');
+    store.close();
+  });
+
+  test('getPromptBlock returns empty for no observations', () => {
+    const store = new ObservationStore(dbPath);
+    const cache = new ObservationCache(store, 'oracle');
+    const block = cache.getPromptBlock();
+
+    expect(block.text).toBe('');
+    expect(block.tokens).toBe(0);
+    expect(block.count).toBe(0);
+    store.close();
+  });
+
+  test('only loads observations for the specified agent', () => {
+    const store = new ObservationStore(dbPath);
+    insertProcessedObs(store, { id: 'obs-oracle', source: { agentId: 'oracle' } });
+    insertProcessedObs(store, { id: 'obs-atlas', source: { agentId: 'atlas' } });
+
+    const cache = new ObservationCache(store, 'oracle');
+    const obs = cache.getObservations();
+
+    expect(obs).toHaveLength(1);
+    expect(obs[0].id).toBe('obs-oracle');
+    store.close();
+  });
+
+  test('getTotalTokens returns accurate estimate', () => {
+    const store = new ObservationStore(dbPath);
+    // "Hello world" = 11 chars / 4 = 3 tokens (ceil)
+    insertProcessedObs(store, { id: 'obs-1', content: 'Hello world' });
+
+    const cache = new ObservationCache(store, 'oracle', { charsPerToken: 4 });
+    expect(cache.getTotalTokens()).toBe(3);
+    store.close();
+  });
+});

--- a/lib/__tests__/reflector-agent.test.ts
+++ b/lib/__tests__/reflector-agent.test.ts
@@ -1,0 +1,717 @@
+/**
+ * Tests for ReflectorAgent — Issue #232 (Phase 3)
+ *
+ * Validates the reflection/GC pipeline: threshold detection, LLM-driven
+ * decisions (keep/merge/discard), soft-delete via reflected_at, minimum
+ * retained floor, mutex guard, reflection log, and memory_state update.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { ObservationStore } from '../observation-store';
+import { ObservationCache } from '../observation-cache';
+import {
+  ReflectorAgent,
+  parseReflectorResponse,
+  type ReflectorLLMClient,
+} from '../reflector-agent';
+import type { Observation, ReflectionLLMResult } from '../types/observation';
+
+let tmpDir: string;
+let dbPath: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'reflector-test-'));
+  dbPath = path.join(tmpDir, 'test-obs.db');
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function makeObs(overrides: Partial<Observation> = {}): Observation {
+  return {
+    id: `obs-${Math.random().toString(36).slice(2, 10)}`,
+    createdAt: '2026-02-18T00:00:00.000Z',
+    category: 'fact',
+    content: 'Test observation',
+    source: { agentId: 'oracle', conversationId: 'conv-1' },
+    status: 'processed',
+    priority: 'medium',
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function seedObservations(store: ObservationStore, count: number, agentId = 'oracle'): Observation[] {
+  const obs: Observation[] = [];
+  for (let i = 0; i < count; i++) {
+    const o = makeObs({
+      id: `obs-${i}`,
+      content: `Observation number ${i} with content for testing reflection`,
+      source: { agentId, conversationId: 'conv-1' },
+      priority: i < 2 ? 'high' : i < 5 ? 'medium' : 'info',
+    });
+    obs.push(o);
+  }
+  store.insertBatch(obs);
+  return obs;
+}
+
+function makeLLMClient(response: ReflectionLLMResult | string | Error): ReflectorLLMClient {
+  return {
+    chatCompletion: async () => {
+      if (response instanceof Error) throw response;
+      if (typeof response === 'string') return response;
+      return JSON.stringify(response);
+    },
+  };
+}
+
+function makeKeepAllResponse(ids: string[]): ReflectionLLMResult {
+  return {
+    decisions: ids.map((id) => ({
+      observationId: id,
+      decision: 'keep' as const,
+      reason: 'Still relevant',
+    })),
+    summary: 'All observations are still relevant',
+  };
+}
+
+function makeDiscardResponse(keepIds: string[], discardIds: string[]): ReflectionLLMResult {
+  return {
+    decisions: [
+      ...keepIds.map((id) => ({
+        observationId: id,
+        decision: 'keep' as const,
+        reason: 'Still relevant',
+      })),
+      ...discardIds.map((id) => ({
+        observationId: id,
+        decision: 'discard' as const,
+        reason: 'No longer relevant',
+      })),
+    ],
+  };
+}
+
+function makeMergeResponse(
+  keepIds: string[],
+  mergeSource: string,
+  mergeTarget: string,
+  mergedContent: string,
+): ReflectionLLMResult {
+  return {
+    decisions: [
+      ...keepIds.map((id) => ({
+        observationId: id,
+        decision: 'keep' as const,
+        reason: 'Still relevant',
+      })),
+      {
+        observationId: mergeSource,
+        decision: 'merge' as const,
+        reason: 'Duplicate of another observation',
+        mergeIntoId: mergeTarget,
+        mergedContent,
+      },
+    ],
+  };
+}
+
+describe('ReflectorAgent', () => {
+  // ─── parseReflectorResponse ────────────────────────────────────────
+
+  describe('parseReflectorResponse', () => {
+    test('parses valid JSON response', () => {
+      const input = JSON.stringify({
+        decisions: [
+          { observationId: 'obs-1', decision: 'keep', reason: 'still relevant' },
+          { observationId: 'obs-2', decision: 'discard', reason: 'stale' },
+        ],
+        summary: 'Cleaned up stale observations',
+      });
+
+      const result = parseReflectorResponse(input);
+      expect(result).not.toBeNull();
+      expect(result!.decisions).toHaveLength(2);
+      expect(result!.decisions[0].decision).toBe('keep');
+      expect(result!.decisions[1].decision).toBe('discard');
+      expect(result!.summary).toBe('Cleaned up stale observations');
+    });
+
+    test('handles markdown-fenced JSON', () => {
+      const input = '```json\n{"decisions":[{"observationId":"obs-1","decision":"keep","reason":"ok"}]}\n```';
+      const result = parseReflectorResponse(input);
+      expect(result).not.toBeNull();
+      expect(result!.decisions).toHaveLength(1);
+    });
+
+    test('extracts JSON from surrounding text', () => {
+      const input = 'Here is my analysis:\n{"decisions":[{"observationId":"obs-1","decision":"discard","reason":"stale"}]}\nDone.';
+      const result = parseReflectorResponse(input);
+      expect(result).not.toBeNull();
+      expect(result!.decisions).toHaveLength(1);
+    });
+
+    test('returns null for completely invalid input', () => {
+      expect(parseReflectorResponse('not json at all')).toBeNull();
+    });
+
+    test('filters out invalid decisions', () => {
+      const input = JSON.stringify({
+        decisions: [
+          { observationId: 'obs-1', decision: 'keep', reason: 'ok' },
+          { observationId: 'obs-2', decision: 'invalid_decision', reason: 'bad' },
+          { decision: 'keep', reason: 'missing id' },
+        ],
+      });
+      const result = parseReflectorResponse(input);
+      expect(result!.decisions).toHaveLength(1);
+    });
+
+    test('parses merge decisions with merge fields', () => {
+      const input = JSON.stringify({
+        decisions: [{
+          observationId: 'obs-1',
+          decision: 'merge',
+          reason: 'duplicate',
+          mergeIntoId: 'obs-2',
+          mergedContent: 'Combined content',
+        }],
+      });
+      const result = parseReflectorResponse(input);
+      expect(result!.decisions[0].mergeIntoId).toBe('obs-2');
+      expect(result!.decisions[0].mergedContent).toBe('Combined content');
+    });
+  });
+
+  // ─── shouldReflect ─────────────────────────────────────────────────
+
+  describe('shouldReflect', () => {
+    test('returns false when no memory state exists', () => {
+      const store = new ObservationStore(dbPath);
+      const llm = makeLLMClient({ decisions: [] });
+      const reflector = new ReflectorAgent(store, llm, { tokenBudgetThreshold: 100 });
+
+      expect(reflector.shouldReflect('oracle')).toBe(false);
+      store.close();
+    });
+
+    test('returns false when under threshold', () => {
+      const store = new ObservationStore(dbPath);
+      store.upsertMemoryState({
+        agentId: 'oracle',
+        observationsTokens: 50,
+        rawBufferTokens: 0,
+        lastObservationAt: null,
+        lastReflectionAt: null,
+        observationCount: 5,
+      });
+
+      const llm = makeLLMClient({ decisions: [] });
+      const reflector = new ReflectorAgent(store, llm, { tokenBudgetThreshold: 100 });
+
+      expect(reflector.shouldReflect('oracle')).toBe(false);
+      store.close();
+    });
+
+    test('returns true when over threshold', () => {
+      const store = new ObservationStore(dbPath);
+      store.upsertMemoryState({
+        agentId: 'oracle',
+        observationsTokens: 200,
+        rawBufferTokens: 0,
+        lastObservationAt: null,
+        lastReflectionAt: null,
+        observationCount: 20,
+      });
+
+      const llm = makeLLMClient({ decisions: [] });
+      const reflector = new ReflectorAgent(store, llm, { tokenBudgetThreshold: 100 });
+
+      expect(reflector.shouldReflect('oracle')).toBe(true);
+      store.close();
+    });
+
+    test('returns false when disabled', () => {
+      const store = new ObservationStore(dbPath);
+      store.upsertMemoryState({
+        agentId: 'oracle',
+        observationsTokens: 200,
+        rawBufferTokens: 0,
+        lastObservationAt: null,
+        lastReflectionAt: null,
+        observationCount: 20,
+      });
+
+      const llm = makeLLMClient({ decisions: [] });
+      const reflector = new ReflectorAgent(store, llm, {
+        enabled: false,
+        tokenBudgetThreshold: 100,
+      });
+
+      expect(reflector.shouldReflect('oracle')).toBe(false);
+      store.close();
+    });
+  });
+
+  // ─── runReflectionPass ─────────────────────────────────────────────
+
+  describe('runReflectionPass', () => {
+    test('returns success with zero observations when none exist', async () => {
+      const store = new ObservationStore(dbPath);
+      const llm = makeLLMClient({ decisions: [] });
+      const reflector = new ReflectorAgent(store, llm, { silent: true });
+
+      const result = await reflector.runReflectionPass('oracle');
+
+      expect(result.success).toBe(true);
+      expect(result.observationsEvaluated).toBe(0);
+      store.close();
+    });
+
+    test('keeps all observations when LLM says keep', async () => {
+      const store = new ObservationStore(dbPath);
+      const obs = seedObservations(store, 8);
+
+      const llmResponse = makeKeepAllResponse(obs.map((o) => o.id));
+      const llm = makeLLMClient(llmResponse);
+      const reflector = new ReflectorAgent(store, llm, { silent: true });
+
+      const result = await reflector.runReflectionPass('oracle');
+
+      expect(result.success).toBe(true);
+      expect(result.kept).toBe(8);
+      expect(result.discarded).toBe(0);
+      expect(result.merged).toBe(0);
+
+      // All observations still active
+      const active = store.getActiveObservations('oracle');
+      expect(active).toHaveLength(8);
+      store.close();
+    });
+
+    test('soft-deletes discarded observations via reflected_at', async () => {
+      const store = new ObservationStore(dbPath);
+      const obs = seedObservations(store, 8);
+
+      const keepIds = obs.slice(0, 5).map((o) => o.id);
+      const discardIds = obs.slice(5).map((o) => o.id);
+      const llm = makeLLMClient(makeDiscardResponse(keepIds, discardIds));
+      const reflector = new ReflectorAgent(store, llm, { silent: true });
+
+      const result = await reflector.runReflectionPass('oracle');
+
+      expect(result.success).toBe(true);
+      expect(result.discarded).toBe(3);
+
+      // Discarded observations have reflected_at set
+      for (const id of discardIds) {
+        const o = store.getById(id);
+        expect(o).not.toBeNull();
+        expect(o!.reflectedAt).toBeTruthy();
+      }
+
+      // Kept observations still active
+      const active = store.getActiveObservations('oracle');
+      expect(active).toHaveLength(5);
+      store.close();
+    });
+
+    test('applies merge operations — updates target content and soft-deletes source', async () => {
+      const store = new ObservationStore(dbPath);
+      const obs = seedObservations(store, 6);
+
+      const keepIds = obs.slice(0, 4).map((o) => o.id);
+      const mergeSource = obs[4].id;
+      const mergeTarget = obs[0].id;
+      const mergedContent = 'Combined: observation 0 and observation 4';
+
+      const llm = makeLLMClient(makeMergeResponse(keepIds, mergeSource, mergeTarget, mergedContent));
+      // obs[5] gets no decision → defaults to keep
+      const reflector = new ReflectorAgent(store, llm, { silent: true });
+
+      const result = await reflector.runReflectionPass('oracle');
+
+      expect(result.success).toBe(true);
+      expect(result.merged).toBeGreaterThanOrEqual(1);
+
+      // Source observation is soft-deleted
+      const source = store.getById(mergeSource);
+      expect(source!.reflectedAt).toBeTruthy();
+
+      // Target observation has updated content
+      const target = store.getById(mergeTarget);
+      expect(target!.content).toBe(mergedContent);
+
+      store.close();
+    });
+
+    test('enforces minimum retained observations floor', async () => {
+      const store = new ObservationStore(dbPath);
+      const obs = seedObservations(store, 6);
+
+      // LLM wants to discard all but 2 — floor is 5
+      const keepIds = obs.slice(0, 2).map((o) => o.id);
+      const discardIds = obs.slice(2).map((o) => o.id);
+      const llm = makeLLMClient(makeDiscardResponse(keepIds, discardIds));
+      const reflector = new ReflectorAgent(store, llm, {
+        silent: true,
+        minRetainedObservations: 5,
+      });
+
+      const result = await reflector.runReflectionPass('oracle');
+
+      expect(result.success).toBe(true);
+      // At least 5 should be retained
+      const active = store.getActiveObservations('oracle');
+      expect(active.length).toBeGreaterThanOrEqual(5);
+      store.close();
+    });
+
+    test('skips pass when already at or below minimum floor', async () => {
+      const store = new ObservationStore(dbPath);
+      seedObservations(store, 3); // Only 3 observations
+
+      let llmCalled = false;
+      const llm: ReflectorLLMClient = {
+        chatCompletion: async () => {
+          llmCalled = true;
+          return '{"decisions":[]}';
+        },
+      };
+
+      const reflector = new ReflectorAgent(store, llm, {
+        silent: true,
+        minRetainedObservations: 5,
+      });
+
+      const result = await reflector.runReflectionPass('oracle');
+
+      expect(result.success).toBe(true);
+      expect(result.kept).toBe(3);
+      expect(llmCalled).toBe(false); // LLM was never called
+      store.close();
+    });
+
+    test('mutex prevents concurrent runs', async () => {
+      const store = new ObservationStore(dbPath);
+      seedObservations(store, 10);
+
+      // Slow LLM that takes time
+      const llm: ReflectorLLMClient = {
+        chatCompletion: async () => {
+          await new Promise((r) => setTimeout(r, 100));
+          return JSON.stringify(makeKeepAllResponse(
+            Array.from({ length: 10 }, (_, i) => `obs-${i}`),
+          ));
+        },
+      };
+
+      const reflector = new ReflectorAgent(store, llm, { silent: true });
+
+      // Start two passes concurrently
+      const [result1, result2] = await Promise.all([
+        reflector.runReflectionPass('oracle'),
+        reflector.runReflectionPass('oracle'),
+      ]);
+
+      // One should succeed, one should be skipped
+      const successes = [result1, result2].filter((r) => r.success);
+      const skipped = [result1, result2].filter((r) => !r.success && r.error?.includes('already in progress'));
+      expect(successes).toHaveLength(1);
+      expect(skipped).toHaveLength(1);
+
+      const metrics = reflector.getMetrics();
+      expect(metrics.skippedDueToLock).toBe(1);
+      store.close();
+    });
+
+    test('handles LLM failure gracefully', async () => {
+      const store = new ObservationStore(dbPath);
+      seedObservations(store, 8);
+
+      const llm = makeLLMClient(new Error('API timeout'));
+      const reflector = new ReflectorAgent(store, llm, {
+        silent: true,
+        maxRetries: 0, // No retries for faster test
+      });
+
+      const result = await reflector.runReflectionPass('oracle');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('API timeout');
+
+      // All observations still active (no data loss)
+      const active = store.getActiveObservations('oracle');
+      expect(active).toHaveLength(8);
+
+      const metrics = reflector.getMetrics();
+      expect(metrics.llmFailures).toBe(1);
+      store.close();
+    });
+
+    test('handles unparseable LLM response gracefully', async () => {
+      const store = new ObservationStore(dbPath);
+      seedObservations(store, 8);
+
+      const llm = makeLLMClient('This is not valid JSON at all and cannot be parsed');
+      const reflector = new ReflectorAgent(store, llm, { silent: true });
+
+      const result = await reflector.runReflectionPass('oracle');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Failed to parse');
+
+      // All observations still active
+      const active = store.getActiveObservations('oracle');
+      expect(active).toHaveLength(8);
+      store.close();
+    });
+
+    test('recalculates memory_state tokens after reflection', async () => {
+      const store = new ObservationStore(dbPath);
+      const obs = seedObservations(store, 10);
+
+      // Set initial memory state
+      store.upsertMemoryState({
+        agentId: 'oracle',
+        observationsTokens: 9999,
+        rawBufferTokens: 0,
+        lastObservationAt: '2026-02-18T00:00:00Z',
+        lastReflectionAt: null,
+        observationCount: 10,
+      });
+
+      // Discard 5 observations
+      const keepIds = obs.slice(0, 5).map((o) => o.id);
+      const discardIds = obs.slice(5).map((o) => o.id);
+      const llm = makeLLMClient(makeDiscardResponse(keepIds, discardIds));
+      const reflector = new ReflectorAgent(store, llm, { silent: true });
+
+      await reflector.runReflectionPass('oracle');
+
+      const state = store.getMemoryState('oracle');
+      expect(state).not.toBeNull();
+      expect(state!.observationsTokens).toBeLessThan(9999);
+      expect(state!.lastReflectionAt).toBeTruthy();
+      expect(state!.observationCount).toBe(5);
+      store.close();
+    });
+
+    test('logs reflection run into reflection_log table', async () => {
+      const store = new ObservationStore(dbPath);
+      const obs = seedObservations(store, 8);
+
+      const keepIds = obs.slice(0, 5).map((o) => o.id);
+      const discardIds = obs.slice(5).map((o) => o.id);
+      const llm = makeLLMClient(makeDiscardResponse(keepIds, discardIds));
+      const reflector = new ReflectorAgent(store, llm, { silent: true });
+
+      await reflector.runReflectionPass('oracle');
+
+      const logs = store.getReflectionLogs('oracle');
+      expect(logs.length).toBeGreaterThanOrEqual(1);
+
+      const log = logs[0];
+      expect(log.agentId).toBe('oracle');
+      expect(log.observationsEvaluated).toBe(8);
+      expect(log.observationsDiscarded).toBe(3);
+      expect(log.modelUsed).toBe('gpt-4o-mini');
+      expect(log.durationMs).toBeGreaterThanOrEqual(0);
+      store.close();
+    });
+
+    test('invalidates observation cache after successful pass', async () => {
+      const store = new ObservationStore(dbPath);
+      const obs = seedObservations(store, 8);
+
+      const cache = new ObservationCache(store, 'oracle');
+      // Prime the cache
+      cache.getSnapshot();
+
+      const keepIds = obs.slice(0, 5).map((o) => o.id);
+      const discardIds = obs.slice(5).map((o) => o.id);
+      const llm = makeLLMClient(makeDiscardResponse(keepIds, discardIds));
+      const reflector = new ReflectorAgent(store, llm, { silent: true }, cache);
+
+      await reflector.runReflectionPass('oracle');
+
+      // Cache should reflect the new state
+      const snap = cache.getSnapshot();
+      expect(snap.observations).toHaveLength(5);
+      store.close();
+    });
+  });
+
+  // ─── Metrics ──────────────────────────────────────────────────────
+
+  describe('metrics', () => {
+    test('tracks cumulative metrics across passes', async () => {
+      const store = new ObservationStore(dbPath);
+      seedObservations(store, 8);
+
+      const keepAll = makeKeepAllResponse(
+        Array.from({ length: 8 }, (_, i) => `obs-${i}`),
+      );
+      const llm = makeLLMClient(keepAll);
+      const reflector = new ReflectorAgent(store, llm, { silent: true });
+
+      await reflector.runReflectionPass('oracle');
+      await reflector.runReflectionPass('oracle');
+
+      const m = reflector.getMetrics();
+      expect(m.passesAttempted).toBe(2);
+      expect(m.passesCompleted).toBe(2);
+      expect(m.observationsEvaluated).toBe(16); // 8 + 8
+      expect(m.llmCalls).toBe(2);
+      expect(m.lastPassAt).toBeTruthy();
+      store.close();
+    });
+  });
+
+  // ─── Store Methods (Phase 3 additions) ─────────────────────────────
+
+  describe('ObservationStore Phase 3 methods', () => {
+    test('getActiveObservations excludes reflected observations', () => {
+      const store = new ObservationStore(dbPath);
+      seedObservations(store, 5);
+
+      store.markReflected(['obs-0', 'obs-1'], '2026-02-18T12:00:00Z');
+
+      const active = store.getActiveObservations('oracle');
+      expect(active).toHaveLength(3);
+      const activeIds = active.map((o) => o.id);
+      expect(activeIds).not.toContain('obs-0');
+      expect(activeIds).not.toContain('obs-1');
+      store.close();
+    });
+
+    test('markReflected returns count of changed rows', () => {
+      const store = new ObservationStore(dbPath);
+      seedObservations(store, 5);
+
+      const changed = store.markReflected(['obs-0', 'obs-1', 'nonexistent'], '2026-02-18T12:00:00Z');
+      expect(changed).toBe(2);
+
+      // Marking again returns 0 (already reflected)
+      const changed2 = store.markReflected(['obs-0'], '2026-02-18T13:00:00Z');
+      expect(changed2).toBe(0);
+      store.close();
+    });
+
+    test('insertReflectionLog and getReflectionLogs roundtrip', () => {
+      const store = new ObservationStore(dbPath);
+
+      store.insertReflectionLog({
+        id: 'refl-1',
+        agentId: 'oracle',
+        runAt: '2026-02-18T12:00:00Z',
+        observationsEvaluated: 10,
+        observationsKept: 7,
+        observationsMerged: 1,
+        observationsDiscarded: 2,
+        tokensBefore: 5000,
+        tokensAfter: 3500,
+        modelUsed: 'gpt-4o-mini',
+        durationMs: 1200,
+      });
+
+      const logs = store.getReflectionLogs('oracle');
+      expect(logs).toHaveLength(1);
+      expect(logs[0].id).toBe('refl-1');
+      expect(logs[0].observationsEvaluated).toBe(10);
+      expect(logs[0].observationsKept).toBe(7);
+      expect(logs[0].tokensBefore).toBe(5000);
+      expect(logs[0].tokensAfter).toBe(3500);
+      store.close();
+    });
+
+    test('getReflectionLogs returns newest first', () => {
+      const store = new ObservationStore(dbPath);
+
+      store.insertReflectionLog({
+        id: 'refl-old',
+        agentId: 'oracle',
+        runAt: '2026-02-18T10:00:00Z',
+        observationsEvaluated: 5,
+        observationsKept: 5,
+        observationsMerged: 0,
+        observationsDiscarded: 0,
+        tokensBefore: 1000,
+        tokensAfter: 1000,
+        modelUsed: 'gpt-4o-mini',
+        durationMs: 500,
+      });
+
+      store.insertReflectionLog({
+        id: 'refl-new',
+        agentId: 'oracle',
+        runAt: '2026-02-18T14:00:00Z',
+        observationsEvaluated: 8,
+        observationsKept: 6,
+        observationsMerged: 0,
+        observationsDiscarded: 2,
+        tokensBefore: 2000,
+        tokensAfter: 1500,
+        modelUsed: 'gpt-4o-mini',
+        durationMs: 800,
+      });
+
+      const logs = store.getReflectionLogs('oracle');
+      expect(logs[0].id).toBe('refl-new');
+      expect(logs[1].id).toBe('refl-old');
+      store.close();
+    });
+
+    test('updateContent modifies observation content', () => {
+      const store = new ObservationStore(dbPath);
+      store.insert(makeObs({ id: 'obs-update', content: 'Original content' }));
+
+      store.updateContent('obs-update', 'Updated merged content');
+
+      const loaded = store.getById('obs-update');
+      expect(loaded!.content).toBe('Updated merged content');
+      store.close();
+    });
+
+    test('reflection_log table is created with indexes', () => {
+      const store = new ObservationStore(dbPath);
+      store.close();
+
+      // Verify via raw SQL
+      const Database = require('better-sqlite3');
+      const db = new Database(dbPath, { readonly: true });
+
+      const tables = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='reflection_log'",
+      ).all() as any[];
+      expect(tables).toHaveLength(1);
+
+      const indexes = db.prepare(
+        "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='reflection_log'",
+      ).all() as any[];
+      const indexNames = indexes.map((i: any) => i.name);
+      expect(indexNames).toContain('idx_reflection_log_agent');
+      expect(indexNames).toContain('idx_reflection_log_run_at');
+
+      db.close();
+    });
+
+    test('reflected_at column exists on observations table', () => {
+      const store = new ObservationStore(dbPath);
+      store.insert(makeObs({ id: 'obs-col-check' }));
+      store.close();
+
+      const Database = require('better-sqlite3');
+      const db = new Database(dbPath, { readonly: true });
+      const columns = db.prepare("PRAGMA table_info('observations')").all() as any[];
+      const colNames = columns.map((c: any) => c.name);
+      expect(colNames).toContain('reflected_at');
+      db.close();
+    });
+  });
+});

--- a/lib/observation-cache.ts
+++ b/lib/observation-cache.ts
@@ -1,0 +1,240 @@
+/**
+ * Observation Cache — VentureOS Prompt-Ready Observation Buffer (Phase 3)
+ *
+ * In-memory cache that provides a token-bounded, priority-ordered view
+ * of active observations for prompt injection. Rebuilt from the store
+ * on demand and invalidated after reflection passes.
+ *
+ * Key behaviors:
+ * - Observations ordered by priority (high > medium > info), then recency
+ * - Token budget enforced — excess observations trimmed from the tail
+ * - Cache is invalidated after reflection or new observations
+ * - Thread-safe via simple generation counter (no async contention in Node)
+ *
+ * Issue #232 — Phase 3 of #218: Reflector Agent GC + Prompt Cache
+ */
+
+import type { ObservationStore } from './observation-store';
+import type { Observation, ObservationPriority } from './types/observation';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+export interface ObservationCacheConfig {
+  /** Maximum token budget for cached observations. Default: 50_000 */
+  maxTokenBudget: number;
+  /** Characters-per-token for estimation. Default: 4 */
+  charsPerToken: number;
+  /** Maximum observations to load from store. Default: 500 */
+  maxObservations: number;
+}
+
+export interface CacheSnapshot {
+  /** Cached observations in priority/recency order. */
+  observations: Observation[];
+  /** Total estimated tokens of cached observations. */
+  totalTokens: number;
+  /** Generation counter (increments on each rebuild). */
+  generation: number;
+  /** ISO timestamp of last rebuild. */
+  rebuiltAt: string;
+}
+
+export interface PromptBlock {
+  /** Formatted text ready for prompt injection. */
+  text: string;
+  /** Total tokens of the block. */
+  tokens: number;
+  /** Number of observations included. */
+  count: number;
+}
+
+// ─── Priority ordering ──────────────────────────────────────────────────────
+
+const PRIORITY_ORDER: Record<ObservationPriority, number> = {
+  high: 0,
+  medium: 1,
+  info: 2,
+};
+
+function priorityRank(p?: ObservationPriority): number {
+  return p ? (PRIORITY_ORDER[p] ?? 3) : 3;
+}
+
+// ─── Token estimation ───────────────────────────────────────────────────────
+
+function estimateTokens(content: string, charsPerToken: number): number {
+  return Math.max(1, Math.ceil(content.length / Math.max(1, charsPerToken)));
+}
+
+// ─── Observation Cache ──────────────────────────────────────────────────────
+
+const DEFAULT_CONFIG: ObservationCacheConfig = {
+  maxTokenBudget: 50_000,
+  charsPerToken: 4,
+  maxObservations: 500,
+};
+
+/**
+ * In-memory cache of active observations for a single agent.
+ *
+ * Usage:
+ * ```ts
+ * const cache = new ObservationCache(store, 'oracle');
+ * const block = cache.getPromptBlock();
+ * // inject block.text into system prompt
+ * ```
+ */
+export class ObservationCache {
+  private readonly store: ObservationStore;
+  private readonly agentId: string;
+  private readonly config: ObservationCacheConfig;
+
+  private cached: Observation[] = [];
+  private totalTokens = 0;
+  private generation = 0;
+  private rebuiltAt: string | null = null;
+  private dirty = true;
+
+  constructor(
+    store: ObservationStore,
+    agentId: string,
+    config: Partial<ObservationCacheConfig> = {},
+  ) {
+    this.store = store;
+    this.agentId = agentId;
+    this.config = { ...DEFAULT_CONFIG, ...config };
+  }
+
+  /**
+   * Invalidate the cache. Next access will trigger a rebuild.
+   */
+  invalidate(): void {
+    this.dirty = true;
+  }
+
+  /**
+   * Rebuild the cache from the observation store.
+   * Loads active observations, sorts by priority/recency, and trims to budget.
+   */
+  rebuild(): CacheSnapshot {
+    const observations = this.store.getActiveObservations(
+      this.agentId,
+      this.config.maxObservations,
+    );
+
+    // Sort by priority (high first), then created_at DESC
+    observations.sort((a, b) => {
+      const pa = priorityRank(a.priority);
+      const pb = priorityRank(b.priority);
+      if (pa !== pb) return pa - pb;
+      return b.createdAt.localeCompare(a.createdAt);
+    });
+
+    // Trim to token budget
+    let runningTokens = 0;
+    const trimmed: Observation[] = [];
+
+    for (const obs of observations) {
+      const tokens = estimateTokens(obs.content, this.config.charsPerToken);
+      if (runningTokens + tokens > this.config.maxTokenBudget && trimmed.length > 0) {
+        break;
+      }
+      trimmed.push(obs);
+      runningTokens += tokens;
+    }
+
+    this.cached = trimmed;
+    this.totalTokens = runningTokens;
+    this.generation++;
+    this.rebuiltAt = new Date().toISOString();
+    this.dirty = false;
+
+    return this.getSnapshot();
+  }
+
+  /**
+   * Get the current cache snapshot, rebuilding if dirty.
+   */
+  getSnapshot(): CacheSnapshot {
+    if (this.dirty) {
+      return this.rebuild();
+    }
+    return {
+      observations: [...this.cached],
+      totalTokens: this.totalTokens,
+      generation: this.generation,
+      rebuiltAt: this.rebuiltAt ?? new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Get the cached observations, rebuilding if dirty.
+   */
+  getObservations(): Observation[] {
+    if (this.dirty) this.rebuild();
+    return [...this.cached];
+  }
+
+  /**
+   * Get total estimated tokens, rebuilding if dirty.
+   */
+  getTotalTokens(): number {
+    if (this.dirty) this.rebuild();
+    return this.totalTokens;
+  }
+
+  /**
+   * Check if observations exceed the token budget threshold.
+   * Useful for the reflector to decide whether to trigger.
+   */
+  exceedsBudget(threshold?: number): boolean {
+    const budget = threshold ?? this.config.maxTokenBudget;
+    return this.getTotalTokens() > budget;
+  }
+
+  /**
+   * Format active observations as a prompt block for injection.
+   * Groups by priority level with headers.
+   */
+  getPromptBlock(): PromptBlock {
+    const observations = this.getObservations();
+    if (observations.length === 0) {
+      return { text: '', tokens: 0, count: 0 };
+    }
+
+    const groups: Record<string, Observation[]> = {};
+    for (const obs of observations) {
+      const key = obs.priority ?? 'info';
+      if (!groups[key]) groups[key] = [];
+      groups[key].push(obs);
+    }
+
+    const lines: string[] = ['## Active Observations'];
+    const priorityOrder: ObservationPriority[] = ['high', 'medium', 'info'];
+    const priorityLabels: Record<ObservationPriority, string> = {
+      high: '🔴 High Priority',
+      medium: '🟡 Medium Priority',
+      info: '🟢 Info',
+    };
+
+    for (const p of priorityOrder) {
+      const group = groups[p];
+      if (!group || group.length === 0) continue;
+      lines.push('');
+      lines.push(`### ${priorityLabels[p]}`);
+      for (const obs of group) {
+        const dateRef = obs.referencedDate ? ` [ref: ${obs.referencedDate}]` : '';
+        lines.push(`- ${obs.content}${dateRef}`);
+      }
+    }
+
+    const text = lines.join('\n');
+    return {
+      text,
+      tokens: estimateTokens(text, this.config.charsPerToken),
+      count: observations.length,
+    };
+  }
+}
+
+export default ObservationCache;

--- a/lib/observation-store.ts
+++ b/lib/observation-store.ts
@@ -15,9 +15,12 @@ import type {
   ObservationId,
   ObservationQuery,
   ObservationStatus,
+  ObservationPriority,
   TokenUsageSummary,
   IObservationStore,
   MemoryState,
+  MemoryStateSnapshot,
+  ReflectionLogEntry,
 } from './types/observation';
 
 /**
@@ -103,11 +106,34 @@ export class ObservationStore implements IObservationStore {
         last_reflection_at TEXT,
         observation_count INTEGER NOT NULL DEFAULT 0
       );
+
+      -- Reflection log: audit trail for reflector GC passes (Phase 3 / #232)
+      CREATE TABLE IF NOT EXISTS reflection_log (
+        id TEXT PRIMARY KEY,
+        agent_id TEXT NOT NULL,
+        run_at TEXT NOT NULL,
+        observations_evaluated INTEGER NOT NULL DEFAULT 0,
+        observations_kept INTEGER NOT NULL DEFAULT 0,
+        observations_merged INTEGER NOT NULL DEFAULT 0,
+        observations_discarded INTEGER NOT NULL DEFAULT 0,
+        tokens_before INTEGER NOT NULL DEFAULT 0,
+        tokens_after INTEGER NOT NULL DEFAULT 0,
+        model_used TEXT NOT NULL,
+        duration_ms INTEGER NOT NULL DEFAULT 0,
+        error TEXT
+      );
+      CREATE INDEX IF NOT EXISTS idx_reflection_log_agent
+        ON reflection_log(agent_id);
+      CREATE INDEX IF NOT EXISTS idx_reflection_log_run_at
+        ON reflection_log(run_at);
     `);
 
     // Phase 2 migration: add new columns to existing databases.
     // SQLite ALTER TABLE ADD COLUMN is idempotent-safe via try/catch.
     this.migratePhase2Columns();
+
+    // Phase 3 migration: add reflected_at column for soft-delete
+    this.migratePhase3Columns();
 
     // Create index on priority column (must come after migration adds the column)
     this.db.exec(`
@@ -127,6 +153,18 @@ export class ObservationStore implements IObservationStore {
       } catch {
         // Column already exists — safe to ignore
       }
+    }
+  }
+
+  /**
+   * Add Phase 3 columns if missing (backward-compatible migration).
+   * reflected_at: ISO timestamp when the reflector soft-deleted this observation.
+   */
+  private migratePhase3Columns(): void {
+    try {
+      this.db.exec('ALTER TABLE observations ADD COLUMN reflected_at TEXT');
+    } catch {
+      // Column already exists — safe to ignore
     }
   }
 
@@ -355,6 +393,210 @@ export class ObservationStore implements IObservationStore {
     );
   }
 
+  // ─── Reflector GC (Phase 3 / #232) ──────────────────────────────────
+
+  /**
+   * Get active (non-reflected) observations for an agent.
+   * Returns observations that have NOT been soft-deleted by the reflector.
+   * Ordered by priority (high first), then created_at DESC.
+   */
+  getActiveObservations(agentId: string, limit = 500): Observation[] {
+    const rows = this.db.prepare(`
+      SELECT * FROM observations
+      WHERE source_agent_id = ?
+        AND status = 'processed'
+        AND reflected_at IS NULL
+      ORDER BY
+        CASE priority WHEN 'high' THEN 0 WHEN 'medium' THEN 1 WHEN 'info' THEN 2 ELSE 3 END,
+        created_at DESC
+      LIMIT ?
+    `).all(agentId, limit) as any[];
+    return rows.map((r) => this.rowToObservation(r));
+  }
+
+  /**
+   * Soft-delete observations by setting reflected_at timestamp.
+   * This is the GC mechanism — no hard deletes.
+   */
+  markReflected(observationIds: string[], reflectedAt: string): number {
+    if (observationIds.length === 0) return 0;
+    const placeholders = observationIds.map(() => '?').join(',');
+    const result = this.db.prepare(
+      `UPDATE observations SET reflected_at = ? WHERE id IN (${placeholders}) AND reflected_at IS NULL`,
+    ).run(reflectedAt, ...observationIds);
+    return result.changes;
+  }
+
+  /**
+   * Insert a reflection log entry for audit trail.
+   */
+  insertReflectionLog(entry: ReflectionLogEntry): void {
+    this.db.prepare(`
+      INSERT INTO reflection_log
+        (id, agent_id, run_at, observations_evaluated, observations_kept,
+         observations_merged, observations_discarded, tokens_before, tokens_after,
+         model_used, duration_ms, error)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      entry.id,
+      entry.agentId,
+      entry.runAt,
+      entry.observationsEvaluated,
+      entry.observationsKept,
+      entry.observationsMerged,
+      entry.observationsDiscarded,
+      entry.tokensBefore,
+      entry.tokensAfter,
+      entry.modelUsed,
+      entry.durationMs,
+      entry.error ?? null,
+    );
+  }
+
+  /**
+   * Get reflection log entries for an agent.
+   */
+  getReflectionLogs(agentId: string, limit = 20): ReflectionLogEntry[] {
+    const rows = this.db.prepare(
+      'SELECT * FROM reflection_log WHERE agent_id = ? ORDER BY run_at DESC LIMIT ?',
+    ).all(agentId, limit) as any[];
+    return rows.map((r) => ({
+      id: r.id,
+      agentId: r.agent_id,
+      runAt: r.run_at,
+      observationsEvaluated: r.observations_evaluated,
+      observationsKept: r.observations_kept,
+      observationsMerged: r.observations_merged,
+      observationsDiscarded: r.observations_discarded,
+      tokensBefore: r.tokens_before,
+      tokensAfter: r.tokens_after,
+      modelUsed: r.model_used,
+      durationMs: r.duration_ms,
+      error: r.error ?? undefined,
+    }));
+  }
+
+  /**
+   * Update the content of an observation (used for merge operations).
+   */
+  updateContent(id: ObservationId, content: string): void {
+    this.db.prepare('UPDATE observations SET content = ? WHERE id = ?').run(content, id);
+  }
+
+  // ─── Phase 4 Read Methods (#233) ───────────────────────────────────────
+
+  /**
+   * Check whether the `reflected_at` column exists on the observations table.
+   * Returns false gracefully if the column hasn't been migrated yet (#232).
+   */
+  hasReflectedAtColumn(): boolean {
+    try {
+      const cols = this.db.prepare("PRAGMA table_info(observations)").all() as any[];
+      return cols.some((c: any) => c.name === 'reflected_at');
+    } catch {
+      return false;
+    }
+  }
+
+  /**
+   * Count observations grouped by priority for an agent.
+   * Only counts non-token_usage, processed observations.
+   * Gracefully handles missing reflected_at column.
+   */
+  getPriorityCounts(agentId: string): { high: number; medium: number; info: number } {
+    const hasReflected = this.hasReflectedAtColumn();
+    const reflectedClause = hasReflected ? 'AND reflected_at IS NULL' : '';
+    const sql = `
+      SELECT priority, COUNT(*) as cnt
+      FROM observations
+      WHERE source_agent_id = ?
+        AND status = 'processed'
+        AND category != 'token_usage'
+        ${reflectedClause}
+      GROUP BY priority
+    `;
+    const rows = this.db.prepare(sql).all(agentId) as any[];
+    const counts = { high: 0, medium: 0, info: 0 };
+    for (const row of rows) {
+      const p = row.priority as string;
+      if (p === 'high' || p === 'medium' || p === 'info') {
+        counts[p] = row.cnt;
+      }
+    }
+    return counts;
+  }
+
+  /**
+   * Build a full MemoryStateSnapshot for an agent.
+   * Used by GET /api/memory/state and the /observations command.
+   */
+  getMemoryStateSnapshot(agentId: string): MemoryStateSnapshot {
+    const memState = this.getMemoryState(agentId);
+    const priorityCounts = this.getPriorityCounts(agentId);
+    const hasReflected = this.hasReflectedAtColumn();
+
+    return {
+      agentId,
+      enabled: true,
+      observationsTokens: memState?.observationsTokens ?? 0,
+      rawBufferTokens: memState?.rawBufferTokens ?? 0,
+      observationCount: memState?.observationCount ?? 0,
+      priorityCounts,
+      lastObservationAt: memState?.lastObservationAt ?? null,
+      lastReflectionAt: memState?.lastReflectionAt ?? null,
+      reflectionSupported: hasReflected,
+    };
+  }
+
+  /**
+   * Query active (non-reflected) observations with optional priority filter.
+   * Used by GET /api/memory/observations and /observations command.
+   * Gracefully handles missing reflected_at column.
+   */
+  queryActiveObservations(opts: {
+    agentId: string;
+    limit?: number;
+    priority?: ObservationPriority;
+    since?: string;
+  }): Observation[] {
+    const conditions: string[] = [
+      'source_agent_id = ?',
+      "status = 'processed'",
+      "category != 'token_usage'",
+    ];
+    const params: unknown[] = [opts.agentId];
+
+    const hasReflected = this.hasReflectedAtColumn();
+    if (hasReflected) {
+      conditions.push('reflected_at IS NULL');
+    }
+
+    if (opts.priority) {
+      conditions.push('priority = ?');
+      params.push(opts.priority);
+    }
+
+    if (opts.since) {
+      conditions.push('created_at >= ?');
+      params.push(opts.since);
+    }
+
+    const limit = Math.min(opts.limit ?? 50, 500);
+    const where = conditions.join(' AND ');
+    const sql = `
+      SELECT * FROM observations
+      WHERE ${where}
+      ORDER BY
+        CASE priority WHEN 'high' THEN 0 WHEN 'medium' THEN 1 WHEN 'info' THEN 2 ELSE 3 END,
+        created_at DESC
+      LIMIT ?
+    `;
+    params.push(limit);
+
+    const rows = this.db.prepare(sql).all(...params) as any[];
+    return rows.map((r) => this.rowToObservation(r));
+  }
+
   /**
    * Close the database connection.
    */
@@ -415,6 +657,9 @@ export class ObservationStore implements IObservationStore {
     if (row.priority) observation.priority = row.priority;
     if (row.referenced_date) observation.referencedDate = row.referenced_date;
     if (sourceMessageIds) observation.sourceMessageIds = sourceMessageIds;
+
+    // Phase 3 fields
+    if (row.reflected_at) observation.reflectedAt = row.reflected_at;
 
     return observation;
   }

--- a/lib/reflector-agent.ts
+++ b/lib/reflector-agent.ts
@@ -1,0 +1,619 @@
+/**
+ * Reflector Agent — VentureOS Observation GC + Memory Consolidation (Phase 3)
+ *
+ * Periodic garbage collector that evaluates accumulated observations and
+ * decides which to keep, merge, or discard. Runs when the observation
+ * token budget exceeds a configurable threshold.
+ *
+ * Architecture:
+ * - Loads active (non-reflected) observations from the store
+ * - Single LLM call evaluates each observation: keep / merge / discard
+ * - Discarded observations are soft-deleted via `reflected_at` (no hard deletes)
+ * - Merged observations combine content into the target observation
+ * - High-priority observations are preserved unless explicitly contradicted
+ * - Minimum retained floor prevents over-aggressive GC
+ * - Mutex guard prevents concurrent reflector runs
+ * - Each run is logged in `reflection_log` for audit trail
+ * - memory_state tokens recalculated after each pass
+ *
+ * Issue #232 — Phase 3 of #218: Reflector Agent GC + Prompt Cache
+ */
+
+import crypto from 'node:crypto';
+import type { ObservationStore } from './observation-store';
+import type { ObservationCache } from './observation-cache';
+import type {
+  Observation,
+  ReflectorAgentConfig,
+  ReflectionLogEntry,
+  ReflectionLLMResult,
+  ReflectionObservationDecision,
+  MemoryState,
+} from './types/observation';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/** LLM call interface — injected for testability (same pattern as ObserverAgent). */
+export interface ReflectorLLMClient {
+  chatCompletion(params: {
+    model: string;
+    messages: Array<{ role: 'system' | 'user'; content: string }>;
+    temperature?: number;
+    maxTokens?: number;
+  }): Promise<string>;
+}
+
+/** Metrics exposed by the reflector agent. */
+export interface ReflectorAgentMetrics {
+  passesAttempted: number;
+  passesCompleted: number;
+  observationsEvaluated: number;
+  observationsKept: number;
+  observationsMerged: number;
+  observationsDiscarded: number;
+  llmCalls: number;
+  llmFailures: number;
+  skippedDueToLock: number;
+  lastPassAt: string | null;
+  lastErrorAt: string | null;
+}
+
+/** Result of a single reflection pass. */
+export interface ReflectionPassResult {
+  success: boolean;
+  observationsEvaluated: number;
+  kept: number;
+  merged: number;
+  discarded: number;
+  tokensBefore: number;
+  tokensAfter: number;
+  error?: string;
+}
+
+// ─── Default Config ─────────────────────────────────────────────────────────
+
+const DEFAULT_CONFIG: ReflectorAgentConfig = {
+  enabled: true,
+  charsPerToken: 4,
+  tokenBudgetThreshold: 50_000,
+  minRetainedObservations: 5,
+  maxRetries: 1,
+  modelId: 'gpt-4o-mini',
+  silent: false,
+};
+
+// ─── Prompt Templates ───────────────────────────────────────────────────────
+
+const REFLECTOR_SYSTEM_PROMPT = `You are a memory reflection agent for an AI assistant system. Your job is to evaluate a set of stored observations and decide which ones to keep, merge, or discard.
+
+Rules:
+1. HIGH PRIORITY observations (🔴) should almost always be kept, unless they are clearly contradicted by a newer observation or are provably stale/completed.
+2. MEDIUM PRIORITY observations (🟡) should be kept if still relevant. Merge duplicates.
+3. INFO PRIORITY observations (🟢) are candidates for discard if they add little value or are subsumed by other observations.
+4. Never discard an observation that contains an active commitment, deadline, or open question unless it has been explicitly resolved.
+5. When merging, combine the content into a single clear statement and specify which observation to merge INTO (the one to keep) and which to discard.
+6. Preserve temporal context — if an observation references a specific date that is still in the future, keep it.
+
+Output Format — respond ONLY with a JSON object:
+{
+  "decisions": [
+    {
+      "observationId": "<id>",
+      "decision": "keep" | "merge" | "discard",
+      "reason": "<brief reason>",
+      "mergeIntoId": "<id of target observation, only if decision=merge>",
+      "mergedContent": "<combined text, only if decision=merge>"
+    }
+  ],
+  "summary": "<optional one-line summary of what you did>"
+}`;
+
+function buildReflectorUserPrompt(observations: Observation[], currentDate: string): string {
+  const lines: string[] = [
+    `Current date: ${currentDate}`,
+    `Total observations to evaluate: ${observations.length}`,
+    '',
+    'Observations:',
+  ];
+
+  for (const obs of observations) {
+    const priority = obs.priority ?? 'info';
+    const emoji = priority === 'high' ? '🔴' : priority === 'medium' ? '🟡' : '🟢';
+    const dateRef = obs.referencedDate ? ` | ref_date: ${obs.referencedDate}` : '';
+    const created = obs.createdAt ? ` | created: ${obs.createdAt.split('T')[0]}` : '';
+    lines.push(`[${obs.id}] ${emoji} ${priority.toUpperCase()}${created}${dateRef}`);
+    lines.push(`  ${obs.content}`);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+// ─── Response Parsing ───────────────────────────────────────────────────────
+
+const VALID_DECISIONS = new Set(['keep', 'merge', 'discard']);
+
+function parseReflectorResponse(responseText: string): ReflectionLLMResult | null {
+  let cleaned = responseText.trim();
+  if (cleaned.startsWith('```')) {
+    cleaned = cleaned.replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '');
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch {
+    // Try extracting JSON object
+    const match = cleaned.match(/\{[\s\S]*\}/);
+    if (match) {
+      try {
+        parsed = JSON.parse(match[0]);
+      } catch {
+        return null;
+      }
+    } else {
+      return null;
+    }
+  }
+
+  if (!parsed || typeof parsed !== 'object') return null;
+  const obj = parsed as Record<string, unknown>;
+
+  if (!Array.isArray(obj.decisions)) return null;
+
+  const decisions: ReflectionObservationDecision[] = [];
+  for (const raw of obj.decisions) {
+    if (!raw || typeof raw !== 'object') continue;
+    const d = raw as Record<string, unknown>;
+
+    if (typeof d.observationId !== 'string') continue;
+    if (typeof d.decision !== 'string' || !VALID_DECISIONS.has(d.decision)) continue;
+
+    decisions.push({
+      observationId: d.observationId,
+      decision: d.decision as 'keep' | 'merge' | 'discard',
+      reason: typeof d.reason === 'string' ? d.reason : '',
+      mergeIntoId: typeof d.mergeIntoId === 'string' ? d.mergeIntoId : undefined,
+      mergedContent: typeof d.mergedContent === 'string' ? d.mergedContent : undefined,
+    });
+  }
+
+  return {
+    decisions,
+    summary: typeof obj.summary === 'string' ? obj.summary : undefined,
+  };
+}
+
+// ─── Utility ────────────────────────────────────────────────────────────────
+
+function genLogId(): string {
+  return `refl_${crypto.randomBytes(8).toString('hex')}_${Date.now()}`;
+}
+
+function estimateTokens(content: string, charsPerToken: number): number {
+  return Math.max(1, Math.ceil(content.length / Math.max(1, charsPerToken)));
+}
+
+// ─── Reflector Agent ────────────────────────────────────────────────────────
+
+export class ReflectorAgent {
+  private readonly config: ReflectorAgentConfig;
+  private readonly store: ObservationStore;
+  private readonly llm: ReflectorLLMClient;
+  private readonly cache: ObservationCache | null;
+
+  /** Mutex: true when a reflection pass is running. */
+  private running = false;
+
+  private metrics: ReflectorAgentMetrics = {
+    passesAttempted: 0,
+    passesCompleted: 0,
+    observationsEvaluated: 0,
+    observationsKept: 0,
+    observationsMerged: 0,
+    observationsDiscarded: 0,
+    llmCalls: 0,
+    llmFailures: 0,
+    skippedDueToLock: 0,
+    lastPassAt: null,
+    lastErrorAt: null,
+  };
+
+  constructor(
+    store: ObservationStore,
+    llm: ReflectorLLMClient,
+    config: Partial<ReflectorAgentConfig> = {},
+    cache?: ObservationCache | null,
+  ) {
+    this.config = { ...DEFAULT_CONFIG, ...config };
+    this.store = store;
+    this.llm = llm;
+    this.cache = cache ?? null;
+  }
+
+  // ─── Lifecycle ──────────────────────────────────────────────────────
+
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  getMetrics(): Readonly<ReflectorAgentMetrics> {
+    return { ...this.metrics };
+  }
+
+  // ─── Threshold Check ────────────────────────────────────────────────
+
+  /**
+   * Check whether reflection should be triggered for an agent.
+   * Returns true if observations token count exceeds threshold.
+   */
+  shouldReflect(agentId: string): boolean {
+    if (!this.config.enabled) return false;
+    const state = this.store.getMemoryState(agentId);
+    if (!state) return false;
+    return state.observationsTokens > this.config.tokenBudgetThreshold;
+  }
+
+  // ─── Reflection Pass ────────────────────────────────────────────────
+
+  /**
+   * Run a reflection pass for the specified agent.
+   *
+   * Pipeline:
+   * 1. Acquire mutex
+   * 2. Load active observations
+   * 3. Check minimum floor (skip if already at/below)
+   * 4. Call LLM for decisions
+   * 5. Apply decisions: soft-delete discards, update merges
+   * 6. Enforce minimum retained floor
+   * 7. Recalculate memory_state tokens
+   * 8. Log the reflection run
+   * 9. Invalidate prompt cache
+   */
+  async runReflectionPass(agentId: string): Promise<ReflectionPassResult> {
+    if (this.running) {
+      this.metrics.skippedDueToLock++;
+      return {
+        success: false,
+        observationsEvaluated: 0,
+        kept: 0,
+        merged: 0,
+        discarded: 0,
+        tokensBefore: 0,
+        tokensAfter: 0,
+        error: 'Reflection pass already in progress',
+      };
+    }
+
+    this.running = true;
+    this.metrics.passesAttempted++;
+    const startTime = Date.now();
+
+    try {
+      // 1. Load active observations
+      const activeObs = this.store.getActiveObservations(agentId);
+
+      if (activeObs.length === 0) {
+        return this.completePass(agentId, {
+          success: true,
+          observationsEvaluated: 0,
+          kept: 0, merged: 0, discarded: 0,
+          tokensBefore: 0, tokensAfter: 0,
+        }, startTime);
+      }
+
+      // 2. Check minimum floor
+      if (activeObs.length <= this.config.minRetainedObservations) {
+        return this.completePass(agentId, {
+          success: true,
+          observationsEvaluated: activeObs.length,
+          kept: activeObs.length, merged: 0, discarded: 0,
+          tokensBefore: this.calcTokens(activeObs),
+          tokensAfter: this.calcTokens(activeObs),
+        }, startTime);
+      }
+
+      const tokensBefore = this.calcTokens(activeObs);
+
+      // 3. Call LLM
+      const currentDate = new Date().toISOString().split('T')[0];
+      const userPrompt = buildReflectorUserPrompt(activeObs, currentDate);
+
+      let responseText: string | null = null;
+      let lastError: string | null = null;
+
+      for (let attempt = 0; attempt <= this.config.maxRetries; attempt++) {
+        try {
+          this.metrics.llmCalls++;
+          responseText = await this.llm.chatCompletion({
+            model: this.config.modelId,
+            messages: [
+              { role: 'system', content: REFLECTOR_SYSTEM_PROMPT },
+              { role: 'user', content: userPrompt },
+            ],
+            temperature: 0.2,
+            maxTokens: 4000,
+          });
+          break;
+        } catch (err: unknown) {
+          lastError = err instanceof Error ? err.message : String(err);
+          if (attempt < this.config.maxRetries) {
+            await new Promise((r) => setTimeout(r, 500));
+          }
+        }
+      }
+
+      if (responseText === null) {
+        this.metrics.llmFailures++;
+        this.metrics.lastErrorAt = new Date().toISOString();
+        const errMsg = `LLM call failed after ${this.config.maxRetries + 1} attempts: ${lastError}`;
+        if (!this.config.silent) console.warn(`[reflector-agent] ${errMsg}`);
+
+        this.logReflection(agentId, {
+          observationsEvaluated: activeObs.length,
+          kept: activeObs.length, merged: 0, discarded: 0,
+          tokensBefore, tokensAfter: tokensBefore,
+          error: errMsg,
+        }, startTime);
+
+        return {
+          success: false,
+          observationsEvaluated: activeObs.length,
+          kept: activeObs.length, merged: 0, discarded: 0,
+          tokensBefore, tokensAfter: tokensBefore,
+          error: errMsg,
+        };
+      }
+
+      // 4. Parse response
+      const llmResult = parseReflectorResponse(responseText);
+      if (!llmResult || llmResult.decisions.length === 0) {
+        const errMsg = 'Failed to parse LLM reflection response';
+        if (!this.config.silent) console.warn(`[reflector-agent] ${errMsg}`);
+
+        this.logReflection(agentId, {
+          observationsEvaluated: activeObs.length,
+          kept: activeObs.length, merged: 0, discarded: 0,
+          tokensBefore, tokensAfter: tokensBefore,
+          error: errMsg,
+        }, startTime);
+
+        return {
+          success: false,
+          observationsEvaluated: activeObs.length,
+          kept: activeObs.length, merged: 0, discarded: 0,
+          tokensBefore, tokensAfter: tokensBefore,
+          error: errMsg,
+        };
+      }
+
+      // 5. Apply decisions
+      const result = this.applyDecisions(activeObs, llmResult.decisions);
+
+      // 6. Recalculate memory_state
+      const remainingObs = this.store.getActiveObservations(agentId);
+      const tokensAfter = this.calcTokens(remainingObs);
+      this.updateMemoryState(agentId, tokensAfter, remainingObs.length);
+
+      // 7. Invalidate cache
+      if (this.cache) {
+        this.cache.invalidate();
+      }
+
+      const passResult: ReflectionPassResult = {
+        success: true,
+        observationsEvaluated: activeObs.length,
+        kept: result.kept,
+        merged: result.merged,
+        discarded: result.discarded,
+        tokensBefore,
+        tokensAfter,
+      };
+
+      return this.completePass(agentId, passResult, startTime);
+
+    } catch (err: unknown) {
+      const errMsg = err instanceof Error ? err.message : String(err);
+      this.metrics.lastErrorAt = new Date().toISOString();
+      if (!this.config.silent) console.warn(`[reflector-agent] Reflection pass error: ${errMsg}`);
+      return {
+        success: false,
+        observationsEvaluated: 0,
+        kept: 0, merged: 0, discarded: 0,
+        tokensBefore: 0, tokensAfter: 0,
+        error: errMsg,
+      };
+    } finally {
+      this.running = false;
+    }
+  }
+
+  // ─── Decision Application ───────────────────────────────────────────
+
+  private applyDecisions(
+    activeObs: Observation[],
+    decisions: ReflectionObservationDecision[],
+  ): { kept: number; merged: number; discarded: number } {
+    const obsMap = new Map(activeObs.map((o) => [o.id, o]));
+    const now = new Date().toISOString();
+
+    // Build decision map (only for IDs that exist in active observations)
+    const decisionMap = new Map<string, ReflectionObservationDecision>();
+    for (const d of decisions) {
+      if (obsMap.has(d.observationId)) {
+        decisionMap.set(d.observationId, d);
+      }
+    }
+
+    // Count planned actions
+    let keepCount = 0;
+    let mergeCount = 0;
+    let discardCount = 0;
+
+    const toDiscard: string[] = [];
+    const mergeOps: Array<{ targetId: string; content: string; sourceId: string }> = [];
+
+    for (const obs of activeObs) {
+      const decision = decisionMap.get(obs.id);
+      if (!decision || decision.decision === 'keep') {
+        keepCount++;
+        continue;
+      }
+
+      if (decision.decision === 'discard') {
+        discardCount++;
+        toDiscard.push(obs.id);
+      } else if (decision.decision === 'merge') {
+        if (decision.mergeIntoId && decision.mergedContent && obsMap.has(decision.mergeIntoId)) {
+          mergeCount++;
+          toDiscard.push(obs.id);
+          mergeOps.push({
+            targetId: decision.mergeIntoId,
+            content: decision.mergedContent,
+            sourceId: obs.id,
+          });
+        } else {
+          // Invalid merge target — keep the observation instead
+          keepCount++;
+        }
+      }
+    }
+
+    // Enforce minimum retained floor
+    const totalAfter = keepCount; // merges reduce count because source is discarded
+    if (totalAfter < this.config.minRetainedObservations) {
+      // Rescue observations from the discard list (lowest-impact first = info priority)
+      const rescueNeeded = this.config.minRetainedObservations - totalAfter;
+      // Sort toDiscard by priority — rescue info-priority first (they were less aggressively removed)
+      const discardedWithPriority = toDiscard
+        .map((id) => ({ id, priority: obsMap.get(id)?.priority ?? 'info' }))
+        .sort((a, b) => {
+          // Rescue in reverse priority: info last to discard → first to rescue
+          const pa = a.priority === 'high' ? 0 : a.priority === 'medium' ? 1 : 2;
+          const pb = b.priority === 'high' ? 0 : b.priority === 'medium' ? 1 : 2;
+          return pb - pa; // Higher rank = rescued first
+        });
+
+      const rescued = new Set<string>();
+      for (let i = 0; i < Math.min(rescueNeeded, discardedWithPriority.length); i++) {
+        rescued.add(discardedWithPriority[i].id);
+      }
+
+      // Remove rescued IDs from discard list
+      const filteredDiscard = toDiscard.filter((id) => !rescued.has(id));
+      const actualDiscarded = filteredDiscard.length;
+      const actualMerged = mergeOps.filter((op) => !rescued.has(op.sourceId)).length;
+      const actualKept = activeObs.length - actualDiscarded - actualMerged;
+
+      // Apply merge content updates (only non-rescued merges)
+      for (const op of mergeOps) {
+        if (!rescued.has(op.sourceId)) {
+          this.store.updateContent(op.targetId, op.content);
+        }
+      }
+
+      // Apply soft-deletes
+      if (filteredDiscard.length > 0) {
+        this.store.markReflected(filteredDiscard, now);
+      }
+
+      return { kept: actualKept, merged: actualMerged, discarded: actualDiscarded - actualMerged };
+    }
+
+    // Apply merge content updates
+    for (const op of mergeOps) {
+      this.store.updateContent(op.targetId, op.content);
+    }
+
+    // Apply soft-deletes (both discards and merge sources)
+    if (toDiscard.length > 0) {
+      this.store.markReflected(toDiscard, now);
+    }
+
+    return { kept: keepCount, merged: mergeCount, discarded: discardCount };
+  }
+
+  // ─── Helpers ────────────────────────────────────────────────────────
+
+  private calcTokens(observations: Observation[]): number {
+    return observations.reduce(
+      (sum, obs) => sum + estimateTokens(obs.content, this.config.charsPerToken),
+      0,
+    );
+  }
+
+  private updateMemoryState(agentId: string, tokensAfter: number, obsCount: number): void {
+    const existing = this.store.getMemoryState(agentId);
+    const now = new Date().toISOString();
+    const newState: MemoryState = {
+      agentId,
+      observationsTokens: tokensAfter,
+      rawBufferTokens: existing?.rawBufferTokens ?? 0,
+      lastObservationAt: existing?.lastObservationAt ?? null,
+      lastReflectionAt: now,
+      observationCount: obsCount,
+    };
+    this.store.upsertMemoryState(newState);
+  }
+
+  private logReflection(
+    agentId: string,
+    data: {
+      observationsEvaluated: number;
+      kept: number;
+      merged: number;
+      discarded: number;
+      tokensBefore: number;
+      tokensAfter: number;
+      error?: string;
+    },
+    startTime: number,
+  ): void {
+    const entry: ReflectionLogEntry = {
+      id: genLogId(),
+      agentId,
+      runAt: new Date().toISOString(),
+      observationsEvaluated: data.observationsEvaluated,
+      observationsKept: data.kept,
+      observationsMerged: data.merged,
+      observationsDiscarded: data.discarded,
+      tokensBefore: data.tokensBefore,
+      tokensAfter: data.tokensAfter,
+      modelUsed: this.config.modelId,
+      durationMs: Date.now() - startTime,
+      error: data.error,
+    };
+    this.store.insertReflectionLog(entry);
+  }
+
+  private completePass(
+    agentId: string,
+    result: ReflectionPassResult,
+    startTime: number,
+  ): ReflectionPassResult {
+    const now = new Date().toISOString();
+
+    this.metrics.passesCompleted++;
+    this.metrics.observationsEvaluated += result.observationsEvaluated;
+    this.metrics.observationsKept += result.kept;
+    this.metrics.observationsMerged += result.merged;
+    this.metrics.observationsDiscarded += result.discarded;
+    this.metrics.lastPassAt = now;
+
+    this.logReflection(agentId, {
+      observationsEvaluated: result.observationsEvaluated,
+      kept: result.kept,
+      merged: result.merged,
+      discarded: result.discarded,
+      tokensBefore: result.tokensBefore,
+      tokensAfter: result.tokensAfter,
+    }, startTime);
+
+    return result;
+  }
+}
+
+// ─── Exports ────────────────────────────────────────────────────────────────
+
+export { parseReflectorResponse, buildReflectorUserPrompt, REFLECTOR_SYSTEM_PROMPT };
+export default ReflectorAgent;

--- a/lib/types/observation.ts
+++ b/lib/types/observation.ts
@@ -122,6 +122,11 @@ export interface Observation {
    * Populated by the observer agent (Phase 2).
    */
   sourceMessageIds?: string[];
+  /**
+   * Timestamp when the reflector soft-deleted this observation (Phase 3 / #232).
+   * Non-null means the observation is "GC'd" — excluded from prompt cache.
+   */
+  reflectedAt?: string;
   /** Arbitrary metadata for future extension. */
   metadata?: Record<string, unknown>;
 }
@@ -233,7 +238,133 @@ export interface ObserverLLMObservation {
   source_message_ids: string[];
 }
 
+// ─── Memory State Snapshot (Phase 4 — #233) ────────────────────────────────
+
+/**
+ * A point-in-time snapshot of an agent's observational memory state.
+ * Returned by GET /api/memory/state and used by the dashboard gauge widget.
+ */
+export interface MemoryStateSnapshot {
+  /** Agent ID. */
+  agentId: string;
+  /** Whether observational memory is enabled for this agent. */
+  enabled: boolean;
+  /** Total compressed observation tokens. */
+  observationsTokens: number;
+  /** Raw buffer tokens awaiting observation. */
+  rawBufferTokens: number;
+  /** Total observations stored. */
+  observationCount: number;
+  /** Breakdown of observations by priority. */
+  priorityCounts: {
+    high: number;
+    medium: number;
+    info: number;
+  };
+  /** ISO timestamp of last observation pass (null if never). */
+  lastObservationAt: string | null;
+  /** ISO timestamp of last reflection pass (null if never). */
+  lastReflectionAt: string | null;
+  /** Whether the reflected_at column is available (Phase 3 / #232). */
+  reflectionSupported: boolean;
+}
+
 // ─── Observer Agent Config (Phase 2) ───────────────────────────────────────
+
+// ─── Reflector Types (Phase 3 / #232) ───────────────────────────────────────
+
+/**
+ * Decision the reflector can make about a single observation.
+ * - keep:    Observation remains active in the prompt cache.
+ * - merge:   Observation is merged into another (content combined).
+ * - discard: Observation is soft-deleted via `reflected_at` timestamp.
+ */
+export type ReflectionDecision = 'keep' | 'merge' | 'discard';
+
+/**
+ * Per-observation decision returned by the LLM reflector pass.
+ */
+export interface ReflectionObservationDecision {
+  /** Observation ID being evaluated. */
+  observationId: string;
+  /** Decision: keep, merge, or discard. */
+  decision: ReflectionDecision;
+  /** Brief reasoning for the decision. */
+  reason: string;
+  /** If decision=merge, the observation ID to merge into. */
+  mergeIntoId?: string;
+  /** If decision=merge, the merged content text. */
+  mergedContent?: string;
+}
+
+/**
+ * Complete result returned by the LLM for a reflection pass.
+ */
+export interface ReflectionLLMResult {
+  /** Per-observation decisions. */
+  decisions: ReflectionObservationDecision[];
+  /** Optional summary of what the reflector found. */
+  summary?: string;
+}
+
+/**
+ * Log entry for a completed reflection pass.
+ * Persisted in the `reflection_log` table for auditability.
+ */
+export interface ReflectionLogEntry {
+  /** Unique log entry ID. */
+  id: string;
+  /** Agent whose observations were reflected. */
+  agentId: string;
+  /** When the reflection pass ran (ISO 8601). */
+  runAt: string;
+  /** Number of observations evaluated. */
+  observationsEvaluated: number;
+  /** Number of observations kept. */
+  observationsKept: number;
+  /** Number of observations merged. */
+  observationsMerged: number;
+  /** Number of observations discarded (soft-deleted). */
+  observationsDiscarded: number;
+  /** Token count of observations before reflection. */
+  tokensBefore: number;
+  /** Token count of observations after reflection. */
+  tokensAfter: number;
+  /** Model used for reflection. */
+  modelUsed: string;
+  /** Duration of the reflection pass in milliseconds. */
+  durationMs: number;
+  /** Error message if the pass failed. */
+  error?: string;
+}
+
+/**
+ * Configuration for the Reflector Agent.
+ */
+export interface ReflectorAgentConfig {
+  /** Enable/disable the reflector. Default: true */
+  enabled: boolean;
+  /** Characters-per-token for estimation. Default: 4 */
+  charsPerToken: number;
+  /**
+   * Token budget threshold that triggers reflection.
+   * When observations_tokens in memory_state exceeds this, reflector runs.
+   * Default: 50_000
+   */
+  tokenBudgetThreshold: number;
+  /**
+   * Minimum number of active observations to retain after reflection.
+   * The reflector will never reduce below this floor.
+   * Default: 5
+   */
+  minRetainedObservations: number;
+  /** Maximum retries on LLM failure. Default: 1 */
+  maxRetries: number;
+  /** Model ID used for the reflection pass. Default: 'gpt-4o-mini' */
+  modelId: string;
+  /** Suppress console.warn on errors. Default: false */
+  silent: boolean;
+}
 
 /**
  * Configuration for the Observer Agent.


### PR DESCRIPTION
## Summary

Phase 3 of the observation memory pipeline (#218). Implements the **Reflector Agent** for garbage collection of accumulated observations, plus a **Prompt Cache** for token-bounded observation injection into system prompts.

### New Files
- `lib/reflector-agent.ts` — LLM-driven reflection pass: evaluates observations → keep/merge/discard
- `lib/observation-cache.ts` — Priority-ordered, token-bounded prompt cache
- `lib/__tests__/reflector-agent.test.ts` — 30 tests
- `lib/__tests__/observation-cache.test.ts` — 12 tests

### Modified (additive only)
- `lib/observation-store.ts` — `reflection_log` table + methods: `insertReflectionLog`, `getReflectionLogs`, `markReflected`, `getActiveObservations`, `updateContent`. Phase 3 migration (`reflected_at` column).
- `lib/types/observation.ts` — `ReflectionLogEntry`, `ReflectionDecision`, `ReflectionObservationDecision`, `ReflectionLLMResult`, `ReflectorAgentConfig` types. `reflectedAt` field on `Observation`.

### Behavior
- **Trigger**: `observations_tokens > threshold` in `memory_state` → reflector runs
- **Priority preservation**: High-priority observations kept unless explicitly contradicted
- **Soft-delete**: `reflected_at` timestamp (no hard deletes, fully reversible)
- **Minimum floor**: Configurable `minRetainedObservations` prevents over-aggressive GC
- **Token recalculation**: `memory_state.observations_tokens` updated after each pass
- **Audit trail**: Every reflection run logged in `reflection_log` table
- **Mutex guard**: Prevents concurrent reflector runs
- **Cache invalidation**: Prompt cache invalidated after reflection
- **Model router pattern**: LLM client injected (no embedded credentials)

### Validation
- `npx tsc --noEmit` — clean
- 71 targeted tests pass (42 new + 29 existing regression)
- Zero regressions on Phase 2 observer-agent tests (42/42)

### No-touch zones (confirmed)
- ❌ dashboard/*
- ❌ conversation-engine.ts / conversation-api.ts
- ❌ observer prompt files

Closes #232