### PR TITLE
feat(observations): Phase 4 — /observations command + dashboard memory gauge (#233)

### DIFF
--- a/dashboard/server/routes/index.ts
+++ b/dashboard/server/routes/index.ts
@@ -15,3 +15,4 @@ export { handleTacticalMapReplay } from './tactical-map-replay.js';
 export { handleAgentDiagnostics } from './agent-diagnostics.js';
 export { handleChangelog } from './changelog.js';
 export { handleTaskBoard } from './task-board.js';
+export { handleMemoryState } from './memory-state.js';

--- a/dashboard/server/routes/memory-state.ts
+++ b/dashboard/server/routes/memory-state.ts
@@ -1,0 +1,164 @@
+/**
+ * Memory State Route Handlers — Phase 4 (#233)
+ *
+ * Provides API endpoints for the dashboard memory gauge widget:
+ *   GET /api/memory/state?agent_id=<id>          — Memory state snapshot
+ *   GET /api/memory/observations?agent_id=<id>   — Active observations list
+ *
+ * Uses the ObservationStore from lib/ for data access.
+ * Gracefully degrades if the database or reflected_at column is missing.
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { ObservationStore } from '../../../lib/observation-store.js';
+import type { ObservationPriority } from '../../../lib/types/observation.js';
+import structuredLogger from '../../../lib/structured-logger.js';
+
+const { logInfo, logError, OBSERVATION_EVENTS } = structuredLogger as typeof import('../../../lib/structured-logger.js');
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface MemoryStateDeps {
+  /** Path to the observations SQLite database. */
+  dbPath: string;
+  /** Default agent ID if not specified in query. */
+  defaultAgentId: string;
+  /** Send JSON response helper. */
+  sendJson: (res: ServerResponse, data: unknown, status?: number) => void;
+}
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function parseUrl(req: IncomingMessage): URL | null {
+  try {
+    return new URL(req.url ?? '', 'http://localhost');
+  } catch {
+    return null;
+  }
+}
+
+function openStore(dbPath: string): ObservationStore | null {
+  try {
+    return new ObservationStore(dbPath);
+  } catch {
+    return null;
+  }
+}
+
+// ─── Route Handler ───────────────────────────────────────────────────────────
+
+/**
+ * Handle memory state API requests.
+ *
+ * @returns true if the request was handled, false to pass to next handler.
+ */
+export function handleMemoryState(
+  req: IncomingMessage,
+  res: ServerResponse,
+  deps: MemoryStateDeps,
+): boolean {
+  if (!req.url || req.method !== 'GET') return false;
+
+  // GET /api/memory/state
+  if (req.url.startsWith('/api/memory/state')) {
+    const parsed = parseUrl(req);
+    if (!parsed) {
+      deps.sendJson(res, { ok: false, error: 'Bad request' }, 400);
+      return true;
+    }
+
+    const agentId = parsed.searchParams.get('agent_id') || deps.defaultAgentId;
+    const store = openStore(deps.dbPath);
+
+    if (!store) {
+      logInfo('memory-state', OBSERVATION_EVENTS.API_MEMORY_STATE, 'Store unavailable', { agentId });
+      deps.sendJson(res, {
+        agentId,
+        enabled: false,
+        observationsTokens: 0,
+        rawBufferTokens: 0,
+        observationCount: 0,
+        priorityCounts: { high: 0, medium: 0, info: 0 },
+        lastObservationAt: null,
+        lastReflectionAt: null,
+        reflectionSupported: false,
+      });
+      return true;
+    }
+
+    try {
+      const snapshot = store.getMemoryStateSnapshot(agentId);
+      logInfo('memory-state', OBSERVATION_EVENTS.API_MEMORY_STATE, 'Served memory state', {
+        agentId,
+        observationCount: snapshot.observationCount,
+      });
+      deps.sendJson(res, snapshot);
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : 'Unknown error';
+      logError('memory-state', OBSERVATION_EVENTS.API_MEMORY_ERROR, msg, { agentId });
+      deps.sendJson(res, { ok: false, error: 'Internal error reading memory state' }, 500);
+    } finally {
+      store.close();
+    }
+
+    return true;
+  }
+
+  // GET /api/memory/observations
+  if (req.url.startsWith('/api/memory/observations')) {
+    const parsed = parseUrl(req);
+    if (!parsed) {
+      deps.sendJson(res, { ok: false, error: 'Bad request' }, 400);
+      return true;
+    }
+
+    const agentId = parsed.searchParams.get('agent_id') || deps.defaultAgentId;
+    const limitStr = parsed.searchParams.get('limit');
+    const limit = limitStr ? Math.min(Math.max(parseInt(limitStr, 10) || 50, 1), 500) : 50;
+    const priorityParam = parsed.searchParams.get('priority') as ObservationPriority | null;
+    const priority = (priorityParam === 'high' || priorityParam === 'medium' || priorityParam === 'info')
+      ? priorityParam
+      : undefined;
+
+    const store = openStore(deps.dbPath);
+
+    if (!store) {
+      logInfo('memory-state', OBSERVATION_EVENTS.API_MEMORY_OBSERVATIONS, 'Store unavailable', { agentId });
+      deps.sendJson(res, { agentId, observations: [], total: 0 });
+      return true;
+    }
+
+    try {
+      const observations = store.queryActiveObservations({ agentId, limit, priority });
+
+      logInfo('memory-state', OBSERVATION_EVENTS.API_MEMORY_OBSERVATIONS, 'Served observations', {
+        agentId,
+        count: observations.length,
+        priority: priority ?? 'all',
+      });
+
+      deps.sendJson(res, {
+        agentId,
+        observations: observations.map(obs => ({
+          id: obs.id,
+          createdAt: obs.createdAt,
+          category: obs.category,
+          content: obs.content,
+          priority: obs.priority ?? null,
+          referencedDate: obs.referencedDate ?? null,
+        })),
+        total: observations.length,
+      });
+    } catch (e: unknown) {
+      const msg = e instanceof Error ? e.message : 'Unknown error';
+      logError('memory-state', OBSERVATION_EVENTS.API_MEMORY_ERROR, msg, { agentId });
+      deps.sendJson(res, { ok: false, error: 'Internal error reading observations' }, 500);
+    } finally {
+      store.close();
+    }
+
+    return true;
+  }
+
+  return false;
+}

--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -108,6 +108,7 @@ import { handleProgressionApi } from './routes/progression.js';
 import { handleProgressionV2Api } from '../../lib/progression-http-v2.js';
 import { handleChangelog } from './routes/changelog.js';
 import { handleTaskBoard } from './routes/task-board.js';
+import { handleMemoryState } from './routes/memory-state.js';
 
 // ─── Configuration ───────────────────────────────────────────────────────────
 // All VentureOS data paths flow through lib/paths.ts (no os.homedir() needed).
@@ -2887,6 +2888,18 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
   } catch {
     // ignore
   }
+
+  // Memory State API — Phase 4 (#233)
+  try {
+    if (handleMemoryState(req, res, {
+      dbPath: process.env.OBSERVATIONS_DB_PATH ?? path.join(dataDir, 'observations.db'),
+      defaultAgentId: AGENT_ID,
+      sendJson,
+    })) return;
+  } catch {
+    // ignore
+  }
+
   try {
     if (handleAgentHealth(req, res, { OPENCLAW_DIR, WORKSPACE_DIR, sendJson })) return;
   } catch {

--- a/dashboard/server/types.ts
+++ b/dashboard/server/types.ts
@@ -720,3 +720,32 @@ export interface TaskBoardDeps {
   sendJson: (res: ServerResponse, data: unknown, status?: number) => void;
   readRequestBody: (req: IncomingMessage, opts?: { maxBytes?: number }) => Promise<string>;
 }
+
+// ─── Memory State Domain (Phase 4 — #233) ────────────────────────────────────
+
+/** Response shape for GET /api/memory/state. */
+export interface MemoryStateResponse {
+  agentId: string;
+  enabled: boolean;
+  observationsTokens: number;
+  rawBufferTokens: number;
+  observationCount: number;
+  priorityCounts: { high: number; medium: number; info: number };
+  lastObservationAt: string | null;
+  lastReflectionAt: string | null;
+  reflectionSupported: boolean;
+}
+
+/** Response shape for GET /api/memory/observations. */
+export interface MemoryObservationsResponse {
+  agentId: string;
+  observations: Array<{
+    id: string;
+    createdAt: string;
+    category: string;
+    content: string;
+    priority: string | null;
+    referencedDate: string | null;
+  }>;
+  total: number;
+}

--- a/dashboard/tests/unit/routes/memory-state.test.ts
+++ b/dashboard/tests/unit/routes/memory-state.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Memory State route handler tests — Phase 4 (#233)
+ *
+ * Tests for GET /api/memory/state and GET /api/memory/observations endpoints.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import Database from 'better-sqlite3';
+import { mockRequest, mockResponse, parseJsonBody } from '../../helpers.js';
+import { handleMemoryState } from '../../../server/routes/memory-state.js';
+import type { ServerResponse } from 'node:http';
+
+let tmpDir: string;
+let dbPath: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'memory-state-test-'));
+  dbPath = path.join(tmpDir, 'test-obs.db');
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function createDeps(overrides: Partial<{ dbPath: string; defaultAgentId: string }> = {}) {
+  return {
+    dbPath: overrides.dbPath ?? dbPath,
+    defaultAgentId: overrides.defaultAgentId ?? 'oracle',
+    sendJson: (res: ServerResponse, data: unknown, status = 200) => {
+      (res as any).writeHead(status, { 'Content-Type': 'application/json' });
+      (res as any).end(JSON.stringify(data));
+    },
+  };
+}
+
+/**
+ * Create the observation tables directly using better-sqlite3 (avoids CJS/ESM import issues
+ * when importing ObservationStore from the lib/ CJS module into the dashboard ESM test env).
+ */
+function createTables(db: Database.Database): void {
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS observations (
+      id TEXT PRIMARY KEY,
+      created_at TEXT NOT NULL,
+      category TEXT NOT NULL DEFAULT 'other',
+      content TEXT NOT NULL,
+      source_conversation_id TEXT,
+      source_message_id TEXT,
+      source_agent_id TEXT NOT NULL,
+      source_channel TEXT,
+      status TEXT NOT NULL DEFAULT 'pending',
+      token_input INTEGER,
+      token_output INTEGER,
+      token_total INTEGER,
+      token_model TEXT,
+      token_cost_usd REAL,
+      metadata TEXT DEFAULT '{}',
+      priority TEXT,
+      referenced_date TEXT,
+      source_message_ids TEXT
+    );
+    CREATE TABLE IF NOT EXISTS memory_state (
+      agent_id TEXT PRIMARY KEY,
+      observations_tokens INTEGER NOT NULL DEFAULT 0,
+      raw_buffer_tokens INTEGER NOT NULL DEFAULT 0,
+      last_observation_at TEXT,
+      last_reflection_at TEXT,
+      observation_count INTEGER NOT NULL DEFAULT 0
+    );
+    CREATE INDEX IF NOT EXISTS idx_observations_status ON observations(status);
+    CREATE INDEX IF NOT EXISTS idx_observations_agent ON observations(source_agent_id);
+    CREATE INDEX IF NOT EXISTS idx_observations_priority ON observations(priority);
+  `);
+}
+
+function insertObservation(db: Database.Database, opts: {
+  id: string;
+  agentId?: string;
+  priority?: string;
+  content?: string;
+  status?: string;
+  category?: string;
+}): void {
+  db.prepare(`
+    INSERT INTO observations (id, created_at, category, content, source_agent_id, status, priority, metadata)
+    VALUES (?, ?, ?, ?, ?, ?, ?, '{}')
+  `).run(
+    opts.id,
+    new Date().toISOString(),
+    opts.category ?? 'fact',
+    opts.content ?? 'Test observation.',
+    opts.agentId ?? 'oracle',
+    opts.status ?? 'processed',
+    opts.priority ?? 'medium',
+  );
+}
+
+function insertMemoryState(db: Database.Database, opts: {
+  agentId: string;
+  observationsTokens?: number;
+  observationCount?: number;
+}): void {
+  db.prepare(`
+    INSERT INTO memory_state (agent_id, observations_tokens, raw_buffer_tokens, last_observation_at, observation_count)
+    VALUES (?, ?, 0, ?, ?)
+  `).run(
+    opts.agentId,
+    opts.observationsTokens ?? 1000,
+    new Date().toISOString(),
+    opts.observationCount ?? 0,
+  );
+}
+
+function seedDb(observations: Array<{ id: string; agentId?: string; priority?: string; content?: string }>): void {
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  createTables(db);
+  for (const obs of observations) {
+    insertObservation(db, obs);
+  }
+  if (observations.length > 0) {
+    insertMemoryState(db, {
+      agentId: observations[0].agentId ?? 'oracle',
+      observationsTokens: 1000,
+      observationCount: observations.length,
+    });
+  }
+  db.close();
+}
+
+function createEmptyDb(): void {
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  createTables(db);
+  db.close();
+}
+
+describe('Memory State Routes', () => {
+  // ─── Routing ────────────────────────────────────────────────────────
+
+  describe('routing', () => {
+    it('returns false for non-memory URLs', () => {
+      expect(handleMemoryState(
+        mockRequest({ url: '/api/sessions' }),
+        mockResponse(),
+        createDeps(),
+      )).toBe(false);
+    });
+
+    it('returns false for POST method', () => {
+      expect(handleMemoryState(
+        mockRequest({ url: '/api/memory/state', method: 'POST' }),
+        mockResponse(),
+        createDeps(),
+      )).toBe(false);
+    });
+  });
+
+  // ─── GET /api/memory/state ──────────────────────────────────────────
+
+  describe('GET /api/memory/state', () => {
+    it('returns disabled state when database does not exist', () => {
+      const res = mockResponse();
+      handleMemoryState(
+        mockRequest({ url: '/api/memory/state?agent_id=oracle' }),
+        res,
+        createDeps({ dbPath: path.join(tmpDir, 'nonexistent', 'no.db') }),
+      );
+      const body = parseJsonBody(res);
+      expect(body.enabled).toBe(false);
+      expect(body.agentId).toBe('oracle');
+      expect(body.observationCount).toBe(0);
+    });
+
+    it('returns snapshot when database exists with data', () => {
+      seedDb([
+        { id: 'obs-1', priority: 'high' },
+        { id: 'obs-2', priority: 'medium' },
+        { id: 'obs-3', priority: 'info' },
+      ]);
+
+      const res = mockResponse();
+      handleMemoryState(
+        mockRequest({ url: '/api/memory/state?agent_id=oracle' }),
+        res,
+        createDeps(),
+      );
+      const body = parseJsonBody(res);
+      expect(body.enabled).toBe(true);
+      expect(body.agentId).toBe('oracle');
+      expect(body.observationCount).toBe(3);
+      expect(body.observationsTokens).toBe(1000);
+      expect(body.priorityCounts).toEqual({ high: 1, medium: 1, info: 1 });
+    });
+
+    it('uses default agent ID when not specified', () => {
+      createEmptyDb();
+      const db = new Database(dbPath);
+      insertMemoryState(db, { agentId: 'oracle', observationsTokens: 100 });
+      db.close();
+
+      const res = mockResponse();
+      handleMemoryState(
+        mockRequest({ url: '/api/memory/state' }),
+        res,
+        createDeps({ defaultAgentId: 'oracle' }),
+      );
+      const body = parseJsonBody(res);
+      expect(body.agentId).toBe('oracle');
+    });
+
+    it('returns empty state for agent with no data', () => {
+      createEmptyDb();
+
+      const res = mockResponse();
+      handleMemoryState(
+        mockRequest({ url: '/api/memory/state?agent_id=nonexistent' }),
+        res,
+        createDeps(),
+      );
+      const body = parseJsonBody(res);
+      expect(body.enabled).toBe(true);
+      expect(body.observationCount).toBe(0);
+      expect(body.priorityCounts).toEqual({ high: 0, medium: 0, info: 0 });
+    });
+  });
+
+  // ─── GET /api/memory/observations ───────────────────────────────────
+
+  describe('GET /api/memory/observations', () => {
+    it('returns empty list when database does not exist', () => {
+      const res = mockResponse();
+      handleMemoryState(
+        mockRequest({ url: '/api/memory/observations?agent_id=oracle' }),
+        res,
+        createDeps({ dbPath: path.join(tmpDir, 'nonexistent', 'no.db') }),
+      );
+      const body = parseJsonBody(res);
+      expect(body.observations).toEqual([]);
+      expect(body.total).toBe(0);
+    });
+
+    it('returns observations with expected fields', () => {
+      seedDb([
+        { id: 'obs-1', priority: 'high', content: 'High item' },
+        { id: 'obs-2', priority: 'medium', content: 'Medium item' },
+      ]);
+
+      const res = mockResponse();
+      handleMemoryState(
+        mockRequest({ url: '/api/memory/observations?agent_id=oracle' }),
+        res,
+        createDeps(),
+      );
+      const body = parseJsonBody(res);
+      expect(body.agentId).toBe('oracle');
+      expect(body.total).toBe(2);
+      expect(body.observations).toHaveLength(2);
+      const obs = body.observations[0] as Record<string, unknown>;
+      expect(obs).toHaveProperty('id');
+      expect(obs).toHaveProperty('createdAt');
+      expect(obs).toHaveProperty('category');
+      expect(obs).toHaveProperty('content');
+      expect(obs).toHaveProperty('priority');
+    });
+
+    it('respects limit parameter', () => {
+      const observations = Array.from({ length: 10 }, (_, i) => ({
+        id: `obs-${i}`,
+        content: `Item ${i}`,
+      }));
+      seedDb(observations);
+
+      const res = mockResponse();
+      handleMemoryState(
+        mockRequest({ url: '/api/memory/observations?agent_id=oracle&limit=3' }),
+        res,
+        createDeps(),
+      );
+      const body = parseJsonBody(res);
+      expect(body.observations).toHaveLength(3);
+    });
+
+    it('filters by priority', () => {
+      seedDb([
+        { id: 'obs-h', priority: 'high', content: 'High' },
+        { id: 'obs-m', priority: 'medium', content: 'Medium' },
+        { id: 'obs-i', priority: 'info', content: 'Info' },
+      ]);
+
+      const res = mockResponse();
+      handleMemoryState(
+        mockRequest({ url: '/api/memory/observations?agent_id=oracle&priority=high' }),
+        res,
+        createDeps(),
+      );
+      const body = parseJsonBody(res);
+      expect(body.total).toBe(1);
+      expect((body.observations as any[])[0].priority).toBe('high');
+    });
+
+    it('ignores invalid priority parameter', () => {
+      seedDb([
+        { id: 'obs-1', priority: 'high' },
+        { id: 'obs-2', priority: 'medium' },
+      ]);
+
+      const res = mockResponse();
+      handleMemoryState(
+        mockRequest({ url: '/api/memory/observations?agent_id=oracle&priority=invalid' }),
+        res,
+        createDeps(),
+      );
+      const body = parseJsonBody(res);
+      expect(body.total).toBe(2);
+    });
+
+    it('caps limit at 500', () => {
+      seedDb([{ id: 'obs-1' }]);
+
+      const res = mockResponse();
+      handleMemoryState(
+        mockRequest({ url: '/api/memory/observations?agent_id=oracle&limit=9999' }),
+        res,
+        createDeps(),
+      );
+      const body = parseJsonBody(res);
+      expect(body.observations).toBeDefined();
+    });
+  });
+});

--- a/dashboard/tsconfig.json
+++ b/dashboard/tsconfig.json
@@ -12,6 +12,6 @@
     "isolatedModules": true,
     "resolveJsonModule": true
   },
-  "include": ["server/**/*.ts", "../lib/rpg-http.ts", "../lib/conversation-http.ts", "../lib/progression-http.ts", "../lib/progression-engine.ts", "../lib/progression-store.ts", "../lib/types/*.ts", "../lib/paths.ts", "../lib/http-types.ts", "../lib/error-handler.ts"],
+  "include": ["server/**/*.ts", "../lib/rpg-http.ts", "../lib/conversation-http.ts", "../lib/progression-http.ts", "../lib/progression-engine.ts", "../lib/progression-store.ts", "../lib/types/*.ts", "../lib/paths.ts", "../lib/http-types.ts", "../lib/error-handler.ts", "../lib/observation-store.ts", "../lib/structured-logger.ts"],
   "exclude": ["dist", "node_modules", "tests"]
 }

--- a/lib/__tests__/observations-command.test.ts
+++ b/lib/__tests__/observations-command.test.ts
@@ -1,0 +1,289 @@
+/**
+ * Tests for /observations command — Phase 4 (#233)
+ *
+ * Validates command output formatting, filtering, Discord char limits,
+ * and graceful degradation when database is unavailable.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import { ObservationStore } from '../observation-store';
+import {
+  executeObservationsCommand,
+  parseSinceFilter,
+} from '../observations-command';
+import type { Observation, ObservationPriority } from '../types/observation';
+
+let tmpDir: string;
+let dbPath: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'obs-cmd-test-'));
+  dbPath = path.join(tmpDir, 'test-obs.db');
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function makeObservation(overrides: Partial<Observation> = {}): Observation {
+  return {
+    id: `obs-${Math.random().toString(36).slice(2, 10)}`,
+    createdAt: new Date().toISOString(),
+    category: 'fact',
+    content: 'Test observation content.',
+    source: {
+      agentId: 'oracle',
+      conversationId: 'conv-1',
+    },
+    status: 'processed',
+    priority: 'medium',
+    metadata: {},
+    ...overrides,
+  };
+}
+
+function seedStore(observations: Observation[]): void {
+  const store = new ObservationStore(dbPath);
+  store.insertBatch(observations);
+  // Also update memory_state so the snapshot works
+  if (observations.length > 0) {
+    store.upsertMemoryState({
+      agentId: observations[0].source.agentId,
+      observationsTokens: 1000,
+      rawBufferTokens: 500,
+      lastObservationAt: observations[0].createdAt,
+      lastReflectionAt: null,
+      observationCount: observations.length,
+    });
+  }
+  store.close();
+}
+
+describe('parseSinceFilter', () => {
+  test('parses hour-based filters', () => {
+    const result = parseSinceFilter('24h');
+    expect(result).toBeTruthy();
+    const parsed = new Date(result!);
+    const diff = Date.now() - parsed.getTime();
+    // Should be roughly 24 hours ago (within 5 seconds tolerance)
+    expect(diff).toBeGreaterThan(23 * 3600_000);
+    expect(diff).toBeLessThan(25 * 3600_000);
+  });
+
+  test('parses day-based filters', () => {
+    const result = parseSinceFilter('7d');
+    expect(result).toBeTruthy();
+    const parsed = new Date(result!);
+    const diff = Date.now() - parsed.getTime();
+    expect(diff).toBeGreaterThan(6 * 86400_000);
+    expect(diff).toBeLessThan(8 * 86400_000);
+  });
+
+  test('parses minute-based filters', () => {
+    const result = parseSinceFilter('30m');
+    expect(result).toBeTruthy();
+    const parsed = new Date(result!);
+    const diff = Date.now() - parsed.getTime();
+    expect(diff).toBeGreaterThan(29 * 60_000);
+    expect(diff).toBeLessThan(31 * 60_000);
+  });
+
+  test('returns ISO date unchanged', () => {
+    const result = parseSinceFilter('2026-02-15T00:00:00Z');
+    expect(result).toBe('2026-02-15T00:00:00Z');
+  });
+
+  test('returns null for invalid input', () => {
+    expect(parseSinceFilter('')).toBeNull();
+    expect(parseSinceFilter('abc')).toBeNull();
+    expect(parseSinceFilter('24x')).toBeNull();
+  });
+});
+
+describe('executeObservationsCommand', () => {
+  test('returns friendly message when database does not exist', () => {
+    const result = executeObservationsCommand({
+      agentId: 'oracle',
+      dbPath: path.join(tmpDir, 'nonexistent', 'nope.db'),
+    });
+
+    expect(result.enabled).toBe(false);
+    expect(result.count).toBe(0);
+    expect(result.output).toContain('not configured');
+    expect(result.output.length).toBeLessThanOrEqual(2000);
+  });
+
+  test('returns friendly message when no observations exist', () => {
+    // Create an empty store
+    const store = new ObservationStore(dbPath);
+    store.close();
+
+    const result = executeObservationsCommand({
+      agentId: 'oracle',
+      dbPath,
+    });
+
+    expect(result.enabled).toBe(true);
+    expect(result.count).toBe(0);
+    expect(result.output).toContain('No observations recorded');
+    expect(result.output.length).toBeLessThanOrEqual(2000);
+  });
+
+  test('displays observations with priority indicators', () => {
+    const obs = [
+      makeObservation({ id: 'obs-h1', priority: 'high', content: 'High priority item' }),
+      makeObservation({ id: 'obs-m1', priority: 'medium', content: 'Medium priority item' }),
+      makeObservation({ id: 'obs-i1', priority: 'info', content: 'Info item' }),
+    ];
+    seedStore(obs);
+
+    const result = executeObservationsCommand({
+      agentId: 'oracle',
+      dbPath,
+    });
+
+    expect(result.enabled).toBe(true);
+    expect(result.count).toBe(3);
+    expect(result.output).toContain('🔴');
+    expect(result.output).toContain('🟡');
+    expect(result.output).toContain('🟢');
+    expect(result.output).toContain('High priority item');
+    expect(result.output).toContain('Observational Memory');
+    expect(result.output.length).toBeLessThanOrEqual(2000);
+  });
+
+  test('filters by priority', () => {
+    const obs = [
+      makeObservation({ id: 'obs-h1', priority: 'high', content: 'High priority item' }),
+      makeObservation({ id: 'obs-m1', priority: 'medium', content: 'Medium priority item' }),
+    ];
+    seedStore(obs);
+
+    const result = executeObservationsCommand({
+      agentId: 'oracle',
+      priority: 'high',
+      dbPath,
+    });
+
+    expect(result.count).toBe(1);
+    expect(result.output).toContain('High priority item');
+    expect(result.output).toContain('priority=high');
+  });
+
+  test('filters by since', () => {
+    const oldDate = new Date(Date.now() - 48 * 3600_000).toISOString();
+    const newDate = new Date().toISOString();
+
+    const obs = [
+      makeObservation({ id: 'obs-old', createdAt: oldDate, content: 'Old observation' }),
+      makeObservation({ id: 'obs-new', createdAt: newDate, content: 'New observation' }),
+    ];
+    seedStore(obs);
+
+    const result = executeObservationsCommand({
+      agentId: 'oracle',
+      since: '24h',
+      dbPath,
+    });
+
+    expect(result.count).toBe(1);
+    expect(result.output).toContain('New observation');
+    expect(result.output).toContain('since=24h');
+  });
+
+  test('output never exceeds 2000 chars', () => {
+    // Create many observations to push past the limit
+    const obs = Array.from({ length: 50 }, (_, i) =>
+      makeObservation({
+        id: `obs-${i}`,
+        content: `Observation number ${i}: ${('x').repeat(80)}`,
+        priority: ['high', 'medium', 'info'][i % 3] as ObservationPriority,
+      }),
+    );
+    seedStore(obs);
+
+    const result = executeObservationsCommand({
+      agentId: 'oracle',
+      dbPath,
+    });
+
+    expect(result.output.length).toBeLessThanOrEqual(2000);
+    // Should mention there are more
+    expect(result.output).toMatch(/more observations|Active observations/);
+  });
+
+  test('shows summary counts in header', () => {
+    const obs = [
+      makeObservation({ id: 'obs-h1', priority: 'high' }),
+      makeObservation({ id: 'obs-h2', priority: 'high' }),
+      makeObservation({ id: 'obs-m1', priority: 'medium' }),
+    ];
+    seedStore(obs);
+
+    const result = executeObservationsCommand({
+      agentId: 'oracle',
+      dbPath,
+    });
+
+    expect(result.output).toContain('🔴 2 high');
+    expect(result.output).toContain('🟡 1 medium');
+    expect(result.snapshot).not.toBeNull();
+    expect(result.snapshot!.priorityCounts.high).toBe(2);
+    expect(result.snapshot!.priorityCounts.medium).toBe(1);
+  });
+
+  test('truncates long observation content', () => {
+    const longContent = 'A'.repeat(200);
+    seedStore([makeObservation({ id: 'obs-long', content: longContent })]);
+
+    const result = executeObservationsCommand({
+      agentId: 'oracle',
+      dbPath,
+    });
+
+    // Content should be truncated with ...
+    expect(result.output).toContain('...');
+    // Original 200-char string should NOT appear in full
+    expect(result.output).not.toContain(longContent);
+  });
+
+  test('handles different agent IDs', () => {
+    const obs = [
+      makeObservation({ id: 'obs-oracle', source: { agentId: 'oracle', conversationId: 'c1' } }),
+      makeObservation({ id: 'obs-atlas', source: { agentId: 'atlas', conversationId: 'c2' } }),
+    ];
+    const store = new ObservationStore(dbPath);
+    store.insertBatch(obs);
+    store.upsertMemoryState({
+      agentId: 'oracle',
+      observationsTokens: 500,
+      rawBufferTokens: 0,
+      lastObservationAt: new Date().toISOString(),
+      lastReflectionAt: null,
+      observationCount: 1,
+    });
+    store.upsertMemoryState({
+      agentId: 'atlas',
+      observationsTokens: 300,
+      rawBufferTokens: 0,
+      lastObservationAt: new Date().toISOString(),
+      lastReflectionAt: null,
+      observationCount: 1,
+    });
+    store.close();
+
+    const oracleResult = executeObservationsCommand({
+      agentId: 'oracle',
+      dbPath,
+    });
+    const atlasResult = executeObservationsCommand({
+      agentId: 'atlas',
+      dbPath,
+    });
+
+    expect(oracleResult.count).toBe(1);
+    expect(atlasResult.count).toBe(1);
+  });
+});

--- a/lib/observations-command.ts
+++ b/lib/observations-command.ts
@@ -1,0 +1,239 @@
+/**
+ * /observations Command Handler — Phase 4 (#233)
+ *
+ * Formats observational memory state for Discord (≤ 2000 chars).
+ * Supports priority + since filters.
+ *
+ * Usage:
+ *   /observations                    — Show all active observations
+ *   /observations --priority high    — Filter by priority
+ *   /observations --since 24h        — Only observations from the last 24 hours
+ *   /observations --priority high --since 7d
+ */
+
+import { ObservationStore } from './observation-store';
+import { PRIORITY_EMOJI } from './types/observation';
+import type { Observation, ObservationPriority, MemoryStateSnapshot } from './types/observation';
+import structuredLogger from './structured-logger';
+
+const { logInfo, OBSERVATION_EVENTS } = structuredLogger;
+
+/** Maximum Discord message length. */
+const DISCORD_MAX_CHARS = 2000;
+
+/** Maximum observations to include in output. */
+const MAX_DISPLAY_OBSERVATIONS = 25;
+
+export interface ObservationsCommandOptions {
+  /** Agent ID to query. */
+  agentId: string;
+  /** Filter by priority level. */
+  priority?: ObservationPriority;
+  /** Time filter: '1h', '24h', '7d', or ISO date string. */
+  since?: string;
+  /** Path to the observations database. */
+  dbPath: string;
+}
+
+export interface ObservationsCommandResult {
+  /** Formatted output string (≤ 2000 chars for Discord). */
+  output: string;
+  /** Number of observations returned. */
+  count: number;
+  /** Whether observational memory is enabled. */
+  enabled: boolean;
+  /** The memory state snapshot (for programmatic use). */
+  snapshot: MemoryStateSnapshot | null;
+}
+
+/**
+ * Parse a relative time string like '24h', '7d', '1h' into an ISO date string.
+ * Returns null if parsing fails.
+ */
+export function parseSinceFilter(since: string): string | null {
+  if (!since) return null;
+
+  // Already an ISO date?
+  if (/^\d{4}-\d{2}-\d{2}/.test(since)) return since;
+
+  const match = since.match(/^(\d+)\s*(h|d|m)$/i);
+  if (!match) return null;
+
+  const value = parseInt(match[1], 10);
+  const unit = match[2].toLowerCase();
+
+  const now = Date.now();
+  let offsetMs: number;
+  switch (unit) {
+    case 'h':
+      offsetMs = value * 3600_000;
+      break;
+    case 'd':
+      offsetMs = value * 86400_000;
+      break;
+    case 'm':
+      offsetMs = value * 60_000;
+      break;
+    default:
+      return null;
+  }
+
+  return new Date(now - offsetMs).toISOString();
+}
+
+/**
+ * Format a relative time string from an ISO date.
+ */
+function timeAgo(isoDate: string): string {
+  const diff = Date.now() - new Date(isoDate).getTime();
+  const minutes = Math.floor(diff / 60_000);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+/**
+ * Format an observation for display.
+ */
+function formatObservation(obs: Observation): string {
+  const emoji = obs.priority ? PRIORITY_EMOJI[obs.priority] : '⚪';
+  const age = timeAgo(obs.createdAt);
+  // Truncate content to keep output compact
+  const content = obs.content.length > 120
+    ? obs.content.slice(0, 117) + '...'
+    : obs.content;
+  return `${emoji} ${content} _(${age})_`;
+}
+
+/**
+ * Execute the /observations command.
+ *
+ * Opens a temporary store connection, queries, formats, and closes.
+ * Returns a Discord-safe string ≤ 2000 chars.
+ */
+export function executeObservationsCommand(
+  opts: ObservationsCommandOptions,
+): ObservationsCommandResult {
+  const { agentId, priority, since, dbPath } = opts;
+
+  logInfo('observations', OBSERVATION_EVENTS.COMMAND_INVOKED, '/observations command', {
+    agentId,
+    priority: priority ?? null,
+    since: since ?? null,
+  });
+
+  let store: ObservationStore;
+  try {
+    store = new ObservationStore(dbPath);
+  } catch {
+    // Database doesn't exist or can't be opened — observational memory not set up
+    logInfo('observations', OBSERVATION_EVENTS.COMMAND_EMPTY, 'Observation store unavailable');
+    return {
+      output: '🧠 **Observational Memory**\n\n_Observational memory is not configured for this agent. No observations database found._',
+      count: 0,
+      enabled: false,
+      snapshot: null,
+    };
+  }
+
+  try {
+    // Build snapshot
+    const snapshot = store.getMemoryStateSnapshot(agentId);
+
+    // If no observations at all, give a friendly message
+    if (snapshot.observationCount === 0) {
+      logInfo('observations', OBSERVATION_EVENTS.COMMAND_EMPTY, 'No observations found', { agentId });
+      return {
+        output: '🧠 **Observational Memory**\n\n_No observations recorded yet for this agent. Observations are captured automatically during conversations._',
+        count: 0,
+        enabled: true,
+        snapshot,
+      };
+    }
+
+    // Resolve since filter
+    const sinceIso = since ? parseSinceFilter(since) : undefined;
+
+    // Query active observations
+    const observations = store.queryActiveObservations({
+      agentId,
+      limit: MAX_DISPLAY_OBSERVATIONS,
+      priority,
+      since: sinceIso ?? undefined,
+    });
+
+    // Build header
+    const lines: string[] = [];
+    lines.push('🧠 **Observational Memory**');
+    lines.push('');
+
+    // Summary line
+    const { high, medium, info } = snapshot.priorityCounts;
+    const summaryParts: string[] = [];
+    if (high > 0) summaryParts.push(`🔴 ${high} high`);
+    if (medium > 0) summaryParts.push(`🟡 ${medium} medium`);
+    if (info > 0) summaryParts.push(`🟢 ${info} info`);
+    const summaryStr = summaryParts.length > 0
+      ? summaryParts.join(' · ')
+      : '_none_';
+
+    lines.push(`**${snapshot.observationCount}** observations stored | ${summaryStr}`);
+
+    // Last activity
+    if (snapshot.lastObservationAt) {
+      lines.push(`Last observed: ${timeAgo(snapshot.lastObservationAt)}`);
+    }
+
+    // Filter info
+    const filterParts: string[] = [];
+    if (priority) filterParts.push(`priority=${priority}`);
+    if (since) filterParts.push(`since=${since}`);
+    if (filterParts.length > 0) {
+      lines.push(`Filter: ${filterParts.join(', ')}`);
+    }
+
+    lines.push('');
+
+    if (observations.length === 0) {
+      lines.push('_No observations match the current filters._');
+    } else {
+      // Add observations, respecting Discord char limit
+      lines.push(`**Active observations** (${observations.length}${observations.length >= MAX_DISPLAY_OBSERVATIONS ? '+' : ''}):`);
+
+      for (const obs of observations) {
+        const formatted = formatObservation(obs);
+        const tentative = lines.join('\n') + '\n' + formatted;
+        if (tentative.length > DISCORD_MAX_CHARS - 50) {
+          // Reserve space for the "and N more" footer
+          const remaining = observations.length - lines.filter(l => l.startsWith('🔴') || l.startsWith('🟡') || l.startsWith('🟢') || l.startsWith('⚪')).length;
+          if (remaining > 0) {
+            lines.push(`_...and ${remaining} more observations_`);
+          }
+          break;
+        }
+        lines.push(formatted);
+      }
+    }
+
+    const output = lines.join('\n').slice(0, DISCORD_MAX_CHARS);
+
+    logInfo('observations', OBSERVATION_EVENTS.COMMAND_RESULT, 'Command completed', {
+      agentId,
+      count: observations.length,
+      totalObservations: snapshot.observationCount,
+    });
+
+    return {
+      output,
+      count: observations.length,
+      enabled: true,
+      snapshot,
+    };
+  } finally {
+    store.close();
+  }
+}
+
+export default { executeObservationsCommand, parseSinceFilter };

--- a/lib/structured-logger.ts
+++ b/lib/structured-logger.ts
@@ -231,6 +231,27 @@ export function logError(subsystem: string, event: string, message: string, fiel
   return structuredLog('error', subsystem, event, message, fields);
 }
 
+// ─── Observation Event Constants (Phase 4 — #233) ───────────────────────────
+
+/**
+ * Stable event names for observational memory subsystem logging.
+ * Use these instead of raw strings to enable grep/query consistency.
+ */
+export const OBSERVATION_EVENTS = {
+  /** /observations command invoked */
+  COMMAND_INVOKED: 'observations_command_invoked',
+  /** /observations command returned results */
+  COMMAND_RESULT: 'observations_command_result',
+  /** /observations command found no data */
+  COMMAND_EMPTY: 'observations_command_empty',
+  /** GET /api/memory/state served */
+  API_MEMORY_STATE: 'api_memory_state',
+  /** GET /api/memory/observations served */
+  API_MEMORY_OBSERVATIONS: 'api_memory_observations',
+  /** Memory API error */
+  API_MEMORY_ERROR: 'api_memory_error',
+} as const;
+
 export default {
   structuredLog,
   logDebug,
@@ -243,4 +264,5 @@ export default {
   runWithCorrelation,
   correlationStore,
   setLogOutput,
+  OBSERVATION_EVENTS,
 };


### PR DESCRIPTION
## Summary

Phase 4 of the Observational Memory pipeline (#218). Adds the **/observations** Discord command and dashboard memory state API endpoints.

Closes #233

## New Files
| File | Purpose |
|------|---------|
| `lib/observations-command.ts` | /observations command — priority/since filters, ≤2000 char Discord output |
| `dashboard/server/routes/memory-state.ts` | GET /api/memory/state, GET /api/memory/observations |
| `lib/__tests__/observations-command.test.ts` | 14 tests |
| `dashboard/tests/unit/routes/memory-state.test.ts` | 12 tests |

## Modified Files (surgical)
| File | Change |
|------|--------|
| `lib/observation-store.ts` | +4 read methods: `hasReflectedAtColumn()`, `getPriorityCounts()`, `getMemoryStateSnapshot()`, `queryActiveObservations()` |
| `lib/types/observation.ts` | +`MemoryStateSnapshot` interface |
| `lib/structured-logger.ts` | +`OBSERVATION_EVENTS` constants (additive) |
| `dashboard/server/routes/index.ts` | Export `handleMemoryState` |
| `dashboard/server/server.ts` | Wire memory state routes |
| `dashboard/server/types.ts` | +`MemoryStateResponse`, `MemoryObservationsResponse` |
| `dashboard/tsconfig.json` | Include observation-store.ts + structured-logger.ts |

## Behavior
- `/observations` supports `--priority high|medium|info` and `--since 24h|7d` filters
- Output respects Discord 2000 char limit with graceful truncation
- `GET /api/memory/state?agent_id=` returns `MemoryStateSnapshot` with priority breakdown
- `GET /api/memory/observations?agent_id=&limit=&priority=` returns active observations
- **Graceful degradation**: if `reflected_at` column from #232 is not yet present, queries omit the filter instead of crashing
- Friendly output when observational memory is disabled or has no data

## Not Touched (per scope)
- ❌ reflector-agent.ts / observation-cache.ts / observer-agent.ts / prompts
- ❌ No security/auth changes
- ❌ No unrelated refactors

## Validation
| Suite | Result |
|-------|--------|
| `npx tsc --noEmit` (root) | ✅ Clean |
| `npx tsc --noEmit` (dashboard) | ✅ Clean |
| Jest root (59 suites / 1298 tests) | ✅ Pass |
| Vitest dashboard (30 suites / 382 tests) | ✅ Pass |
| Pre-existing failure | ⚠️ `conversation-body-limits.test.ts` vitest/CJS conflict (unrelated) |