### PR TITLE
feat(dashboard): Task Board Kanban UI panel — Phase 2 (#219)

### DIFF
--- a/dashboard/client/index.html
+++ b/dashboard/client/index.html
@@ -963,6 +963,257 @@ body {
 
 .mb-24 { margin-bottom: 24px; }
 
+/* ─── Task Board (Kanban) — Issue #219 ──────────────────────────────── */
+
+.tb-board {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  gap: 16px;
+  min-height: 400px;
+}
+
+.tb-column {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  display: flex;
+  flex-direction: column;
+  min-height: 300px;
+}
+
+.tb-column-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 14px 16px 10px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  border-bottom: 1px solid var(--border);
+}
+
+.tb-column-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.tb-column-count {
+  margin-left: auto;
+  background: var(--bg-tertiary);
+  color: var(--text-muted);
+  font-size: 11px;
+  font-weight: 600;
+  padding: 2px 7px;
+  border-radius: 10px;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.tb-column-cards {
+  flex: 1;
+  padding: 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  overflow-y: auto;
+  max-height: 600px;
+}
+
+.tb-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px 14px;
+  cursor: default;
+  transition: all 0.2s;
+  position: relative;
+}
+
+.tb-card:hover {
+  border-color: rgba(99, 102, 241, 0.4);
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.2);
+}
+
+.tb-card-title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+  margin-bottom: 6px;
+  line-height: 1.4;
+  word-break: break-word;
+}
+
+.tb-card-desc {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 8px;
+  line-height: 1.4;
+  max-height: 40px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tb-card-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+  font-size: 10px;
+}
+
+.tb-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 2px 7px;
+  border-radius: 6px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.tb-badge-critical { background: rgba(239, 68, 68, 0.15); color: var(--red); }
+.tb-badge-high { background: rgba(245, 158, 11, 0.15); color: var(--yellow); }
+.tb-badge-medium { background: rgba(99, 102, 241, 0.12); color: var(--accent); }
+.tb-badge-low { background: rgba(113, 113, 122, 0.15); color: var(--text-muted); }
+
+.tb-badge-agent {
+  background: rgba(6, 182, 212, 0.12);
+  color: var(--cyan);
+}
+
+.tb-card-actions {
+  display: none;
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  gap: 4px;
+}
+
+.tb-card:hover .tb-card-actions {
+  display: flex;
+}
+
+.tb-card-action-btn {
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  color: var(--text-muted);
+  width: 22px;
+  height: 22px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 11px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  transition: all 0.15s;
+}
+
+.tb-card-action-btn:hover {
+  border-color: var(--accent);
+  color: var(--text-primary);
+  background: var(--bg-card);
+}
+
+.tb-btn {
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  border: 1px solid var(--border);
+  transition: all 0.2s;
+  font-family: inherit;
+}
+
+.tb-btn-primary {
+  background: var(--accent);
+  color: #fff;
+  border-color: var(--accent);
+}
+
+.tb-btn-primary:hover {
+  filter: brightness(1.15);
+  box-shadow: 0 4px 12px var(--accent-glow);
+}
+
+.tb-btn-secondary {
+  background: var(--bg-tertiary);
+  color: var(--text-primary);
+}
+
+.tb-btn-secondary:hover {
+  border-color: var(--accent);
+}
+
+.tb-label {
+  display: block;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  margin-bottom: 6px;
+}
+
+.tb-input {
+  width: 100%;
+  padding: 8px 12px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  color: var(--text-primary);
+  font-size: 13px;
+  font-family: inherit;
+  transition: border-color 0.2s;
+}
+
+.tb-input:focus {
+  outline: none;
+  border-color: var(--accent);
+}
+
+.tb-card-transitions {
+  display: flex;
+  gap: 4px;
+  margin-top: 8px;
+  flex-wrap: wrap;
+}
+
+.tb-transition-btn {
+  padding: 2px 8px;
+  font-size: 10px;
+  font-weight: 600;
+  border-radius: 5px;
+  border: 1px solid var(--border);
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.15s;
+  font-family: inherit;
+}
+
+.tb-transition-btn:hover {
+  border-color: var(--accent);
+  color: var(--text-primary);
+}
+
+.tb-time-ago {
+  color: var(--text-muted);
+  font-size: 10px;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+@media (max-width: 1200px) {
+  .tb-board { grid-template-columns: repeat(3, 1fr); }
+}
+@media (max-width: 768px) {
+  .tb-board { grid-template-columns: 1fr; }
+}
+
+/* ─── End Task Board ────────────────────────────────────────────────── */
+
 /* Mobile + Tablet Responsive */
 @media (max-width: 1024px) {
   /* Bottom nav */
@@ -1321,6 +1572,10 @@ body {
       <div class="nav-item" data-page="memory">
         <span class="icon">🧠</span>
         <span class="nav-text">Memory</span>
+      </div>
+      <div class="nav-item" data-page="taskboard">
+        <span class="icon">📌</span>
+        <span class="nav-text">Task Board</span>
       </div>
       <div class="nav-item" data-page="logs">
         <span class="icon">📋</span>
@@ -2395,6 +2650,141 @@ body {
       </div>
     </div>
 
+    <!-- ═══════════════════════════════════════════════════════════════════════
+         Task Board (Kanban) — Issue #219, Phase 2
+         ═══════════════════════════════════════════════════════════════════ -->
+    <div class="page" id="taskboard">
+      <div class="page-header">
+        <div style="display:flex;align-items:center;justify-content:space-between;width:100%;">
+          <div>
+            <h1 class="page-title">Task Board</h1>
+            <p class="page-subtitle">Kanban view — agent task lifecycle management</p>
+          </div>
+          <div style="display:flex;gap:8px;">
+            <button onclick="tbRefresh()" class="tb-btn tb-btn-secondary" title="Refresh">🔄 Refresh</button>
+            <button onclick="tbShowCreateForm()" class="tb-btn tb-btn-primary" title="New Task">＋ New Task</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Summary cards -->
+      <div class="grid mb-24" style="grid-template-columns: repeat(5, 1fr);">
+        <div class="card" style="padding:16px;">
+          <div class="metric" style="gap:6px;">
+            <div class="metric-value" style="font-size:28px;color:var(--text-muted);" id="tbCountBacklog">0</div>
+            <div class="metric-label">Backlog</div>
+          </div>
+        </div>
+        <div class="card" style="padding:16px;">
+          <div class="metric" style="gap:6px;">
+            <div class="metric-value" style="font-size:28px;color:var(--blue);" id="tbCountQueued">0</div>
+            <div class="metric-label">Queued</div>
+          </div>
+        </div>
+        <div class="card" style="padding:16px;">
+          <div class="metric" style="gap:6px;">
+            <div class="metric-value" style="font-size:28px;color:var(--yellow);" id="tbCountRunning">0</div>
+            <div class="metric-label">Running</div>
+          </div>
+        </div>
+        <div class="card" style="padding:16px;">
+          <div class="metric" style="gap:6px;">
+            <div class="metric-value" style="font-size:28px;color:var(--green);" id="tbCountDone">0</div>
+            <div class="metric-label">Done</div>
+          </div>
+        </div>
+        <div class="card" style="padding:16px;">
+          <div class="metric" style="gap:6px;">
+            <div class="metric-value" style="font-size:28px;color:var(--red);" id="tbCountFailed">0</div>
+            <div class="metric-label">Failed</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Create task form (hidden by default) -->
+      <div class="card mb-24" id="tbCreateForm" style="display:none;">
+        <h3 class="card-title">Create Task</h3>
+        <div style="display:grid;grid-template-columns:1fr 1fr;gap:12px;">
+          <div style="grid-column:1/-1;">
+            <label class="tb-label">Title *</label>
+            <input type="text" id="tbNewTitle" class="tb-input" placeholder="Task title…" maxlength="200">
+          </div>
+          <div style="grid-column:1/-1;">
+            <label class="tb-label">Description</label>
+            <textarea id="tbNewDesc" class="tb-input" placeholder="Optional description…" rows="2" maxlength="2000" style="resize:vertical;"></textarea>
+          </div>
+          <div>
+            <label class="tb-label">Priority</label>
+            <select id="tbNewPriority" class="tb-input">
+              <option value="low">Low</option>
+              <option value="medium" selected>Medium</option>
+              <option value="high">High</option>
+              <option value="critical">Critical</option>
+            </select>
+          </div>
+          <div>
+            <label class="tb-label">Agent ID (optional)</label>
+            <input type="text" id="tbNewAgent" class="tb-input" placeholder="e.g. synth, nexus…">
+          </div>
+          <div style="grid-column:1/-1;display:flex;gap:8px;justify-content:flex-end;margin-top:4px;">
+            <button onclick="tbHideCreateForm()" class="tb-btn tb-btn-secondary">Cancel</button>
+            <button onclick="tbCreateTask()" class="tb-btn tb-btn-primary">Create</button>
+          </div>
+        </div>
+      </div>
+
+      <!-- Kanban columns -->
+      <div class="tb-board">
+        <div class="tb-column" data-status="backlog">
+          <div class="tb-column-header">
+            <span class="tb-column-dot" style="background:var(--text-muted);"></span>
+            <span>Backlog</span>
+            <span class="tb-column-count" id="tbColBacklog">0</span>
+          </div>
+          <div class="tb-column-cards" id="tbCardsBacklog"></div>
+        </div>
+        <div class="tb-column" data-status="queued">
+          <div class="tb-column-header">
+            <span class="tb-column-dot" style="background:var(--blue);"></span>
+            <span>Queued</span>
+            <span class="tb-column-count" id="tbColQueued">0</span>
+          </div>
+          <div class="tb-column-cards" id="tbCardsQueued"></div>
+        </div>
+        <div class="tb-column" data-status="running">
+          <div class="tb-column-header">
+            <span class="tb-column-dot" style="background:var(--yellow);"></span>
+            <span>Running</span>
+            <span class="tb-column-count" id="tbColRunning">0</span>
+          </div>
+          <div class="tb-column-cards" id="tbCardsRunning"></div>
+        </div>
+        <div class="tb-column" data-status="done">
+          <div class="tb-column-header">
+            <span class="tb-column-dot" style="background:var(--green);"></span>
+            <span>Done</span>
+            <span class="tb-column-count" id="tbColDone">0</span>
+          </div>
+          <div class="tb-column-cards" id="tbCardsDone"></div>
+        </div>
+        <div class="tb-column" data-status="failed">
+          <div class="tb-column-header">
+            <span class="tb-column-dot" style="background:var(--red);"></span>
+            <span>Failed</span>
+            <span class="tb-column-count" id="tbColFailed">0</span>
+          </div>
+          <div class="tb-column-cards" id="tbCardsFailed"></div>
+        </div>
+      </div>
+
+      <!-- Empty state -->
+      <div id="tbEmpty" style="display:none;text-align:center;padding:60px 20px;color:var(--text-muted);">
+        <div style="font-size:48px;margin-bottom:16px;opacity:0.5;">📌</div>
+        <div style="font-size:16px;margin-bottom:8px;">No tasks yet</div>
+        <div style="font-size:13px;">Click "New Task" to create your first card.</div>
+      </div>
+    </div>
+
   </main>
 </div>
 
@@ -2547,6 +2937,9 @@ document.querySelectorAll('.nav-item').forEach(item => {
     }
     if (page === 'observations') {
       fetchObservationsNow();
+    }
+    if (page === 'taskboard') {
+      tbRefresh();
     }
     if (page === 'logs') {
       loadLogSources();
@@ -5717,6 +6110,217 @@ function renderChangelog() {
 }
 
 function escHtml(s) { if (!s) return ''; const d = document.createElement('div'); d.textContent = s; return d.innerHTML; }
+
+// ═══════════════════════════════════════════════════════════════════════════
+// Task Board (Kanban) — Issue #219, Phase 2
+// ═══════════════════════════════════════════════════════════════════════════
+
+const TB_TRANSITIONS = {
+  backlog: ['queued', 'done'],
+  queued: ['running', 'backlog', 'done'],
+  running: ['done', 'failed'],
+  done: ['backlog'],
+  failed: ['backlog', 'queued'],
+};
+
+const TB_STATUS_EMOJI = {
+  backlog: '📋', queued: '⏳', running: '⚡', done: '✅', failed: '❌',
+};
+
+const TB_PRIORITY_ORDER = { critical: 0, high: 1, medium: 2, low: 3 };
+
+let tbTasks = [];
+let tbAutoRefreshTimer = null;
+
+async function tbRefresh() {
+  try {
+    const [tasksRes, summaryRes] = await Promise.all([
+      fetch('/api/task-board').then(r => r.json()),
+      fetch('/api/task-board/summary').then(r => r.json()),
+    ]);
+    tbTasks = (tasksRes.tasks || []).sort((a, b) =>
+      (TB_PRIORITY_ORDER[a.priority] ?? 9) - (TB_PRIORITY_ORDER[b.priority] ?? 9)
+    );
+
+    // Update summary counts
+    const cols = summaryRes.columns || {};
+    document.getElementById('tbCountBacklog').textContent = cols.backlog ?? 0;
+    document.getElementById('tbCountQueued').textContent = cols.queued ?? 0;
+    document.getElementById('tbCountRunning').textContent = cols.running ?? 0;
+    document.getElementById('tbCountDone').textContent = cols.done ?? 0;
+    document.getElementById('tbCountFailed').textContent = cols.failed ?? 0;
+
+    tbRenderBoard();
+  } catch (e) {
+    console.error('[task-board] refresh error', e);
+  }
+}
+
+function tbRenderBoard() {
+  const groups = { backlog: [], queued: [], running: [], done: [], failed: [] };
+  for (const t of tbTasks) {
+    if (groups[t.status]) groups[t.status].push(t);
+  }
+
+  const isEmpty = tbTasks.length === 0;
+  document.getElementById('tbEmpty').style.display = isEmpty ? '' : 'none';
+  document.querySelector('.tb-board').style.display = isEmpty ? 'none' : '';
+
+  for (const [status, cards] of Object.entries(groups)) {
+    const colId = 'tbCards' + status.charAt(0).toUpperCase() + status.slice(1);
+    const countId = 'tbCol' + status.charAt(0).toUpperCase() + status.slice(1);
+    const container = document.getElementById(colId);
+    const countEl = document.getElementById(countId);
+    if (!container) continue;
+
+    countEl.textContent = cards.length;
+    if (cards.length === 0) {
+      container.innerHTML = '<div style="text-align:center;color:var(--text-muted);font-size:12px;padding:20px 8px;opacity:0.6;">No tasks</div>';
+      continue;
+    }
+
+    container.innerHTML = cards.map(c => tbRenderCard(c)).join('');
+  }
+}
+
+function tbRenderCard(card) {
+  const transitions = TB_TRANSITIONS[card.status] || [];
+  const priClass = 'tb-badge-' + card.priority;
+  const ago = tbTimeAgo(card.createdAt);
+  const desc = card.description ? `<div class="tb-card-desc">${tbEsc(card.description)}</div>` : '';
+  const agent = card.agentId ? `<span class="tb-badge tb-badge-agent">🤖 ${tbEsc(card.agentId)}</span>` : '';
+  const result = card.resultSummary ? `<div style="margin-top:6px;font-size:11px;color:var(--green);"><b>Result:</b> ${tbEsc(card.resultSummary)}</div>` : '';
+  const errorMsg = card.error ? `<div style="margin-top:6px;font-size:11px;color:var(--red);"><b>Error:</b> ${tbEsc(card.error)}</div>` : '';
+  const tokens = card.tokensUsed ? `<span class="tb-badge" style="background:rgba(168,85,247,0.12);color:var(--purple);">🪙 ${card.tokensUsed.toLocaleString()}</span>` : '';
+  const elapsed = card.startedAt && card.completedAt
+    ? `<span class="tb-time-ago">${tbDuration(card.completedAt - card.startedAt)}</span>`
+    : card.startedAt
+    ? `<span class="tb-time-ago" style="color:var(--yellow);">⏱ running…</span>`
+    : '';
+
+  const transitionBtns = transitions.map(s =>
+    `<button class="tb-transition-btn" onclick="tbTransition('${card.id}','${s}')" title="Move to ${s}">${TB_STATUS_EMOJI[s] || ''} ${s}</button>`
+  ).join('');
+
+  return `<div class="tb-card" data-id="${card.id}">
+    <div class="tb-card-actions">
+      <button class="tb-card-action-btn" onclick="tbDeleteTask('${card.id}')" title="Delete">🗑</button>
+    </div>
+    <div class="tb-card-title">${tbEsc(card.title)}</div>
+    ${desc}
+    <div class="tb-card-meta">
+      <span class="tb-badge ${priClass}">${card.priority}</span>
+      ${agent}
+      ${tokens}
+      ${elapsed}
+      <span class="tb-time-ago" style="margin-left:auto;">${ago}</span>
+    </div>
+    ${result}
+    ${errorMsg}
+    ${transitionBtns ? `<div class="tb-card-transitions">${transitionBtns}</div>` : ''}
+  </div>`;
+}
+
+function tbEsc(s) {
+  if (!s) return '';
+  const d = document.createElement('div');
+  d.textContent = s;
+  return d.innerHTML;
+}
+
+function tbTimeAgo(ts) {
+  if (!ts) return '';
+  const diff = Date.now() - ts;
+  if (diff < 60000) return 'just now';
+  if (diff < 3600000) return Math.floor(diff / 60000) + 'm ago';
+  if (diff < 86400000) return Math.floor(diff / 3600000) + 'h ago';
+  return Math.floor(diff / 86400000) + 'd ago';
+}
+
+function tbDuration(ms) {
+  if (ms < 1000) return ms + 'ms';
+  if (ms < 60000) return (ms / 1000).toFixed(1) + 's';
+  if (ms < 3600000) return Math.floor(ms / 60000) + 'm ' + Math.floor((ms % 60000) / 1000) + 's';
+  return Math.floor(ms / 3600000) + 'h ' + Math.floor((ms % 3600000) / 60000) + 'm';
+}
+
+function tbShowCreateForm() {
+  document.getElementById('tbCreateForm').style.display = '';
+  document.getElementById('tbNewTitle').focus();
+}
+
+function tbHideCreateForm() {
+  document.getElementById('tbCreateForm').style.display = 'none';
+  document.getElementById('tbNewTitle').value = '';
+  document.getElementById('tbNewDesc').value = '';
+  document.getElementById('tbNewPriority').value = 'medium';
+  document.getElementById('tbNewAgent').value = '';
+}
+
+async function tbCreateTask() {
+  const title = document.getElementById('tbNewTitle').value.trim();
+  if (!title) { document.getElementById('tbNewTitle').focus(); return; }
+  const body = {
+    title,
+    description: document.getElementById('tbNewDesc').value.trim(),
+    priority: document.getElementById('tbNewPriority').value,
+    agentId: document.getElementById('tbNewAgent').value.trim() || null,
+  };
+  try {
+    const res = await fetch('/api/task-board', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      alert('Failed to create task: ' + (err.error || res.statusText));
+      return;
+    }
+    tbHideCreateForm();
+    await tbRefresh();
+  } catch (e) {
+    alert('Network error creating task: ' + e.message);
+  }
+}
+
+async function tbTransition(id, newStatus) {
+  try {
+    const res = await fetch('/api/task-board/' + id, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ status: newStatus }),
+    });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      alert('Transition failed: ' + (err.error || res.statusText));
+      return;
+    }
+    await tbRefresh();
+  } catch (e) {
+    alert('Network error: ' + e.message);
+  }
+}
+
+async function tbDeleteTask(id) {
+  if (!confirm('Delete this task?')) return;
+  try {
+    await fetch('/api/task-board/' + id, { method: 'DELETE' });
+    await tbRefresh();
+  } catch (e) {
+    alert('Delete failed: ' + e.message);
+  }
+}
+
+// Auto-refresh task board every 15s when visible
+function tbStartAutoRefresh() {
+  if (tbAutoRefreshTimer) return;
+  tbAutoRefreshTimer = setInterval(() => {
+    const activePage = document.querySelector('.page.active');
+    if (activePage && activePage.id === 'taskboard') tbRefresh();
+  }, 15000);
+}
+tbStartAutoRefresh();
 </script>
 </body>
 </html>

--- a/dashboard/tests/unit/routes/task-board.test.ts
+++ b/dashboard/tests/unit/routes/task-board.test.ts
@@ -532,4 +532,302 @@ describe('handleTaskBoard', () => {
       expect(handled).toBe(false);
     });
   });
+
+  // ── Phase 2: additional coverage for Kanban UI integration ────────────────
+
+  describe('full lifecycle workflow', () => {
+    it('card flows backlog → queued → running → done', async () => {
+      // Create
+      const createRes = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board', method: 'POST' }),
+        createRes,
+        depsWithBody({ title: 'Lifecycle test', priority: 'high' }),
+      );
+      expect(createRes._statusCode).toBe(201);
+      const cardId = parseJsonBody<{ card: TaskCard }>(createRes).card.id;
+
+      // backlog → queued
+      const r1 = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: `/api/task-board/${cardId}`, method: 'PATCH' }),
+        r1,
+        depsWithBody({ status: 'queued' }),
+      );
+      expect(parseJsonBody<{ card: TaskCard }>(r1).card.status).toBe('queued');
+      expect(parseJsonBody<{ card: TaskCard }>(r1).card.queuedAt).toBeTruthy();
+
+      // queued → running
+      const r2 = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: `/api/task-board/${cardId}`, method: 'PATCH' }),
+        r2,
+        depsWithBody({ status: 'running' }),
+      );
+      const runCard = parseJsonBody<{ card: TaskCard }>(r2).card;
+      expect(runCard.status).toBe('running');
+      expect(runCard.startedAt).toBeTruthy();
+
+      // running → done with result
+      const r3 = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: `/api/task-board/${cardId}`, method: 'PATCH' }),
+        r3,
+        depsWithBody({ status: 'done', resultSummary: 'Shipped!', tokensUsed: 1234 }),
+      );
+      const doneCard = parseJsonBody<{ card: TaskCard }>(r3).card;
+      expect(doneCard.status).toBe('done');
+      expect(doneCard.completedAt).toBeTruthy();
+      expect(doneCard.resultSummary).toBe('Shipped!');
+      expect(doneCard.tokensUsed).toBe(1234);
+
+      // Summary reflects the final state
+      const sumRes = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/summary' }),
+        sumRes,
+        createDeps(),
+      );
+      const sum = parseJsonBody<{ columns: Record<string, number>; total: number }>(sumRes);
+      expect(sum.total).toBe(1);
+      expect(sum.columns.done).toBe(1);
+    });
+
+    it('card flows running → failed → backlog → queued (retry path)', async () => {
+      // Seed a running card
+      const card = makeSampleCard({ id: 'retry-card', status: 'running', startedAt: Date.now() });
+      seedTasks([card]);
+
+      // running → failed
+      const r1 = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/retry-card', method: 'PATCH' }),
+        r1,
+        depsWithBody({ status: 'failed', error: 'Timeout exceeded' }),
+      );
+      const failedCard = parseJsonBody<{ card: TaskCard }>(r1).card;
+      expect(failedCard.status).toBe('failed');
+      expect(failedCard.error).toBe('Timeout exceeded');
+      expect(failedCard.completedAt).toBeTruthy();
+
+      // failed → backlog
+      const r2 = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/retry-card', method: 'PATCH' }),
+        r2,
+        depsWithBody({ status: 'backlog' }),
+      );
+      expect(parseJsonBody<{ card: TaskCard }>(r2).card.status).toBe('backlog');
+
+      // backlog → queued
+      const r3 = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/retry-card', method: 'PATCH' }),
+        r3,
+        depsWithBody({ status: 'queued' }),
+      );
+      expect(parseJsonBody<{ card: TaskCard }>(r3).card.status).toBe('queued');
+    });
+  });
+
+  describe('POST edge cases', () => {
+    it('trims whitespace from title', async () => {
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board', method: 'POST' }),
+        res,
+        depsWithBody({ title: '  Whitespace task  ' }),
+      );
+      expect(res._statusCode).toBe(201);
+      expect(parseJsonBody<{ card: TaskCard }>(res).card.title).toBe('Whitespace task');
+    });
+
+    it('rejects title over 200 chars', async () => {
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board', method: 'POST' }),
+        res,
+        depsWithBody({ title: 'x'.repeat(201) }),
+      );
+      expect(res._statusCode).toBe(400);
+      expect(parseJsonBody(res).error).toContain('200');
+    });
+
+    it('rejects description over 2000 chars', async () => {
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board', method: 'POST' }),
+        res,
+        depsWithBody({ title: 'Valid', description: 'y'.repeat(2001) }),
+      );
+      expect(res._statusCode).toBe(400);
+      expect(parseJsonBody(res).error).toContain('2000');
+    });
+
+    it('allows creating card with initial queued status', async () => {
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board', method: 'POST' }),
+        res,
+        depsWithBody({ title: 'Pre-queued', status: 'queued' }),
+      );
+      expect(res._statusCode).toBe(201);
+      const card = parseJsonBody<{ card: TaskCard }>(res).card;
+      expect(card.status).toBe('queued');
+      expect(card.queuedAt).toBeTruthy();
+    });
+
+    it('rejects invalid initial status', async () => {
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board', method: 'POST' }),
+        res,
+        depsWithBody({ title: 'Bad status', status: 'exploding' }),
+      );
+      expect(res._statusCode).toBe(400);
+    });
+
+    it('handles malformed JSON body gracefully', async () => {
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board', method: 'POST' }),
+        res,
+        createDeps({ readRequestBody: async () => '{not json' }),
+      );
+      expect(res._statusCode).toBe(400);
+      expect(parseJsonBody(res).error).toContain('invalid JSON');
+    });
+  });
+
+  describe('PATCH edge cases', () => {
+    it('handles malformed JSON in PATCH body', async () => {
+      seedTasks([makeSampleCard({ id: 'card-1' })]);
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/card-1', method: 'PATCH' }),
+        res,
+        createDeps({ readRequestBody: async () => 'broken{' }),
+      );
+      expect(res._statusCode).toBe(400);
+    });
+
+    it('rejects invalid status value in PATCH', async () => {
+      seedTasks([makeSampleCard({ id: 'card-1', status: 'backlog' })]);
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/card-1', method: 'PATCH' }),
+        res,
+        depsWithBody({ status: 'nonexistent' }),
+      );
+      expect(res._statusCode).toBe(400);
+      expect(parseJsonBody(res).error).toContain('invalid status');
+    });
+
+    it('ignores invalid priority in PATCH', async () => {
+      seedTasks([makeSampleCard({ id: 'card-1', priority: 'low' })]);
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/card-1', method: 'PATCH' }),
+        res,
+        depsWithBody({ priority: 'ultra' }),
+      );
+      // Should succeed but not change priority
+      expect(res._statusCode).toBe(200);
+      expect(parseJsonBody<{ card: TaskCard }>(res).card.priority).toBe('low');
+    });
+
+    it('clears agentId when set to empty string', async () => {
+      seedTasks([makeSampleCard({ id: 'card-1', agentId: 'oracle' })]);
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/card-1', method: 'PATCH' }),
+        res,
+        depsWithBody({ agentId: '' }),
+      );
+      expect(parseJsonBody<{ card: TaskCard }>(res).card.agentId).toBeNull();
+    });
+
+    it('truncates title to 200 chars in PATCH', async () => {
+      seedTasks([makeSampleCard({ id: 'card-1' })]);
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/card-1', method: 'PATCH' }),
+        res,
+        depsWithBody({ title: 'z'.repeat(300) }),
+      );
+      expect(parseJsonBody<{ card: TaskCard }>(res).card.title).toHaveLength(200);
+    });
+  });
+
+  describe('summary with multiple agents', () => {
+    it('returns accurate per-agent breakdown across all statuses', async () => {
+      seedTasks([
+        makeSampleCard({ agentId: 'alpha', status: 'backlog' }),
+        makeSampleCard({ agentId: 'alpha', status: 'running' }),
+        makeSampleCard({ agentId: 'alpha', status: 'done' }),
+        makeSampleCard({ agentId: 'beta', status: 'queued' }),
+        makeSampleCard({ agentId: 'beta', status: 'failed' }),
+        makeSampleCard({ agentId: null, status: 'backlog' }),
+      ]);
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/summary' }),
+        res,
+        createDeps(),
+      );
+      const body = parseJsonBody<{
+        columns: Record<string, number>;
+        byAgent: Record<string, Record<string, number>>;
+        total: number;
+      }>(res);
+      expect(body.total).toBe(6);
+      expect(body.columns.backlog).toBe(2);
+      expect(body.columns.running).toBe(1);
+      expect(body.columns.queued).toBe(1);
+      expect(body.columns.done).toBe(1);
+      expect(body.columns.failed).toBe(1);
+
+      expect(body.byAgent['alpha'].running).toBe(1);
+      expect(body.byAgent['alpha'].done).toBe(1);
+      expect(body.byAgent['beta'].queued).toBe(1);
+      expect(body.byAgent['beta'].failed).toBe(1);
+      expect(body.byAgent['_unassigned'].backlog).toBe(1);
+    });
+  });
+
+  describe('combined filter coverage', () => {
+    it('filters by priority + agentId', async () => {
+      seedTasks([
+        makeSampleCard({ id: 'a', agentId: 'oracle', priority: 'critical', status: 'backlog' }),
+        makeSampleCard({ id: 'b', agentId: 'oracle', priority: 'low', status: 'backlog' }),
+        makeSampleCard({ id: 'c', agentId: 'sentinel', priority: 'critical', status: 'running' }),
+      ]);
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board?priority=critical&agentId=oracle' }),
+        res,
+        createDeps(),
+      );
+      const body = parseJsonBody<{ tasks: TaskCard[] }>(res);
+      expect(body.tasks).toHaveLength(1);
+      expect(body.tasks[0].id).toBe('a');
+    });
+
+    it('filters by all three: status + agentId + priority', async () => {
+      seedTasks([
+        makeSampleCard({ id: 'x', agentId: 'nexus', priority: 'high', status: 'running' }),
+        makeSampleCard({ id: 'y', agentId: 'nexus', priority: 'high', status: 'backlog' }),
+        makeSampleCard({ id: 'z', agentId: 'nexus', priority: 'low', status: 'running' }),
+      ]);
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board?status=running&agentId=nexus&priority=high' }),
+        res,
+        createDeps(),
+      );
+      const body = parseJsonBody<{ tasks: TaskCard[] }>(res);
+      expect(body.tasks).toHaveLength(1);
+      expect(body.tasks[0].id).toBe('x');
+    });
+  });
 });


### PR DESCRIPTION
## Summary

Adds an interactive Kanban board UI panel to the dashboard, connecting to the CRUD API landed in Phase 1 (PR #235). This is the second vertical slice of the [Agent Task Board epic (#219)](https://github.com/zachyzissou/ventureos/issues/219).

## What's New

### Dashboard UI
- **Sidebar nav item** (📌 Task Board) with auto-refresh on page navigation
- **Summary stat cards** — per-column task counts at a glance (Backlog / Queued / Running / Done / Failed)
- **5-column Kanban board** with task cards showing:
  - Priority badges (critical/high/medium/low)
  - Agent assignment tags
  - Token usage counts
  - Elapsed time / running indicators
  - Result summaries and error messages
- **Create task form** — title, description, priority, optional agent assignment
- **Status transition buttons** — click to move cards between columns (respects the state machine from Phase 1)
- **Delete with confirmation**
- **Auto-refresh** every 15s when the task board page is visible
- **Responsive layout** — 5 cols → 3 cols → 1 col at breakpoints
- **Empty state** with guidance to create first task

### Test Coverage (16 new, 61 total)
- Full lifecycle workflow: backlog → queued → running → done
- Retry path workflow: running → failed → backlog → queued
- POST edge cases: whitespace trim, char length limits, initial status, malformed JSON
- PATCH edge cases: invalid status/priority, empty agentId, title truncation
- Multi-agent summary accuracy
- Combined triple-filter coverage (status + agentId + priority)

## Files Changed
| File | Change |
|------|--------|
| `dashboard/client/index.html` | +604 lines (nav item + page HTML + CSS + JS) |
| `dashboard/tests/unit/routes/task-board.test.ts` | +298 lines (16 new tests) |

## Test Results
```
✓ task-board.test.ts (61 tests) — 19ms
✓ Dashboard full suite: 432/432 passed (excluding pre-existing live-telemetry port conflict)
✓ TypeScript typecheck: clean (tsc --noEmit)
```

## Risk Assessment
- **Low risk** — purely additive frontend (CSS + JS) + expanded test coverage
- No backend changes, no new dependencies
- No auth/security changes — uses existing dashboard auth posture
- All state machine enforcement remains server-side (Phase 1)
- Reversible: removing the nav item + page div reverts cleanly

## Remaining Scope for #219
- [ ] Drag-and-drop card reordering between columns
- [ ] WebSocket/SSE real-time card state push
- [ ] Heartbeat integration (auto-pickup queued tasks)
- [ ] Task execution wrapper (metrics capture: time, tokens, cost)
- [ ] Task card detail view / expanded execution log
- [ ] Task history + 30-day retention policy
- [ ] Stuck-task alerting (running > timeout)

Refs #219