### PR TITLE
feat(#245): Curator Agent Template + Daily Roundtable (Phase 5)

### DIFF
--- a/lib/__tests__/curator-agent.test.ts
+++ b/lib/__tests__/curator-agent.test.ts
@@ -1,0 +1,758 @@
+/**
+ * Tests for CuratorAgent + RoundtableScheduler — Issue #245
+ * Phase 5 of #217 (Shared Agent Memory Layer)
+ *
+ * Validates:
+ * - Roundtable synthesis with multiple agent outputs
+ * - Empty day handling (no outputs = graceful skip)
+ * - Token budget enforcement (<5KB output)
+ * - Priority extraction and update
+ * - Single-agent degenerate case
+ * - Concurrent run protection (mutex)
+ * - Timeout enforcement
+ * - File collection logic (date matching)
+ * - Scheduler cron parsing and shouldRunNow logic
+ * - Scheduler runIfDue / forceRun integration
+ * - LLM failure resilience
+ * - Input size limit enforcement
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import os from 'node:os';
+
+// ─── Test Helpers ───────────────────────────────────────────────────────────
+
+let tmpDir: string;
+let sharedContextRoot: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'curator-agent-test-'));
+  sharedContextRoot = path.join(tmpDir, 'shared-context');
+  fs.mkdirSync(sharedContextRoot, { recursive: true });
+
+  // Point SHARED_CONTEXT to our temp dir
+  process.env.SHARED_CONTEXT = sharedContextRoot;
+  jest.resetModules();
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+  delete process.env.SHARED_CONTEXT;
+  jest.resetModules();
+});
+
+/**
+ * Create a team shared-context directory with agent outputs.
+ */
+function setupTeamOutputs(
+  teamName: string,
+  outputs: Array<{ agentId: string; filename: string; content: string; mtime?: Date }>,
+): string {
+  const teamDir = path.join(sharedContextRoot, teamName);
+  const agentOutputsDir = path.join(teamDir, 'agent-outputs');
+  const roundtableDir = path.join(teamDir, 'roundtable');
+  fs.mkdirSync(agentOutputsDir, { recursive: true });
+  fs.mkdirSync(roundtableDir, { recursive: true });
+
+  for (const output of outputs) {
+    const agentDir = path.join(agentOutputsDir, output.agentId);
+    fs.mkdirSync(agentDir, { recursive: true });
+    const filePath = path.join(agentDir, output.filename);
+    fs.writeFileSync(filePath, output.content, 'utf-8');
+    if (output.mtime) {
+      fs.utimesSync(filePath, output.mtime, output.mtime);
+    }
+  }
+
+  return teamDir;
+}
+
+/** Create a mock LLM client that returns a predetermined response. */
+function mockLLM(response: string = '# Daily Roundtable\n\nTest roundtable content.') {
+  return {
+    chatCompletion: jest.fn().mockResolvedValue(response),
+  };
+}
+
+/** Create a mock LLM that returns different responses for synthesis vs priority calls. */
+function mockLLMWithPriorities(
+  synthesisResponse: string = '# Daily Roundtable\n\nSynthesis.',
+  priorityResponse: string = '# Team Priorities\n\n1. Test priority',
+) {
+  const fn = jest.fn()
+    .mockResolvedValueOnce(synthesisResponse)
+    .mockResolvedValueOnce(priorityResponse);
+  return { chatCompletion: fn };
+}
+
+/** Create a mock LLM that throws on the first call. */
+function mockLLMFailing(error: string = 'LLM API error') {
+  return {
+    chatCompletion: jest.fn().mockRejectedValue(new Error(error)),
+  };
+}
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('CuratorAgent', () => {
+  async function createCurator(overrides: Record<string, any> = {}) {
+    const { CuratorAgent } = await import('../curator-agent');
+    const llm = overrides.llm ?? mockLLM();
+    return {
+      curator: new CuratorAgent({
+        llm,
+        timeoutMs: overrides.timeoutMs ?? 5000,
+        now: overrides.now ?? (() => new Date('2026-02-18T23:00:00Z')),
+        ...overrides,
+      }),
+      llm,
+    };
+  }
+
+  // ─── Core Synthesis ─────────────────────────────────────────────────
+
+  describe('synthesize()', () => {
+    it('produces roundtable from multiple agent outputs', async () => {
+      setupTeamOutputs('test-team', [
+        { agentId: 'nexus', filename: '2026-02-18-status.md', content: 'Nexus completed PR #42.' },
+        { agentId: 'oracle', filename: '2026-02-18-research.md', content: 'Oracle found 3 security risks.' },
+        { agentId: 'synth', filename: '2026-02-18-build.md', content: 'Synth deployed v2.1.0.' },
+      ]);
+
+      const roundtableContent = '# Daily Roundtable — 2026-02-18\n\n## Summary\nThree agents active.\n\n## Agent Activity\n- **nexus**: Completed PR #42\n- **oracle**: Found 3 security risks\n- **synth**: Deployed v2.1.0';
+      const { curator, llm } = await createCurator({ llm: mockLLMWithPriorities(roundtableContent) });
+
+      const result = await curator.synthesize('test-team', '2026-02-18');
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBe(false);
+      expect(result.agentCount).toBe(3);
+      expect(result.fileCount).toBe(3);
+      expect(result.roundtablePath).toContain('roundtable/2026-02-18.md');
+      expect(result.outputBytes).toBeGreaterThan(0);
+      expect(result.durationMs).toBeGreaterThanOrEqual(0);
+
+      // Verify file was actually written
+      const written = fs.readFileSync(result.roundtablePath!, 'utf-8');
+      expect(written).toContain('Daily Roundtable');
+
+      // Verify LLM was called with correct structure
+      expect(llm.chatCompletion).toHaveBeenCalledTimes(2); // synthesis + priority
+      const firstCall = llm.chatCompletion.mock.calls[0][0];
+      expect(firstCall.messages[0].role).toBe('system');
+      expect(firstCall.messages[1].role).toBe('user');
+      expect(firstCall.messages[1].content.toLowerCase()).toContain('nexus');
+      expect(firstCall.messages[1].content.toLowerCase()).toContain('oracle');
+      expect(firstCall.messages[1].content.toLowerCase()).toContain('synth');
+    });
+
+    it('handles single-agent degenerate case', async () => {
+      setupTeamOutputs('solo-team', [
+        { agentId: 'nexus', filename: '2026-02-18-work.md', content: 'Only agent working today.' },
+      ]);
+
+      const { curator } = await createCurator({ llm: mockLLMWithPriorities() });
+      const result = await curator.synthesize('solo-team', '2026-02-18');
+
+      expect(result.success).toBe(true);
+      expect(result.agentCount).toBe(1);
+      expect(result.fileCount).toBe(1);
+      expect(result.roundtablePath).not.toBeNull();
+    });
+
+    it('gracefully skips when no outputs exist for the day', async () => {
+      // Create team dir but no outputs for target date
+      const teamDir = path.join(sharedContextRoot, 'empty-team');
+      fs.mkdirSync(path.join(teamDir, 'agent-outputs', 'nexus'), { recursive: true });
+      const oldFilePath = path.join(teamDir, 'agent-outputs', 'nexus', '2026-02-17-old.md');
+      fs.writeFileSync(oldFilePath, 'Old stuff');
+      // Set mtime to an old date so it doesn't match 2026-02-18
+      const oldDate = new Date('2026-02-17T12:00:00Z');
+      fs.utimesSync(oldFilePath, oldDate, oldDate);
+
+      const { curator, llm } = await createCurator();
+      const result = await curator.synthesize('empty-team', '2026-02-18');
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBe(true);
+      expect(result.agentCount).toBe(0);
+      expect(result.roundtablePath).toBeNull();
+      // LLM should NOT have been called
+      expect(llm.chatCompletion).not.toHaveBeenCalled();
+    });
+
+    it('gracefully skips when agent-outputs directory does not exist', async () => {
+      const teamDir = path.join(sharedContextRoot, 'no-outputs-team');
+      fs.mkdirSync(teamDir, { recursive: true });
+
+      const { curator, llm } = await createCurator();
+      const result = await curator.synthesize('no-outputs-team', '2026-02-18');
+
+      expect(result.success).toBe(true);
+      expect(result.skipped).toBe(true);
+      expect(llm.chatCompletion).not.toHaveBeenCalled();
+    });
+
+    it('uses today date when no date parameter provided', async () => {
+      const fixedDate = new Date('2026-02-18T23:00:00Z');
+      setupTeamOutputs('auto-date-team', [
+        { agentId: 'nexus', filename: '2026-02-18-work.md', content: 'Work done.' },
+      ]);
+
+      const { curator } = await createCurator({
+        llm: mockLLMWithPriorities(),
+        now: () => fixedDate,
+      });
+      const result = await curator.synthesize('auto-date-team');
+
+      expect(result.date).toBe('2026-02-18');
+      expect(result.success).toBe(true);
+    });
+  });
+
+  // ─── Token Budget Enforcement ───────────────────────────────────────
+
+  describe('output size enforcement', () => {
+    it('truncates roundtable output exceeding 5KB', async () => {
+      setupTeamOutputs('big-output-team', [
+        { agentId: 'nexus', filename: '2026-02-18-work.md', content: 'Work done.' },
+      ]);
+
+      // Generate a response >5KB
+      const bigResponse = '# Roundtable\n\n' + 'A'.repeat(6000);
+      const { curator } = await createCurator({
+        llm: mockLLMWithPriorities(bigResponse),
+      });
+
+      const result = await curator.synthesize('big-output-team', '2026-02-18');
+
+      expect(result.success).toBe(true);
+      const written = fs.readFileSync(result.roundtablePath!, 'utf-8');
+      expect(Buffer.byteLength(written, 'utf-8')).toBeLessThanOrEqual(5100); // small tolerance for truncation footer
+      expect(written).toContain('truncated');
+    });
+
+    it('respects custom maxOutputBytes', async () => {
+      setupTeamOutputs('custom-limit-team', [
+        { agentId: 'nexus', filename: '2026-02-18-work.md', content: 'Work done.' },
+      ]);
+
+      const response = 'A'.repeat(3000);
+      const { curator } = await createCurator({
+        llm: mockLLMWithPriorities(response),
+        maxOutputBytes: 2000,
+      });
+
+      const result = await curator.synthesize('custom-limit-team', '2026-02-18');
+      expect(result.success).toBe(true);
+      const written = fs.readFileSync(result.roundtablePath!, 'utf-8');
+      expect(written).toContain('truncated');
+    });
+  });
+
+  // ─── Input Size Enforcement ─────────────────────────────────────────
+
+  describe('input size enforcement', () => {
+    it('rejects when total input exceeds maxInputBytes', async () => {
+      setupTeamOutputs('huge-input-team', [
+        { agentId: 'nexus', filename: '2026-02-18-huge.md', content: 'X'.repeat(50_000) },
+        { agentId: 'oracle', filename: '2026-02-18-huge.md', content: 'Y'.repeat(60_000) },
+      ]);
+
+      const { curator, llm } = await createCurator({ maxInputBytes: 80_000 });
+      const result = await curator.synthesize('huge-input-team', '2026-02-18');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('exceeds limit');
+      expect(llm.chatCompletion).not.toHaveBeenCalled();
+    });
+  });
+
+  // ─── Priority Update ───────────────────────────────────────────────
+
+  describe('priority update', () => {
+    it('writes updated priorities.md after synthesis', async () => {
+      setupTeamOutputs('priority-team', [
+        { agentId: 'nexus', filename: '2026-02-18-work.md', content: 'Shipped feature X.' },
+      ]);
+
+      const priorityContent = '# Team Priorities\n\n_Updated: 2026-02-18_\n\n1. Ship feature Y (source: roundtable)';
+      const { curator } = await createCurator({
+        llm: mockLLMWithPriorities('# Roundtable\n\nContent.', priorityContent),
+        updatePriorities: true,
+      });
+
+      const result = await curator.synthesize('priority-team', '2026-02-18');
+
+      expect(result.success).toBe(true);
+      expect(result.prioritiesPath).not.toBeNull();
+      const written = fs.readFileSync(result.prioritiesPath!, 'utf-8');
+      expect(written).toContain('Team Priorities');
+      expect(written).toContain('feature Y');
+    });
+
+    it('skips priority update when updatePriorities is false', async () => {
+      setupTeamOutputs('no-priority-team', [
+        { agentId: 'nexus', filename: '2026-02-18-work.md', content: 'Work.' },
+      ]);
+
+      const { curator, llm } = await createCurator({
+        llm: mockLLM(),
+        updatePriorities: false,
+      });
+      const result = await curator.synthesize('no-priority-team', '2026-02-18');
+
+      expect(result.success).toBe(true);
+      expect(result.prioritiesPath).toBeNull();
+      // Only 1 LLM call (synthesis only, no priority)
+      expect(llm.chatCompletion).toHaveBeenCalledTimes(1);
+    });
+
+    it('succeeds even when priority update LLM call fails', async () => {
+      setupTeamOutputs('priority-fail-team', [
+        { agentId: 'nexus', filename: '2026-02-18-work.md', content: 'Work.' },
+      ]);
+
+      const llm = {
+        chatCompletion: jest.fn()
+          .mockResolvedValueOnce('# Roundtable\n\nContent.') // synthesis succeeds
+          .mockRejectedValueOnce(new Error('Priority LLM failed')), // priority fails
+      };
+
+      const { curator } = await createCurator({ llm, updatePriorities: true });
+      const result = await curator.synthesize('priority-fail-team', '2026-02-18');
+
+      // Overall run still succeeds — priority failure is non-fatal
+      expect(result.success).toBe(true);
+      expect(result.roundtablePath).not.toBeNull();
+      expect(result.prioritiesPath).toBeNull();
+    });
+  });
+
+  // ─── LLM Failure Resilience ─────────────────────────────────────────
+
+  describe('LLM failure handling', () => {
+    it('returns failure result when synthesis LLM call fails', async () => {
+      setupTeamOutputs('llm-fail-team', [
+        { agentId: 'nexus', filename: '2026-02-18-work.md', content: 'Work.' },
+      ]);
+
+      const { curator } = await createCurator({ llm: mockLLMFailing('API timeout') });
+      const result = await curator.synthesize('llm-fail-team', '2026-02-18');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('API timeout');
+      expect(result.roundtablePath).toBeNull();
+    });
+  });
+
+  // ─── Concurrent Run Protection ──────────────────────────────────────
+
+  describe('mutex / concurrent run protection', () => {
+    it('blocks concurrent synthesis runs', async () => {
+      setupTeamOutputs('mutex-team', [
+        { agentId: 'nexus', filename: '2026-02-18-work.md', content: 'Work.' },
+      ]);
+
+      // LLM that takes time to resolve
+      let resolveCall: (value: string) => void;
+      const llm = {
+        chatCompletion: jest.fn().mockImplementation(
+          () => new Promise<string>((resolve) => { resolveCall = resolve; }),
+        ),
+      };
+
+      const { curator } = await createCurator({ llm, updatePriorities: false });
+
+      // Start first run (will block on LLM)
+      const firstRun = curator.synthesize('mutex-team', '2026-02-18');
+
+      // Wait a tick for the first run to acquire the mutex
+      await new Promise(r => setTimeout(r, 10));
+
+      // Second run should be blocked
+      const secondResult = await curator.synthesize('mutex-team', '2026-02-18');
+      expect(secondResult.success).toBe(false);
+      expect(secondResult.skipped).toBe(true);
+      expect(secondResult.error).toContain('concurrent');
+
+      // Complete the first run
+      resolveCall!('# Roundtable');
+      const firstResult = await firstRun;
+      expect(firstResult.success).toBe(true);
+    });
+  });
+
+  // ─── Timeout Enforcement ────────────────────────────────────────────
+
+  describe('timeout enforcement', () => {
+    it('times out long-running synthesis', async () => {
+      setupTeamOutputs('timeout-team', [
+        { agentId: 'nexus', filename: '2026-02-18-work.md', content: 'Work.' },
+      ]);
+
+      // LLM that never resolves
+      const llm = {
+        chatCompletion: jest.fn().mockImplementation(
+          () => new Promise(() => { /* never resolves */ }),
+        ),
+      };
+
+      const { curator } = await createCurator({ llm, timeoutMs: 100 });
+      const result = await curator.synthesize('timeout-team', '2026-02-18');
+
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('timed out');
+    }, 10_000);
+  });
+
+  // ─── File Collection Logic ──────────────────────────────────────────
+
+  describe('collectAgentOutputs()', () => {
+    it('matches files by date in filename', async () => {
+      setupTeamOutputs('collect-team', [
+        { agentId: 'nexus', filename: '2026-02-18-report.md', content: 'Today report' },
+        { agentId: 'nexus', filename: '2026-02-17-old.md', content: 'Yesterday report', mtime: new Date('2026-02-17T12:00:00Z') },
+      ]);
+
+      const { CuratorAgent } = await import('../curator-agent');
+      const curator = new CuratorAgent({ llm: mockLLM() });
+      const outputsDir = path.join(sharedContextRoot, 'collect-team', 'agent-outputs');
+      const results = curator.collectAgentOutputs(outputsDir, '2026-02-18');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].filename).toBe('2026-02-18-report.md');
+      expect(results[0].agentId).toBe('nexus');
+    });
+
+    it('matches files by modification date', async () => {
+      const today = new Date('2026-02-18T12:00:00Z');
+      setupTeamOutputs('mtime-team', [
+        { agentId: 'oracle', filename: 'analysis.md', content: 'Analysis', mtime: today },
+        { agentId: 'oracle', filename: 'old-analysis.md', content: 'Old', mtime: new Date('2026-02-16T12:00:00Z') },
+      ]);
+
+      const { CuratorAgent } = await import('../curator-agent');
+      const curator = new CuratorAgent({ llm: mockLLM() });
+      const outputsDir = path.join(sharedContextRoot, 'mtime-team', 'agent-outputs');
+      const results = curator.collectAgentOutputs(outputsDir, '2026-02-18');
+
+      expect(results).toHaveLength(1);
+      expect(results[0].filename).toBe('analysis.md');
+    });
+
+    it('returns empty array when directory is missing', async () => {
+      const { CuratorAgent } = await import('../curator-agent');
+      const curator = new CuratorAgent({ llm: mockLLM() });
+      const results = curator.collectAgentOutputs('/nonexistent/path', '2026-02-18');
+
+      expect(results).toEqual([]);
+    });
+
+    it('sorts outputs by agent then filename', async () => {
+      setupTeamOutputs('sort-team', [
+        { agentId: 'synth', filename: '2026-02-18-b.md', content: 'B' },
+        { agentId: 'nexus', filename: '2026-02-18-a.md', content: 'A' },
+        { agentId: 'synth', filename: '2026-02-18-a.md', content: 'A' },
+        { agentId: 'nexus', filename: '2026-02-18-b.md', content: 'B' },
+      ]);
+
+      const { CuratorAgent } = await import('../curator-agent');
+      const curator = new CuratorAgent({ llm: mockLLM() });
+      const outputsDir = path.join(sharedContextRoot, 'sort-team', 'agent-outputs');
+      const results = curator.collectAgentOutputs(outputsDir, '2026-02-18');
+
+      expect(results.map(r => `${r.agentId}/${r.filename}`)).toEqual([
+        'nexus/2026-02-18-a.md',
+        'nexus/2026-02-18-b.md',
+        'synth/2026-02-18-a.md',
+        'synth/2026-02-18-b.md',
+      ]);
+    });
+
+    it('respects MAX_FILES_PER_DAY limit', async () => {
+      const outputs = Array.from({ length: 60 }, (_, i) => ({
+        agentId: 'nexus',
+        filename: `2026-02-18-file-${String(i).padStart(3, '0')}.md`,
+        content: `File ${i}`,
+      }));
+      setupTeamOutputs('many-files-team', outputs);
+
+      const { CuratorAgent, MAX_FILES_PER_DAY } = await import('../curator-agent');
+      const curator = new CuratorAgent({ llm: mockLLM() });
+      const outputsDir = path.join(sharedContextRoot, 'many-files-team', 'agent-outputs');
+      const results = curator.collectAgentOutputs(outputsDir, '2026-02-18');
+
+      expect(results.length).toBeLessThanOrEqual(MAX_FILES_PER_DAY);
+    });
+  });
+
+  // ─── isRunning ──────────────────────────────────────────────────────
+
+  describe('isRunning()', () => {
+    it('returns false when idle', async () => {
+      const { curator } = await createCurator();
+      expect(curator.isRunning()).toBe(false);
+    });
+  });
+});
+
+// ─── RoundtableScheduler Tests ──────────────────────────────────────────────
+
+describe('RoundtableScheduler', () => {
+  async function createScheduler(overrides: Record<string, any> = {}) {
+    const { CuratorAgent, RoundtableScheduler } = await import('../curator-agent');
+    const llm = overrides.llm ?? mockLLMWithPriorities();
+    const now = overrides.now ?? (() => new Date('2026-02-18T23:00:00Z'));
+    const curator = new CuratorAgent({ llm, timeoutMs: 5000, now, ...overrides.curatorOverrides });
+    const scheduler = new RoundtableScheduler(
+      curator,
+      {
+        teamName: overrides.teamName ?? 'test-team',
+        cron: overrides.cron ?? '0 23 * * *',
+        enabled: overrides.enabled ?? true,
+        ...(overrides.scheduleOverrides ?? {}),
+      },
+      now,
+    );
+    return { scheduler, curator, llm, RoundtableScheduler };
+  }
+
+  // ─── Cron Parsing ───────────────────────────────────────────────────
+
+  describe('parseCronTime()', () => {
+    it('parses standard daily cron', async () => {
+      const { RoundtableScheduler } = await import('../curator-agent');
+      expect(RoundtableScheduler.parseCronTime('0 23 * * *')).toEqual({ minute: 0, hour: 23 });
+      expect(RoundtableScheduler.parseCronTime('30 8 * * *')).toEqual({ minute: 30, hour: 8 });
+      expect(RoundtableScheduler.parseCronTime('0 0 * * *')).toEqual({ minute: 0, hour: 0 });
+    });
+
+    it('returns null for invalid cron expressions', async () => {
+      const { RoundtableScheduler } = await import('../curator-agent');
+      expect(RoundtableScheduler.parseCronTime('')).toBeNull();
+      expect(RoundtableScheduler.parseCronTime('invalid')).toBeNull();
+      expect(RoundtableScheduler.parseCronTime('60 23 * * *')).toBeNull(); // minute > 59
+      expect(RoundtableScheduler.parseCronTime('0 24 * * *')).toBeNull(); // hour > 23
+      expect(RoundtableScheduler.parseCronTime('-1 0 * * *')).toBeNull(); // negative minute
+      expect(RoundtableScheduler.parseCronTime('* * * * *')).toBeNull(); // wildcard minute/hour
+    });
+  });
+
+  describe('isValidCron()', () => {
+    it('validates well-formed cron expressions', async () => {
+      const { RoundtableScheduler } = await import('../curator-agent');
+      expect(RoundtableScheduler.isValidCron('0 23 * * *')).toBe(true);
+      expect(RoundtableScheduler.isValidCron('garbage')).toBe(false);
+    });
+  });
+
+  // ─── shouldRunNow ───────────────────────────────────────────────────
+
+  describe('shouldRunNow()', () => {
+    it('returns true when time matches cron and has not run today', async () => {
+      // Construct a date whose local getHours()===23, getMinutes()===0
+      const d = new Date(2026, 1, 18, 23, 0, 0); // Feb 18, 2026 at 23:00 local
+      const { scheduler } = await createScheduler({
+        now: () => d,
+        cron: '0 23 * * *',
+      });
+      expect(scheduler.shouldRunNow()).toBe(true);
+    });
+
+    it('returns false when time does not match cron', async () => {
+      const d = new Date(2026, 1, 18, 14, 0, 0); // Feb 18, 2026 at 14:00 local
+      const { scheduler } = await createScheduler({
+        now: () => d,
+        cron: '0 23 * * *',
+      });
+      expect(scheduler.shouldRunNow()).toBe(false);
+    });
+
+    it('returns false when schedule is disabled', async () => {
+      const { scheduler } = await createScheduler({
+        now: () => new Date('2026-02-18T23:00:00Z'),
+        enabled: false,
+      });
+      expect(scheduler.shouldRunNow()).toBe(false);
+    });
+
+    it('returns false when already ran today', async () => {
+      const d = new Date(2026, 1, 18, 23, 0, 0);
+      const dateStr = `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+
+      setupTeamOutputs('ran-today-team', [
+        { agentId: 'nexus', filename: `${dateStr}-work.md`, content: 'Work.' },
+      ]);
+
+      const { scheduler } = await createScheduler({
+        teamName: 'ran-today-team',
+        now: () => d,
+        cron: '0 23 * * *',
+      });
+
+      // Force a run to set lastRunDate
+      await scheduler.forceRun(dateStr);
+      expect(scheduler.shouldRunNow()).toBe(false);
+    });
+  });
+
+  // ─── runIfDue ───────────────────────────────────────────────────────
+
+  describe('runIfDue()', () => {
+    it('runs when due and returns result', async () => {
+      const d = new Date(2026, 1, 18, 23, 0, 0); // local 23:00
+      const dateStr = `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+
+      setupTeamOutputs('due-team', [
+        { agentId: 'nexus', filename: `${dateStr}-work.md`, content: 'Work.' },
+      ]);
+
+      const { scheduler } = await createScheduler({
+        teamName: 'due-team',
+        now: () => d,
+        cron: '0 23 * * *',
+      });
+
+      const result = await scheduler.runIfDue();
+      expect(result).not.toBeNull();
+      expect(result!.success).toBe(true);
+      expect(scheduler.getLastRunDate()).toBe(dateStr);
+    });
+
+    it('returns null when not due', async () => {
+      const { scheduler } = await createScheduler({
+        now: () => new Date('2026-02-18T14:00:00Z'),
+        cron: '0 23 * * *',
+      });
+
+      const result = await scheduler.runIfDue();
+      expect(result).toBeNull();
+    });
+
+    it('does not update lastRunDate on failure', async () => {
+      const d = new Date(2026, 1, 18, 23, 0, 0);
+      const dateStr = `${d.getFullYear()}-${String(d.getMonth()+1).padStart(2,'0')}-${String(d.getDate()).padStart(2,'0')}`;
+
+      setupTeamOutputs('fail-due-team', [
+        { agentId: 'nexus', filename: `${dateStr}-work.md`, content: 'Work.' },
+      ]);
+
+      const { scheduler } = await createScheduler({
+        teamName: 'fail-due-team',
+        now: () => d,
+        cron: '0 23 * * *',
+        llm: mockLLMFailing(),
+      });
+
+      const result = await scheduler.runIfDue();
+      expect(result).not.toBeNull();
+      expect(result!.success).toBe(false);
+      expect(scheduler.getLastRunDate()).toBeNull();
+    });
+  });
+
+  // ─── forceRun ───────────────────────────────────────────────────────
+
+  describe('forceRun()', () => {
+    it('runs regardless of schedule', async () => {
+      setupTeamOutputs('force-team', [
+        { agentId: 'nexus', filename: '2026-02-18-work.md', content: 'Work.' },
+      ]);
+
+      const { scheduler } = await createScheduler({
+        teamName: 'force-team',
+        now: () => new Date('2026-02-18T14:00:00Z'), // Not at schedule time
+        enabled: false, // Schedule disabled
+      });
+
+      const result = await scheduler.forceRun('2026-02-18');
+      expect(result.success).toBe(true);
+      expect(scheduler.getLastRunDate()).toBe('2026-02-18');
+    });
+
+    it('uses current date when no date provided', async () => {
+      const fixedDate = new Date('2026-02-18T14:00:00Z');
+      setupTeamOutputs('force-today-team', [
+        { agentId: 'nexus', filename: '2026-02-18-work.md', content: 'Work.' },
+      ]);
+
+      const { scheduler } = await createScheduler({
+        teamName: 'force-today-team',
+        now: () => fixedDate,
+      });
+
+      const result = await scheduler.forceRun();
+      expect(result.date).toBe('2026-02-18');
+    });
+  });
+
+  // ─── Config Accessors ───────────────────────────────────────────────
+
+  describe('config accessors', () => {
+    it('returns schedule config', async () => {
+      const { scheduler } = await createScheduler({
+        teamName: 'config-team',
+        cron: '30 8 * * *',
+      });
+
+      const config = scheduler.getConfig();
+      expect(config.teamName).toBe('config-team');
+      expect(config.cron).toBe('30 8 * * *');
+      expect(config.enabled).toBe(true);
+    });
+
+    it('returns null for lastRunDate when never run', async () => {
+      const { scheduler } = await createScheduler();
+      expect(scheduler.getLastRunDate()).toBeNull();
+    });
+  });
+});
+
+// ─── Curator Prompt Tests ───────────────────────────────────────────────────
+
+describe('Curator Prompts', () => {
+  it('builds user prompt with agent outputs', async () => {
+    const { buildCuratorUserPrompt } = await import('../prompts/curator');
+    const prompt = buildCuratorUserPrompt('2026-02-18', [
+      { agentId: 'nexus', filename: 'report.md', content: 'Nexus report.' },
+      { agentId: 'oracle', filename: 'analysis.md', content: 'Oracle analysis.' },
+    ]);
+
+    expect(prompt).toContain('Date: 2026-02-18');
+    expect(prompt).toContain('Agent count: 2');
+    expect(prompt).toContain('BEGIN NEXUS OUTPUT');
+    expect(prompt).toContain('Nexus report.');
+    expect(prompt).toContain('BEGIN ORACLE OUTPUT');
+    expect(prompt).toContain('Oracle analysis.');
+  });
+
+  it('builds priority extraction prompt', async () => {
+    const { buildCuratorPriorityPrompt } = await import('../prompts/curator');
+    const prompt = buildCuratorPriorityPrompt('2026-02-18', '# Roundtable\n\nContent.');
+
+    expect(prompt).toContain('Date: 2026-02-18');
+    expect(prompt).toContain('--- ROUNDTABLE ---');
+    expect(prompt).toContain('# Roundtable');
+  });
+
+  it('system prompts are non-empty strings', async () => {
+    const { CURATOR_SYSTEM_PROMPT, CURATOR_PRIORITY_SYSTEM_PROMPT } = await import('../prompts/curator');
+    expect(typeof CURATOR_SYSTEM_PROMPT).toBe('string');
+    expect(CURATOR_SYSTEM_PROMPT.length).toBeGreaterThan(100);
+    expect(typeof CURATOR_PRIORITY_SYSTEM_PROMPT).toBe('string');
+    expect(CURATOR_PRIORITY_SYSTEM_PROMPT.length).toBeGreaterThan(50);
+  });
+});
+
+// ─── SquadRole Integration ──────────────────────────────────────────────────
+
+describe('SquadRole integration', () => {
+  it('curator is a valid SquadRole', async () => {
+    // Runtime assertion that 'curator' is accepted as a SquadRole.
+    // The real check is that tsc compiles this file with the type annotation below.
+    const curatorRole: import('../mission-state-machine').SquadRole = 'curator';
+    expect(curatorRole).toBe('curator');
+  });
+});

--- a/lib/curator-agent.ts
+++ b/lib/curator-agent.ts
@@ -1,0 +1,614 @@
+/**
+ * Curator Agent — VentureOS Daily Roundtable Synthesizer (Phase 5)
+ *
+ * Periodically (or on-demand) reads all agent outputs for a given day,
+ * synthesizes them into a daily roundtable document, and optionally
+ * updates the team priority stack.
+ *
+ * Design:
+ * - Filesystem-based: reads from `agent-outputs/{agent}/` and writes
+ *   to `roundtable/YYYY-MM-DD.md` within the team's shared-context dir.
+ * - Bounded execution: configurable timeout, token budget (<5KB output),
+ *   and total input cap to prevent runaway LLM calls.
+ * - Non-blocking: runs in isolation, never throws into the caller's
+ *   critical path. All errors are captured in the result object.
+ * - Observable: emits structured log events and returns full metrics.
+ *
+ * Issue #245 — Phase 5 of #217: Curator Agent Template + Daily Roundtable
+ */
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+import { structuredLog } from './structured-logger';
+import { teamSharedContextDir } from './paths';
+import {
+  CURATOR_SYSTEM_PROMPT,
+  CURATOR_PRIORITY_SYSTEM_PROMPT,
+  buildCuratorUserPrompt,
+  buildCuratorPriorityPrompt,
+  type CuratorAgentOutput,
+} from './prompts/curator';
+
+// ─── Constants ──────────────────────────────────────────────────────────────
+
+const SUBSYSTEM = 'curator-agent';
+
+/** Maximum roundtable output size in bytes. */
+export const MAX_ROUNDTABLE_BYTES = 5000;
+
+/** Maximum total input size in bytes (all agent outputs combined). */
+export const MAX_TOTAL_INPUT_BYTES = 100_000; // 100KB
+
+/** Default execution timeout in milliseconds. */
+export const DEFAULT_TIMEOUT_MS = 30_000; // 30s
+
+/** Maximum number of agent output files to process per day. */
+export const MAX_FILES_PER_DAY = 50;
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+/** LLM call interface — injected for testability. */
+export interface CuratorLLMClient {
+  chatCompletion(params: {
+    model: string;
+    messages: Array<{ role: 'system' | 'user'; content: string }>;
+    temperature?: number;
+    maxTokens?: number;
+  }): Promise<string>;
+}
+
+/** Configuration for the CuratorAgent. */
+export interface CuratorAgentConfig {
+  /** LLM client for synthesis calls. */
+  llm: CuratorLLMClient;
+  /** LLM model identifier for synthesis. Default: 'gpt-4o-mini'. */
+  model?: string;
+  /** Whether to update priorities.md after synthesis. Default: true. */
+  updatePriorities?: boolean;
+  /** Execution timeout in ms. Default: 30000. */
+  timeoutMs?: number;
+  /** Maximum roundtable output size in bytes. Default: 5000. */
+  maxOutputBytes?: number;
+  /** Maximum total input size in bytes. Default: 100000. */
+  maxInputBytes?: number;
+  /** Optional time source for testability. */
+  now?: () => Date;
+}
+
+/** Result of a roundtable synthesis run. */
+export interface RoundtableResult {
+  /** Unique run identifier. */
+  runId: string;
+  /** Team name. */
+  teamName: string;
+  /** Date synthesized (YYYY-MM-DD). */
+  date: string;
+  /** Whether the run completed successfully. */
+  success: boolean;
+  /** Number of agents that had output. */
+  agentCount: number;
+  /** Number of output files processed. */
+  fileCount: number;
+  /** Total input bytes processed. */
+  inputBytes: number;
+  /** Roundtable output size in bytes. */
+  outputBytes: number;
+  /** Path to the written roundtable file (null if not written). */
+  roundtablePath: string | null;
+  /** Path to the updated priorities file (null if not updated). */
+  prioritiesPath: string | null;
+  /** Execution duration in ms. */
+  durationMs: number;
+  /** Error message if the run failed. */
+  error?: string;
+  /** Whether the run was skipped (no outputs for the day). */
+  skipped: boolean;
+}
+
+/** Schedule configuration for automated curator runs. */
+export interface CuratorScheduleConfig {
+  /** Cron expression for daily runs. Default: '0 23 * * *' (11pm daily). */
+  cron: string;
+  /** Team name to run the curator for. */
+  teamName: string;
+  /** Timezone for the cron schedule. Default: 'America/Chicago'. */
+  timezone: string;
+  /** Whether the schedule is enabled. */
+  enabled: boolean;
+}
+
+/** Default schedule configuration. */
+export const DEFAULT_SCHEDULE_CONFIG: Readonly<CuratorScheduleConfig> = {
+  cron: '0 23 * * *',
+  teamName: '',
+  timezone: 'America/Chicago',
+  enabled: false,
+} as const;
+
+// ─── Curator Agent ──────────────────────────────────────────────────────────
+
+export class CuratorAgent {
+  private readonly llm: CuratorLLMClient;
+  private readonly model: string;
+  private readonly updatePriorities: boolean;
+  private readonly timeoutMs: number;
+  private readonly maxOutputBytes: number;
+  private readonly maxInputBytes: number;
+  private readonly now: () => Date;
+
+  /** Mutex to prevent concurrent runs. */
+  private running = false;
+
+  constructor(config: CuratorAgentConfig) {
+    if (!config?.llm) throw new Error('CuratorAgent requires llm client');
+    this.llm = config.llm;
+    this.model = config.model ?? 'gpt-4o-mini';
+    this.updatePriorities = config.updatePriorities ?? true;
+    this.timeoutMs = config.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+    this.maxOutputBytes = config.maxOutputBytes ?? MAX_ROUNDTABLE_BYTES;
+    this.maxInputBytes = config.maxInputBytes ?? MAX_TOTAL_INPUT_BYTES;
+    this.now = config.now ?? (() => new Date());
+  }
+
+  /**
+   * Check if a roundtable synthesis is currently running.
+   */
+  isRunning(): boolean {
+    return this.running;
+  }
+
+  /**
+   * Run the daily roundtable synthesis for a team.
+   *
+   * @param teamName - Team name (used to resolve shared-context directory).
+   * @param date - Optional date override (YYYY-MM-DD). Defaults to today.
+   * @returns RoundtableResult with full run details.
+   */
+  async synthesize(teamName: string, date?: string): Promise<RoundtableResult> {
+    const runId = crypto.randomUUID();
+    const startTime = Date.now();
+    const targetDate = date ?? this.formatDate(this.now());
+
+    // Prevent concurrent runs
+    if (this.running) {
+      structuredLog('warn', SUBSYSTEM, 'concurrent_run_blocked', 'Synthesis already in progress', { runId, teamName });
+      return this.makeResult(runId, teamName, targetDate, {
+        success: false,
+        error: 'Synthesis already in progress (concurrent run blocked)',
+        skipped: true,
+        durationMs: Date.now() - startTime,
+      });
+    }
+
+    this.running = true;
+    structuredLog('info', SUBSYSTEM, 'synthesis_started', `Starting roundtable synthesis for ${teamName}`, { runId, teamName, date: targetDate });
+
+    try {
+      return await this.withTimeout(
+        this.doSynthesize(runId, teamName, targetDate, startTime),
+        this.timeoutMs,
+      );
+    } catch (err: any) {
+      const errorMsg = err?.message ?? String(err);
+      structuredLog('error', SUBSYSTEM, 'synthesis_failed', `Synthesis failed: ${errorMsg}`, { runId, teamName, date: targetDate });
+      return this.makeResult(runId, teamName, targetDate, {
+        success: false,
+        error: errorMsg,
+        skipped: false,
+        durationMs: Date.now() - startTime,
+      });
+    } finally {
+      this.running = false;
+    }
+  }
+
+  // ─── Internal Pipeline ──────────────────────────────────────────────
+
+  private async doSynthesize(
+    runId: string,
+    teamName: string,
+    date: string,
+    startTime: number,
+  ): Promise<RoundtableResult> {
+    // 1. Resolve team shared-context directory
+    const teamDir = teamSharedContextDir(teamName);
+    const agentOutputsDir = path.join(teamDir, 'agent-outputs');
+
+    if (!fs.existsSync(agentOutputsDir)) {
+      structuredLog('info', SUBSYSTEM, 'no_outputs_dir', `No agent-outputs directory for ${teamName}`, { runId, teamName });
+      return this.makeResult(runId, teamName, date, {
+        success: true,
+        skipped: true,
+        durationMs: Date.now() - startTime,
+      });
+    }
+
+    // 2. Collect agent outputs for the target date
+    const outputs = this.collectAgentOutputs(agentOutputsDir, date);
+
+    if (outputs.length === 0) {
+      structuredLog('info', SUBSYSTEM, 'no_outputs', `No agent outputs for ${teamName} on ${date}`, { runId, teamName, date });
+      return this.makeResult(runId, teamName, date, {
+        success: true,
+        skipped: true,
+        durationMs: Date.now() - startTime,
+      });
+    }
+
+    // 3. Calculate input size and enforce limit
+    const totalInputBytes = outputs.reduce((sum, o) => sum + Buffer.byteLength(o.content, 'utf-8'), 0);
+    if (totalInputBytes > this.maxInputBytes) {
+      structuredLog('warn', SUBSYSTEM, 'input_too_large', `Total input exceeds limit: ${totalInputBytes} > ${this.maxInputBytes}`, {
+        runId, teamName, date, totalInputBytes, maxInputBytes: this.maxInputBytes,
+      });
+      return this.makeResult(runId, teamName, date, {
+        success: false,
+        error: `Total input size (${totalInputBytes} bytes) exceeds limit (${this.maxInputBytes} bytes)`,
+        skipped: false,
+        agentCount: new Set(outputs.map(o => o.agentId)).size,
+        fileCount: outputs.length,
+        inputBytes: totalInputBytes,
+        durationMs: Date.now() - startTime,
+      });
+    }
+
+    const agentCount = new Set(outputs.map(o => o.agentId)).size;
+    structuredLog('info', SUBSYSTEM, 'outputs_collected', `Collected ${outputs.length} files from ${agentCount} agents`, {
+      runId, teamName, date, fileCount: outputs.length, agentCount, totalInputBytes,
+    });
+
+    // 4. Call LLM for roundtable synthesis
+    const userPrompt = buildCuratorUserPrompt(date, outputs);
+    let roundtableContent: string;
+    try {
+      roundtableContent = await this.llm.chatCompletion({
+        model: this.model,
+        messages: [
+          { role: 'system', content: CURATOR_SYSTEM_PROMPT },
+          { role: 'user', content: userPrompt },
+        ],
+        temperature: 0.3,
+        maxTokens: 2000,
+      });
+    } catch (err: any) {
+      structuredLog('error', SUBSYSTEM, 'llm_synthesis_failed', `LLM synthesis call failed: ${err.message}`, { runId, teamName });
+      return this.makeResult(runId, teamName, date, {
+        success: false,
+        error: `LLM synthesis failed: ${err.message}`,
+        skipped: false,
+        agentCount,
+        fileCount: outputs.length,
+        inputBytes: totalInputBytes,
+        durationMs: Date.now() - startTime,
+      });
+    }
+
+    // 5. Enforce output size limit
+    const outputBytes = Buffer.byteLength(roundtableContent, 'utf-8');
+    if (outputBytes > this.maxOutputBytes) {
+      // Truncate with a warning footer
+      const truncateTarget = this.maxOutputBytes - 100; // room for footer
+      roundtableContent = roundtableContent.slice(0, truncateTarget) +
+        '\n\n> ⚠️ _Roundtable truncated to fit 5KB budget._\n';
+      structuredLog('warn', SUBSYSTEM, 'output_truncated', `Roundtable truncated: ${outputBytes} → ${this.maxOutputBytes}`, { runId });
+    }
+
+    // 6. Write roundtable to filesystem
+    const roundtableDir = path.join(teamDir, 'roundtable');
+    fs.mkdirSync(roundtableDir, { recursive: true });
+    const roundtablePath = path.join(roundtableDir, `${date}.md`);
+    fs.writeFileSync(roundtablePath, roundtableContent, 'utf-8');
+
+    structuredLog('info', SUBSYSTEM, 'roundtable_written', `Roundtable written to ${roundtablePath}`, {
+      runId, teamName, date, outputBytes: Buffer.byteLength(roundtableContent, 'utf-8'),
+    });
+
+    // 7. Optionally update priorities
+    let prioritiesPath: string | null = null;
+    if (this.updatePriorities) {
+      prioritiesPath = await this.updatePrioritiesFile(runId, teamName, teamDir, date, roundtableContent);
+    }
+
+    const finalOutputBytes = Buffer.byteLength(roundtableContent, 'utf-8');
+    return this.makeResult(runId, teamName, date, {
+      success: true,
+      skipped: false,
+      agentCount,
+      fileCount: outputs.length,
+      inputBytes: totalInputBytes,
+      outputBytes: finalOutputBytes,
+      roundtablePath,
+      prioritiesPath,
+      durationMs: Date.now() - startTime,
+    });
+  }
+
+  // ─── File Collection ────────────────────────────────────────────────
+
+  /**
+   * Collect agent output files for a specific date.
+   *
+   * Looks in `agent-outputs/{agentId}/` for files that either:
+   * - Have the date in the filename (e.g., `2026-02-18-report.md`)
+   * - Were modified on the target date
+   *
+   * Returns up to MAX_FILES_PER_DAY files, sorted by agent then filename.
+   */
+  collectAgentOutputs(agentOutputsDir: string, date: string): CuratorAgentOutput[] {
+    const outputs: CuratorAgentOutput[] = [];
+
+    let agentDirs: string[];
+    try {
+      agentDirs = fs.readdirSync(agentOutputsDir, { withFileTypes: true })
+        .filter(d => d.isDirectory())
+        .map(d => d.name);
+    } catch {
+      return [];
+    }
+
+    for (const agentId of agentDirs) {
+      const agentDir = path.join(agentOutputsDir, agentId);
+      let files: string[];
+      try {
+        files = fs.readdirSync(agentDir);
+      } catch {
+        continue;
+      }
+
+      for (const filename of files) {
+        const filePath = path.join(agentDir, filename);
+
+        // Skip non-files
+        let stat: fs.Stats;
+        try {
+          stat = fs.statSync(filePath);
+          if (!stat.isFile()) continue;
+        } catch {
+          continue;
+        }
+
+        // Match by date in filename or modification date
+        const fileDate = this.formatDate(stat.mtime);
+        const filenameContainsDate = filename.includes(date);
+        if (!filenameContainsDate && fileDate !== date) continue;
+
+        // Read content
+        try {
+          const content = fs.readFileSync(filePath, 'utf-8');
+          outputs.push({ agentId, filename, content });
+        } catch {
+          structuredLog('warn', SUBSYSTEM, 'file_read_failed', `Failed to read ${filePath}`);
+        }
+
+        if (outputs.length >= MAX_FILES_PER_DAY) break;
+      }
+
+      if (outputs.length >= MAX_FILES_PER_DAY) break;
+    }
+
+    // Sort by agent, then filename for deterministic ordering
+    outputs.sort((a, b) => a.agentId.localeCompare(b.agentId) || a.filename.localeCompare(b.filename));
+    return outputs;
+  }
+
+  // ─── Priority Update ───────────────────────────────────────────────
+
+  private async updatePrioritiesFile(
+    runId: string,
+    teamName: string,
+    teamDir: string,
+    date: string,
+    roundtableContent: string,
+  ): Promise<string | null> {
+    try {
+      const priorityPrompt = buildCuratorPriorityPrompt(date, roundtableContent);
+      const priorityContent = await this.llm.chatCompletion({
+        model: this.model,
+        messages: [
+          { role: 'system', content: CURATOR_PRIORITY_SYSTEM_PROMPT },
+          { role: 'user', content: priorityPrompt },
+        ],
+        temperature: 0.2,
+        maxTokens: 1000,
+      });
+
+      const prioritiesPath = path.join(teamDir, 'priorities.md');
+      fs.writeFileSync(prioritiesPath, priorityContent, 'utf-8');
+      structuredLog('info', SUBSYSTEM, 'priorities_updated', `Priorities updated at ${prioritiesPath}`, { runId, teamName, date });
+      return prioritiesPath;
+    } catch (err: any) {
+      // Priority update failure is non-fatal
+      structuredLog('warn', SUBSYSTEM, 'priorities_update_failed', `Priority update failed: ${err.message}`, { runId, teamName });
+      return null;
+    }
+  }
+
+  // ─── Helpers ────────────────────────────────────────────────────────
+
+  private formatDate(d: Date): string {
+    const year = d.getFullYear();
+    const month = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+
+  private makeResult(
+    runId: string,
+    teamName: string,
+    date: string,
+    overrides: Partial<RoundtableResult>,
+  ): RoundtableResult {
+    return {
+      runId,
+      teamName,
+      date,
+      success: false,
+      agentCount: 0,
+      fileCount: 0,
+      inputBytes: 0,
+      outputBytes: 0,
+      roundtablePath: null,
+      prioritiesPath: null,
+      durationMs: 0,
+      skipped: false,
+      ...overrides,
+    };
+  }
+
+  /**
+   * Wrap a promise with a timeout. Rejects with a descriptive error
+   * if the promise doesn't resolve within the given time.
+   */
+  private withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+    return new Promise<T>((resolve, reject) => {
+      const timer = setTimeout(
+        () => reject(new Error(`Curator synthesis timed out after ${ms}ms`)),
+        ms,
+      );
+      promise
+        .then((val) => { clearTimeout(timer); resolve(val); })
+        .catch((err) => { clearTimeout(timer); reject(err); });
+    });
+  }
+}
+
+// ─── Roundtable Scheduler ───────────────────────────────────────────────────
+
+/**
+ * RoundtableScheduler — lightweight scheduling glue for the CuratorAgent.
+ *
+ * Rather than inventing a new daemon, this provides:
+ * 1. A `parseCron` utility to validate cron expressions
+ * 2. A `shouldRunNow` check for heartbeat-triggered synthesis
+ * 3. A `runIfDue` method that integrates with existing cron/job primitives
+ *
+ * Designed to be called from an existing heartbeat/cron hook rather than
+ * running its own event loop.
+ */
+export class RoundtableScheduler {
+  private readonly curator: CuratorAgent;
+  private readonly config: CuratorScheduleConfig;
+  private lastRunDate: string | null = null;
+  private readonly now: () => Date;
+
+  constructor(
+    curator: CuratorAgent,
+    config: Partial<CuratorScheduleConfig> & { teamName: string },
+    now?: () => Date,
+  ) {
+    this.curator = curator;
+    this.config = { ...DEFAULT_SCHEDULE_CONFIG, ...config };
+    this.now = now ?? (() => new Date());
+  }
+
+  /**
+   * Get the current schedule configuration.
+   */
+  getConfig(): Readonly<CuratorScheduleConfig> {
+    return { ...this.config };
+  }
+
+  /**
+   * Get the date of the last successful run.
+   */
+  getLastRunDate(): string | null {
+    return this.lastRunDate;
+  }
+
+  /**
+   * Check if the scheduler should run now based on:
+   * 1. Schedule is enabled
+   * 2. Current time matches the cron hour/minute
+   * 3. Haven't already run today
+   */
+  shouldRunNow(): boolean {
+    if (!this.config.enabled) return false;
+
+    const now = this.now();
+    const today = this.formatDate(now);
+
+    // Already ran today
+    if (this.lastRunDate === today) return false;
+
+    // Parse cron for hour/minute check (simplified: minute hour * * *)
+    const parsed = RoundtableScheduler.parseCronTime(this.config.cron);
+    if (!parsed) return false;
+
+    return now.getHours() === parsed.hour && now.getMinutes() === parsed.minute;
+  }
+
+  /**
+   * Run the curator synthesis if it's due. Designed to be called from
+   * an existing periodic heartbeat (e.g., every minute).
+   *
+   * Returns null if not due, or the RoundtableResult if run.
+   */
+  async runIfDue(): Promise<RoundtableResult | null> {
+    if (!this.shouldRunNow()) return null;
+
+    const today = this.formatDate(this.now());
+    const result = await this.curator.synthesize(this.config.teamName, today);
+
+    if (result.success) {
+      this.lastRunDate = today;
+    }
+
+    return result;
+  }
+
+  /**
+   * Force a run regardless of schedule. Used for manual triggers.
+   */
+  async forceRun(date?: string): Promise<RoundtableResult> {
+    const targetDate = date ?? this.formatDate(this.now());
+    const result = await this.curator.synthesize(this.config.teamName, targetDate);
+
+    if (result.success) {
+      this.lastRunDate = targetDate;
+    }
+
+    return result;
+  }
+
+  // ─── Cron Utilities ─────────────────────────────────────────────────
+
+  /**
+   * Parse a simple cron expression to extract hour and minute.
+   * Supports standard `minute hour * * *` format.
+   * Returns null if the expression is invalid or uses complex patterns.
+   */
+  static parseCronTime(cron: string): { minute: number; hour: number } | null {
+    if (!cron || typeof cron !== 'string') return null;
+
+    const parts = cron.trim().split(/\s+/);
+    if (parts.length < 5) return null;
+
+    const [minuteStr, hourStr] = parts;
+
+    // Only support simple numeric values (no ranges, lists, steps)
+    const minute = Number(minuteStr);
+    const hour = Number(hourStr);
+
+    if (!Number.isInteger(minute) || minute < 0 || minute > 59) return null;
+    if (!Number.isInteger(hour) || hour < 0 || hour > 23) return null;
+
+    return { minute, hour };
+  }
+
+  /**
+   * Validate a cron expression for use with the scheduler.
+   */
+  static isValidCron(cron: string): boolean {
+    return RoundtableScheduler.parseCronTime(cron) !== null;
+  }
+
+  private formatDate(d: Date): string {
+    const year = d.getFullYear();
+    const month = String(d.getMonth() + 1).padStart(2, '0');
+    const day = String(d.getDate()).padStart(2, '0');
+    return `${year}-${month}-${day}`;
+  }
+}
+
+export default { CuratorAgent, RoundtableScheduler, DEFAULT_SCHEDULE_CONFIG };

--- a/lib/mission-state-machine.ts
+++ b/lib/mission-state-machine.ts
@@ -24,7 +24,7 @@ export type MissionPhase =
   | 'closed'
   | 'error';
 
-export type SquadRole = 'oracle' | 'atlas' | 'sentinel' | 'verifier' | 'archivist' | 'synth';
+export type SquadRole = 'oracle' | 'atlas' | 'sentinel' | 'verifier' | 'archivist' | 'synth' | 'curator';
 
 export interface MissionBrief {
   title: string;

--- a/lib/prompts/curator.ts
+++ b/lib/prompts/curator.ts
@@ -1,0 +1,126 @@
+/**
+ * Curator Prompt Template — VentureOS Daily Roundtable (Phase 5)
+ *
+ * Structured prompts for the Curator Agent LLM synthesis call.
+ * The system prompt is static (cache-friendly); only the user content
+ * varies per daily run.
+ *
+ * Issue #245 — Phase 5 of #217: Curator Agent Template + Daily Roundtable
+ */
+
+// ─── System Prompt (Static — prompt-cache friendly) ─────────────────────────
+
+export const CURATOR_SYSTEM_PROMPT = `You are a cross-agent synthesis engine. Your job is to read all agent outputs for a given day and produce a concise daily roundtable summary document.
+
+## Rules
+
+1. **Synthesize, don't concatenate.** Merge overlapping work, highlight dependencies, surface conflicts.
+2. **Structure the output** using the exact markdown template below. Do not add extra sections.
+3. **Extract priorities.** Identify the top 3-5 priorities for the next day based on today's work.
+4. **Flag blockers.** If any agent's output mentions blockers, risks, or unresolved issues, surface them prominently.
+5. **Be concise.** The entire roundtable document MUST be under 5000 bytes (roughly 4KB of text). Prefer bullet points over paragraphs.
+6. **Attribute work.** When referencing work, mention the agent that produced it.
+7. **Preserve specifics.** Keep issue numbers, PR numbers, commit SHAs, deadlines, and metric values.
+8. **Handle sparse days.** If only one agent produced output, still produce a valid roundtable — just note limited activity.
+
+## Output Template
+
+\`\`\`markdown
+# Daily Roundtable — {DATE}
+
+## Summary
+{1-3 sentence overview of the day's collective progress}
+
+## Agent Activity
+{For each agent that produced output:}
+- **{agent-name}**: {1-2 sentence summary of their work}
+
+## Key Decisions & Outcomes
+- {Bullet list of important decisions, completions, or milestones}
+
+## Blockers & Risks
+- {Bullet list of open blockers, risks, or concerns — or "None identified."}
+
+## Tomorrow's Priorities
+1. {Top priority}
+2. {Second priority}
+3. {Third priority}
+\`\`\`
+
+Respond with ONLY the markdown document. No JSON wrapping, no code fences around the whole thing, no preamble.`;
+
+// ─── Priority Extraction Prompt ─────────────────────────────────────────────
+
+export const CURATOR_PRIORITY_SYSTEM_PROMPT = `You are a priority extraction engine. Given a daily roundtable summary, extract an updated priority stack as a markdown document.
+
+## Rules
+
+1. Output a numbered list of 3-7 priorities, ordered by urgency/impact.
+2. Each priority should be one clear sentence.
+3. Include the source (which agent/roundtable insight) in parentheses.
+4. If no clear priorities emerged, output "No priority changes identified."
+
+## Output Format
+
+\`\`\`markdown
+# Team Priorities
+
+_Updated: {DATE}_
+
+1. {Priority description} (source: {agent/roundtable})
+2. ...
+\`\`\`
+
+Respond with ONLY the markdown. No fences, no preamble.`;
+
+// ─── User Prompt Builders ───────────────────────────────────────────────────
+
+export interface CuratorAgentOutput {
+  /** Agent identifier (e.g. 'nexus', 'oracle', 'synth'). */
+  agentId: string;
+  /** Filename of the output. */
+  filename: string;
+  /** File content (text). */
+  content: string;
+}
+
+/**
+ * Build the user prompt for the daily roundtable synthesis.
+ * Only the agent outputs vary — the system prompt is static
+ * for maximum prompt-cache reuse.
+ */
+export function buildCuratorUserPrompt(
+  date: string,
+  agentOutputs: CuratorAgentOutput[],
+): string {
+  const lines: string[] = [];
+  lines.push(`Date: ${date}`);
+  lines.push(`Agent count: ${agentOutputs.length}`);
+  lines.push('');
+
+  for (const output of agentOutputs) {
+    lines.push(`--- BEGIN ${output.agentId.toUpperCase()} OUTPUT (${output.filename}) ---`);
+    lines.push(output.content);
+    lines.push(`--- END ${output.agentId.toUpperCase()} OUTPUT ---`);
+    lines.push('');
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Build the user prompt for priority extraction from a roundtable.
+ */
+export function buildCuratorPriorityPrompt(
+  date: string,
+  roundtableContent: string,
+): string {
+  return `Date: ${date}\n\n--- ROUNDTABLE ---\n${roundtableContent}\n--- END ROUNDTABLE ---`;
+}
+
+export default {
+  CURATOR_SYSTEM_PROMPT,
+  CURATOR_PRIORITY_SYSTEM_PROMPT,
+  buildCuratorUserPrompt,
+  buildCuratorPriorityPrompt,
+};


### PR DESCRIPTION
## Summary
Implements Phase 5 of the Shared Agent Memory Layer epic (#217): Curator Agent Template + Daily Roundtable.

Closes #245

## Changes

### New Files
- **`lib/curator-agent.ts`** — `CuratorAgent` class + `RoundtableScheduler`
  - Reads `agent-outputs/{agent}/` for the target day
  - LLM-powered synthesis → `roundtable/YYYY-MM-DD.md`
  - Optional priority extraction → `priorities.md` update
  - Bounded execution: configurable timeout (30s default), input cap (100KB), output cap (5KB with auto-truncation), file limit (50 files/day)
  - Mutex prevents concurrent runs; all errors captured in result object
  - `RoundtableScheduler`: cron parsing, `shouldRunNow()` heartbeat check, `runIfDue()` + `forceRun()` for integration with existing job primitives
- **`lib/prompts/curator.ts`** — Prompt templates for synthesis + priority extraction
  - Static system prompts (cache-friendly), dynamic user prompt builders
  - Structured output format matching roundtable markdown spec
- **`lib/__tests__/curator-agent.test.ts`** — 38 tests (all passing)

### Modified Files
- **`lib/mission-state-machine.ts`** — Added `'curator'` to `SquadRole` union type

## Test Matrix (38/38 passing)

| Category | Tests | Status |
|----------|-------|--------|
| Core synthesis (multi-agent, single-agent, auto-date) | 5 | ✅ |
| Empty day / missing dir graceful skip | 2 | ✅ |
| Output size enforcement (<5KB + truncation) | 2 | ✅ |
| Input size enforcement | 1 | ✅ |
| Priority update (success, skip, non-fatal failure) | 3 | ✅ |
| LLM failure resilience | 1 | ✅ |
| Concurrent run mutex | 1 | ✅ |
| Timeout enforcement | 1 | ✅ |
| File collection (date/mtime matching, sort, limit) | 5 | ✅ |
| Scheduler cron parsing + validation | 3 | ✅ |
| Scheduler shouldRunNow logic | 4 | ✅ |
| Scheduler runIfDue / forceRun | 5 | ✅ |
| Prompt builders | 3 | ✅ |
| SquadRole type integration | 1 | ✅ |
| Existing squad-coordinator tests | ✅ | No regressions |
| Existing team-service tests | ✅ | No regressions |
| TypeScript typecheck | ✅ | Clean |

## Architecture Notes

- **No new daemon/process** — `RoundtableScheduler` is designed to be called from an existing heartbeat or cron hook. It provides `shouldRunNow()` and `runIfDue()` methods rather than running its own event loop.
- **Bounded by design** — Every execution path has limits: timeout (30s), input size (100KB), output size (5KB), file count (50), and mutex exclusion.
- **Non-blocking** — Errors are always captured in the `RoundtableResult` object, never thrown into the caller's critical path. Priority update failures are non-fatal.
- **Observable** — Every phase emits structured log events via the existing `structuredLog` infrastructure.
- **LLM-injectable** — The `CuratorLLMClient` interface is injected, making the agent fully testable without real API calls.

## Risk Assessment
- **Low risk**: All changes are additive. The only modification to existing code is adding `'curator'` to the `SquadRole` union type, which is a backward-compatible widening.
- **No auth/security changes**: Curator uses the same filesystem access patterns as the existing shared-context infrastructure.
- **Follow-ups**: Dashboard integration for roundtable viewing, actual cron registration in the gateway, Curator role in SquadCoordinator `inferRolesFromBrief()` if desired.