### PR TITLE
feat(#219): Task Board real-time SSE updates — Phase 3

### DIFF
--- a/dashboard/client/index.html
+++ b/dashboard/client/index.html
@@ -6312,15 +6312,116 @@ async function tbDeleteTask(id) {
   }
 }
 
-// Auto-refresh task board every 15s when visible
-function tbStartAutoRefresh() {
+// ── Real-time SSE subscription (Issue #219) ─────────────────────────────────
+// Prefer SSE for live updates; fall back to 15s polling if unavailable.
+
+let tbEventSource = null;
+let tbSseConnected = false;
+let tbReconnectTimer = null;
+const TB_RECONNECT_DELAY_MS = 5000;
+const TB_POLL_INTERVAL_MS = 15000;
+
+function tbConnectSse() {
+  if (tbEventSource) return;
+  try {
+    tbEventSource = new EventSource('/api/task-board/events');
+
+    tbEventSource.onopen = () => {
+      tbSseConnected = true;
+      // Stop polling — SSE is live
+      if (tbAutoRefreshTimer) {
+        clearInterval(tbAutoRefreshTimer);
+        tbAutoRefreshTimer = null;
+      }
+      console.log('[task-board] SSE connected');
+    };
+
+    tbEventSource.onmessage = (ev) => {
+      try {
+        const data = JSON.parse(ev.data);
+        if (data.type === 'connected') return; // handshake
+
+        if (data.type === 'task:created' || data.type === 'task:updated' || data.type === 'task:deleted') {
+          tbApplyEvent(data);
+        }
+      } catch (e) {
+        console.warn('[task-board] SSE parse error', e);
+      }
+    };
+
+    tbEventSource.onerror = () => {
+      console.warn('[task-board] SSE error — falling back to polling');
+      tbDisconnectSse();
+      tbStartPollingFallback();
+      // Attempt reconnect after delay
+      tbReconnectTimer = setTimeout(tbConnectSse, TB_RECONNECT_DELAY_MS);
+    };
+  } catch (e) {
+    console.warn('[task-board] SSE not available', e);
+    tbStartPollingFallback();
+  }
+}
+
+function tbDisconnectSse() {
+  tbSseConnected = false;
+  if (tbEventSource) {
+    try { tbEventSource.close(); } catch {}
+    tbEventSource = null;
+  }
+}
+
+/**
+ * Apply a real-time event to the local task list and re-render.
+ * Avoids a full refresh — updates in-place.
+ */
+function tbApplyEvent(event) {
+  const card = event.card;
+  if (!card || !card.id) return;
+
+  if (event.type === 'task:created') {
+    // Only add if not already present (idempotency)
+    if (!tbTasks.find(t => t.id === card.id)) {
+      tbTasks.push(card);
+    }
+  } else if (event.type === 'task:updated') {
+    const idx = tbTasks.findIndex(t => t.id === card.id);
+    if (idx !== -1) {
+      tbTasks[idx] = card;
+    } else {
+      tbTasks.push(card); // card appeared (possibly missed create)
+    }
+  } else if (event.type === 'task:deleted') {
+    tbTasks = tbTasks.filter(t => t.id !== card.id);
+  }
+
+  // Re-sort and render
+  tbTasks.sort((a, b) =>
+    (TB_PRIORITY_ORDER[a.priority] ?? 9) - (TB_PRIORITY_ORDER[b.priority] ?? 9)
+  );
+
+  // Update summary counts inline
+  const cols = { backlog: 0, queued: 0, running: 0, done: 0, failed: 0 };
+  for (const t of tbTasks) { cols[t.status] = (cols[t.status] || 0) + 1; }
+  const el = (id) => document.getElementById(id);
+  if (el('tbCountBacklog')) el('tbCountBacklog').textContent = cols.backlog;
+  if (el('tbCountQueued')) el('tbCountQueued').textContent = cols.queued;
+  if (el('tbCountRunning')) el('tbCountRunning').textContent = cols.running;
+  if (el('tbCountDone')) el('tbCountDone').textContent = cols.done;
+  if (el('tbCountFailed')) el('tbCountFailed').textContent = cols.failed;
+
+  tbRenderBoard();
+}
+
+function tbStartPollingFallback() {
   if (tbAutoRefreshTimer) return;
   tbAutoRefreshTimer = setInterval(() => {
     const activePage = document.querySelector('.page.active');
     if (activePage && activePage.id === 'taskboard') tbRefresh();
-  }, 15000);
+  }, TB_POLL_INTERVAL_MS);
 }
-tbStartAutoRefresh();
+
+// Start SSE on load; falls back to polling automatically
+tbConnectSse();
 </script>
 </body>
 </html>

--- a/dashboard/server/routes/index.ts
+++ b/dashboard/server/routes/index.ts
@@ -15,5 +15,13 @@ export { handleTacticalMapReplay } from './tactical-map-replay.js';
 export { handleAgentDiagnostics } from './agent-diagnostics.js';
 export { handleChangelog } from './changelog.js';
 export { handleTaskBoard } from './task-board.js';
+export {
+  emitTaskEvent,
+  broadcastTaskEvent,
+  addClient,
+  removeClient,
+  removeAllClients,
+  clientCount,
+} from '../task-board-events.js';
 export { handleMemoryState } from './memory-state.js';
 export { handleSharedContext } from './shared-context.js';

--- a/dashboard/server/routes/task-board.ts
+++ b/dashboard/server/routes/task-board.ts
@@ -1,9 +1,12 @@
 /**
  * Task Board (Kanban) route handlers.
- * Issue #219 — first vertical slice.
+ * Issue #219 — first vertical slice + SSE real-time updates.
  *
  * Provides CRUD + summary endpoints for task cards that flow through
  * Backlog → Queued → Running → Done/Failed columns.
+ *
+ * SSE stream at GET /api/task-board/events pushes task:created,
+ * task:updated, and task:deleted events to connected clients.
  *
  * Data is persisted as a single JSON file on disk (consistent with
  * the rest of the dashboard's filesystem-based storage).
@@ -21,6 +24,12 @@ import type {
   TaskPriority,
   TaskBoardSummary,
 } from '../types.js';
+
+import {
+  addClient,
+  removeClient,
+  clientCount,
+} from '../task-board-events.js';
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -170,6 +179,28 @@ export async function handleTaskBoard(
   const url = req.url;
   const method = req.method ?? 'GET';
 
+  // ── GET /api/task-board/events (SSE) ─────────────────────────────────────
+  // Real-time event stream for task mutations. Issue #219.
+  if (url === '/api/task-board/events' && method === 'GET') {
+    if (!addClient(res)) {
+      sendJson(res, { error: 'too many SSE connections' }, 503);
+      return true;
+    }
+
+    res.writeHead(200, {
+      'Content-Type': 'text/event-stream',
+      'Cache-Control': 'no-cache',
+      Connection: 'keep-alive',
+    });
+    res.write(`data: ${JSON.stringify({ type: 'connected', ts: Date.now(), clients: clientCount() })}\n\n`);
+
+    req.on('close', () => {
+      removeClient(res);
+    });
+
+    return true;
+  }
+
   // ── GET /api/task-board ────────────────────────────────────────────────────
   // Returns filtered list of cards. Query params: status, agentId, priority.
   if (url.startsWith('/api/task-board') && !url.startsWith('/api/task-board/') && method === 'GET') {
@@ -228,6 +259,7 @@ export async function handleTaskBoard(
     const tasks = loadTasks(dataDir);
     tasks.push(result.card);
     saveTasks(dataDir, tasks);
+    deps.emitEvent?.('task:created', result.card);
     sendJson(res, { card: result.card }, 201);
     return true;
   }
@@ -291,6 +323,7 @@ export async function handleTaskBoard(
 
     tasks[idx] = card;
     saveTasks(dataDir, tasks);
+    deps.emitEvent?.('task:updated', card);
     sendJson(res, { card });
     return true;
   }
@@ -308,8 +341,10 @@ export async function handleTaskBoard(
       return true;
     }
 
+    const deletedCard = tasks[idx];
     tasks.splice(idx, 1);
     saveTasks(dataDir, tasks);
+    deps.emitEvent?.('task:deleted', deletedCard);
     sendJson(res, { ok: true });
     return true;
   }

--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -108,6 +108,7 @@ import { handleProgressionApi } from './routes/progression.js';
 import { handleProgressionV2Api } from '../../lib/progression-http-v2.js';
 import { handleChangelog } from './routes/changelog.js';
 import { handleTaskBoard } from './routes/task-board.js';
+import { emitTaskEvent } from './task-board-events.js';
 import { handleMemoryState } from './routes/memory-state.js';
 import { handleSharedContext } from './routes/shared-context.js';
 
@@ -3223,6 +3224,7 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
         dataDir: DASHBOARD_DATA_DIR,
         sendJson,
         readRequestBody,
+        emitEvent: emitTaskEvent,
       });
       if (handled) return;
     } catch (e: unknown) {

--- a/dashboard/server/task-board-events.ts
+++ b/dashboard/server/task-board-events.ts
@@ -1,0 +1,121 @@
+/**
+ * Task Board SSE event bus — Issue #219.
+ *
+ * Provides a bounded pub/sub for task board mutations (create/update/delete).
+ * SSE clients subscribe via GET /api/task-board/events.
+ *
+ * Design:
+ * - Follows the existing /api/live and /api/live-telemetry SSE patterns.
+ * - Max connections capped to prevent resource exhaustion.
+ * - Heartbeat keepalive to detect stale connections.
+ * - Graceful cleanup on client disconnect.
+ */
+
+import type { ServerResponse } from 'node:http';
+import type { TaskCard } from './types.js';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type TaskBoardEventType = 'task:created' | 'task:updated' | 'task:deleted';
+
+export interface TaskBoardEvent {
+  type: TaskBoardEventType;
+  ts: number;
+  card: TaskCard;
+  /** For deletes, card is the last-known state before removal. */
+}
+
+// ─── Event Bus ───────────────────────────────────────────────────────────────
+
+/** Maximum simultaneous SSE connections for the task board stream. */
+const MAX_CLIENTS = 50;
+
+/** Heartbeat interval in ms — keeps connections alive through proxies. */
+const HEARTBEAT_INTERVAL_MS = 30_000;
+
+interface SseClient {
+  res: ServerResponse;
+  heartbeat: NodeJS.Timeout;
+}
+
+let clients: SseClient[] = [];
+
+/** Number of currently connected SSE clients. */
+export function clientCount(): number {
+  return clients.length;
+}
+
+/**
+ * Register an SSE client. Returns false if at capacity.
+ * The caller should already have written the SSE headers.
+ */
+export function addClient(res: ServerResponse): boolean {
+  if (clients.length >= MAX_CLIENTS) return false;
+
+  const heartbeat = setInterval(() => {
+    try {
+      if (!res.writable) {
+        removeClient(res);
+        return;
+      }
+      res.write(':heartbeat\n\n');
+    } catch {
+      removeClient(res);
+    }
+  }, HEARTBEAT_INTERVAL_MS);
+
+  clients.push({ res, heartbeat });
+  return true;
+}
+
+/** Remove a client and clean up its heartbeat timer. */
+export function removeClient(res: ServerResponse): void {
+  const idx = clients.findIndex((c) => c.res === res);
+  if (idx === -1) return;
+  clearInterval(clients[idx].heartbeat);
+  clients.splice(idx, 1);
+}
+
+/** Remove all clients — used for tests and graceful shutdown. */
+export function removeAllClients(): void {
+  for (const c of clients) {
+    clearInterval(c.heartbeat);
+  }
+  clients = [];
+}
+
+/**
+ * Broadcast a task board event to all connected SSE clients.
+ * Non-writable clients are pruned automatically.
+ */
+export function broadcastTaskEvent(event: TaskBoardEvent): void {
+  if (clients.length === 0) return;
+  const message = `data: ${JSON.stringify(event)}\n\n`;
+  const stale: ServerResponse[] = [];
+
+  for (const c of clients) {
+    try {
+      if (!c.res.writable) {
+        stale.push(c.res);
+        continue;
+      }
+      c.res.write(message);
+    } catch {
+      stale.push(c.res);
+    }
+  }
+
+  for (const res of stale) {
+    removeClient(res);
+  }
+}
+
+/**
+ * Emit helper — convenience wrapper used by route handlers.
+ */
+export function emitTaskEvent(
+  type: TaskBoardEventType,
+  card: TaskCard,
+): void {
+  broadcastTaskEvent({ type, ts: Date.now(), card });
+}

--- a/dashboard/server/types.ts
+++ b/dashboard/server/types.ts
@@ -719,6 +719,12 @@ export interface TaskBoardDeps {
   dataDir: string;
   sendJson: (res: ServerResponse, data: unknown, status?: number) => void;
   readRequestBody: (req: IncomingMessage, opts?: { maxBytes?: number }) => Promise<string>;
+  /**
+   * Optional callback to emit real-time events on task mutations.
+   * When provided, called after successful create/update/delete.
+   * Issue #219 — SSE real-time updates.
+   */
+  emitEvent?: (type: 'task:created' | 'task:updated' | 'task:deleted', card: TaskCard) => void;
 }
 
 // ─── Memory State Domain (Phase 4 — #233) ────────────────────────────────────

--- a/dashboard/tests/unit/routes/task-board-events.test.ts
+++ b/dashboard/tests/unit/routes/task-board-events.test.ts
@@ -1,0 +1,410 @@
+/**
+ * Task Board SSE event bus tests — Issue #219.
+ *
+ * Tests the event bus (task-board-events.ts) and the SSE endpoint
+ * integration in the task-board route handler.
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { mockRequest, mockResponse, parseJsonBody } from '../../helpers.js';
+import {
+  handleTaskBoard,
+  loadTasks,
+} from '../../../server/routes/task-board.js';
+import {
+  addClient,
+  removeClient,
+  removeAllClients,
+  clientCount,
+  broadcastTaskEvent,
+  emitTaskEvent,
+} from '../../../server/task-board-events.js';
+import type { TaskBoardDeps, TaskCard } from '../../../server/types.js';
+
+const testDataDir = path.join('/tmp', 'test-tb-events-' + process.pid);
+
+/**
+ * Create a mock response that behaves as an SSE-capable writable stream.
+ * The standard mockResponse doesn't expose `writable`, which broadcastTaskEvent checks.
+ */
+function mockSseResponse() {
+  const res = mockResponse();
+  // Mark as writable so broadcastTaskEvent doesn't prune it
+  (res as any).writable = true;
+  return res;
+}
+
+/**
+ * Create a mock response that simulates a non-writable (disconnected) stream.
+ */
+function mockStaleResponse() {
+  const res = mockResponse();
+  (res as any).writable = false;
+  return res;
+}
+
+function createDeps(overrides: Partial<TaskBoardDeps> = {}): TaskBoardDeps {
+  return {
+    dataDir: testDataDir,
+    sendJson: (res, data, status = 200) => {
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+    },
+    readRequestBody: async () => '{}',
+    ...overrides,
+  };
+}
+
+function depsWithBody(body: unknown, overrides: Partial<TaskBoardDeps> = {}): TaskBoardDeps {
+  return createDeps({
+    readRequestBody: async () => JSON.stringify(body),
+    ...overrides,
+  });
+}
+
+function seedTasks(tasks: TaskCard[]): void {
+  fs.mkdirSync(testDataDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(testDataDir, 'task-board.json'),
+    JSON.stringify({ tasks, updatedAt: Date.now() }),
+  );
+}
+
+function makeSampleCard(overrides: Partial<TaskCard> = {}): TaskCard {
+  return {
+    id: 'test-' + Math.random().toString(36).slice(2, 8),
+    agentId: 'oracle',
+    title: 'Test task',
+    description: 'A test task',
+    priority: 'medium',
+    status: 'backlog',
+    createdAt: Date.now(),
+    queuedAt: null,
+    startedAt: null,
+    completedAt: null,
+    resultSummary: null,
+    tokensUsed: null,
+    error: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  fs.mkdirSync(testDataDir, { recursive: true });
+  const fp = path.join(testDataDir, 'task-board.json');
+  if (fs.existsSync(fp)) fs.unlinkSync(fp);
+  removeAllClients();
+});
+
+afterEach(() => {
+  removeAllClients();
+  try {
+    fs.rmSync(testDataDir, { recursive: true, force: true });
+  } catch {
+    // ignore
+  }
+});
+
+// ─── Event Bus Unit Tests ────────────────────────────────────────────────────
+
+describe('task-board-events: client management', () => {
+  it('starts with zero clients', () => {
+    expect(clientCount()).toBe(0);
+  });
+
+  it('adds a client and increments count', () => {
+    const res = mockSseResponse();
+    const added = addClient(res as any);
+    expect(added).toBe(true);
+    expect(clientCount()).toBe(1);
+  });
+
+  it('removes a client', () => {
+    const res = mockSseResponse();
+    addClient(res as any);
+    expect(clientCount()).toBe(1);
+    removeClient(res as any);
+    expect(clientCount()).toBe(0);
+  });
+
+  it('removeClient is idempotent', () => {
+    const res = mockSseResponse();
+    addClient(res as any);
+    removeClient(res as any);
+    removeClient(res as any); // second call is a no-op
+    expect(clientCount()).toBe(0);
+  });
+
+  it('removeAllClients clears all', () => {
+    addClient(mockSseResponse() as any);
+    addClient(mockSseResponse() as any);
+    addClient(mockSseResponse() as any);
+    expect(clientCount()).toBe(3);
+    removeAllClients();
+    expect(clientCount()).toBe(0);
+  });
+
+  it('rejects clients beyond MAX_CLIENTS', () => {
+    // Add 50 clients (the max)
+    for (let i = 0; i < 50; i++) {
+      expect(addClient(mockSseResponse() as any)).toBe(true);
+    }
+    expect(clientCount()).toBe(50);
+    // 51st should be rejected
+    expect(addClient(mockSseResponse() as any)).toBe(false);
+    expect(clientCount()).toBe(50);
+  });
+});
+
+describe('task-board-events: broadcastTaskEvent', () => {
+  it('sends event data to all connected clients', () => {
+    const res1 = mockSseResponse();
+    const res2 = mockSseResponse();
+    addClient(res1 as any);
+    addClient(res2 as any);
+
+    const card = makeSampleCard({ id: 'bcast-1' });
+    broadcastTaskEvent({ type: 'task:created', ts: Date.now(), card });
+
+    const body1 = res1._body;
+    const body2 = res2._body;
+    expect(body1).toContain('"type":"task:created"');
+    expect(body1).toContain('"id":"bcast-1"');
+    expect(body2).toContain('"type":"task:created"');
+  });
+
+  it('does nothing when no clients connected', () => {
+    // Should not throw
+    broadcastTaskEvent({
+      type: 'task:deleted',
+      ts: Date.now(),
+      card: makeSampleCard(),
+    });
+  });
+
+  it('prunes non-writable clients', () => {
+    const goodRes = mockSseResponse();
+    const badRes = mockStaleResponse();
+
+    addClient(goodRes as any);
+    addClient(badRes as any);
+    expect(clientCount()).toBe(2);
+
+    broadcastTaskEvent({
+      type: 'task:updated',
+      ts: Date.now(),
+      card: makeSampleCard(),
+    });
+
+    // Bad client should have been pruned
+    expect(clientCount()).toBe(1);
+  });
+});
+
+describe('emitTaskEvent', () => {
+  it('convenience wrapper broadcasts correctly', () => {
+    const res = mockSseResponse();
+    addClient(res as any);
+    const card = makeSampleCard({ id: 'emit-1' });
+    emitTaskEvent('task:created', card);
+
+    expect(res._body).toContain('"type":"task:created"');
+    expect(res._body).toContain('"id":"emit-1"');
+  });
+});
+
+// ─── SSE Endpoint Tests ─────────────────────────────────────────────────────
+
+describe('GET /api/task-board/events (SSE endpoint)', () => {
+  it('returns SSE headers and connected message', async () => {
+    const res = mockSseResponse();
+    const req = mockRequest({ url: '/api/task-board/events' });
+
+    const handled = await handleTaskBoard(req, res, createDeps());
+    expect(handled).toBe(true);
+    expect(res._headers['content-type']).toBe('text/event-stream');
+    expect(res._headers['cache-control']).toBe('no-cache');
+    expect(res._body).toContain('"type":"connected"');
+    expect(clientCount()).toBe(1);
+  });
+
+  it('returns 503 when at capacity', async () => {
+    // Fill up to max
+    for (let i = 0; i < 50; i++) {
+      addClient(mockSseResponse() as any);
+    }
+
+    const res = mockSseResponse();
+    const handled = await handleTaskBoard(
+      mockRequest({ url: '/api/task-board/events' }),
+      res,
+      createDeps(),
+    );
+    expect(handled).toBe(true);
+    expect(res._statusCode).toBe(503);
+    const body = parseJsonBody(res);
+    expect(body.error).toContain('too many');
+  });
+
+  it('removes client on request close', async () => {
+    const res = mockSseResponse();
+    const req = mockRequest({ url: '/api/task-board/events' });
+
+    await handleTaskBoard(req, res, createDeps());
+    expect(clientCount()).toBe(1);
+
+    // Simulate client disconnect
+    req.emit('close');
+    expect(clientCount()).toBe(0);
+  });
+});
+
+// ─── Integration: CRUD emits events ──────────────────────────────────────────
+
+describe('CRUD operations emit SSE events', () => {
+  it('POST /api/task-board emits task:created', async () => {
+    const emitted: Array<{ type: string; card: TaskCard }> = [];
+    const deps = depsWithBody(
+      { title: 'SSE create test', priority: 'high' },
+      {
+        emitEvent: (type, card) => { emitted.push({ type, card }); },
+      },
+    );
+
+    const res = mockResponse();
+    await handleTaskBoard(
+      mockRequest({ url: '/api/task-board', method: 'POST' }),
+      res,
+      deps,
+    );
+
+    expect(res._statusCode).toBe(201);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].type).toBe('task:created');
+    expect(emitted[0].card.title).toBe('SSE create test');
+  });
+
+  it('PATCH /api/task-board/:id emits task:updated', async () => {
+    seedTasks([makeSampleCard({ id: 'upd-1', status: 'backlog' })]);
+
+    const emitted: Array<{ type: string; card: TaskCard }> = [];
+    const deps = depsWithBody(
+      { status: 'queued' },
+      {
+        emitEvent: (type, card) => { emitted.push({ type, card }); },
+      },
+    );
+
+    const res = mockResponse();
+    await handleTaskBoard(
+      mockRequest({ url: '/api/task-board/upd-1', method: 'PATCH' }),
+      res,
+      deps,
+    );
+
+    expect(res._statusCode).toBe(200);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].type).toBe('task:updated');
+    expect(emitted[0].card.status).toBe('queued');
+  });
+
+  it('DELETE /api/task-board/:id emits task:deleted with last-known card', async () => {
+    const card = makeSampleCard({ id: 'del-1', title: 'Delete me' });
+    seedTasks([card]);
+
+    const emitted: Array<{ type: string; card: TaskCard }> = [];
+    const deps = createDeps({
+      emitEvent: (type, c) => { emitted.push({ type, card: c }); },
+    });
+
+    const res = mockResponse();
+    await handleTaskBoard(
+      mockRequest({ url: '/api/task-board/del-1', method: 'DELETE' }),
+      res,
+      deps,
+    );
+
+    expect(res._statusCode).toBe(200);
+    expect(emitted).toHaveLength(1);
+    expect(emitted[0].type).toBe('task:deleted');
+    expect(emitted[0].card.id).toBe('del-1');
+    expect(emitted[0].card.title).toBe('Delete me');
+
+    // Verify the card is actually gone
+    expect(loadTasks(testDataDir)).toHaveLength(0);
+  });
+
+  it('no emitEvent when deps.emitEvent is not provided', async () => {
+    // This test verifies the optional nature — no error when omitted
+    const deps = depsWithBody({ title: 'No emit' });
+    const res = mockResponse();
+    await handleTaskBoard(
+      mockRequest({ url: '/api/task-board', method: 'POST' }),
+      res,
+      deps,
+    );
+    expect(res._statusCode).toBe(201);
+    // No crash — the optional chaining handles it
+  });
+
+  it('failed mutation does not emit events', async () => {
+    seedTasks([makeSampleCard({ id: 'no-emit-1', status: 'backlog' })]);
+
+    const emitted: Array<{ type: string }> = [];
+    const deps = depsWithBody(
+      { status: 'running' }, // invalid transition from backlog
+      {
+        emitEvent: (type) => { emitted.push({ type }); },
+      },
+    );
+
+    const res = mockResponse();
+    await handleTaskBoard(
+      mockRequest({ url: '/api/task-board/no-emit-1', method: 'PATCH' }),
+      res,
+      deps,
+    );
+
+    expect(res._statusCode).toBe(400);
+    expect(emitted).toHaveLength(0); // No event emitted for invalid transition
+  });
+});
+
+// ─── End-to-end: broadcast reaches SSE client ────────────────────────────────
+
+describe('end-to-end: mutation → broadcast → SSE client', () => {
+  it('POST creates card and SSE client receives the event', async () => {
+    // Connect an SSE client
+    const sseRes = mockSseResponse();
+    const sseReq = mockRequest({ url: '/api/task-board/events' });
+    await handleTaskBoard(sseReq, sseRes, createDeps());
+    expect(clientCount()).toBe(1);
+
+    // Clear the connected message
+    const connectedBody = sseRes._body;
+    expect(connectedBody).toContain('"type":"connected"');
+
+    // Create a task with emitEvent wired to the real broadcastTaskEvent
+    const deps = depsWithBody(
+      { title: 'E2E test', priority: 'critical' },
+      {
+        emitEvent: emitTaskEvent,
+      },
+    );
+
+    const createRes = mockResponse();
+    await handleTaskBoard(
+      mockRequest({ url: '/api/task-board', method: 'POST' }),
+      createRes,
+      deps,
+    );
+    expect(createRes._statusCode).toBe(201);
+
+    // SSE client should have received the event
+    expect(sseRes._body).toContain('"type":"task:created"');
+    expect(sseRes._body).toContain('"title":"E2E test"');
+    expect(sseRes._body).toContain('"priority":"critical"');
+  });
+});


### PR DESCRIPTION
## Summary

Refs #219

Adds **Server-Sent Events (SSE)** to the Task Board so dashboard clients receive instant updates when tasks are created, updated, or deleted — replacing the 15-second polling interval.

## What Changed

### Backend
- **`dashboard/server/task-board-events.ts`** — New bounded pub/sub event bus:
  - Max 50 simultaneous SSE connections (returns 503 at capacity)
  - 30s heartbeat keepalive to detect stale connections through proxies
  - Automatic pruning of non-writable clients on broadcast
- **`GET /api/task-board/events`** — SSE endpoint following the existing `/api/live-telemetry` pattern
- **POST/PATCH/DELETE handlers** now emit `task:created` / `task:updated` / `task:deleted` events via an optional `deps.emitEvent` callback (zero change to callers that don't provide it)
- **`TaskBoardDeps.emitEvent`** is optional — all existing tests untouched

### Frontend
- `EventSource` connects to `/api/task-board/events` on dashboard load
- In-place board updates via `tbApplyEvent()` — no full refresh needed
- **Graceful fallback** to 15s polling if SSE unavailable or errors
- Auto-reconnect after 5s on SSE failure

### Tests (19 new, 454 suite-wide — all green ✅)
- Event bus: client add/remove/capacity/pruning/removeAll
- Broadcast: multi-client delivery, stale client pruning, no-op when empty
- SSE endpoint: headers, connected message, 503 at capacity, cleanup on close
- CRUD integration: emitEvent on create/update/delete, not called on validation failures
- E2E: POST mutation → broadcast → SSE client receives event

## Risk Assessment
- **Low risk.** All changes are strictly additive.
- SSE is bounded (50 clients max) with automatic cleanup.
- No auth changes — SSE endpoint inherits the same middleware pipeline.
- Frontend falls back gracefully to polling if SSE is unavailable.
- `emitEvent` is optional — backward compatible with all existing callers.

## Remaining Scope for #219
- Auth-gating the SSE endpoint (currently inherits general middleware; may want explicit token check)
- Per-agent/per-filter SSE subscriptions (currently broadcasts all events)
- Drag-and-drop reordering within columns
- Task detail modal / inline editing UX
- Bulk operations (move multiple, archive done/failed)
- Board view preferences (collapsed columns, sort order persistence)