### PR TITLE
feat(#241): TeamService + shared-context directory scaffold (Phase 1)

### DIFF
--- a/lib/__tests__/team-service.test.ts
+++ b/lib/__tests__/team-service.test.ts
@@ -1,0 +1,685 @@
+/**
+ * Tests for TeamService — Issue #241
+ * Phase 1 of #217 (Shared Agent Memory Layer)
+ *
+ * Validates team CRUD operations, agent membership management,
+ * directory scaffold creation, manifest initialization, and edge cases.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import Database from 'better-sqlite3';
+import type { TeamService as TeamServiceType } from '../team-service';
+import type { SharedContextManifest, TeamAgentRole } from '../types/team';
+import { SHARED_CONTEXT_SUBDIRS } from '../types/team';
+
+// ─── Test Helpers ───────────────────────────────────────────────────────────
+
+let tmpDir: string;
+let dbPath: string;
+let sharedContextRoot: string;
+
+/**
+ * Override SHARED_CONTEXT_DIR so teamSharedContextDir() resolves
+ * to our temp directory. We re-require paths each time to pick up
+ * the env var change.
+ */
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'team-service-test-'));
+  dbPath = path.join(tmpDir, 'teams.db');
+  sharedContextRoot = path.join(tmpDir, 'shared-context');
+  fs.mkdirSync(sharedContextRoot, { recursive: true });
+
+  // Point SHARED_CONTEXT to our temp dir
+  process.env.SHARED_CONTEXT = sharedContextRoot;
+  // Clear module cache so paths.ts re-evaluates with new env
+  jest.resetModules();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.SHARED_CONTEXT;
+  jest.resetModules();
+});
+
+/**
+ * Create a fresh TeamService instance.
+ * Must be called AFTER jest.resetModules() in the test body
+ * so it picks up the overridden SHARED_CONTEXT env var.
+ */
+function createService(): TeamServiceType {
+  // Re-require to get fresh module with updated env
+  const { TeamService: TS } = require('../team-service');
+  return new TS(dbPath);
+}
+
+// ─── Schema Tests ───────────────────────────────────────────────────────────
+
+describe('TeamService — Schema', () => {
+  test('creates teams and team_agents tables on initialization', () => {
+    const svc = createService();
+    svc.close();
+
+    const db = new Database(dbPath, { readonly: true });
+    const tables = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='table' AND name IN ('teams','team_agents')")
+      .all() as any[];
+    const names = tables.map((t: any) => t.name).sort();
+    expect(names).toEqual(['team_agents', 'teams']);
+    db.close();
+  });
+
+  test('creates expected indexes', () => {
+    const svc = createService();
+    svc.close();
+
+    const db = new Database(dbPath, { readonly: true });
+    const indexes = db
+      .prepare("SELECT name FROM sqlite_master WHERE type='index'")
+      .all() as any[];
+    const indexNames = indexes.map((i: any) => i.name);
+    expect(indexNames).toContain('idx_team_agents_agent');
+    expect(indexNames).toContain('idx_teams_name');
+    db.close();
+  });
+
+  test('schema creation is idempotent', () => {
+    const svc1 = createService();
+    svc1.close();
+    // Second initialization should not throw
+    const svc2 = createService();
+    svc2.close();
+  });
+});
+
+// ─── Team CRUD Tests ────────────────────────────────────────────────────────
+
+describe('TeamService — Team CRUD', () => {
+  test('createTeam returns team with correct fields', () => {
+    const svc = createService();
+    try {
+      const team = svc.createTeam('alpha-squad', ['nexus', 'oracle'], 'user-1');
+
+      expect(team.id).toBeTruthy();
+      expect(team.name).toBe('alpha-squad');
+      expect(team.ownerUserId).toBe('user-1');
+      expect(team.createdAt).toBeTruthy();
+      expect(team.agents).toHaveLength(2);
+      expect(team.agents[0].agentId).toBe('nexus');
+      expect(team.agents[0].role).toBe('member');
+      expect(team.agents[1].agentId).toBe('oracle');
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('createTeam with empty agent list succeeds', () => {
+    const svc = createService();
+    try {
+      const team = svc.createTeam('lonely-team', [], 'user-1');
+
+      expect(team.agents).toHaveLength(0);
+      expect(team.name).toBe('lonely-team');
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('createTeam with many agents succeeds', () => {
+    const svc = createService();
+    try {
+      const agents = Array.from({ length: 12 }, (_, i) => `agent-${i}`);
+      const team = svc.createTeam('big-team', agents, 'user-1');
+
+      expect(team.agents).toHaveLength(12);
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('createTeam sanitizes team name', () => {
+    const svc = createService();
+    try {
+      const team = svc.createTeam('My Team Name!', ['nexus'], 'user-1');
+      expect(team.name).toBe('my-team-name');
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('createTeam rejects empty/invalid names', () => {
+    const svc = createService();
+    try {
+      expect(() => svc.createTeam('', [], 'user-1')).toThrow(/Invalid team name/);
+      expect(() => svc.createTeam('!!!', [], 'user-1')).toThrow(/Invalid team name/);
+      expect(() => svc.createTeam('   ', [], 'user-1')).toThrow(/Invalid team name/);
+
+      try {
+        svc.createTeam('', [], 'user-1');
+      } catch (err: any) {
+        expect(err.code).toBe('INVALID_TEAM_NAME');
+        expect(err.name).toBe('TeamServiceError');
+      }
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('createTeam rejects duplicate names', () => {
+    const svc = createService();
+    try {
+      svc.createTeam('alpha', ['nexus'], 'user-1');
+
+      expect(() => svc.createTeam('alpha', ['oracle'], 'user-2')).toThrow(/already taken/);
+
+      try {
+        svc.createTeam('alpha', ['oracle'], 'user-2');
+      } catch (err: any) {
+        expect(err.code).toBe('TEAM_NAME_TAKEN');
+        expect(err.name).toBe('TeamServiceError');
+      }
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('getTeam returns team with agents', () => {
+    const svc = createService();
+    try {
+      const created = svc.createTeam('bravo', ['nexus', 'oracle'], 'user-1');
+      const fetched = svc.getTeam(created.id);
+
+      expect(fetched).not.toBeNull();
+      expect(fetched!.id).toBe(created.id);
+      expect(fetched!.name).toBe('bravo');
+      expect(fetched!.agents).toHaveLength(2);
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('getTeam returns null for non-existent team', () => {
+    const svc = createService();
+    try {
+      expect(svc.getTeam('non-existent-id')).toBeNull();
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('listTeams returns all teams', () => {
+    const svc = createService();
+    try {
+      svc.createTeam('team-a', ['nexus'], 'user-1');
+      svc.createTeam('team-b', ['oracle'], 'user-1');
+      svc.createTeam('team-c', [], 'user-2');
+
+      const teams = svc.listTeams();
+      expect(teams).toHaveLength(3);
+
+      const names = teams.map((t: any) => t.name).sort();
+      expect(names).toEqual(['team-a', 'team-b', 'team-c']);
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('listTeams returns empty array when no teams exist', () => {
+    const svc = createService();
+    try {
+      expect(svc.listTeams()).toEqual([]);
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('deleteTeam removes team and cascades to agents', () => {
+    const svc = createService();
+    try {
+      const team = svc.createTeam('doomed', ['nexus', 'oracle'], 'user-1');
+
+      const deleted = svc.deleteTeam(team.id);
+      expect(deleted).toBe(true);
+
+      // Team should be gone
+      expect(svc.getTeam(team.id)).toBeNull();
+
+      // Agents should no longer be associated
+      expect(svc.getTeamForAgent('nexus')).toBeNull();
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('deleteTeam returns false for non-existent team', () => {
+    const svc = createService();
+    try {
+      expect(svc.deleteTeam('non-existent')).toBe(false);
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('deleteTeam preserves shared-context directory', () => {
+    const svc = createService();
+    try {
+      const team = svc.createTeam('preserve-me', ['nexus'], 'user-1');
+      const teamDir = path.join(sharedContextRoot, 'preserve-me');
+
+      // Directory should exist after creation
+      expect(fs.existsSync(teamDir)).toBe(true);
+
+      // Delete the team record
+      svc.deleteTeam(team.id);
+
+      // Directory should still exist
+      expect(fs.existsSync(teamDir)).toBe(true);
+    } finally {
+      svc.close();
+    }
+  });
+});
+
+// ─── Agent Membership Tests ─────────────────────────────────────────────────
+
+describe('TeamService — Agent Membership', () => {
+  test('addAgent adds agent with specified role', () => {
+    const svc = createService();
+    try {
+      const team = svc.createTeam('roles-team', [], 'user-1');
+      const agent = svc.addAgent(team.id, 'curator-bot', 'curator');
+
+      expect(agent.teamId).toBe(team.id);
+      expect(agent.agentId).toBe('curator-bot');
+      expect(agent.role).toBe('curator');
+      expect(agent.joinedAt).toBeTruthy();
+
+      const fetched = svc.getTeam(team.id);
+      expect(fetched!.agents).toHaveLength(1);
+      expect(fetched!.agents[0].role).toBe('curator');
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('addAgent defaults to member role', () => {
+    const svc = createService();
+    try {
+      const team = svc.createTeam('default-role', [], 'user-1');
+      const agent = svc.addAgent(team.id, 'oracle');
+
+      expect(agent.role).toBe('member');
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('addAgent rejects invalid role', () => {
+    const svc = createService();
+    try {
+      const team = svc.createTeam('bad-role', [], 'user-1');
+
+      expect(() =>
+        svc.addAgent(team.id, 'nexus', 'admin' as TeamAgentRole),
+      ).toThrow(/Invalid role/);
+
+      try {
+        svc.addAgent(team.id, 'nexus', 'admin' as TeamAgentRole);
+      } catch (err: any) {
+        expect(err.code).toBe('INVALID_ROLE');
+        expect(err.name).toBe('TeamServiceError');
+      }
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('addAgent rejects non-existent team', () => {
+    const svc = createService();
+    try {
+      expect(() => svc.addAgent('fake-team', 'nexus')).toThrow(/not found/);
+
+      try {
+        svc.addAgent('fake-team', 'nexus');
+      } catch (err: any) {
+        expect(err.code).toBe('TEAM_NOT_FOUND');
+        expect(err.name).toBe('TeamServiceError');
+      }
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('addAgent rejects duplicate agent', () => {
+    const svc = createService();
+    try {
+      const team = svc.createTeam('dupe-team', ['nexus'], 'user-1');
+
+      expect(() => svc.addAgent(team.id, 'nexus')).toThrow(/already in team/);
+
+      try {
+        svc.addAgent(team.id, 'nexus');
+      } catch (err: any) {
+        expect(err.code).toBe('AGENT_ALREADY_IN_TEAM');
+        expect(err.name).toBe('TeamServiceError');
+      }
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('addAgent creates agent output directory', () => {
+    const svc = createService();
+    try {
+      const team = svc.createTeam('output-dir', [], 'user-1');
+      svc.addAgent(team.id, 'synth');
+
+      const outputDir = path.join(sharedContextRoot, 'output-dir', 'agent-outputs', 'synth');
+      expect(fs.existsSync(outputDir)).toBe(true);
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('removeAgent removes agent from team', () => {
+    const svc = createService();
+    try {
+      const team = svc.createTeam('remove-test', ['nexus', 'oracle'], 'user-1');
+
+      const removed = svc.removeAgent(team.id, 'nexus');
+      expect(removed).toBe(true);
+
+      const fetched = svc.getTeam(team.id);
+      expect(fetched!.agents).toHaveLength(1);
+      expect(fetched!.agents[0].agentId).toBe('oracle');
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('removeAgent returns false for non-member', () => {
+    const svc = createService();
+    try {
+      const team = svc.createTeam('no-member', ['nexus'], 'user-1');
+      const removed = svc.removeAgent(team.id, 'not-in-team');
+      expect(removed).toBe(false);
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('removeAgent throws for non-existent team', () => {
+    const svc = createService();
+    try {
+      expect(() => svc.removeAgent('fake-team', 'nexus')).toThrow(/not found/);
+
+      try {
+        svc.removeAgent('fake-team', 'nexus');
+      } catch (err: any) {
+        expect(err.code).toBe('TEAM_NOT_FOUND');
+        expect(err.name).toBe('TeamServiceError');
+      }
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('getTeamForAgent returns team membership', () => {
+    const svc = createService();
+    try {
+      const team = svc.createTeam('lookup-test', ['nexus', 'oracle'], 'user-1');
+      const found = svc.getTeamForAgent('oracle');
+
+      expect(found).not.toBeNull();
+      expect(found!.id).toBe(team.id);
+      expect(found!.name).toBe('lookup-test');
+      expect(found!.agents).toHaveLength(2);
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('getTeamForAgent returns null for unaffiliated agent', () => {
+    const svc = createService();
+    try {
+      expect(svc.getTeamForAgent('loner')).toBeNull();
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('all three roles can be assigned', () => {
+    const svc = createService();
+    try {
+      const team = svc.createTeam('all-roles', [], 'user-1');
+      svc.addAgent(team.id, 'member-agent', 'member');
+      svc.addAgent(team.id, 'curator-agent', 'curator');
+      svc.addAgent(team.id, 'observer-agent', 'observer');
+
+      const fetched = svc.getTeam(team.id);
+      const roles = fetched!.agents.map((a: any) => a.role).sort();
+      expect(roles).toEqual(['curator', 'member', 'observer']);
+    } finally {
+      svc.close();
+    }
+  });
+});
+
+// ─── Directory Scaffold Tests ───────────────────────────────────────────────
+
+describe('TeamService — Directory Scaffold', () => {
+  test('createTeam creates correct directory structure', () => {
+    const svc = createService();
+    try {
+      svc.createTeam('scaffold-test', ['nexus', 'oracle'], 'user-1');
+      const teamDir = path.join(sharedContextRoot, 'scaffold-test');
+
+      // Base directory exists
+      expect(fs.existsSync(teamDir)).toBe(true);
+
+      // All standard subdirectories exist
+      for (const subdir of SHARED_CONTEXT_SUBDIRS) {
+        const fullPath = path.join(teamDir, subdir);
+        expect(fs.existsSync(fullPath)).toBe(true);
+        expect(fs.statSync(fullPath).isDirectory()).toBe(true);
+      }
+
+      // Per-agent output directories exist
+      expect(fs.existsSync(path.join(teamDir, 'agent-outputs', 'nexus'))).toBe(true);
+      expect(fs.existsSync(path.join(teamDir, 'agent-outputs', 'oracle'))).toBe(true);
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('scaffold creates priorities.md', () => {
+    const svc = createService();
+    try {
+      svc.createTeam('priorities-test', [], 'user-1');
+      const filePath = path.join(sharedContextRoot, 'priorities-test', 'priorities.md');
+
+      expect(fs.existsSync(filePath)).toBe(true);
+      const content = fs.readFileSync(filePath, 'utf-8');
+      expect(content).toContain('# Team Priorities');
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('scaffold creates .meta/manifest.json with correct structure', () => {
+    const svc = createService();
+    try {
+      svc.createTeam('manifest-test', [], 'user-1');
+      const manifestPath = path.join(sharedContextRoot, 'manifest-test', '.meta', 'manifest.json');
+
+      expect(fs.existsSync(manifestPath)).toBe(true);
+
+      const manifest: SharedContextManifest = JSON.parse(
+        fs.readFileSync(manifestPath, 'utf-8'),
+      );
+      expect(manifest.files).toEqual([]);
+      expect(manifest.lastSync).toEqual({});
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('scaffold creates .meta/last-sync.json', () => {
+    const svc = createService();
+    try {
+      svc.createTeam('sync-test', [], 'user-1');
+      const syncPath = path.join(sharedContextRoot, 'sync-test', '.meta', 'last-sync.json');
+
+      expect(fs.existsSync(syncPath)).toBe(true);
+
+      const content = JSON.parse(fs.readFileSync(syncPath, 'utf-8'));
+      expect(content).toEqual({});
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('scaffold is idempotent — calling twice does not error or overwrite', () => {
+    const svc = createService();
+    try {
+      svc.createTeam('idempotent-test', ['nexus'], 'user-1');
+
+      // Modify priorities.md to prove it won't be overwritten
+      const priPath = path.join(sharedContextRoot, 'idempotent-test', 'priorities.md');
+      fs.writeFileSync(priPath, '# Custom priorities\n', 'utf-8');
+
+      // Call scaffoldDirectory again directly
+      const { teamSharedContextDir } = require('../paths');
+      svc.scaffoldDirectory('idempotent-test', ['nexus', 'oracle']);
+
+      // Custom content should be preserved
+      const content = fs.readFileSync(priPath, 'utf-8');
+      expect(content).toBe('# Custom priorities\n');
+
+      // New agent directory should exist too
+      expect(
+        fs.existsSync(path.join(sharedContextRoot, 'idempotent-test', 'agent-outputs', 'oracle')),
+      ).toBe(true);
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('scaffold matches #217 epic directory structure exactly', () => {
+    const svc = createService();
+    try {
+      svc.createTeam('spec-check', ['agent-a'], 'user-1');
+      const teamDir = path.join(sharedContextRoot, 'spec-check');
+
+      // From #217 spec:
+      // shared-context/{team-name}/
+      // ├── priorities.md
+      // ├── agent-outputs/{agent-name}/
+      // ├── feedback/
+      // ├── kpis/
+      // ├── calendar/
+      // ├── roundtable/
+      // └── .meta/
+      //     ├── manifest.json
+      //     └── last-sync.json
+
+      const expectedPaths = [
+        'priorities.md',
+        'agent-outputs/agent-a',
+        'feedback',
+        'kpis',
+        'calendar',
+        'roundtable',
+        '.meta/manifest.json',
+        '.meta/last-sync.json',
+      ];
+
+      for (const relPath of expectedPaths) {
+        const fullPath = path.join(teamDir, relPath);
+        expect(fs.existsSync(fullPath)).toBe(true);
+      }
+    } finally {
+      svc.close();
+    }
+  });
+});
+
+// ─── Edge Cases ─────────────────────────────────────────────────────────────
+
+describe('TeamService — Edge Cases', () => {
+  test('team names with special characters are sanitized consistently', () => {
+    const svc = createService();
+    try {
+      const team = svc.createTeam('Hello World! @#$%', ['nexus'], 'user-1');
+      expect(team.name).toBe('hello-world');
+
+      // Directory should use the sanitized name
+      const teamDir = path.join(sharedContextRoot, 'hello-world');
+      expect(fs.existsSync(teamDir)).toBe(true);
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('team names with underscores are preserved', () => {
+    const svc = createService();
+    try {
+      const team = svc.createTeam('my_team_name', [], 'user-1');
+      expect(team.name).toBe('my_team_name');
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('sanitized names that collide are treated as duplicates', () => {
+    const svc = createService();
+    try {
+      svc.createTeam('alpha', [], 'user-1');
+
+      // "ALPHA" sanitizes to "alpha" — should conflict
+      expect(() => svc.createTeam('ALPHA', [], 'user-2')).toThrow(/already taken/);
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('UUID uniqueness across many teams', () => {
+    const svc = createService();
+    try {
+      const ids = new Set<string>();
+      for (let i = 0; i < 50; i++) {
+        const team = svc.createTeam(`team-${i}`, [], 'user-1');
+        ids.add(team.id);
+      }
+      expect(ids.size).toBe(50);
+    } finally {
+      svc.close();
+    }
+  });
+
+  test('close is idempotent', () => {
+    const svc = createService();
+    svc.close();
+    svc.close(); // Should not throw
+  });
+
+  test('agent membership survives service restart', () => {
+    // Create with one service instance
+    const svc1 = createService();
+    const team = svc1.createTeam('persistent', ['nexus', 'oracle'], 'user-1');
+    const teamId = team.id;
+    svc1.close();
+
+    // Re-open with a fresh instance
+    const svc2 = createService();
+    try {
+      const fetched = svc2.getTeam(teamId);
+      expect(fetched).not.toBeNull();
+      expect(fetched!.name).toBe('persistent');
+      expect(fetched!.agents).toHaveLength(2);
+    } finally {
+      svc2.close();
+    }
+  });
+});

--- a/lib/paths.ts
+++ b/lib/paths.ts
@@ -109,6 +109,17 @@ export function agentWorkspaceDir(agentId: string): string {
   return path.join(OPENCLAW_DIR, `workspace-${safe}`);
 }
 
+/**
+ * Resolve the shared-context directory for a given team.
+ * Team names are sanitized to lowercase alphanumeric + hyphens/underscores.
+ */
+export function teamSharedContextDir(teamName: string): string {
+  const safe = String(teamName || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\-_]/g, '');
+  return path.join(SHARED_CONTEXT_DIR, safe);
+}
+
 
 const defaultPathsExport = {
   VENTUREOS_ROOT,
@@ -124,6 +135,7 @@ const defaultPathsExport = {
   PRIORITIES_PATH,
   agentSessionsDir,
   agentWorkspaceDir,
+  teamSharedContextDir,
   paths,
 } as const;
 

--- a/lib/team-service.ts
+++ b/lib/team-service.ts
@@ -1,0 +1,437 @@
+/**
+ * TeamService — VentureOS Team Management & Shared-Context Scaffold
+ *
+ * SQLite-backed service for team CRUD operations and agent membership
+ * management. On team creation, scaffolds the standard shared-context
+ * directory tree per the #217 epic specification.
+ *
+ * Follows the same patterns as ObservationStore — lazy table creation,
+ * WAL mode, prepared statements for performance.
+ *
+ * Phase 1 (#241): Core CRUD + directory scaffold
+ * Phase 2 (#242): Symlink manager integration
+ * Phase 3 (#243): Agent injection hook + file watcher
+ */
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+import { teamSharedContextDir } from './paths';
+import type {
+  Team,
+  TeamAgent,
+  TeamAgentRole,
+  TeamWithAgents,
+  SharedContextManifest,
+} from './types/team';
+import {
+  VALID_TEAM_AGENT_ROLES,
+  SHARED_CONTEXT_SUBDIRS,
+  SHARED_CONTEXT_INITIAL_FILES,
+} from './types/team';
+
+// ─── Error Types ────────────────────────────────────────────────────────────
+
+export class TeamServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly code: TeamServiceErrorCode,
+  ) {
+    super(message);
+    this.name = 'TeamServiceError';
+  }
+}
+
+export type TeamServiceErrorCode =
+  | 'TEAM_NOT_FOUND'
+  | 'TEAM_NAME_TAKEN'
+  | 'AGENT_ALREADY_IN_TEAM'
+  | 'AGENT_NOT_IN_TEAM'
+  | 'INVALID_ROLE'
+  | 'INVALID_TEAM_NAME'
+  | 'SCAFFOLD_FAILED';
+
+// ─── Service ────────────────────────────────────────────────────────────────
+
+export class TeamService {
+  private db: Database.Database;
+
+  // Prepared statements (lazily initialized after ensureTables)
+  private insertTeamStmt!: Database.Statement;
+  private getTeamStmt!: Database.Statement;
+  private deleteTeamStmt!: Database.Statement;
+  private insertAgentStmt!: Database.Statement;
+  private removeAgentStmt!: Database.Statement;
+  private getAgentsForTeamStmt!: Database.Statement;
+  private getTeamForAgentStmt!: Database.Statement;
+
+  constructor(dbPath: string) {
+    this.db = new Database(dbPath, { readonly: false });
+    this.db.pragma('journal_mode = WAL');
+    this.db.pragma('foreign_keys = ON');
+    this.ensureTables();
+    this.prepareStatements();
+  }
+
+  // ─── Schema ─────────────────────────────────────────────────────────
+
+  /**
+   * Create tables and indexes if they don't exist.
+   * Safe for existing databases — uses IF NOT EXISTS throughout.
+   */
+  private ensureTables(): void {
+    this.db.exec(`
+      CREATE TABLE IF NOT EXISTS teams (
+        id TEXT PRIMARY KEY,
+        name TEXT NOT NULL UNIQUE,
+        created_at TEXT NOT NULL DEFAULT (datetime('now')),
+        owner_user_id TEXT NOT NULL
+      );
+
+      CREATE TABLE IF NOT EXISTS team_agents (
+        team_id TEXT NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+        agent_id TEXT NOT NULL,
+        role TEXT NOT NULL CHECK(role IN ('member','curator','observer')),
+        joined_at TEXT NOT NULL DEFAULT (datetime('now')),
+        PRIMARY KEY (team_id, agent_id)
+      );
+
+      CREATE INDEX IF NOT EXISTS idx_team_agents_agent
+        ON team_agents(agent_id);
+      CREATE INDEX IF NOT EXISTS idx_teams_name
+        ON teams(name);
+    `);
+  }
+
+  /**
+   * Prepare frequently-used statements for performance.
+   */
+  private prepareStatements(): void {
+    this.insertTeamStmt = this.db.prepare(
+      'INSERT INTO teams (id, name, created_at, owner_user_id) VALUES (?, ?, ?, ?)',
+    );
+    this.getTeamStmt = this.db.prepare('SELECT * FROM teams WHERE id = ?');
+    this.deleteTeamStmt = this.db.prepare('DELETE FROM teams WHERE id = ?');
+    this.insertAgentStmt = this.db.prepare(
+      'INSERT INTO team_agents (team_id, agent_id, role, joined_at) VALUES (?, ?, ?, ?)',
+    );
+    this.removeAgentStmt = this.db.prepare(
+      'DELETE FROM team_agents WHERE team_id = ? AND agent_id = ?',
+    );
+    this.getAgentsForTeamStmt = this.db.prepare(
+      'SELECT * FROM team_agents WHERE team_id = ? ORDER BY joined_at ASC',
+    );
+    this.getTeamForAgentStmt = this.db.prepare(`
+      SELECT t.* FROM teams t
+      INNER JOIN team_agents ta ON t.id = ta.team_id
+      WHERE ta.agent_id = ?
+    `);
+  }
+
+  // ─── Team CRUD ──────────────────────────────────────────────────────
+
+  /**
+   * Create a new team with initial agent members.
+   * Scaffolds the shared-context directory structure on success.
+   *
+   * @param name - Human-readable team name (must be unique).
+   * @param agentIds - Initial agent IDs to add as members.
+   * @param ownerUserId - User ID of the team creator.
+   * @returns The created team with its agent membership list.
+   */
+  createTeam(name: string, agentIds: string[], ownerUserId: string): TeamWithAgents {
+    // Validate team name
+    const safeName = this.sanitizeTeamName(name);
+    if (!safeName) {
+      throw new TeamServiceError(
+        `Invalid team name: "${name}". Must contain at least one alphanumeric character.`,
+        'INVALID_TEAM_NAME',
+      );
+    }
+
+    const id = crypto.randomUUID();
+    const now = new Date().toISOString();
+
+    // Use a transaction for atomicity
+    const result = this.db.transaction(() => {
+      try {
+        this.insertTeamStmt.run(id, safeName, now, ownerUserId);
+      } catch (err: any) {
+        if (err.message?.includes('UNIQUE constraint failed: teams.name')) {
+          throw new TeamServiceError(
+            `Team name "${safeName}" is already taken.`,
+            'TEAM_NAME_TAKEN',
+          );
+        }
+        throw err;
+      }
+
+      // Add initial agents as members
+      const agents: TeamAgent[] = [];
+      for (const agentId of agentIds) {
+        const agent: TeamAgent = {
+          teamId: id,
+          agentId,
+          role: 'member',
+          joinedAt: now,
+        };
+        this.insertAgentStmt.run(id, agentId, 'member', now);
+        agents.push(agent);
+      }
+
+      return {
+        id,
+        name: safeName,
+        createdAt: now,
+        ownerUserId,
+        agents,
+      } satisfies TeamWithAgents;
+    })();
+
+    // Scaffold directory structure outside the transaction
+    // (filesystem ops shouldn't block DB rollback)
+    this.scaffoldDirectory(safeName, agentIds);
+
+    return result;
+  }
+
+  /**
+   * Get a team by ID with its agent membership list.
+   * Returns null if the team doesn't exist.
+   */
+  getTeam(teamId: string): TeamWithAgents | null {
+    const row = this.getTeamStmt.get(teamId) as any;
+    if (!row) return null;
+
+    const agentRows = this.getAgentsForTeamStmt.all(teamId) as any[];
+
+    return {
+      id: row.id,
+      name: row.name,
+      createdAt: row.created_at,
+      ownerUserId: row.owner_user_id,
+      agents: agentRows.map(this.rowToTeamAgent),
+    };
+  }
+
+  /**
+   * List all teams with their agent membership.
+   */
+  listTeams(): TeamWithAgents[] {
+    const teamRows = this.db.prepare('SELECT * FROM teams ORDER BY created_at DESC').all() as any[];
+    return teamRows.map((row) => {
+      const agentRows = this.getAgentsForTeamStmt.all(row.id) as any[];
+      return {
+        id: row.id,
+        name: row.name,
+        createdAt: row.created_at,
+        ownerUserId: row.owner_user_id,
+        agents: agentRows.map(this.rowToTeamAgent),
+      };
+    });
+  }
+
+  /**
+   * Delete a team by ID.
+   * Removes the team record and agent memberships (via CASCADE).
+   * Preserves the shared-context directory on disk for safety.
+   *
+   * @returns true if the team was deleted, false if it didn't exist.
+   */
+  deleteTeam(teamId: string): boolean {
+    const result = this.deleteTeamStmt.run(teamId);
+    return result.changes > 0;
+  }
+
+  // ─── Agent Membership ───────────────────────────────────────────────
+
+  /**
+   * Add an agent to a team with a specified role.
+   */
+  addAgent(teamId: string, agentId: string, role: TeamAgentRole = 'member'): TeamAgent {
+    // Validate role
+    if (!VALID_TEAM_AGENT_ROLES.includes(role)) {
+      throw new TeamServiceError(
+        `Invalid role "${role}". Must be one of: ${VALID_TEAM_AGENT_ROLES.join(', ')}`,
+        'INVALID_ROLE',
+      );
+    }
+
+    // Verify team exists
+    const team = this.getTeamStmt.get(teamId) as any;
+    if (!team) {
+      throw new TeamServiceError(
+        `Team "${teamId}" not found.`,
+        'TEAM_NOT_FOUND',
+      );
+    }
+
+    const now = new Date().toISOString();
+
+    try {
+      this.insertAgentStmt.run(teamId, agentId, role, now);
+    } catch (err: any) {
+      if (err.message?.includes('UNIQUE constraint failed') ||
+          err.message?.includes('PRIMARY KEY constraint failed')) {
+        throw new TeamServiceError(
+          `Agent "${agentId}" is already in team "${teamId}".`,
+          'AGENT_ALREADY_IN_TEAM',
+        );
+      }
+      throw err;
+    }
+
+    // Create agent-specific output directory if it doesn't exist
+    const teamRow = team as { name: string };
+    const agentOutputDir = path.join(
+      teamSharedContextDir(teamRow.name),
+      'agent-outputs',
+      agentId,
+    );
+    fs.mkdirSync(agentOutputDir, { recursive: true });
+
+    return {
+      teamId,
+      agentId,
+      role,
+      joinedAt: now,
+    };
+  }
+
+  /**
+   * Remove an agent from a team.
+   *
+   * @returns true if the agent was removed, false if they weren't in the team.
+   */
+  removeAgent(teamId: string, agentId: string): boolean {
+    // Verify team exists
+    const team = this.getTeamStmt.get(teamId) as any;
+    if (!team) {
+      throw new TeamServiceError(
+        `Team "${teamId}" not found.`,
+        'TEAM_NOT_FOUND',
+      );
+    }
+
+    const result = this.removeAgentStmt.run(teamId, agentId);
+    return result.changes > 0;
+  }
+
+  /**
+   * Get the team that an agent belongs to.
+   * Returns null if the agent isn't in any team.
+   *
+   * Note: In Phase 1, an agent can only be in one team.
+   * This returns the first match if multiple exist.
+   */
+  getTeamForAgent(agentId: string): TeamWithAgents | null {
+    const row = this.getTeamForAgentStmt.get(agentId) as any;
+    if (!row) return null;
+
+    const agentRows = this.getAgentsForTeamStmt.all(row.id) as any[];
+
+    return {
+      id: row.id,
+      name: row.name,
+      createdAt: row.created_at,
+      ownerUserId: row.owner_user_id,
+      agents: agentRows.map(this.rowToTeamAgent),
+    };
+  }
+
+  // ─── Directory Scaffold ─────────────────────────────────────────────
+
+  /**
+   * Create the standard shared-context directory structure for a team.
+   * Idempotent — safe to call multiple times (uses recursive mkdir).
+   *
+   * Structure:
+   * ```
+   * shared-context/{team-name}/
+   * ├── priorities.md
+   * ├── agent-outputs/
+   * │   └── {agent-name}/    (one per member)
+   * ├── feedback/
+   * ├── kpis/
+   * ├── calendar/
+   * ├── roundtable/
+   * └── .meta/
+   *     ├── manifest.json
+   *     └── last-sync.json
+   * ```
+   */
+  scaffoldDirectory(teamName: string, agentIds: string[] = []): string {
+    const teamDir = teamSharedContextDir(teamName);
+
+    try {
+      // Create base directory and standard subdirectories
+      for (const subdir of SHARED_CONTEXT_SUBDIRS) {
+        fs.mkdirSync(path.join(teamDir, subdir), { recursive: true });
+      }
+
+      // Create per-agent output directories
+      for (const agentId of agentIds) {
+        fs.mkdirSync(path.join(teamDir, 'agent-outputs', agentId), { recursive: true });
+      }
+
+      // Create initial files (only if they don't already exist — idempotent)
+      for (const [relPath, content] of Object.entries(SHARED_CONTEXT_INITIAL_FILES)) {
+        const fullPath = path.join(teamDir, relPath);
+        if (!fs.existsSync(fullPath)) {
+          fs.writeFileSync(fullPath, content, 'utf-8');
+        }
+      }
+
+      return teamDir;
+    } catch (err: any) {
+      throw new TeamServiceError(
+        `Failed to scaffold directory for team "${teamName}": ${err.message}`,
+        'SCAFFOLD_FAILED',
+      );
+    }
+  }
+
+  // ─── Lifecycle ──────────────────────────────────────────────────────
+
+  /**
+   * Close the database connection.
+   */
+  close(): void {
+    try {
+      this.db.close();
+    } catch {
+      // ignore close errors
+    }
+  }
+
+  // ─── Internal Helpers ─────────────────────────────────────────────────
+
+  /**
+   * Sanitize a team name for use as a directory name.
+   * Returns empty string if the name is entirely invalid.
+   */
+  private sanitizeTeamName(name: string): string {
+    return String(name || '')
+      .toLowerCase()
+      .trim()
+      .replace(/\s+/g, '-')
+      .replace(/[^a-z0-9\-_]/g, '')
+      .replace(/-{2,}/g, '-')
+      .replace(/^-|-$/g, '');
+  }
+
+  /**
+   * Convert a database row to a TeamAgent object.
+   */
+  private rowToTeamAgent(row: any): TeamAgent {
+    return {
+      teamId: row.team_id,
+      agentId: row.agent_id,
+      role: row.role as TeamAgentRole,
+      joinedAt: row.joined_at,
+    };
+  }
+}
+
+export default TeamService;

--- a/lib/types/team.ts
+++ b/lib/types/team.ts
@@ -1,0 +1,122 @@
+/**
+ * Team Data Model Types — VentureOS Shared Agent Memory Layer
+ *
+ * Type contracts for the team service data layer. Teams group agents
+ * that share a common context directory for coordination via filesystem
+ * primitives (symlinks + markdown).
+ *
+ * Phase 1 (#241): TeamService foundation + directory scaffold
+ * Phase 2 (#242): Symlink manager — workspace links at agent boot
+ * Phase 3 (#243): Agent injection hook + file watcher
+ */
+
+// ─── Core Types ─────────────────────────────────────────────────────────────
+
+/**
+ * A team is a named group of agents that share a context directory.
+ */
+export interface Team {
+  /** Unique team identifier (UUID v4). */
+  id: string;
+  /** Human-readable team name (unique, used for directory naming). */
+  name: string;
+  /** ISO 8601 timestamp of team creation. */
+  createdAt: string;
+  /** User ID of the team owner (who created it). */
+  ownerUserId: string;
+}
+
+/**
+ * Agent membership in a team with role-based access.
+ */
+export interface TeamAgent {
+  /** Team the agent belongs to. */
+  teamId: string;
+  /** Agent identifier (e.g. 'nexus', 'oracle', 'synth'). */
+  agentId: string;
+  /** Role determining access level within the team. */
+  role: TeamAgentRole;
+  /** ISO 8601 timestamp when the agent joined the team. */
+  joinedAt: string;
+}
+
+/**
+ * Agent role within a team.
+ * - member:   Full read/write access to shared context.
+ * - curator:  Can synthesize/organize shared context (auto-roundtable).
+ * - observer: Read-only access to shared context.
+ */
+export type TeamAgentRole = 'member' | 'curator' | 'observer';
+
+/** Valid roles for runtime validation. */
+export const VALID_TEAM_AGENT_ROLES: readonly TeamAgentRole[] = [
+  'member',
+  'curator',
+  'observer',
+] as const;
+
+// ─── Shared Context Manifest ────────────────────────────────────────────────
+
+/**
+ * Manifest tracking files in the shared-context directory.
+ * Lives at `.meta/manifest.json` within the team's shared-context dir.
+ */
+export interface SharedContextManifest {
+  /** Registry of tracked files in the shared context. */
+  files: ManifestEntry[];
+  /** Per-agent read cursors — last sync timestamp per agent. */
+  lastSync: Record<string, string>;
+}
+
+/**
+ * A single file entry in the shared-context manifest.
+ */
+export interface ManifestEntry {
+  /** Relative path within the shared-context directory. */
+  path: string;
+  /** Agent ID that last modified this file. */
+  lastModifiedBy: string;
+  /** ISO 8601 timestamp of last modification. */
+  lastModifiedAt: string;
+  /** File size in bytes. */
+  sizeBytes: number;
+}
+
+// ─── Composite Types ────────────────────────────────────────────────────────
+
+/**
+ * Team with its agent membership list.
+ * Returned by TeamService.getTeam().
+ */
+export interface TeamWithAgents extends Team {
+  /** List of agents in this team. */
+  agents: TeamAgent[];
+}
+
+// ─── Directory Structure Constants ──────────────────────────────────────────
+
+/**
+ * Standard subdirectories created in every team's shared-context directory.
+ * Matches the #217 epic specification.
+ */
+export const SHARED_CONTEXT_SUBDIRS: readonly string[] = [
+  'agent-outputs',
+  'feedback',
+  'kpis',
+  'calendar',
+  'roundtable',
+  '.meta',
+] as const;
+
+/**
+ * Standard files created in every team's shared-context directory.
+ */
+export const SHARED_CONTEXT_INITIAL_FILES: Readonly<Record<string, string>> = {
+  'priorities.md': '# Team Priorities\n\n_No priorities set yet._\n',
+  '.meta/manifest.json': JSON.stringify(
+    { files: [], lastSync: {} } satisfies SharedContextManifest,
+    null,
+    2,
+  ) + '\n',
+  '.meta/last-sync.json': JSON.stringify({}, null, 2) + '\n',
+} as const;


### PR DESCRIPTION
## Summary

Implements **Phase 1** of the Shared Agent Memory Layer epic (#217): TeamService foundation + team-namespaced shared-context directory scaffold.

Closes #241

## Changes

| File | Description |
|------|-------------|
| `lib/types/team.ts` | Team, TeamAgent, TeamWithAgents, SharedContextManifest, ManifestEntry types + directory structure constants |
| `lib/team-service.ts` | SQLite-backed TeamService with full CRUD + filesystem scaffold |
| `lib/paths.ts` | Added `teamSharedContextDir()` helper |
| `lib/__tests__/team-service.test.ts` | 40 tests covering all acceptance criteria |

## TeamService API

- `createTeam(name, agentIds[], ownerUserId)` — creates team record + scaffolds directory
- `getTeam(teamId)` → team metadata + agent membership list
- `listTeams()` → all teams with agents
- `addAgent(teamId, agentId, role)` / `removeAgent(teamId, agentId)`
- `getTeamForAgent(agentId)` → team the agent belongs to
- `deleteTeam(teamId)` — removes record, preserves directory for safety

## Directory Scaffold

On team creation, scaffolds per the #217 spec:
```
shared-context/{team-name}/
├── priorities.md
├── agent-outputs/{agent-name}/
├── feedback/
├── kpis/
├── calendar/
├── roundtable/
└── .meta/
    ├── manifest.json
    └── last-sync.json
```

## Test Evidence

```
40 tests passing across 5 describe blocks:
  TeamService — Schema (3 tests)
  TeamService — Team CRUD (13 tests)
  TeamService — Agent Membership (12 tests)
  TeamService — Directory Scaffold (6 tests)
  TeamService — Edge Cases (6 tests)
```

Coverage includes: schema idempotency, CRUD operations, duplicate name detection, invalid role rejection, team-not-found errors, agent deduplication, directory structure verification, manifest.json initialization, scaffold idempotency, name sanitization collisions, UUID uniqueness, data persistence across service restarts.

Typecheck: ✅ clean (`tsc --noEmit`)
Paths tests: ✅ all 10 existing tests still pass

## Risk Notes

- **Low risk**: Purely additive — only `lib/paths.ts` was modified (one new export added). No existing code paths changed.
- **Scaffold idempotency**: Directory creation uses `recursive: true` and file writes skip existing files, so re-running is safe.
- **Delete safety**: `deleteTeam()` preserves the shared-context directory on disk — only removes the DB record.
- **Foreign keys**: Uses `ON DELETE CASCADE` for team_agents, so deleting a team auto-removes agent membership rows.

## Follow-ups (reserved for later issues)

- #242: Symlink manager — workspace symlink creation at agent boot
- #243: Agent injection hook — load shared-context at session start
- #244: File watcher — cross-agent change event emission
- #245: Dashboard cross-agent activity feed