### PR TITLE
feat(#244): Dashboard Cross-Agent Activity Feed (Phase 4 of #217)

### DIFF
--- a/dashboard/server/routes/index.ts
+++ b/dashboard/server/routes/index.ts
@@ -16,3 +16,4 @@ export { handleAgentDiagnostics } from './agent-diagnostics.js';
 export { handleChangelog } from './changelog.js';
 export { handleTaskBoard } from './task-board.js';
 export { handleMemoryState } from './memory-state.js';
+export { handleSharedContext } from './shared-context.js';

--- a/dashboard/server/routes/shared-context.ts
+++ b/dashboard/server/routes/shared-context.ts
@@ -1,0 +1,565 @@
+/**
+ * Shared-Context (Cross-Agent Activity Feed) Route Handlers
+ *
+ * Phase 4 (#244) of the Shared Agent Memory Layer (#217).
+ *
+ * Provides dashboard API endpoints for the cross-agent activity feed:
+ *   GET /api/shared-context/teams                    — List all teams with agent counts
+ *   GET /api/shared-context/teams/:id                — Team detail (metadata + membership)
+ *   GET /api/shared-context/teams/:id/activity       — Recent audit log entries
+ *   GET /api/shared-context/teams/:id/files          — Directory listing with file metadata
+ *
+ * Integrates with:
+ *   - TeamService (#241) SQLite schema for team/agent queries
+ *   - SharedContextAuditStore (#243) SQLite schema for audit trail
+ *   - Filesystem for directory listings
+ *
+ * Uses direct better-sqlite3 queries (same pattern as memory-state.ts)
+ * to avoid CJS/ESM boundary issues with lib/ imports in the dashboard.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import Database from 'better-sqlite3';
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export interface SharedContextDeps {
+  /** Path to the TeamService SQLite database. */
+  teamDbPath: string;
+  /** Path to the SharedContextAuditStore SQLite database. */
+  auditDbPath: string;
+  /** Root directory for shared-context team directories. */
+  sharedContextDir: string;
+  /** Send JSON response helper. */
+  sendJson: (res: ServerResponse, data: unknown, status?: number) => void;
+  /** Clamp an integer within bounds. */
+  clampInt: (n: string | number | null, lo: number, hi: number, dflt: number) => number;
+}
+
+// ─── Database Helpers ────────────────────────────────────────────────────────
+
+function openDb(dbPath: string): Database.Database | null {
+  try {
+    const db = new Database(dbPath, { readonly: true });
+    db.pragma('journal_mode = WAL');
+    return db;
+  } catch {
+    return null;
+  }
+}
+
+interface TeamRow {
+  id: string;
+  name: string;
+  created_at: string;
+  owner_user_id: string;
+}
+
+interface TeamAgentRow {
+  team_id: string;
+  agent_id: string;
+  role: string;
+  joined_at: string;
+}
+
+interface AuditRow {
+  id: string;
+  team_id: string;
+  agent_id: string;
+  action: string;
+  file_path: string;
+  file_size_bytes: number | null;
+  timestamp: string;
+  detail: string | null;
+}
+
+// ─── URL Helpers ─────────────────────────────────────────────────────────────
+
+function parseUrl(req: IncomingMessage): URL | null {
+  try {
+    return new URL(req.url ?? '', 'http://localhost');
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Extract the team ID from a URL path like /api/shared-context/teams/:id/...
+ */
+function extractTeamId(urlPath: string): string | null {
+  const match = urlPath.match(/^\/api\/shared-context\/teams\/([^/?]+)/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+/**
+ * Determine the sub-route after /api/shared-context/teams/:id/
+ */
+function extractSubRoute(urlPath: string): string | null {
+  const match = urlPath.match(/^\/api\/shared-context\/teams\/[^/?]+\/([^/?]+)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Resolve the team's shared-context directory with path traversal protection.
+ */
+function resolveTeamDir(sharedContextDir: string, teamName: string): string | null {
+  const safe = String(teamName || '')
+    .toLowerCase()
+    .replace(/[^a-z0-9\-_]/g, '');
+  if (!safe) return null;
+
+  const teamDir = path.join(sharedContextDir, safe);
+  const resolved = path.resolve(teamDir);
+  const root = path.resolve(sharedContextDir);
+  if (!resolved.startsWith(root + path.sep) && resolved !== root) return null;
+  if (!fs.existsSync(teamDir)) return null;
+
+  return teamDir;
+}
+
+// ─── File Listing ────────────────────────────────────────────────────────────
+
+interface FileEntry {
+  path: string;
+  name: string;
+  isDirectory: boolean;
+  sizeBytes: number;
+  lastModified: string;
+  author: string | null;
+}
+
+/**
+ * Recursively list files with metadata, bounded to maxFiles.
+ */
+function listDirectoryFiles(baseDir: string, maxFiles: number = 200): FileEntry[] {
+  const entries: FileEntry[] = [];
+
+  function walk(dir: string, relPrefix: string): void {
+    if (entries.length >= maxFiles) return;
+
+    let dirEntries: fs.Dirent[];
+    try {
+      dirEntries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+
+    dirEntries.sort((a, b) => a.name.localeCompare(b.name));
+
+    for (const entry of dirEntries) {
+      if (entries.length >= maxFiles) return;
+
+      const relPath = relPrefix ? `${relPrefix}/${entry.name}` : entry.name;
+      const fullPath = path.join(dir, entry.name);
+
+      // Skip .meta directory at the root level
+      if (entry.name === '.meta' && !relPrefix) continue;
+
+      let stat: fs.Stats;
+      try {
+        stat = fs.statSync(fullPath);
+      } catch {
+        continue;
+      }
+
+      // Infer author from agent-outputs/{agentId}/ path prefix
+      let author: string | null = null;
+      const agentMatch = relPath.match(/^agent-outputs\/([^/]+)/);
+      if (agentMatch) author = agentMatch[1];
+
+      entries.push({
+        path: relPath,
+        name: entry.name,
+        isDirectory: entry.isDirectory(),
+        sizeBytes: entry.isDirectory() ? 0 : stat.size,
+        lastModified: stat.mtime.toISOString(),
+        author,
+      });
+
+      if (entry.isDirectory()) {
+        walk(fullPath, relPath);
+      }
+    }
+  }
+
+  walk(baseDir, '');
+  return entries;
+}
+
+/**
+ * Read manifest.json for author attribution.
+ */
+function readManifestAuthors(teamDir: string): Record<string, string> {
+  try {
+    const manifestPath = path.join(teamDir, '.meta', 'manifest.json');
+    if (!fs.existsSync(manifestPath)) return {};
+    const data = JSON.parse(fs.readFileSync(manifestPath, 'utf-8'));
+    const authors: Record<string, string> = {};
+    if (Array.isArray(data.files)) {
+      for (const f of data.files) {
+        if (f.path && f.lastModifiedBy) {
+          authors[f.path] = f.lastModifiedBy;
+        }
+      }
+    }
+    return authors;
+  } catch {
+    return {};
+  }
+}
+
+// ─── Route Handler ───────────────────────────────────────────────────────────
+
+/**
+ * Handle shared-context API requests.
+ *
+ * @returns true if the request was handled, false to pass to next handler.
+ */
+export function handleSharedContext(
+  req: IncomingMessage,
+  res: ServerResponse,
+  deps: SharedContextDeps,
+): boolean {
+  if (!req.url || !req.url.startsWith('/api/shared-context/')) return false;
+  if (req.method && req.method !== 'GET') return false;
+
+  const parsed = parseUrl(req);
+  if (!parsed) {
+    deps.sendJson(res, { ok: false, error: 'Bad request' }, 400);
+    return true;
+  }
+
+  const urlPath = parsed.pathname;
+
+  // GET /api/shared-context/teams
+  if (urlPath === '/api/shared-context/teams') {
+    return handleListTeams(res, deps);
+  }
+
+  // Routes requiring a team ID
+  const teamId = extractTeamId(urlPath);
+  if (!teamId) {
+    deps.sendJson(res, { ok: false, error: 'Invalid route' }, 404);
+    return true;
+  }
+
+  const subRoute = extractSubRoute(urlPath);
+
+  if (subRoute === 'activity') {
+    const limitParam = parsed.searchParams.get('limit');
+    const limit = deps.clampInt(limitParam, 1, 200, 50);
+    const agentFilter = parsed.searchParams.get('agent_id') || null;
+    const actionFilter = parsed.searchParams.get('action') || null;
+    return handleTeamActivity(res, deps, teamId, limit, agentFilter, actionFilter);
+  }
+
+  if (subRoute === 'files') {
+    return handleTeamFiles(res, deps, teamId);
+  }
+
+  // No sub-route → team detail
+  if (!subRoute) {
+    return handleTeamDetail(res, deps, teamId);
+  }
+
+  deps.sendJson(res, { ok: false, error: `Unknown sub-route: ${subRoute}` }, 404);
+  return true;
+}
+
+// ─── Endpoint Implementations ────────────────────────────────────────────────
+
+function handleListTeams(res: ServerResponse, deps: SharedContextDeps): boolean {
+  const db = openDb(deps.teamDbPath);
+
+  if (!db) {
+    deps.sendJson(res, {
+      teams: [],
+      total: 0,
+      available: false,
+      message: 'Team service unavailable',
+    });
+    return true;
+  }
+
+  try {
+    const teamRows = db.prepare('SELECT * FROM teams ORDER BY created_at DESC').all() as TeamRow[];
+
+    // Open audit store for last activity enrichment
+    const auditDb = openDb(deps.auditDbPath);
+
+    const teams = teamRows.map((row) => {
+      const agents = db.prepare(
+        'SELECT * FROM team_agents WHERE team_id = ? ORDER BY joined_at ASC',
+      ).all(row.id) as TeamAgentRow[];
+
+      let lastActivityAt: string | null = null;
+      if (auditDb) {
+        try {
+          const auditRow = auditDb.prepare(
+            'SELECT timestamp FROM shared_context_audit WHERE team_id = ? ORDER BY timestamp DESC LIMIT 1',
+          ).get(row.id) as { timestamp: string } | undefined;
+          if (auditRow) lastActivityAt = auditRow.timestamp;
+        } catch {
+          // Ignore audit query failures
+        }
+      }
+
+      return {
+        id: row.id,
+        name: row.name,
+        createdAt: row.created_at,
+        ownerUserId: row.owner_user_id,
+        agentCount: agents.length,
+        agents: agents.map((a) => ({
+          agentId: a.agent_id,
+          role: a.role,
+          joinedAt: a.joined_at,
+        })),
+        lastActivityAt,
+      };
+    });
+
+    if (auditDb) try { auditDb.close(); } catch { /* ignore */ }
+
+    deps.sendJson(res, { teams, total: teams.length, available: true });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : 'Unknown error';
+    deps.sendJson(res, { ok: false, error: `Failed to list teams: ${msg}` }, 500);
+  } finally {
+    try { db.close(); } catch { /* ignore */ }
+  }
+
+  return true;
+}
+
+function handleTeamDetail(
+  res: ServerResponse,
+  deps: SharedContextDeps,
+  teamId: string,
+): boolean {
+  const db = openDb(deps.teamDbPath);
+
+  if (!db) {
+    deps.sendJson(res, { ok: false, error: 'Team service unavailable' }, 503);
+    return true;
+  }
+
+  try {
+    const row = db.prepare('SELECT * FROM teams WHERE id = ?').get(teamId) as TeamRow | undefined;
+
+    if (!row) {
+      deps.sendJson(res, { ok: false, error: 'Team not found' }, 404);
+      return true;
+    }
+
+    const agents = db.prepare(
+      'SELECT * FROM team_agents WHERE team_id = ? ORDER BY joined_at ASC',
+    ).all(teamId) as TeamAgentRow[];
+
+    const teamDir = resolveTeamDir(deps.sharedContextDir, row.name);
+    let directoryExists = false;
+    let totalSizeBytes = 0;
+    let fileCount = 0;
+
+    if (teamDir) {
+      directoryExists = true;
+      try {
+        const files = listDirectoryFiles(teamDir);
+        fileCount = files.filter((f) => !f.isDirectory).length;
+        totalSizeBytes = files.reduce((sum, f) => sum + f.sizeBytes, 0);
+      } catch {
+        // Directory listing failed
+      }
+    }
+
+    deps.sendJson(res, {
+      id: row.id,
+      name: row.name,
+      createdAt: row.created_at,
+      ownerUserId: row.owner_user_id,
+      agents: agents.map((a) => ({
+        agentId: a.agent_id,
+        role: a.role,
+        joinedAt: a.joined_at,
+      })),
+      directory: {
+        exists: directoryExists,
+        path: teamDir,
+        fileCount,
+        totalSizeBytes,
+      },
+    });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : 'Unknown error';
+    deps.sendJson(res, { ok: false, error: `Failed to get team: ${msg}` }, 500);
+  } finally {
+    try { db.close(); } catch { /* ignore */ }
+  }
+
+  return true;
+}
+
+function handleTeamActivity(
+  res: ServerResponse,
+  deps: SharedContextDeps,
+  teamId: string,
+  limit: number,
+  agentFilter: string | null,
+  actionFilter: string | null,
+): boolean {
+  // Verify team exists
+  const teamDb = openDb(deps.teamDbPath);
+  if (!teamDb) {
+    deps.sendJson(res, { ok: false, error: 'Team service unavailable' }, 503);
+    return true;
+  }
+
+  let teamExists = false;
+  try {
+    const row = teamDb.prepare('SELECT id FROM teams WHERE id = ?').get(teamId);
+    teamExists = !!row;
+  } catch {
+    // ignore
+  } finally {
+    try { teamDb.close(); } catch { /* ignore */ }
+  }
+
+  if (!teamExists) {
+    deps.sendJson(res, { ok: false, error: 'Team not found' }, 404);
+    return true;
+  }
+
+  const auditDb = openDb(deps.auditDbPath);
+  if (!auditDb) {
+    deps.sendJson(res, {
+      teamId,
+      entries: [],
+      total: 0,
+      limit,
+      available: false,
+      message: 'Audit store unavailable',
+    });
+    return true;
+  }
+
+  try {
+    // Build query dynamically for filtering
+    let query = 'SELECT * FROM shared_context_audit WHERE team_id = ?';
+    const params: (string | number)[] = [teamId];
+
+    if (agentFilter) {
+      query += ' AND agent_id = ?';
+      params.push(agentFilter);
+    }
+    if (actionFilter) {
+      query += ' AND action = ?';
+      params.push(actionFilter);
+    }
+
+    query += ' ORDER BY timestamp DESC LIMIT ?';
+    params.push(limit);
+
+    const rows = auditDb.prepare(query).all(...params) as AuditRow[];
+
+    deps.sendJson(res, {
+      teamId,
+      entries: rows.map((r) => ({
+        id: r.id,
+        agentId: r.agent_id,
+        action: r.action,
+        filePath: r.file_path,
+        fileSizeBytes: r.file_size_bytes,
+        timestamp: r.timestamp,
+        detail: r.detail ?? null,
+      })),
+      total: rows.length,
+      limit,
+      available: true,
+    });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : 'Unknown error';
+    deps.sendJson(res, { ok: false, error: `Failed to query activity: ${msg}` }, 500);
+  } finally {
+    try { auditDb.close(); } catch { /* ignore */ }
+  }
+
+  return true;
+}
+
+function handleTeamFiles(
+  res: ServerResponse,
+  deps: SharedContextDeps,
+  teamId: string,
+): boolean {
+  const db = openDb(deps.teamDbPath);
+  if (!db) {
+    deps.sendJson(res, { ok: false, error: 'Team service unavailable' }, 503);
+    return true;
+  }
+
+  let teamName: string | null = null;
+  try {
+    const row = db.prepare('SELECT name FROM teams WHERE id = ?').get(teamId) as { name: string } | undefined;
+    if (!row) {
+      deps.sendJson(res, { ok: false, error: 'Team not found' }, 404);
+      return true;
+    }
+    teamName = row.name;
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : 'Unknown error';
+    deps.sendJson(res, { ok: false, error: `Failed to look up team: ${msg}` }, 500);
+    return true;
+  } finally {
+    try { db.close(); } catch { /* ignore */ }
+  }
+
+  if (!teamName) {
+    deps.sendJson(res, { ok: false, error: 'Team not found' }, 404);
+    return true;
+  }
+
+  const teamDir = resolveTeamDir(deps.sharedContextDir, teamName);
+
+  if (!teamDir) {
+    deps.sendJson(res, {
+      teamId,
+      teamName,
+      files: [],
+      total: 0,
+      totalSizeBytes: 0,
+      directoryExists: false,
+    });
+    return true;
+  }
+
+  try {
+    const files = listDirectoryFiles(teamDir);
+
+    // Enrich with manifest authors
+    const manifestAuthors = readManifestAuthors(teamDir);
+    for (const file of files) {
+      if (!file.author && manifestAuthors[file.path]) {
+        file.author = manifestAuthors[file.path];
+      }
+    }
+
+    const totalSizeBytes = files.reduce((sum, f) => sum + f.sizeBytes, 0);
+
+    deps.sendJson(res, {
+      teamId,
+      teamName,
+      files,
+      total: files.length,
+      totalSizeBytes,
+      directoryExists: true,
+    });
+  } catch (e: unknown) {
+    const msg = e instanceof Error ? e.message : 'Unknown error';
+    deps.sendJson(res, { ok: false, error: `Failed to list files: ${msg}` }, 500);
+  }
+
+  return true;
+}

--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -109,6 +109,7 @@ import { handleProgressionV2Api } from '../../lib/progression-http-v2.js';
 import { handleChangelog } from './routes/changelog.js';
 import { handleTaskBoard } from './routes/task-board.js';
 import { handleMemoryState } from './routes/memory-state.js';
+import { handleSharedContext } from './routes/shared-context.js';
 
 // ─── Configuration ───────────────────────────────────────────────────────────
 // All VentureOS data paths flow through lib/paths.ts (no os.homedir() needed).
@@ -2898,6 +2899,24 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
     })) return;
   } catch {
     // ignore
+  }
+
+  // Shared-Context Activity Feed — Phase 4 (#244)
+  if (req.url && req.url.startsWith('/api/shared-context/')) {
+    try {
+      if (handleSharedContext(req, res, {
+        teamDbPath: process.env.TEAM_DB_PATH ?? path.join(dataDir, 'teams.db'),
+        auditDbPath: process.env.AUDIT_DB_PATH ?? path.join(dataDir, 'shared-context-audit.db'),
+        sharedContextDir: SHARED_CONTEXT,
+        sendJson,
+        clampInt,
+      })) return;
+    } catch (e: unknown) {
+      const safe = toSafeError(e, { route: 'shared-context' });
+      slogError('dashboard', 'route_error', 'shared-context error', { errorRef: safe.errorRef });
+      sendJson(res, { ok: false, error: safe.error, errorRef: safe.errorRef }, safe.status);
+      return;
+    }
   }
 
   try {

--- a/dashboard/tests/unit/routes/shared-context.test.ts
+++ b/dashboard/tests/unit/routes/shared-context.test.ts
@@ -1,0 +1,882 @@
+/**
+ * Shared-Context (Cross-Agent Activity Feed) route handler tests
+ *
+ * Phase 4 (#244) of the Shared Agent Memory Layer (#217).
+ *
+ * Tests for:
+ *   GET /api/shared-context/teams
+ *   GET /api/shared-context/teams/:id
+ *   GET /api/shared-context/teams/:id/activity
+ *   GET /api/shared-context/teams/:id/files
+ *
+ * Test categories:
+ *   - Routing (returns false for non-matching URLs)
+ *   - Empty state / graceful degradation
+ *   - Happy-path with seeded data
+ *   - Filtering and pagination
+ *   - Auth-safe behavior (no auth bypass in route layer)
+ *   - Error handling
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+import Database from 'better-sqlite3';
+import { mockRequest, mockResponse, parseJsonBody } from '../../helpers.js';
+import { handleSharedContext } from '../../../server/routes/shared-context.js';
+import type { ServerResponse } from 'node:http';
+
+// ─── Test Setup ──────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+let teamDbPath: string;
+let auditDbPath: string;
+let sharedContextDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'shared-ctx-test-'));
+  teamDbPath = path.join(tmpDir, 'teams.db');
+  auditDbPath = path.join(tmpDir, 'audit.db');
+  sharedContextDir = path.join(tmpDir, 'shared-context');
+  fs.mkdirSync(sharedContextDir, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+function createDeps(overrides: Partial<{
+  teamDbPath: string;
+  auditDbPath: string;
+  sharedContextDir: string;
+}> = {}) {
+  return {
+    teamDbPath: overrides.teamDbPath ?? teamDbPath,
+    auditDbPath: overrides.auditDbPath ?? auditDbPath,
+    sharedContextDir: overrides.sharedContextDir ?? sharedContextDir,
+    sendJson: (res: ServerResponse, data: unknown, status = 200) => {
+      (res as any).writeHead(status, { 'Content-Type': 'application/json' });
+      (res as any).end(JSON.stringify(data));
+    },
+    clampInt: (n: string | number | null, lo: number, hi: number, dflt: number) => {
+      const v = parseInt(String(n));
+      if (Number.isNaN(v)) return dflt;
+      return Math.max(lo, Math.min(hi, v));
+    },
+  };
+}
+
+// ─── Database Helpers ────────────────────────────────────────────────────────
+
+function createTeamTables(dbPath: string): Database.Database {
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS teams (
+      id TEXT PRIMARY KEY,
+      name TEXT NOT NULL UNIQUE,
+      created_at TEXT NOT NULL DEFAULT (datetime('now')),
+      owner_user_id TEXT NOT NULL
+    );
+    CREATE TABLE IF NOT EXISTS team_agents (
+      team_id TEXT NOT NULL REFERENCES teams(id) ON DELETE CASCADE,
+      agent_id TEXT NOT NULL,
+      role TEXT NOT NULL CHECK(role IN ('member','curator','observer')),
+      joined_at TEXT NOT NULL DEFAULT (datetime('now')),
+      PRIMARY KEY (team_id, agent_id)
+    );
+    CREATE INDEX IF NOT EXISTS idx_team_agents_agent ON team_agents(agent_id);
+    CREATE INDEX IF NOT EXISTS idx_teams_name ON teams(name);
+  `);
+  return db;
+}
+
+function createAuditTables(dbPath: string): Database.Database {
+  const db = new Database(dbPath);
+  db.pragma('journal_mode = WAL');
+  db.pragma('foreign_keys = ON');
+  db.exec(`
+    CREATE TABLE IF NOT EXISTS shared_context_audit (
+      id TEXT PRIMARY KEY,
+      team_id TEXT NOT NULL,
+      agent_id TEXT NOT NULL,
+      action TEXT NOT NULL CHECK(action IN ('write','delete','read','rename','violation')),
+      file_path TEXT NOT NULL,
+      file_size_bytes INTEGER,
+      timestamp TEXT NOT NULL DEFAULT (datetime('now')),
+      detail TEXT
+    );
+    CREATE INDEX IF NOT EXISTS idx_audit_team_time ON shared_context_audit(team_id, timestamp);
+    CREATE INDEX IF NOT EXISTS idx_audit_agent ON shared_context_audit(agent_id);
+    CREATE INDEX IF NOT EXISTS idx_audit_file ON shared_context_audit(file_path);
+  `);
+  return db;
+}
+
+function seedTeam(opts: {
+  id?: string;
+  name?: string;
+  ownerUserId?: string;
+  agents?: Array<{ agentId: string; role?: string }>;
+}): string {
+  const id = opts.id ?? 'team-' + Math.random().toString(36).slice(2, 8);
+  const name = opts.name ?? 'test-team';
+  const now = new Date().toISOString();
+
+  const db = createTeamTables(teamDbPath);
+  db.prepare('INSERT INTO teams (id, name, created_at, owner_user_id) VALUES (?, ?, ?, ?)')
+    .run(id, name, now, opts.ownerUserId ?? 'user-1');
+
+  for (const agent of opts.agents ?? []) {
+    db.prepare('INSERT INTO team_agents (team_id, agent_id, role, joined_at) VALUES (?, ?, ?, ?)')
+      .run(id, agent.agentId, agent.role ?? 'member', now);
+  }
+
+  db.close();
+  return id;
+}
+
+function seedAuditEntries(entries: Array<{
+  teamId: string;
+  agentId?: string;
+  action?: string;
+  filePath?: string;
+  fileSizeBytes?: number;
+  timestamp?: string;
+  detail?: string;
+}>): void {
+  const db = createAuditTables(auditDbPath);
+  const stmt = db.prepare(`
+    INSERT INTO shared_context_audit (id, team_id, agent_id, action, file_path, file_size_bytes, timestamp, detail)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+  `);
+
+  for (let i = 0; i < entries.length; i++) {
+    const e = entries[i];
+    stmt.run(
+      `audit-${i}-${Math.random().toString(36).slice(2, 8)}`,
+      e.teamId,
+      e.agentId ?? 'nexus',
+      e.action ?? 'write',
+      e.filePath ?? `agent-outputs/nexus/output-${i}.md`,
+      e.fileSizeBytes ?? 1024,
+      e.timestamp ?? new Date(Date.now() - i * 60000).toISOString(),
+      e.detail ?? null,
+    );
+  }
+
+  db.close();
+}
+
+function scaffoldTeamDir(teamName: string, files?: Record<string, string>): string {
+  const safe = teamName.toLowerCase().replace(/[^a-z0-9\-_]/g, '');
+  const teamDir = path.join(sharedContextDir, safe);
+  fs.mkdirSync(path.join(teamDir, 'agent-outputs', 'nexus'), { recursive: true });
+  fs.mkdirSync(path.join(teamDir, 'agent-outputs', 'oracle'), { recursive: true });
+  fs.mkdirSync(path.join(teamDir, 'feedback'), { recursive: true });
+  fs.mkdirSync(path.join(teamDir, 'kpis'), { recursive: true });
+  fs.mkdirSync(path.join(teamDir, '.meta'), { recursive: true });
+
+  // Write priorities.md
+  fs.writeFileSync(
+    path.join(teamDir, 'priorities.md'),
+    '# Team Priorities\n\n_No priorities set yet._\n',
+  );
+
+  // Write manifest.json
+  fs.writeFileSync(
+    path.join(teamDir, '.meta', 'manifest.json'),
+    JSON.stringify({ files: [], lastSync: {} }, null, 2),
+  );
+
+  // Write additional files
+  if (files) {
+    for (const [relPath, content] of Object.entries(files)) {
+      const fullPath = path.join(teamDir, relPath);
+      fs.mkdirSync(path.dirname(fullPath), { recursive: true });
+      fs.writeFileSync(fullPath, content);
+    }
+  }
+
+  return teamDir;
+}
+
+// ─── Routing Tests ───────────────────────────────────────────────────────────
+
+describe('Shared-Context Routes — Routing', () => {
+  it('returns false for non-shared-context URLs', () => {
+    expect(handleSharedContext(
+      mockRequest({ url: '/api/sessions' }),
+      mockResponse(),
+      createDeps(),
+    )).toBe(false);
+  });
+
+  it('returns false for /api/shared-context without trailing slash path', () => {
+    // Only /api/shared-context/ prefix matches
+    expect(handleSharedContext(
+      mockRequest({ url: '/api/shared-contexts' }),
+      mockResponse(),
+      createDeps(),
+    )).toBe(false);
+  });
+
+  it('returns false for POST requests', () => {
+    expect(handleSharedContext(
+      mockRequest({ url: '/api/shared-context/teams', method: 'POST' }),
+      mockResponse(),
+      createDeps(),
+    )).toBe(false);
+  });
+
+  it('returns 404 for unknown sub-routes', () => {
+    // Need to seed a team for the sub-route check to matter
+    seedTeam({ id: 'team-1', name: 'alpha' });
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: '/api/shared-context/teams/team-1/unknown' }),
+      res,
+      createDeps(),
+    );
+    expect(res._statusCode).toBe(404);
+  });
+});
+
+// ─── GET /api/shared-context/teams ───────────────────────────────────────────
+
+describe('GET /api/shared-context/teams', () => {
+  it('returns empty list when no teams exist', () => {
+    // Create an empty database
+    const db = createTeamTables(teamDbPath);
+    db.close();
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: '/api/shared-context/teams' }),
+      res,
+      createDeps(),
+    );
+    const body = parseJsonBody(res);
+    expect(body.teams).toEqual([]);
+    expect(body.total).toBe(0);
+    expect(body.available).toBe(true);
+  });
+
+  it('returns unavailable when database does not exist', () => {
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: '/api/shared-context/teams' }),
+      res,
+      createDeps({ teamDbPath: path.join(tmpDir, 'nonexistent', 'no.db') }),
+    );
+    const body = parseJsonBody(res);
+    expect(body.teams).toEqual([]);
+    expect(body.available).toBe(false);
+  });
+
+  it('returns teams with agent counts', () => {
+    seedTeam({
+      id: 'team-alpha',
+      name: 'alpha-squad',
+      agents: [
+        { agentId: 'nexus', role: 'member' },
+        { agentId: 'oracle', role: 'member' },
+        { agentId: 'synth', role: 'observer' },
+      ],
+    });
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: '/api/shared-context/teams' }),
+      res,
+      createDeps(),
+    );
+    const body = parseJsonBody(res);
+    expect(body.total).toBe(1);
+    expect(body.teams).toHaveLength(1);
+
+    const team = (body.teams as any[])[0];
+    expect(team.id).toBe('team-alpha');
+    expect(team.name).toBe('alpha-squad');
+    expect(team.agentCount).toBe(3);
+    expect(team.agents).toHaveLength(3);
+    expect(team.agents[0].agentId).toBe('nexus');
+    expect(team.agents[0].role).toBe('member');
+  });
+
+  it('returns multiple teams', () => {
+    seedTeam({ id: 'team-a', name: 'alpha', agents: [{ agentId: 'nexus' }] });
+    // Need to re-open database for second team (seedTeam creates fresh tables)
+    const db = new Database(teamDbPath);
+    db.prepare('INSERT INTO teams (id, name, created_at, owner_user_id) VALUES (?, ?, ?, ?)')
+      .run('team-b', 'beta', new Date().toISOString(), 'user-1');
+    db.prepare('INSERT INTO team_agents (team_id, agent_id, role, joined_at) VALUES (?, ?, ?, ?)')
+      .run('team-b', 'oracle', 'member', new Date().toISOString());
+    db.prepare('INSERT INTO team_agents (team_id, agent_id, role, joined_at) VALUES (?, ?, ?, ?)')
+      .run('team-b', 'sentinel', 'curator', new Date().toISOString());
+    db.close();
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: '/api/shared-context/teams' }),
+      res,
+      createDeps(),
+    );
+    const body = parseJsonBody(res);
+    expect(body.total).toBe(2);
+  });
+
+  it('enriches with lastActivityAt from audit store', () => {
+    seedTeam({ id: 'team-a', name: 'alpha', agents: [{ agentId: 'nexus' }] });
+
+    const ts = '2026-02-17T12:00:00.000Z';
+    seedAuditEntries([{
+      teamId: 'team-a',
+      agentId: 'nexus',
+      action: 'write',
+      filePath: 'priorities.md',
+      timestamp: ts,
+    }]);
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: '/api/shared-context/teams' }),
+      res,
+      createDeps(),
+    );
+    const body = parseJsonBody(res);
+    const team = (body.teams as any[])[0];
+    expect(team.lastActivityAt).toBe(ts);
+  });
+});
+
+// ─── GET /api/shared-context/teams/:id ───────────────────────────────────────
+
+describe('GET /api/shared-context/teams/:id', () => {
+  it('returns 404 for non-existent team', () => {
+    const db = createTeamTables(teamDbPath);
+    db.close();
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: '/api/shared-context/teams/nonexistent' }),
+      res,
+      createDeps(),
+    );
+    expect(res._statusCode).toBe(404);
+  });
+
+  it('returns 503 when team service is unavailable', () => {
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: '/api/shared-context/teams/some-id' }),
+      res,
+      createDeps({ teamDbPath: path.join(tmpDir, 'nonexistent', 'no.db') }),
+    );
+    expect(res._statusCode).toBe(503);
+  });
+
+  it('returns team detail with agents', () => {
+    const teamId = seedTeam({
+      name: 'core-team',
+      agents: [
+        { agentId: 'nexus', role: 'member' },
+        { agentId: 'oracle', role: 'curator' },
+      ],
+    });
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: `/api/shared-context/teams/${teamId}` }),
+      res,
+      createDeps(),
+    );
+    expect(res._statusCode).toBe(200);
+    const body = parseJsonBody(res);
+    expect(body.name).toBe('core-team');
+    expect((body.agents as any[]).map((a: any) => a.agentId)).toEqual(['nexus', 'oracle']);
+  });
+
+  it('includes directory info when directory exists', () => {
+    const teamId = seedTeam({
+      name: 'dir-team',
+      agents: [{ agentId: 'nexus' }],
+    });
+    scaffoldTeamDir('dir-team', {
+      'agent-outputs/nexus/task-1.md': '# Task 1\nDone.',
+    });
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: `/api/shared-context/teams/${teamId}` }),
+      res,
+      createDeps(),
+    );
+    const body = parseJsonBody(res);
+    expect((body.directory as any).exists).toBe(true);
+    expect((body.directory as any).fileCount).toBeGreaterThan(0);
+    expect((body.directory as any).totalSizeBytes).toBeGreaterThan(0);
+  });
+
+  it('reports directory as non-existent when not scaffolded', () => {
+    const teamId = seedTeam({
+      name: 'no-dir-team',
+      agents: [{ agentId: 'nexus' }],
+    });
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: `/api/shared-context/teams/${teamId}` }),
+      res,
+      createDeps(),
+    );
+    const body = parseJsonBody(res);
+    expect((body.directory as any).exists).toBe(false);
+    expect((body.directory as any).fileCount).toBe(0);
+  });
+});
+
+// ─── GET /api/shared-context/teams/:id/activity ──────────────────────────────
+
+describe('GET /api/shared-context/teams/:id/activity', () => {
+  it('returns 404 for non-existent team', () => {
+    const db = createTeamTables(teamDbPath);
+    db.close();
+    createAuditTables(auditDbPath).close();
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: '/api/shared-context/teams/nonexistent/activity' }),
+      res,
+      createDeps(),
+    );
+    expect(res._statusCode).toBe(404);
+  });
+
+  it('returns empty entries when no audit data exists', () => {
+    const teamId = seedTeam({ name: 'empty-team', agents: [{ agentId: 'nexus' }] });
+    createAuditTables(auditDbPath).close();
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: `/api/shared-context/teams/${teamId}/activity` }),
+      res,
+      createDeps(),
+    );
+    const body = parseJsonBody(res);
+    expect(body.entries).toEqual([]);
+    expect(body.total).toBe(0);
+    expect(body.available).toBe(true);
+  });
+
+  it('returns audit entries sorted by most recent first', () => {
+    const teamId = seedTeam({ name: 'active-team', agents: [{ agentId: 'nexus' }] });
+
+    const entries = [
+      { teamId, agentId: 'nexus', action: 'write' as const, filePath: 'file-a.md', timestamp: '2026-02-17T10:00:00.000Z' },
+      { teamId, agentId: 'nexus', action: 'write' as const, filePath: 'file-b.md', timestamp: '2026-02-17T12:00:00.000Z' },
+      { teamId, agentId: 'oracle', action: 'delete' as const, filePath: 'file-c.md', timestamp: '2026-02-17T11:00:00.000Z' },
+    ];
+    seedAuditEntries(entries);
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: `/api/shared-context/teams/${teamId}/activity` }),
+      res,
+      createDeps(),
+    );
+    const body = parseJsonBody(res);
+    expect(body.total).toBe(3);
+    const entryList = body.entries as any[];
+    // Should be sorted most recent first (12:00, 11:00, 10:00)
+    expect(entryList[0].timestamp).toBe('2026-02-17T12:00:00.000Z');
+    expect(entryList[1].timestamp).toBe('2026-02-17T11:00:00.000Z');
+    expect(entryList[2].timestamp).toBe('2026-02-17T10:00:00.000Z');
+  });
+
+  it('respects limit parameter', () => {
+    const teamId = seedTeam({ name: 'limited-team', agents: [{ agentId: 'nexus' }] });
+
+    const entries = Array.from({ length: 20 }, (_, i) => ({
+      teamId,
+      agentId: 'nexus',
+      filePath: `file-${i}.md`,
+    }));
+    seedAuditEntries(entries);
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: `/api/shared-context/teams/${teamId}/activity?limit=5` }),
+      res,
+      createDeps(),
+    );
+    const body = parseJsonBody(res);
+    expect(body.total).toBe(5);
+    expect(body.limit).toBe(5);
+  });
+
+  it('clamps limit to bounded range', () => {
+    const teamId = seedTeam({ name: 'clamp-team', agents: [{ agentId: 'nexus' }] });
+    createAuditTables(auditDbPath).close();
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: `/api/shared-context/teams/${teamId}/activity?limit=999` }),
+      res,
+      createDeps(),
+    );
+    const body = parseJsonBody(res);
+    expect(body.limit).toBe(200); // clamped to max
+  });
+
+  it('uses default limit of 50 when not specified', () => {
+    const teamId = seedTeam({ name: 'default-team', agents: [{ agentId: 'nexus' }] });
+    createAuditTables(auditDbPath).close();
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: `/api/shared-context/teams/${teamId}/activity` }),
+      res,
+      createDeps(),
+    );
+    const body = parseJsonBody(res);
+    expect(body.limit).toBe(50);
+  });
+
+  it('filters by agent_id', () => {
+    const teamId = seedTeam({ name: 'filter-team', agents: [{ agentId: 'nexus' }, { agentId: 'oracle' }] });
+
+    seedAuditEntries([
+      { teamId, agentId: 'nexus', filePath: 'nexus-file.md' },
+      { teamId, agentId: 'oracle', filePath: 'oracle-file.md' },
+      { teamId, agentId: 'nexus', filePath: 'nexus-file2.md' },
+    ]);
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: `/api/shared-context/teams/${teamId}/activity?agent_id=nexus` }),
+      res,
+      createDeps(),
+    );
+    const body = parseJsonBody(res);
+    expect(body.total).toBe(2);
+    expect((body.entries as any[]).every((e: any) => e.agentId === 'nexus')).toBe(true);
+  });
+
+  it('filters by action type', () => {
+    const teamId = seedTeam({ name: 'action-filter-team', agents: [{ agentId: 'nexus' }] });
+
+    seedAuditEntries([
+      { teamId, agentId: 'nexus', action: 'write', filePath: 'write.md' },
+      { teamId, agentId: 'nexus', action: 'delete', filePath: 'delete.md' },
+      { teamId, agentId: 'nexus', action: 'write', filePath: 'write2.md' },
+    ]);
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: `/api/shared-context/teams/${teamId}/activity?action=delete` }),
+      res,
+      createDeps(),
+    );
+    const body = parseJsonBody(res);
+    expect(body.total).toBe(1);
+    expect((body.entries as any[])[0].action).toBe('delete');
+  });
+
+  it('returns entries with expected fields', () => {
+    const teamId = seedTeam({ name: 'fields-team', agents: [{ agentId: 'nexus' }] });
+
+    seedAuditEntries([{
+      teamId,
+      agentId: 'nexus',
+      action: 'write',
+      filePath: 'priorities.md',
+      fileSizeBytes: 2048,
+      detail: 'Updated priorities',
+    }]);
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: `/api/shared-context/teams/${teamId}/activity` }),
+      res,
+      createDeps(),
+    );
+    const body = parseJsonBody(res);
+    const entry = (body.entries as any[])[0];
+    expect(entry).toHaveProperty('id');
+    expect(entry).toHaveProperty('agentId');
+    expect(entry).toHaveProperty('action');
+    expect(entry).toHaveProperty('filePath');
+    expect(entry).toHaveProperty('fileSizeBytes');
+    expect(entry).toHaveProperty('timestamp');
+    expect(entry).toHaveProperty('detail');
+    expect(entry.agentId).toBe('nexus');
+    expect(entry.action).toBe('write');
+    expect(entry.filePath).toBe('priorities.md');
+    expect(entry.fileSizeBytes).toBe(2048);
+    expect(entry.detail).toBe('Updated priorities');
+  });
+
+  it('returns unavailable when audit store cannot be opened', () => {
+    const teamId = seedTeam({ name: 'no-audit-team', agents: [{ agentId: 'nexus' }] });
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: `/api/shared-context/teams/${teamId}/activity` }),
+      res,
+      createDeps({ auditDbPath: path.join(tmpDir, 'nonexistent', 'dir', 'audit.db') }),
+    );
+    const body = parseJsonBody(res);
+    expect(body.entries).toEqual([]);
+    expect(body.available).toBe(false);
+  });
+});
+
+// ─── GET /api/shared-context/teams/:id/files ─────────────────────────────────
+
+describe('GET /api/shared-context/teams/:id/files', () => {
+  it('returns 404 for non-existent team', () => {
+    const db = createTeamTables(teamDbPath);
+    db.close();
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: '/api/shared-context/teams/nonexistent/files' }),
+      res,
+      createDeps(),
+    );
+    expect(res._statusCode).toBe(404);
+  });
+
+  it('returns empty file list when directory does not exist', () => {
+    const teamId = seedTeam({ name: 'no-dir-team', agents: [{ agentId: 'nexus' }] });
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: `/api/shared-context/teams/${teamId}/files` }),
+      res,
+      createDeps(),
+    );
+    const body = parseJsonBody(res);
+    expect(body.files).toEqual([]);
+    expect(body.directoryExists).toBe(false);
+    expect(body.total).toBe(0);
+  });
+
+  it('lists files with metadata', () => {
+    const teamId = seedTeam({ name: 'files-team', agents: [{ agentId: 'nexus' }] });
+    scaffoldTeamDir('files-team', {
+      'agent-outputs/nexus/task-1.md': '# Task 1\nCompleted successfully.',
+      'agent-outputs/oracle/analysis.md': '# Analysis\nInsights here.',
+    });
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: `/api/shared-context/teams/${teamId}/files` }),
+      res,
+      createDeps(),
+    );
+    const body = parseJsonBody(res);
+    expect(body.directoryExists).toBe(true);
+    expect(body.total).toBeGreaterThan(0);
+    expect(body.totalSizeBytes).toBeGreaterThan(0);
+
+    const files = body.files as any[];
+    // Find the task-1.md file
+    const taskFile = files.find((f: any) => f.path === 'agent-outputs/nexus/task-1.md');
+    expect(taskFile).toBeDefined();
+    expect(taskFile.sizeBytes).toBeGreaterThan(0);
+    expect(taskFile.lastModified).toBeTruthy();
+    expect(taskFile.isDirectory).toBe(false);
+    expect(taskFile.author).toBe('nexus'); // inferred from path
+  });
+
+  it('includes directories in listing', () => {
+    const teamId = seedTeam({ name: 'dirs-team', agents: [{ agentId: 'nexus' }] });
+    scaffoldTeamDir('dirs-team');
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: `/api/shared-context/teams/${teamId}/files` }),
+      res,
+      createDeps(),
+    );
+    const body = parseJsonBody(res);
+    const files = body.files as any[];
+    const dirs = files.filter((f: any) => f.isDirectory);
+    expect(dirs.length).toBeGreaterThan(0);
+    // Check standard directories exist
+    const dirNames = dirs.map((d: any) => d.name);
+    expect(dirNames).toContain('agent-outputs');
+    expect(dirNames).toContain('feedback');
+    expect(dirNames).toContain('kpis');
+  });
+
+  it('excludes .meta directory from listing', () => {
+    const teamId = seedTeam({ name: 'meta-team', agents: [{ agentId: 'nexus' }] });
+    scaffoldTeamDir('meta-team');
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: `/api/shared-context/teams/${teamId}/files` }),
+      res,
+      createDeps(),
+    );
+    const body = parseJsonBody(res);
+    const files = body.files as any[];
+    const metaEntries = files.filter((f: any) =>
+      f.path === '.meta' || f.path.startsWith('.meta/'),
+    );
+    expect(metaEntries).toHaveLength(0);
+  });
+
+  it('enriches author from manifest when available', () => {
+    const teamId = seedTeam({ name: 'manifest-team', agents: [{ agentId: 'nexus' }] });
+    scaffoldTeamDir('manifest-team', {
+      'priorities.md': '# Updated priorities\n- Task A\n',
+    });
+
+    // Write a manifest with author info
+    const teamDir = path.join(sharedContextDir, 'manifest-team');
+    fs.writeFileSync(
+      path.join(teamDir, '.meta', 'manifest.json'),
+      JSON.stringify({
+        files: [
+          { path: 'priorities.md', lastModifiedBy: 'synth', lastModifiedAt: '2026-02-17T12:00:00Z', sizeBytes: 50 },
+        ],
+        lastSync: {},
+      }),
+    );
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: `/api/shared-context/teams/${teamId}/files` }),
+      res,
+      createDeps(),
+    );
+    const body = parseJsonBody(res);
+    const files = body.files as any[];
+    const prioritiesFile = files.find((f: any) => f.path === 'priorities.md');
+    expect(prioritiesFile).toBeDefined();
+    expect(prioritiesFile.author).toBe('synth'); // from manifest
+  });
+
+  it('returns 503 when team service is unavailable', () => {
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: '/api/shared-context/teams/some-id/files' }),
+      res,
+      createDeps({ teamDbPath: path.join(tmpDir, 'nonexistent', 'no.db') }),
+    );
+    expect(res._statusCode).toBe(503);
+  });
+});
+
+// ─── Auth-Safe Behavior ──────────────────────────────────────────────────────
+
+describe('Auth-Safe Route Behavior', () => {
+  it('does not expose filesystem paths outside shared-context', () => {
+    const teamId = seedTeam({ name: 'safe-team', agents: [{ agentId: 'nexus' }] });
+    scaffoldTeamDir('safe-team');
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: `/api/shared-context/teams/${teamId}/files` }),
+      res,
+      createDeps(),
+    );
+    const body = parseJsonBody(res);
+    const files = body.files as any[];
+
+    // File paths should be relative, not absolute
+    for (const file of files) {
+      expect(file.path).not.toMatch(/^\//);
+      expect(file.path).not.toContain('..');
+    }
+  });
+
+  it('does not handle non-GET methods (relies on existing auth middleware)', () => {
+    // The route handler rejects non-GET methods, returning false
+    // so the server's auth middleware handles them
+    const putResult = handleSharedContext(
+      mockRequest({ url: '/api/shared-context/teams', method: 'PUT' }),
+      mockResponse(),
+      createDeps(),
+    );
+    expect(putResult).toBe(false);
+
+    const deleteResult = handleSharedContext(
+      mockRequest({ url: '/api/shared-context/teams', method: 'DELETE' }),
+      mockResponse(),
+      createDeps(),
+    );
+    expect(deleteResult).toBe(false);
+  });
+});
+
+// ─── Edge Cases ──────────────────────────────────────────────────────────────
+
+describe('Edge Cases', () => {
+  it('handles URL-encoded team IDs', () => {
+    const teamId = seedTeam({ name: 'encoded-team', agents: [{ agentId: 'nexus' }] });
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: `/api/shared-context/teams/${encodeURIComponent(teamId)}` }),
+      res,
+      createDeps(),
+    );
+    expect(res._statusCode).toBe(200);
+  });
+
+  it('handles team with no agents', () => {
+    const teamId = seedTeam({ name: 'empty-agents-team', agents: [] });
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: `/api/shared-context/teams/${teamId}` }),
+      res,
+      createDeps(),
+    );
+    const body = parseJsonBody(res);
+    expect(body.agents).toEqual([]);
+  });
+
+  it('handles combined agent and action filters on activity', () => {
+    const teamId = seedTeam({ name: 'combo-team', agents: [{ agentId: 'nexus' }, { agentId: 'oracle' }] });
+
+    seedAuditEntries([
+      { teamId, agentId: 'nexus', action: 'write', filePath: 'a.md' },
+      { teamId, agentId: 'nexus', action: 'delete', filePath: 'b.md' },
+      { teamId, agentId: 'oracle', action: 'write', filePath: 'c.md' },
+      { teamId, agentId: 'oracle', action: 'delete', filePath: 'd.md' },
+    ]);
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: `/api/shared-context/teams/${teamId}/activity?agent_id=nexus&action=write` }),
+      res,
+      createDeps(),
+    );
+    const body = parseJsonBody(res);
+    expect(body.total).toBe(1);
+    expect((body.entries as any[])[0].agentId).toBe('nexus');
+    expect((body.entries as any[])[0].action).toBe('write');
+  });
+
+  it('handles invalid limit gracefully (uses default)', () => {
+    const teamId = seedTeam({ name: 'bad-limit-team', agents: [{ agentId: 'nexus' }] });
+    createAuditTables(auditDbPath).close();
+
+    const res = mockResponse();
+    handleSharedContext(
+      mockRequest({ url: `/api/shared-context/teams/${teamId}/activity?limit=not-a-number` }),
+      res,
+      createDeps(),
+    );
+    const body = parseJsonBody(res);
+    expect(body.limit).toBe(50); // default
+  });
+});


### PR DESCRIPTION
## Summary

Implements Phase 4 (#244) of the [Shared Agent Memory Layer epic (#217)](https://github.com/zachyzissou/ventureos/issues/217): **Dashboard Cross-Agent Activity Feed**.

Adds 4 read-only API endpoints that surface cross-agent shared-context data in the dashboard, integrating with the TeamService (#241) and SharedContextAuditStore (#243) from prior phases.

## Endpoints

| Method | Path | Description |
|--------|------|-------------|
| GET | `/api/shared-context/teams` | List all teams with agent counts + last activity timestamp |
| GET | `/api/shared-context/teams/:id` | Team detail (metadata, membership, directory info) |
| GET | `/api/shared-context/teams/:id/activity` | Paginated audit trail with `agent_id` / `action` filters |
| GET | `/api/shared-context/teams/:id/files` | Directory listing with file size, last modified, author |

## Implementation Details

- **Direct better-sqlite3 queries** against the existing TeamService and AuditStore schemas (avoids CJS/ESM boundary issues that other dashboard routes face)
- **Bounded queries**: limit clamped to [1, 200], default 50; file listing capped at 200 entries
- **Path traversal protection**: team directory resolution validates against shared-context root
- **Manifest-based author attribution**: enriches file listing from `.meta/manifest.json` when available
- **Graceful degradation**: returns `available: false` with empty data when databases/directories don't exist (no 500s)
- **Follows existing patterns**: dependency injection, sendJson, route handler returns boolean, error handling via toSafeError

## Files Changed

| File | Change |
|------|--------|
| `dashboard/server/routes/shared-context.ts` | **NEW** — Route handler (4 endpoints) |
| `dashboard/server/routes/index.ts` | Export barrel update |
| `dashboard/server/server.ts` | Route dispatch wiring |
| `dashboard/tests/unit/routes/shared-context.test.ts` | **NEW** — 37 unit tests |

## Test Results

```
✓ tests/unit/routes/shared-context.test.ts (37 tests) 89ms

Test categories:
  - Routing (4 tests): URL matching, method filtering, unknown sub-routes
  - GET /api/shared-context/teams (5 tests): empty state, agent counts, multiple teams, audit enrichment
  - GET /api/shared-context/teams/:id (5 tests): 404/503, detail, directory info
  - GET /api/shared-context/teams/:id/activity (10 tests): sorting, pagination, filtering, field validation
  - GET /api/shared-context/teams/:id/files (7 tests): metadata, directories, .meta exclusion, manifest authors
  - Auth-safe behavior (2 tests): relative paths, method rejection
  - Edge cases (4 tests): URL encoding, empty agents, combined filters, invalid limits

Full dashboard suite: 419 tests passed (31 files), 0 failed
TypeScript: tsc --noEmit passes cleanly
```

## Scope Boundaries

- ✅ Dashboard API surfaces for cross-agent activity feed
- ✅ Integration with existing audit trail from #243
- ✅ Tests for filtering, pagination/order, and auth-safe route behavior
- ❌ Does NOT implement curator/roundtable workflows (#245)
- ❌ No client-side UI components (API-only — client panel is a follow-up)
- ❌ No new auth changes (uses existing middleware pipeline)

## Risks / Follow-ups

1. **Client-side panel**: These endpoints are API-only. A dashboard UI component (activity timeline, team selector, file browser) would be the natural next step.
2. **Database path configuration**: Defaults to `dashboard/data/teams.db` and `dashboard/data/shared-context-audit.db`. The server wires these via env vars `TEAM_DB_PATH` / `AUDIT_DB_PATH` if needed.
3. **Performance**: All queries are bounded (max 200 results, max 200 files). For very large teams with thousands of audit entries, the SQL filtering approach is efficient (uses indexed columns).
4. **Read-only mode**: The route handler opens databases in readonly mode for safety. Write operations remain in the lib/ services.

Closes #244