### PR TITLE
feat(#242): SymlinkManager + Agent Boot Injection + Health Endpoint (Phase 2)

### DIFF
--- a/lib/__tests__/symlink-manager.test.ts
+++ b/lib/__tests__/symlink-manager.test.ts
@@ -1,0 +1,657 @@
+/**
+ * Tests for SymlinkManager — Issue #242
+ * Phase 2 of #217 (Shared Agent Memory Layer)
+ *
+ * Validates symlink creation, validation, repair, removal,
+ * idempotency, safe fallback behavior, and non-destructive operation.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import type { SymlinkManager as SymlinkManagerType } from '../symlink-manager';
+import type { SymlinkManagerError as SymlinkManagerErrorType } from '../symlink-manager';
+
+// ─── Test Helpers ───────────────────────────────────────────────────────────
+
+let tmpDir: string;
+let openclawDir: string;
+let sharedContextRoot: string;
+
+/**
+ * Override env vars so paths.ts resolves to our temp directory.
+ * We re-require modules each test to pick up env changes.
+ */
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'symlink-mgr-test-'));
+  openclawDir = path.join(tmpDir, '.openclaw');
+  sharedContextRoot = path.join(tmpDir, 'shared-context');
+  fs.mkdirSync(openclawDir, { recursive: true });
+  fs.mkdirSync(sharedContextRoot, { recursive: true });
+
+  process.env.OPENCLAW_DIR = openclawDir;
+  process.env.SHARED_CONTEXT = sharedContextRoot;
+  jest.resetModules();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.OPENCLAW_DIR;
+  delete process.env.SHARED_CONTEXT;
+  jest.resetModules();
+});
+
+/**
+ * Create a fresh SymlinkManager instance.
+ * Must be called AFTER jest.resetModules() in the test body.
+ */
+function createManager(): SymlinkManagerType {
+  const { SymlinkManager: SM } = require('../symlink-manager');
+  return new SM();
+}
+
+/**
+ * Helper: create a team's shared-context directory.
+ */
+function createTeamDir(teamName: string): string {
+  const dir = path.join(sharedContextRoot, teamName);
+  fs.mkdirSync(dir, { recursive: true });
+  return dir;
+}
+
+/**
+ * Helper: get workspace path for an agent.
+ */
+function workspacePath(agentId: string): string {
+  return path.join(openclawDir, `workspace-${agentId}`);
+}
+
+/**
+ * Helper: get symlink path for an agent.
+ */
+function symlinkPath(agentId: string): string {
+  return path.join(workspacePath(agentId), 'shared-context');
+}
+
+// ─── Symlink Creation Tests ─────────────────────────────────────────────────
+
+describe('SymlinkManager — ensureSymlink', () => {
+  test('creates symlink when none exists', () => {
+    createTeamDir('alpha');
+    const mgr = createManager();
+
+    const result = mgr.ensureSymlink('nexus', 'alpha');
+
+    expect(result.action).toBe('created');
+    expect(result.agentId).toBe('nexus');
+    expect(result.teamId).toBe('alpha');
+
+    // Verify symlink exists and points to correct target
+    const link = symlinkPath('nexus');
+    expect(fs.lstatSync(link).isSymbolicLink()).toBe(true);
+
+    const resolved = fs.realpathSync(link);
+    expect(resolved).toBe(fs.realpathSync(path.join(sharedContextRoot, 'alpha')));
+  });
+
+  test('creates workspace directory if it does not exist', () => {
+    createTeamDir('bravo');
+    const mgr = createManager();
+
+    expect(fs.existsSync(workspacePath('oracle'))).toBe(false);
+
+    mgr.ensureSymlink('oracle', 'bravo');
+
+    expect(fs.existsSync(workspacePath('oracle'))).toBe(true);
+    expect(fs.lstatSync(symlinkPath('oracle')).isSymbolicLink()).toBe(true);
+  });
+
+  test('throws TARGET_NOT_FOUND when team directory does not exist', () => {
+    const { SymlinkManagerError: SME } = require('../symlink-manager');
+    const mgr = createManager();
+
+    expect(() => mgr.ensureSymlink('nexus', 'nonexistent')).toThrow(SME);
+    try {
+      mgr.ensureSymlink('nexus', 'nonexistent');
+    } catch (err: any) {
+      expect(err.code).toBe('TARGET_NOT_FOUND');
+    }
+  });
+
+  test('throws SYMLINK_BLOCKED when a regular file exists at link path', () => {
+    createTeamDir('charlie');
+    const mgr = createManager();
+
+    // Create workspace with a regular file at the symlink path
+    const wsDir = workspacePath('sage');
+    fs.mkdirSync(wsDir, { recursive: true });
+    fs.writeFileSync(path.join(wsDir, 'shared-context'), 'regular file');
+
+    expect(() => mgr.ensureSymlink('sage', 'charlie')).toThrow();
+    try {
+      mgr.ensureSymlink('sage', 'charlie');
+    } catch (err: any) {
+      expect(err.code).toBe('SYMLINK_BLOCKED');
+    }
+  });
+
+  test('throws SYMLINK_BLOCKED when a regular directory exists at link path', () => {
+    createTeamDir('delta');
+    const mgr = createManager();
+
+    // Create workspace with a regular directory at the symlink path
+    const scDir = symlinkPath('synth');
+    fs.mkdirSync(scDir, { recursive: true });
+    fs.writeFileSync(path.join(scDir, 'data.md'), '# test');
+
+    expect(() => mgr.ensureSymlink('synth', 'delta')).toThrow();
+    try {
+      mgr.ensureSymlink('synth', 'delta');
+    } catch (err: any) {
+      expect(err.code).toBe('SYMLINK_BLOCKED');
+    }
+  });
+});
+
+// ─── Idempotency Tests ──────────────────────────────────────────────────────
+
+describe('SymlinkManager — Idempotency', () => {
+  test('no-op when symlink already exists and is correct', () => {
+    createTeamDir('echo');
+    const mgr = createManager();
+
+    // First call creates
+    const first = mgr.ensureSymlink('nexus', 'echo');
+    expect(first.action).toBe('created');
+
+    // Second call is a no-op
+    const second = mgr.ensureSymlink('nexus', 'echo');
+    expect(second.action).toBe('already_valid');
+  });
+
+  test('multiple rapid calls are all safe', () => {
+    createTeamDir('foxtrot');
+    const mgr = createManager();
+
+    // Call 10 times rapidly
+    const results = Array.from({ length: 10 }, () =>
+      mgr.ensureSymlink('oracle', 'foxtrot'),
+    );
+
+    expect(results[0].action).toBe('created');
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i].action).toBe('already_valid');
+    }
+
+    // Final state should be one valid symlink
+    expect(fs.lstatSync(symlinkPath('oracle')).isSymbolicLink()).toBe(true);
+  });
+
+  test('ensureSymlink followed by removeSymlink followed by ensureSymlink', () => {
+    createTeamDir('golf');
+    const mgr = createManager();
+
+    const create = mgr.ensureSymlink('nexus', 'golf');
+    expect(create.action).toBe('created');
+
+    const remove = mgr.removeSymlink('nexus');
+    expect(remove.action).toBe('removed');
+    expect(fs.existsSync(symlinkPath('nexus'))).toBe(false);
+
+    const recreate = mgr.ensureSymlink('nexus', 'golf');
+    expect(recreate.action).toBe('created');
+    expect(fs.lstatSync(symlinkPath('nexus')).isSymbolicLink()).toBe(true);
+  });
+});
+
+// ─── Repair Tests ───────────────────────────────────────────────────────────
+
+describe('SymlinkManager — Broken Symlink Repair', () => {
+  test('repairs broken (dangling) symlink', () => {
+    createTeamDir('hotel');
+    const mgr = createManager();
+
+    // Create a dangling symlink manually
+    const ws = workspacePath('nexus');
+    fs.mkdirSync(ws, { recursive: true });
+    fs.symlinkSync('/nonexistent/target', symlinkPath('nexus'), 'dir');
+    expect(fs.lstatSync(symlinkPath('nexus')).isSymbolicLink()).toBe(true);
+
+    const result = mgr.ensureSymlink('nexus', 'hotel');
+    expect(result.action).toBe('repaired');
+
+    // Should now point to correct target
+    const resolved = fs.realpathSync(symlinkPath('nexus'));
+    expect(resolved).toBe(fs.realpathSync(path.join(sharedContextRoot, 'hotel')));
+  });
+
+  test('repairs symlink pointing to wrong target', () => {
+    createTeamDir('india');
+    createTeamDir('juliet');
+    const mgr = createManager();
+
+    // Create symlink pointing to wrong team
+    mgr.ensureSymlink('nexus', 'india');
+    expect(mgr.ensureSymlink('nexus', 'india').action).toBe('already_valid');
+
+    // Now re-point to 'juliet'
+    const result = mgr.ensureSymlink('nexus', 'juliet');
+    expect(result.action).toBe('repaired');
+
+    const resolved = fs.realpathSync(symlinkPath('nexus'));
+    expect(resolved).toBe(fs.realpathSync(path.join(sharedContextRoot, 'juliet')));
+  });
+
+  test('repairSymlink delegates to ensureSymlink', () => {
+    createTeamDir('kilo');
+    const mgr = createManager();
+
+    const result = mgr.repairSymlink('oracle', 'kilo');
+    expect(result.action).toBe('created');
+
+    const second = mgr.repairSymlink('oracle', 'kilo');
+    expect(second.action).toBe('already_valid');
+  });
+});
+
+// ─── Remove Tests ───────────────────────────────────────────────────────────
+
+describe('SymlinkManager — removeSymlink', () => {
+  test('removes existing symlink', () => {
+    createTeamDir('lima');
+    const mgr = createManager();
+
+    mgr.ensureSymlink('nexus', 'lima');
+    expect(fs.existsSync(symlinkPath('nexus'))).toBe(true);
+
+    const result = mgr.removeSymlink('nexus');
+    expect(result.action).toBe('removed');
+    expect(fs.existsSync(symlinkPath('nexus'))).toBe(false);
+  });
+
+  test('no-op when symlink does not exist', () => {
+    const mgr = createManager();
+
+    const result = mgr.removeSymlink('ghost-agent');
+    expect(result.action).toBe('noop');
+  });
+
+  test('refuses to remove a regular directory', () => {
+    const mgr = createManager();
+
+    // Create a real directory at the symlink path
+    fs.mkdirSync(symlinkPath('nexus'), { recursive: true });
+    fs.writeFileSync(path.join(symlinkPath('nexus'), 'important.md'), '# keep me');
+
+    expect(() => mgr.removeSymlink('nexus')).toThrow();
+    try {
+      mgr.removeSymlink('nexus');
+    } catch (err: any) {
+      expect(err.code).toBe('SYMLINK_BLOCKED');
+    }
+
+    // Verify the directory still exists with its contents
+    expect(fs.existsSync(path.join(symlinkPath('nexus'), 'important.md'))).toBe(true);
+  });
+});
+
+// ─── Validation / Health Check Tests ────────────────────────────────────────
+
+describe('SymlinkManager — validateSymlinks', () => {
+  test('returns healthy for all valid symlinks', () => {
+    createTeamDir('mike');
+    const mgr = createManager();
+
+    mgr.ensureSymlink('nexus', 'mike');
+    mgr.ensureSymlink('oracle', 'mike');
+    mgr.ensureSymlink('synth', 'mike');
+
+    const report = mgr.validateSymlinks('team-1', 'mike', ['nexus', 'oracle', 'synth']);
+
+    expect(report.allHealthy).toBe(true);
+    expect(report.teamId).toBe('team-1');
+    expect(report.teamName).toBe('mike');
+    expect(report.entries).toHaveLength(3);
+    for (const entry of report.entries) {
+      expect(entry.healthy).toBe(true);
+      expect(entry.status).toBe('valid');
+      expect(entry.actualTarget).toBeTruthy();
+    }
+  });
+
+  test('reports missing symlinks', () => {
+    createTeamDir('november');
+    const mgr = createManager();
+
+    // Don't create any symlinks
+    const report = mgr.validateSymlinks('team-2', 'november', ['nexus', 'oracle']);
+
+    expect(report.allHealthy).toBe(false);
+    expect(report.entries[0].status).toBe('missing');
+    expect(report.entries[1].status).toBe('missing');
+  });
+
+  test('reports broken symlinks', () => {
+    createTeamDir('oscar');
+    const mgr = createManager();
+
+    // Create a symlink pointing to a path that will be removed
+    const ws = workspacePath('nexus');
+    fs.mkdirSync(ws, { recursive: true });
+    const tempTarget = path.join(tmpDir, 'will-be-removed');
+    fs.mkdirSync(tempTarget, { recursive: true });
+    fs.symlinkSync(tempTarget, symlinkPath('nexus'), 'dir');
+    // Now remove the target to make it dangling
+    fs.rmSync(tempTarget, { recursive: true });
+
+    const report = mgr.validateSymlinks('team-3', 'oscar', ['nexus']);
+
+    expect(report.allHealthy).toBe(false);
+    expect(report.entries[0].status).toBe('broken');
+    expect(report.entries[0].healthy).toBe(false);
+  });
+
+  test('reports wrong-target symlinks', () => {
+    createTeamDir('papa');
+    createTeamDir('quebec');
+    const mgr = createManager();
+
+    // Create symlink pointing to 'papa' but validate against 'quebec'
+    mgr.ensureSymlink('nexus', 'papa');
+
+    const report = mgr.validateSymlinks('team-4', 'quebec', ['nexus']);
+
+    expect(report.allHealthy).toBe(false);
+    expect(report.entries[0].status).toBe('wrong_target');
+  });
+
+  test('reports non-symlink entries', () => {
+    createTeamDir('romeo');
+    const mgr = createManager();
+
+    // Create a regular directory where symlink should be
+    fs.mkdirSync(symlinkPath('nexus'), { recursive: true });
+
+    const report = mgr.validateSymlinks('team-5', 'romeo', ['nexus']);
+
+    expect(report.allHealthy).toBe(false);
+    expect(report.entries[0].status).toBe('not_symlink');
+  });
+
+  test('includes checkedAt timestamp', () => {
+    createTeamDir('sierra');
+    const mgr = createManager();
+
+    const before = new Date().toISOString();
+    const report = mgr.validateSymlinks('team-6', 'sierra', []);
+    const after = new Date().toISOString();
+
+    expect(report.checkedAt >= before).toBe(true);
+    expect(report.checkedAt <= after).toBe(true);
+  });
+});
+
+// ─── Boot Integration Tests ─────────────────────────────────────────────────
+
+describe('SymlinkManager — ensureTeamSymlinks (boot integration)', () => {
+  test('creates symlink when agent has a team', () => {
+    createTeamDir('tango');
+    const mgr = createManager();
+
+    const result = mgr.ensureTeamSymlinks('nexus', () => ({
+      teamId: 'team-uuid',
+      teamName: 'tango',
+    }));
+
+    expect(result).not.toBeNull();
+    expect(result!.action).toBe('created');
+    expect(fs.lstatSync(symlinkPath('nexus')).isSymbolicLink()).toBe(true);
+  });
+
+  test('returns null when agent is not in any team', () => {
+    const mgr = createManager();
+
+    const result = mgr.ensureTeamSymlinks('loner', () => null);
+
+    expect(result).toBeNull();
+  });
+
+  test('graceful no-op does not crash the agent', () => {
+    const mgr = createManager();
+
+    // Resolver returns null → no-op
+    expect(() => {
+      mgr.ensureTeamSymlinks('nexus', () => null);
+    }).not.toThrow();
+  });
+});
+
+// ─── ensureTeamSymlinksOnBoot standalone function ───────────────────────────
+
+describe('ensureTeamSymlinksOnBoot', () => {
+  test('wires through TeamService.getTeamForAgent correctly', () => {
+    createTeamDir('uniform');
+    const { ensureTeamSymlinksOnBoot } = require('../symlink-manager');
+
+    const mockTeamService = {
+      getTeamForAgent: jest.fn((agentId: string) => {
+        if (agentId === 'nexus') {
+          return { id: 'team-uuid', name: 'uniform' };
+        }
+        return null;
+      }),
+    };
+
+    const result = ensureTeamSymlinksOnBoot('nexus', mockTeamService);
+    expect(result).not.toBeNull();
+    expect(result!.action).toBe('created');
+    expect(mockTeamService.getTeamForAgent).toHaveBeenCalledWith('nexus');
+  });
+
+  test('returns null for agent not in any team', () => {
+    const { ensureTeamSymlinksOnBoot } = require('../symlink-manager');
+
+    const mockTeamService = {
+      getTeamForAgent: jest.fn(() => null),
+    };
+
+    const result = ensureTeamSymlinksOnBoot('orphan', mockTeamService);
+    expect(result).toBeNull();
+  });
+});
+
+// ─── Cross-platform / Edge Cases ────────────────────────────────────────────
+
+describe('SymlinkManager — Edge Cases', () => {
+  test('handles agent names with special characters (sanitized by paths.ts)', () => {
+    createTeamDir('victor');
+    const mgr = createManager();
+
+    // paths.ts sanitizes agent names — only a-z0-9, hyphens, underscores
+    const result = mgr.ensureSymlink('my-agent_01', 'victor');
+    expect(result.action).toBe('created');
+    expect(fs.lstatSync(symlinkPath('my-agent_01')).isSymbolicLink()).toBe(true);
+  });
+
+  test('symlink target is accessible through the link', () => {
+    const teamDir = createTeamDir('whiskey');
+    const mgr = createManager();
+
+    // Write a file into the team's shared-context
+    fs.writeFileSync(path.join(teamDir, 'priorities.md'), '# Team Priorities');
+
+    mgr.ensureSymlink('nexus', 'whiskey');
+
+    // Read through the symlink
+    const content = fs.readFileSync(
+      path.join(symlinkPath('nexus'), 'priorities.md'),
+      'utf-8',
+    );
+    expect(content).toBe('# Team Priorities');
+  });
+
+  test('writing through symlink is visible in original directory', () => {
+    const teamDir = createTeamDir('xray');
+    const mgr = createManager();
+
+    mgr.ensureSymlink('oracle', 'xray');
+
+    // Write through the symlink
+    fs.writeFileSync(
+      path.join(symlinkPath('oracle'), 'test.md'),
+      '# Written by Oracle',
+    );
+
+    // Read from original location
+    const content = fs.readFileSync(
+      path.join(teamDir, 'test.md'),
+      'utf-8',
+    );
+    expect(content).toBe('# Written by Oracle');
+  });
+
+  test('multiple agents sharing same team directory via symlinks', () => {
+    const teamDir = createTeamDir('yankee');
+    const mgr = createManager();
+
+    fs.writeFileSync(path.join(teamDir, 'priorities.md'), '# Shared Priorities');
+
+    mgr.ensureSymlink('nexus', 'yankee');
+    mgr.ensureSymlink('oracle', 'yankee');
+    mgr.ensureSymlink('synth', 'yankee');
+
+    // All three agents should see the same content
+    for (const agent of ['nexus', 'oracle', 'synth']) {
+      const content = fs.readFileSync(
+        path.join(symlinkPath(agent), 'priorities.md'),
+        'utf-8',
+      );
+      expect(content).toBe('# Shared Priorities');
+    }
+  });
+
+  test('removing one agent symlink does not affect others', () => {
+    createTeamDir('zulu');
+    const mgr = createManager();
+
+    mgr.ensureSymlink('nexus', 'zulu');
+    mgr.ensureSymlink('oracle', 'zulu');
+
+    // Remove nexus
+    mgr.removeSymlink('nexus');
+
+    // oracle should still work
+    expect(fs.lstatSync(symlinkPath('oracle')).isSymbolicLink()).toBe(true);
+    expect(fs.existsSync(symlinkPath('nexus'))).toBe(false);
+  });
+});
+
+// ─── HTTP Health Check Integration ──────────────────────────────────────────
+
+describe('Symlink Health HTTP — handleSymlinkHealth', () => {
+  /**
+   * Minimal mock for IncomingMessage and ServerResponse.
+   */
+  function mockReqRes(method: string, url: string) {
+    const req = {
+      method,
+      url,
+      headers: { host: 'localhost:3000' },
+    } as unknown as import('node:http').IncomingMessage;
+
+    let statusCode = 0;
+    let headers: Record<string, string> = {};
+    let body = '';
+
+    const res = {
+      writeHead(code: number, hdrs: Record<string, string | number>) {
+        statusCode = code;
+        headers = hdrs as Record<string, string>;
+      },
+      end(data?: string) {
+        body = data ?? '';
+      },
+    } as unknown as import('node:http').ServerResponse;
+
+    return {
+      req,
+      res,
+      getStatus: () => statusCode,
+      getBody: () => {
+        try {
+          return JSON.parse(body);
+        } catch {
+          return body;
+        }
+      },
+    };
+  }
+
+  test('returns 405 for non-GET methods', () => {
+    const { handleSymlinkHealth } = require('../symlink-health-http');
+    const { req, res, getStatus, getBody } = mockReqRes('POST', '/api/shared-context/symlink-health');
+
+    handleSymlinkHealth(req, res, { dbPath: ':memory:' });
+
+    expect(getStatus()).toBe(405);
+    expect(getBody().code).toBe('METHOD_NOT_ALLOWED');
+  });
+
+  test('returns 400 when team_id is missing', () => {
+    const { handleSymlinkHealth } = require('../symlink-health-http');
+    const { req, res, getStatus, getBody } = mockReqRes('GET', '/api/shared-context/symlink-health');
+
+    handleSymlinkHealth(req, res, { dbPath: ':memory:' });
+
+    expect(getStatus()).toBe(400);
+    expect(getBody().code).toBe('MISSING_TEAM_ID');
+  });
+
+  test('returns 404 when team does not exist', () => {
+    // Create a real DB for this test
+    const dbPath = path.join(tmpDir, 'health-test.db');
+    const { TeamService: TS } = require('../team-service');
+    const svc = new TS(dbPath);
+    svc.close();
+
+    const { handleSymlinkHealth } = require('../symlink-health-http');
+    const { req, res, getStatus, getBody } = mockReqRes(
+      'GET',
+      '/api/shared-context/symlink-health?team_id=nonexistent',
+    );
+
+    handleSymlinkHealth(req, res, { dbPath });
+
+    expect(getStatus()).toBe(404);
+    expect(getBody().code).toBe('TEAM_NOT_FOUND');
+  });
+
+  test('returns 200 with health report for valid team', () => {
+    // Create team with agents
+    const dbPath = path.join(tmpDir, 'health-report.db');
+    const { TeamService: TS } = require('../team-service');
+    const svc = new TS(dbPath);
+    const team = svc.createTeam('test-team', ['nexus', 'oracle'], 'user-1');
+    svc.close();
+
+    // Create symlinks
+    const mgr = createManager();
+    mgr.ensureSymlink('nexus', 'test-team');
+    mgr.ensureSymlink('oracle', 'test-team');
+
+    const { handleSymlinkHealth } = require('../symlink-health-http');
+    const { req, res, getStatus, getBody } = mockReqRes(
+      'GET',
+      `/api/shared-context/symlink-health?team_id=${team.id}`,
+    );
+
+    handleSymlinkHealth(req, res, { dbPath });
+
+    expect(getStatus()).toBe(200);
+    const report = getBody();
+    expect(report.teamId).toBe(team.id);
+    expect(report.teamName).toBe('test-team');
+    expect(report.allHealthy).toBe(true);
+    expect(report.entries).toHaveLength(2);
+  });
+});

--- a/lib/symlink-health-http.ts
+++ b/lib/symlink-health-http.ts
@@ -1,0 +1,127 @@
+/**
+ * Symlink Health Check HTTP Handler — VentureOS
+ *
+ * GET /api/shared-context/symlink-health?team_id=<id>
+ *
+ * Returns per-agent symlink status for a team. Useful for diagnostics
+ * dashboard integration.
+ *
+ * Phase 2 (#242) of the Shared Agent Memory Layer (#217).
+ *
+ * @module
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { URL } from 'node:url';
+import { TeamService } from './team-service';
+import { SymlinkManager } from './symlink-manager';
+import type { SymlinkHealthReport } from './types/team';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+interface SymlinkHealthOptions {
+  /** Path to the SQLite database file. */
+  dbPath: string;
+}
+
+interface HealthErrorResponse {
+  error: string;
+  code: string;
+}
+
+// ─── Handler ────────────────────────────────────────────────────────────────
+
+/**
+ * Handle GET /api/shared-context/symlink-health
+ *
+ * Query params:
+ * - team_id (required): Team UUID
+ *
+ * Response:
+ * - 200: SymlinkHealthReport JSON
+ * - 400: Missing team_id
+ * - 404: Team not found
+ * - 405: Method not allowed
+ * - 500: Internal error
+ */
+export function handleSymlinkHealth(
+  req: IncomingMessage,
+  res: ServerResponse,
+  options: SymlinkHealthOptions,
+): void {
+  // Method check
+  if (req.method !== 'GET') {
+    sendJson(res, 405, {
+      error: 'Method not allowed',
+      code: 'METHOD_NOT_ALLOWED',
+    } satisfies HealthErrorResponse);
+    return;
+  }
+
+  // Parse team_id from query string
+  const url = new URL(req.url ?? '/', `http://${req.headers.host ?? 'localhost'}`);
+  const teamId = url.searchParams.get('team_id');
+
+  if (!teamId) {
+    sendJson(res, 400, {
+      error: 'Missing required query parameter: team_id',
+      code: 'MISSING_TEAM_ID',
+    } satisfies HealthErrorResponse);
+    return;
+  }
+
+  let teamService: TeamService | null = null;
+
+  try {
+    teamService = new TeamService(options.dbPath);
+    const team = teamService.getTeam(teamId);
+
+    if (!team) {
+      sendJson(res, 404, {
+        error: `Team "${teamId}" not found`,
+        code: 'TEAM_NOT_FOUND',
+      } satisfies HealthErrorResponse);
+      return;
+    }
+
+    const manager = new SymlinkManager();
+    const agentIds = team.agents.map((a) => a.agentId);
+    const report: SymlinkHealthReport = manager.validateSymlinks(
+      team.id,
+      team.name,
+      agentIds,
+    );
+
+    sendJson(res, 200, report);
+  } catch (err: any) {
+    sendJson(res, 500, {
+      error: `Internal error: ${err.message}`,
+      code: 'INTERNAL_ERROR',
+    } satisfies HealthErrorResponse);
+  } finally {
+    teamService?.close();
+  }
+}
+
+// ─── Helpers ────────────────────────────────────────────────────────────────
+
+function sendJson(res: ServerResponse, statusCode: number, body: unknown): void {
+  const json = JSON.stringify(body, null, 2);
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json',
+    'Content-Length': Buffer.byteLength(json),
+  });
+  res.end(json);
+}
+
+/**
+ * Factory function to create a symlink health router with a fixed DB path.
+ */
+export function createSymlinkHealthRouter(dbPath: string) {
+  return {
+    handleSymlinkHealth: (req: IncomingMessage, res: ServerResponse) =>
+      handleSymlinkHealth(req, res, { dbPath }),
+  };
+}
+
+export default { handleSymlinkHealth, createSymlinkHealthRouter };

--- a/lib/symlink-manager.ts
+++ b/lib/symlink-manager.ts
@@ -1,0 +1,443 @@
+/**
+ * SymlinkManager — VentureOS Workspace Symlink Management
+ *
+ * Creates, validates, repairs, and removes workspace symlinks so each
+ * agent in a team can transparently access shared-context via:
+ *   `workspace-{agent}/shared-context/ → {shared-context-dir}/{team}/`
+ *
+ * Designed for idempotent, non-destructive operation. Handles:
+ * - Missing workspace directories (creates them)
+ * - Already-correct symlinks (no-op)
+ * - Broken/dangling symlinks (repair)
+ * - Wrong-target symlinks (repair)
+ * - Regular files/directories at symlink path (refuses to overwrite — safety)
+ * - Environments where symlinks are restricted (graceful fallback)
+ *
+ * Phase 2 (#242) of the Shared Agent Memory Layer (#217).
+ *
+ * @module
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { agentWorkspaceDir, teamSharedContextDir } from './paths';
+import type {
+  SymlinkResult,
+  SymlinkHealthEntry,
+  SymlinkHealthReport,
+} from './types/team';
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+/** Name of the symlink directory within each agent's workspace. */
+const SYMLINK_NAME = 'shared-context';
+
+// ─── Error Types ────────────────────────────────────────────────────────────
+
+export class SymlinkManagerError extends Error {
+  constructor(
+    message: string,
+    public readonly code: SymlinkManagerErrorCode,
+  ) {
+    super(message);
+    this.name = 'SymlinkManagerError';
+  }
+}
+
+export type SymlinkManagerErrorCode =
+  | 'SYMLINK_BLOCKED'
+  | 'TARGET_NOT_FOUND'
+  | 'SYMLINK_CREATE_FAILED'
+  | 'SYMLINK_REMOVE_FAILED'
+  | 'SYMLINK_NOT_SUPPORTED';
+
+// ─── SymlinkManager ─────────────────────────────────────────────────────────
+
+export class SymlinkManager {
+  /**
+   * Ensure that an agent's workspace has a `shared-context` symlink
+   * pointing to the team's shared-context directory.
+   *
+   * Idempotent:
+   * - If the symlink already exists and points to the correct target → no-op.
+   * - If missing → creates it.
+   * - If broken or wrong target → removes and recreates.
+   *
+   * @param agentId - Agent identifier (e.g. 'nexus', 'oracle').
+   * @param teamName - Team name (used for directory resolution).
+   * @returns Result of the symlink operation.
+   */
+  ensureSymlink(agentId: string, teamName: string): SymlinkResult {
+    const workspaceDir = agentWorkspaceDir(agentId);
+    const linkPath = path.join(workspaceDir, SYMLINK_NAME);
+    const targetPath = teamSharedContextDir(teamName);
+
+    // Ensure workspace directory exists
+    fs.mkdirSync(workspaceDir, { recursive: true });
+
+    // Verify target directory exists
+    if (!fs.existsSync(targetPath)) {
+      throw new SymlinkManagerError(
+        `Target shared-context directory does not exist: ${targetPath}`,
+        'TARGET_NOT_FOUND',
+      );
+    }
+
+    // Check current state of linkPath
+    const state = this.inspectLink(linkPath, targetPath);
+
+    switch (state) {
+      case 'valid':
+        return {
+          agentId,
+          teamId: teamName,
+          action: 'already_valid',
+          linkPath,
+          targetPath,
+        };
+
+      case 'missing':
+        this.createSymlink(linkPath, targetPath);
+        return {
+          agentId,
+          teamId: teamName,
+          action: 'created',
+          linkPath,
+          targetPath,
+        };
+
+      case 'broken':
+      case 'wrong_target':
+        // Safe repair: remove the broken/wrong symlink and recreate
+        this.safeUnlink(linkPath);
+        this.createSymlink(linkPath, targetPath);
+        return {
+          agentId,
+          teamId: teamName,
+          action: 'repaired',
+          linkPath,
+          targetPath,
+        };
+
+      case 'not_symlink':
+        // Safety: refuse to overwrite a regular file or directory
+        throw new SymlinkManagerError(
+          `Cannot create symlink at ${linkPath}: a regular file or directory already exists there. ` +
+          `Remove it manually to allow symlink creation.`,
+          'SYMLINK_BLOCKED',
+        );
+    }
+  }
+
+  /**
+   * Validate symlinks for all agents in a team.
+   * Returns a health report with per-agent status.
+   *
+   * @param teamId - Team ID (for the report).
+   * @param teamName - Team name (for directory resolution).
+   * @param agentIds - List of agent IDs in the team.
+   * @returns Health report.
+   */
+  validateSymlinks(teamId: string, teamName: string, agentIds: string[]): SymlinkHealthReport {
+    const targetPath = teamSharedContextDir(teamName);
+    const entries: SymlinkHealthEntry[] = [];
+
+    for (const agentId of agentIds) {
+      const linkPath = path.join(agentWorkspaceDir(agentId), SYMLINK_NAME);
+      const state = this.inspectLink(linkPath, targetPath);
+
+      let actualTarget: string | null = null;
+      if (state === 'valid' || state === 'wrong_target') {
+        try {
+          actualTarget = fs.readlinkSync(linkPath);
+          // Resolve relative targets to absolute for comparison
+          if (!path.isAbsolute(actualTarget)) {
+            actualTarget = path.resolve(path.dirname(linkPath), actualTarget);
+          }
+        } catch {
+          actualTarget = null;
+        }
+      }
+
+      entries.push({
+        agentId,
+        healthy: state === 'valid',
+        linkPath,
+        expectedTarget: targetPath,
+        actualTarget,
+        status: state,
+      });
+    }
+
+    return {
+      teamId,
+      teamName,
+      allHealthy: entries.every((e) => e.healthy),
+      entries,
+      checkedAt: new Date().toISOString(),
+    };
+  }
+
+  /**
+   * Repair a single agent's symlink. Removes the existing link (if any)
+   * and recreates it pointing to the correct target.
+   *
+   * @param agentId - Agent identifier.
+   * @param teamName - Team name.
+   * @returns Result of the repair operation.
+   */
+  repairSymlink(agentId: string, teamName: string): SymlinkResult {
+    // ensureSymlink already handles repair logic (idempotent)
+    return this.ensureSymlink(agentId, teamName);
+  }
+
+  /**
+   * Remove an agent's shared-context symlink.
+   * No-op if the symlink doesn't exist.
+   * Safety: refuses to remove non-symlink entries.
+   *
+   * @param agentId - Agent identifier.
+   * @returns Result of the removal.
+   */
+  removeSymlink(agentId: string): SymlinkResult {
+    const linkPath = path.join(agentWorkspaceDir(agentId), SYMLINK_NAME);
+
+    let existingTarget = '';
+    try {
+      const stat = fs.lstatSync(linkPath);
+
+      if (!stat.isSymbolicLink()) {
+        // Safety: refuse to remove a regular file/directory
+        throw new SymlinkManagerError(
+          `Cannot remove ${linkPath}: it is not a symlink. Remove it manually.`,
+          'SYMLINK_BLOCKED',
+        );
+      }
+
+      try {
+        existingTarget = fs.readlinkSync(linkPath);
+      } catch {
+        // broken symlink — still remove it
+      }
+
+      this.safeUnlink(linkPath);
+
+      return {
+        agentId,
+        teamId: '',
+        action: 'removed',
+        linkPath,
+        targetPath: existingTarget,
+      };
+    } catch (err: any) {
+      if (err instanceof SymlinkManagerError) throw err;
+      if (err.code === 'ENOENT') {
+        // Symlink doesn't exist — no-op
+        return {
+          agentId,
+          teamId: '',
+          action: 'noop',
+          linkPath,
+          targetPath: '',
+        };
+      }
+      throw err;
+    }
+  }
+
+  // ─── Boot Integration ───────────────────────────────────────────────
+
+  /**
+   * Convenience function for agent boot-time integration.
+   *
+   * Looks up the agent's team via the provided resolver function,
+   * then ensures the workspace symlink exists. Graceful no-op if
+   * the agent is not in any team.
+   *
+   * This is the primary hook point for OpenClaw gateway to call
+   * on agent session start.
+   *
+   * @param agentId - Agent identifier.
+   * @param teamResolver - Function that returns { teamId, teamName } or null.
+   * @returns Result of the symlink operation, or null if agent has no team.
+   */
+  ensureTeamSymlinks(
+    agentId: string,
+    teamResolver: (agentId: string) => { teamId: string; teamName: string } | null,
+  ): SymlinkResult | null {
+    const team = teamResolver(agentId);
+    if (!team) return null; // Agent is not in any team — graceful no-op
+
+    try {
+      return this.ensureSymlink(agentId, team.teamName);
+    } catch (err: any) {
+      // In boot context, we log but don't crash.
+      // Symlink failure should not prevent agent from starting.
+      if (err instanceof SymlinkManagerError && err.code === 'SYMLINK_NOT_SUPPORTED') {
+        // Fallback: agent starts without shared-context
+        return null;
+      }
+      // For other errors, let the caller decide
+      throw err;
+    }
+  }
+
+  // ─── Internal Helpers ─────────────────────────────────────────────────
+
+  /**
+   * Inspect the state of a potential symlink path.
+   *
+   * @returns State of the link:
+   * - 'valid'        — symlink exists, points to the correct target
+   * - 'missing'      — nothing at the path
+   * - 'broken'       — symlink exists but target doesn't exist
+   * - 'wrong_target' — symlink exists but points to wrong location
+   * - 'not_symlink'  — a regular file or directory exists at the path
+   */
+  private inspectLink(
+    linkPath: string,
+    expectedTarget: string,
+  ): 'valid' | 'missing' | 'broken' | 'wrong_target' | 'not_symlink' {
+    let lstat: fs.Stats;
+    try {
+      lstat = fs.lstatSync(linkPath);
+    } catch (err: any) {
+      if (err.code === 'ENOENT') return 'missing';
+      throw err;
+    }
+
+    if (!lstat.isSymbolicLink()) {
+      return 'not_symlink';
+    }
+
+    // It's a symlink — first check if the target is reachable at all
+    let targetReachable = false;
+    try {
+      fs.statSync(linkPath); // follows the symlink
+      targetReachable = true;
+    } catch {
+      // Target doesn't exist → broken symlink
+    }
+
+    // Read where it points
+    let actualTarget: string;
+    try {
+      actualTarget = fs.readlinkSync(linkPath);
+    } catch {
+      return 'broken';
+    }
+
+    if (!targetReachable) {
+      return 'broken';
+    }
+
+    // Resolve to real paths for comparison (handles /var vs /private/var on macOS)
+    let resolvedActual: string;
+    try {
+      resolvedActual = fs.realpathSync(linkPath);
+    } catch {
+      return 'broken';
+    }
+
+    let resolvedExpected: string;
+    try {
+      resolvedExpected = fs.realpathSync(expectedTarget);
+    } catch {
+      // Expected target doesn't exist — treat as wrong target
+      // (the symlink resolves to somewhere, but not where we want)
+      return 'wrong_target';
+    }
+
+    if (resolvedActual !== resolvedExpected) {
+      return 'wrong_target';
+    }
+
+    return 'valid';
+  }
+
+  /**
+   * Create a symlink from linkPath → targetPath.
+   * Uses relative paths where possible for portability.
+   * Falls back to absolute paths if relative fails.
+   */
+  private createSymlink(linkPath: string, targetPath: string): void {
+    // Compute relative path from link location to target
+    const relativePath = path.relative(path.dirname(linkPath), targetPath);
+
+    try {
+      fs.symlinkSync(relativePath, linkPath, 'dir');
+    } catch (firstErr: any) {
+      // Fallback: try absolute path (some environments restrict relative symlinks)
+      try {
+        fs.symlinkSync(targetPath, linkPath, 'dir');
+      } catch (secondErr: any) {
+        // Check for permission/capability issues
+        if (
+          secondErr.code === 'EPERM' ||
+          secondErr.code === 'EACCES' ||
+          secondErr.code === 'ENOSYS'
+        ) {
+          throw new SymlinkManagerError(
+            `Symlinks are not supported or permitted in this environment. ` +
+            `Shared-context linking is unavailable. Error: ${secondErr.message}`,
+            'SYMLINK_NOT_SUPPORTED',
+          );
+        }
+        throw new SymlinkManagerError(
+          `Failed to create symlink ${linkPath} → ${targetPath}: ${secondErr.message}`,
+          'SYMLINK_CREATE_FAILED',
+        );
+      }
+    }
+  }
+
+  /**
+   * Safely remove a symlink (only unlinks, never recurse-deletes).
+   */
+  private safeUnlink(linkPath: string): void {
+    try {
+      fs.unlinkSync(linkPath);
+    } catch (err: any) {
+      if (err.code !== 'ENOENT') {
+        throw new SymlinkManagerError(
+          `Failed to remove symlink at ${linkPath}: ${err.message}`,
+          'SYMLINK_REMOVE_FAILED',
+        );
+      }
+    }
+  }
+}
+
+// ─── Standalone Boot Helper ─────────────────────────────────────────────────
+
+/**
+ * Standalone boot integration function.
+ *
+ * Call this at agent session start in the OpenClaw gateway:
+ *
+ * ```ts
+ * import { ensureTeamSymlinksOnBoot } from './lib/symlink-manager';
+ * import { TeamService } from './lib/team-service';
+ *
+ * const teamService = new TeamService(dbPath);
+ * const result = ensureTeamSymlinksOnBoot('nexus', teamService);
+ * // result is null if agent has no team, or SymlinkResult on success
+ * ```
+ *
+ * @param agentId - Agent identifier.
+ * @param teamService - TeamService instance for team lookup.
+ * @returns SymlinkResult or null if agent is not in any team.
+ */
+export function ensureTeamSymlinksOnBoot(
+  agentId: string,
+  teamService: { getTeamForAgent(agentId: string): { id: string; name: string } | null },
+): SymlinkResult | null {
+  const manager = new SymlinkManager();
+  return manager.ensureTeamSymlinks(agentId, (id) => {
+    const team = teamService.getTeamForAgent(id);
+    if (!team) return null;
+    return { teamId: team.id, teamName: team.name };
+  });
+}
+
+export default SymlinkManager;

--- a/lib/types/team.ts
+++ b/lib/types/team.ts
@@ -82,6 +82,58 @@ export interface ManifestEntry {
   sizeBytes: number;
 }
 
+// ─── Symlink Types ──────────────────────────────────────────────────────────
+
+/**
+ * Result of a symlink operation (create, repair, remove).
+ */
+export interface SymlinkResult {
+  /** Agent the symlink belongs to. */
+  agentId: string;
+  /** Team the symlink points to. */
+  teamId: string;
+  /** The action that was performed. */
+  action: 'created' | 'already_valid' | 'repaired' | 'removed' | 'noop';
+  /** Full path to the symlink. */
+  linkPath: string;
+  /** Full path to the target directory. */
+  targetPath: string;
+}
+
+/**
+ * Health status of a single agent's workspace symlink.
+ */
+export interface SymlinkHealthEntry {
+  /** Agent identifier. */
+  agentId: string;
+  /** Whether the symlink exists and points to the correct target. */
+  healthy: boolean;
+  /** Full path to the symlink. */
+  linkPath: string;
+  /** Expected target path. */
+  expectedTarget: string;
+  /** Actual target the symlink points to (null if missing/broken). */
+  actualTarget: string | null;
+  /** Diagnostic message. */
+  status: 'valid' | 'missing' | 'broken' | 'wrong_target' | 'not_symlink';
+}
+
+/**
+ * Health report for all symlinks within a team.
+ */
+export interface SymlinkHealthReport {
+  /** Team identifier. */
+  teamId: string;
+  /** Team name. */
+  teamName: string;
+  /** Whether all symlinks are healthy. */
+  allHealthy: boolean;
+  /** Per-agent symlink status. */
+  entries: SymlinkHealthEntry[];
+  /** ISO 8601 timestamp of the check. */
+  checkedAt: string;
+}
+
 // ─── Composite Types ────────────────────────────────────────────────────────
 
 /**


### PR DESCRIPTION
## Summary

Phase 2 of [#217](https://github.com/zachyzissou/ventureos/issues/217) (Shared Agent Memory Layer).
Closes #242.

**Depends on:** #241 (Phase 1 — TeamService) ✅ merged as PR #246.

---

## What's Included

### 1. SymlinkManager (`lib/symlink-manager.ts`)

| Method | Description |
|--------|-------------|
| `ensureSymlink(agentId, teamName)` | Creates `workspace-{agent}/shared-context → {shared-context}/{team}` |
| `validateSymlinks(teamId, teamName, agentIds)` | Returns per-agent health report |
| `repairSymlink(agentId, teamName)` | Broken/wrong-target auto-repair |
| `removeSymlink(agentId)` | Cleanup on agent removal |
| `ensureTeamSymlinks(agentId, resolver)` | Boot-time convenience hook |
| `ensureTeamSymlinksOnBoot(agentId, teamService)` | Standalone gateway integration |

### 2. Health Check Endpoint (`lib/symlink-health-http.ts`)

```
GET /api/shared-context/symlink-health?team_id=<id>
```
Returns `SymlinkHealthReport` with per-agent status: `valid | missing | broken | wrong_target | not_symlink`.

### 3. Type Additions (`lib/types/team.ts`)

- `SymlinkResult` — operation result
- `SymlinkHealthEntry` — per-agent status
- `SymlinkHealthReport` — full team report

### 4. Agent Boot Integration Point

```ts
// In OpenClaw gateway, at agent session start:
import { ensureTeamSymlinksOnBoot } from './lib/symlink-manager';
const result = ensureTeamSymlinksOnBoot(agentId, teamService);
// Returns null if agent has no team (graceful no-op)
```

---

## Safety Guarantees

- **Idempotent**: No-op when symlink already correct
- **Non-destructive**: Refuses to overwrite regular files/directories (`SYMLINK_BLOCKED`)
- **Broken symlink detection**: Dangling symlinks auto-repaired
- **Graceful fallback**: `SYMLINK_NOT_SUPPORTED` error for restricted environments
- **Relative symlinks**: Uses relative paths with absolute fallback for portability
- **Agent isolation**: Removing one agent's symlink never affects others

---

## Test Evidence

**34 tests, all passing:**

```
SymlinkManager — ensureSymlink (5 tests)
  ✓ creates symlink when none exists
  ✓ creates workspace directory if it does not exist
  ✓ throws TARGET_NOT_FOUND when team directory does not exist
  ✓ throws SYMLINK_BLOCKED when a regular file exists at link path
  ✓ throws SYMLINK_BLOCKED when a regular directory exists at link path

SymlinkManager — Idempotency (3 tests)
  ✓ no-op when symlink already exists and is correct
  ✓ multiple rapid calls are all safe
  ✓ ensureSymlink followed by removeSymlink followed by ensureSymlink

SymlinkManager — Broken Symlink Repair (3 tests)
  ✓ repairs broken (dangling) symlink
  ✓ repairs symlink pointing to wrong target
  ✓ repairSymlink delegates to ensureSymlink

SymlinkManager — removeSymlink (3 tests)
  ✓ removes existing symlink
  ✓ no-op when symlink does not exist
  ✓ refuses to remove a regular directory

SymlinkManager — validateSymlinks (6 tests)
  ✓ returns healthy for all valid symlinks
  ✓ reports missing symlinks / broken / wrong-target / non-symlink entries
  ✓ includes checkedAt timestamp

SymlinkManager — Boot Integration (5 tests)
  ✓ creates symlink when agent has a team
  ✓ returns null when agent is not in any team
  ✓ graceful no-op does not crash the agent
  ✓ wires through TeamService.getTeamForAgent correctly
  ✓ returns null for agent not in any team

SymlinkManager — Edge Cases (5 tests)
  ✓ handles sanitized agent names
  ✓ symlink target is accessible through the link
  ✓ writing through symlink is visible in original directory
  ✓ multiple agents sharing same team directory via symlinks
  ✓ removing one agent symlink does not affect others

Symlink Health HTTP (4 tests)
  ✓ returns 405 for non-GET / 400 missing team_id / 404 not found / 200 valid report
```

**Typecheck:** `tsc --noEmit` clean
**Existing tests:** `team-service.test.ts` 40/40 still passing

---

## Risk Notes

| Risk | Mitigation |
|------|-----------|
| Windows symlinks require elevated permissions | `SYMLINK_NOT_SUPPORTED` graceful fallback, macOS is primary target |
| Relative symlink path resolution across mounts | Falls back to absolute paths automatically |
| Race condition if two agents repair simultaneously | `ensureSymlink` is idempotent; last write wins safely |
| Non-symlink entry at link path blocks creation | Explicit `SYMLINK_BLOCKED` error; requires manual resolution |

## Follow-ups (out of scope)

- Phase 3 (#243): Agent injection hook — load shared-context at session start
- Phase 4 (#244): File watcher + cross-agent change events
- Phase 5 (#245): Curator agent template
