### PR TITLE
feat(#219): Task metrics dashboard + stuck-task alerting baseline

### DIFF
--- a/dashboard/client/index.html
+++ b/dashboard/client/index.html
@@ -1711,6 +1711,235 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
 
 /* ─── End Multi-Select & Bulk Operations ────────────────────────────── */
 
+/* ─── Task Metrics Dashboard — Issue #219, Phase 7 ──────────────────── */
+
+.tb-metrics-toggle {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 16px;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  transition: all 0.2s;
+  user-select: none;
+}
+
+.tb-metrics-toggle:hover {
+  border-color: var(--accent);
+  color: var(--text-primary);
+}
+
+.tb-metrics-toggle .tb-metrics-toggle-icon {
+  transition: transform 0.2s;
+}
+
+.tb-metrics-toggle.open .tb-metrics-toggle-icon {
+  transform: rotate(90deg);
+}
+
+.tb-metrics-panel {
+  display: none;
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 12px;
+  padding: 20px;
+  margin-top: 8px;
+}
+
+.tb-metrics-panel.open {
+  display: block;
+}
+
+.tb-metrics-kpi-row {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(140px, 1fr));
+  gap: 12px;
+  margin-bottom: 20px;
+}
+
+.tb-metrics-kpi {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px 16px;
+  text-align: center;
+}
+
+.tb-metrics-kpi-value {
+  font-size: 24px;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', monospace;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+}
+
+.tb-metrics-kpi-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.tb-metrics-section-title {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  margin-bottom: 10px;
+}
+
+/* Mini bar chart for completion trend */
+.tb-trend-chart {
+  display: flex;
+  align-items: flex-end;
+  gap: 6px;
+  height: 80px;
+  padding: 0 4px;
+}
+
+.tb-trend-bar-group {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 2px;
+  height: 100%;
+  justify-content: flex-end;
+}
+
+.tb-trend-bars {
+  display: flex;
+  gap: 2px;
+  align-items: flex-end;
+  width: 100%;
+  justify-content: center;
+}
+
+.tb-trend-bar {
+  width: 12px;
+  min-height: 2px;
+  border-radius: 3px 3px 0 0;
+  transition: height 0.3s;
+}
+
+.tb-trend-bar.done { background: var(--green); }
+.tb-trend-bar.failed { background: var(--red); opacity: 0.7; }
+
+.tb-trend-label {
+  font-size: 9px;
+  color: var(--text-muted);
+  font-family: 'JetBrains Mono', monospace;
+  margin-top: 4px;
+}
+
+/* Agent breakdown table */
+.tb-agent-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.tb-agent-table th {
+  text-align: left;
+  padding: 6px 10px;
+  font-weight: 600;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.tb-agent-table td {
+  padding: 6px 10px;
+  color: var(--text-secondary);
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.tb-agent-table tr:last-child td { border-bottom: none; }
+
+/* Stuck task alert */
+.tb-stuck-alert {
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+  border-radius: 10px;
+  padding: 12px 16px;
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  font-size: 13px;
+  color: var(--yellow);
+}
+
+.tb-stuck-alert-icon {
+  font-size: 20px;
+  flex-shrink: 0;
+  animation: tb-stuck-pulse 2s ease-in-out infinite;
+}
+
+@keyframes tb-stuck-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.4; }
+}
+
+.tb-stuck-alert-list {
+  flex: 1;
+}
+
+.tb-stuck-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  font-size: 12px;
+}
+
+.tb-stuck-item-title {
+  color: var(--text-primary);
+  font-weight: 500;
+}
+
+.tb-stuck-item-time {
+  color: var(--yellow);
+  font-family: 'JetBrains Mono', monospace;
+  font-size: 11px;
+}
+
+/* Stuck badge on kanban cards */
+.tb-card-stuck-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: rgba(245, 158, 11, 0.15);
+  color: var(--yellow);
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 7px;
+  border-radius: 6px;
+  animation: tb-stuck-pulse 2s ease-in-out infinite;
+}
+
+.tb-metrics-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 16px;
+}
+
+@media (max-width: 900px) {
+  .tb-metrics-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+/* ─── End Task Metrics Dashboard ────────────────────────────────────── */
+
 /* ─── End Task Board ────────────────────────────────────────────────── */
 
 /* Mobile + Tablet Responsive */
@@ -3217,6 +3446,87 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
           <div class="metric" style="gap:6px;">
             <div class="metric-value" style="font-size:28px;color:var(--red);" id="tbCountFailed">0</div>
             <div class="metric-label">Failed</div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Task Metrics Dashboard — Issue #219, Phase 7 -->
+      <div class="mb-24">
+        <div class="tb-metrics-toggle" id="tbMetricsToggle" onclick="tbToggleMetrics()">
+          <span class="tb-metrics-toggle-icon">▸</span>
+          <span>📊 Task Metrics &amp; Health</span>
+          <span id="tbMetricsStuckBadge" style="display:none;margin-left:auto;background:rgba(245,158,11,0.15);color:var(--yellow);font-size:11px;padding:2px 8px;border-radius:8px;font-weight:600;"></span>
+        </div>
+        <div class="tb-metrics-panel" id="tbMetricsPanel">
+          <!-- Stuck tasks alert (shown only when stuck tasks exist) -->
+          <div id="tbStuckAlert" class="tb-stuck-alert mb-24" style="display:none;">
+            <span class="tb-stuck-alert-icon">⚠️</span>
+            <div class="tb-stuck-alert-list" id="tbStuckAlertList"></div>
+          </div>
+
+          <!-- KPI row -->
+          <div class="tb-metrics-kpi-row">
+            <div class="tb-metrics-kpi">
+              <div class="tb-metrics-kpi-value" id="tbMetricsThroughput24h">—</div>
+              <div class="tb-metrics-kpi-label">Completed 24h</div>
+            </div>
+            <div class="tb-metrics-kpi">
+              <div class="tb-metrics-kpi-value" id="tbMetricsThroughput7d">—</div>
+              <div class="tb-metrics-kpi-label">Completed 7d</div>
+            </div>
+            <div class="tb-metrics-kpi">
+              <div class="tb-metrics-kpi-value" id="tbMetricsAvgRuntime">—</div>
+              <div class="tb-metrics-kpi-label">Avg Runtime</div>
+            </div>
+            <div class="tb-metrics-kpi">
+              <div class="tb-metrics-kpi-value" id="tbMetricsMedianRuntime">—</div>
+              <div class="tb-metrics-kpi-label">Median Runtime</div>
+            </div>
+            <div class="tb-metrics-kpi">
+              <div class="tb-metrics-kpi-value" id="tbMetricsSuccessRate">—</div>
+              <div class="tb-metrics-kpi-label">Success Rate</div>
+            </div>
+            <div class="tb-metrics-kpi" id="tbMetricsStuckKpi" style="border-color:transparent;">
+              <div class="tb-metrics-kpi-value" id="tbMetricsStuckCount" style="color:var(--text-muted);">0</div>
+              <div class="tb-metrics-kpi-label">Stuck Tasks</div>
+            </div>
+          </div>
+
+          <div class="tb-metrics-grid">
+            <!-- Completion trend chart -->
+            <div>
+              <div class="tb-metrics-section-title">7-Day Completion Trend</div>
+              <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:14px;">
+                <div class="tb-trend-chart" id="tbTrendChart">
+                  <div style="text-align:center;color:var(--text-muted);font-size:12px;width:100%;padding:20px;">No data yet</div>
+                </div>
+                <div style="display:flex;gap:16px;justify-content:center;margin-top:10px;font-size:11px;">
+                  <span style="display:flex;align-items:center;gap:4px;color:var(--text-muted);"><span style="width:10px;height:10px;background:var(--green);border-radius:2px;display:inline-block;"></span> Done</span>
+                  <span style="display:flex;align-items:center;gap:4px;color:var(--text-muted);"><span style="width:10px;height:10px;background:var(--red);opacity:0.7;border-radius:2px;display:inline-block;"></span> Failed</span>
+                </div>
+              </div>
+            </div>
+
+            <!-- Agent breakdown -->
+            <div>
+              <div class="tb-metrics-section-title">Agent Breakdown</div>
+              <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:14px;overflow-x:auto;">
+                <table class="tb-agent-table" id="tbAgentTable">
+                  <thead>
+                    <tr>
+                      <th>Agent</th>
+                      <th>Running</th>
+                      <th>Done</th>
+                      <th>Failed</th>
+                      <th>Avg Runtime</th>
+                    </tr>
+                  </thead>
+                  <tbody id="tbAgentTableBody">
+                    <tr><td colspan="5" style="text-align:center;color:var(--text-muted);padding:16px;">No agent data</td></tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
           </div>
         </div>
       </div>
@@ -6850,6 +7160,9 @@ async function tbRefresh() {
     tbPopulateAgentFilter(tbTasks);
 
     tbRenderBoard();
+
+    // Also refresh metrics if the panel is open
+    if (tbMetricsOpen) tbRefreshMetrics();
   } catch (e) {
     console.error('[task-board] refresh error', e);
   }
@@ -6905,6 +7218,8 @@ function tbRenderCard(card) {
   const result = card.resultSummary ? `<div style="margin-top:6px;font-size:11px;color:var(--green);"><b>Result:</b> ${tbEsc(card.resultSummary)}</div>` : '';
   const errorMsg = card.error ? `<div style="margin-top:6px;font-size:11px;color:var(--red);"><b>Error:</b> ${tbEsc(card.error)}</div>` : '';
   const tokens = card.tokensUsed ? `<span class="tb-badge" style="background:rgba(168,85,247,0.12);color:var(--purple);">🪙 ${card.tokensUsed.toLocaleString()}</span>` : '';
+  const isStuck = tbStuckIds.has(card.id);
+  const stuckBadge = isStuck ? '<span class="tb-card-stuck-badge">⚠️ Stuck</span>' : '';
   const elapsed = card.startedAt && card.completedAt
     ? `<span class="tb-time-ago">${tbDuration(card.completedAt - card.startedAt)}</span>`
     : card.startedAt
@@ -6934,6 +7249,7 @@ function tbRenderCard(card) {
     <div class="tb-card-meta">
       <span class="tb-badge ${priClass}">${card.priority}</span>
       ${agent}
+      ${stuckBadge}
       ${tokens}
       ${elapsed}
       <span class="tb-time-ago" style="margin-left:auto;">${ago}</span>
@@ -7607,6 +7923,152 @@ async function tbBulkArchive() {
   }
 }
 
+// ── Task Metrics Dashboard (Issue #219 — Phase 7) ───────────────────────────
+// Fetches computed metrics from /api/task-board/metrics and renders KPIs,
+// trend chart, agent breakdown, and stuck-task alerts.
+
+let tbMetricsOpen = false;
+let tbMetricsData = null;
+let tbStuckIds = new Set(); // Track stuck task IDs for card badge rendering
+
+/** Toggle the metrics panel open/closed. */
+function tbToggleMetrics() {
+  tbMetricsOpen = !tbMetricsOpen;
+  const toggle = document.getElementById('tbMetricsToggle');
+  const panel = document.getElementById('tbMetricsPanel');
+  if (toggle) toggle.classList.toggle('open', tbMetricsOpen);
+  if (panel) panel.classList.toggle('open', tbMetricsOpen);
+  if (tbMetricsOpen) tbRefreshMetrics();
+}
+
+/** Fetch metrics from the API and render all panels. */
+async function tbRefreshMetrics() {
+  try {
+    const res = await fetch('/api/task-board/metrics');
+    if (!res.ok) return;
+    tbMetricsData = await res.json();
+    tbRenderMetrics(tbMetricsData);
+  } catch (e) {
+    console.warn('[task-board] metrics fetch error', e);
+  }
+}
+
+/** Render all metrics panels from data. */
+function tbRenderMetrics(m) {
+  if (!m) return;
+
+  // KPIs
+  const el = (id) => document.getElementById(id);
+  el('tbMetricsThroughput24h').textContent = m.throughput?.last24h ?? '—';
+  el('tbMetricsThroughput7d').textContent = m.throughput?.last7d ?? '—';
+  el('tbMetricsAvgRuntime').textContent = m.avgRuntimeMs != null ? tbDuration(m.avgRuntimeMs) : '—';
+  el('tbMetricsMedianRuntime').textContent = m.medianRuntimeMs != null ? tbDuration(m.medianRuntimeMs) : '—';
+  el('tbMetricsSuccessRate').textContent = m.successRate != null
+    ? (m.successRate * 100).toFixed(1) + '%'
+    : '—';
+
+  // Stuck count + highlight
+  const stuckCount = m.stuckCount ?? 0;
+  const stuckEl = el('tbMetricsStuckCount');
+  const stuckKpi = el('tbMetricsStuckKpi');
+  if (stuckEl) {
+    stuckEl.textContent = stuckCount;
+    stuckEl.style.color = stuckCount > 0 ? 'var(--yellow)' : 'var(--text-muted)';
+  }
+  if (stuckKpi) {
+    stuckKpi.style.borderColor = stuckCount > 0 ? 'rgba(245, 158, 11, 0.3)' : 'transparent';
+    stuckKpi.style.background = stuckCount > 0 ? 'rgba(245, 158, 11, 0.05)' : '';
+  }
+
+  // Stuck badge on toggle button
+  const stuckBadge = el('tbMetricsStuckBadge');
+  if (stuckBadge) {
+    if (stuckCount > 0) {
+      stuckBadge.style.display = '';
+      stuckBadge.textContent = '⚠️ ' + stuckCount + ' stuck';
+    } else {
+      stuckBadge.style.display = 'none';
+    }
+  }
+
+  // Stuck tasks alert panel
+  tbStuckIds = new Set((m.stuckTasks || []).map(s => s.id));
+  const alertEl = el('tbStuckAlert');
+  const alertList = el('tbStuckAlertList');
+  if (alertEl && alertList) {
+    if (stuckCount > 0) {
+      alertEl.style.display = '';
+      alertList.innerHTML = m.stuckTasks.map(s =>
+        `<div class="tb-stuck-item">
+          <span class="tb-stuck-item-title">${tbEsc(s.title)}</span>
+          ${s.agentId ? `<span class="tb-badge tb-badge-agent" style="font-size:10px;">🤖 ${tbEsc(s.agentId)}</span>` : ''}
+          <span class="tb-stuck-item-time">⏱ ${tbDuration(s.runningMs)} (${s.overshootRatio.toFixed(1)}× threshold)</span>
+        </div>`
+      ).join('');
+    } else {
+      alertEl.style.display = 'none';
+    }
+  }
+
+  // Completion trend chart
+  tbRenderTrendChart(m.completionTrend7d || []);
+
+  // Agent breakdown table
+  tbRenderAgentTable(m.agentBreakdown || []);
+
+  // Re-render board to pick up stuck badges on cards
+  tbRenderBoard();
+}
+
+/** Render the 7-day completion trend mini bar chart. */
+function tbRenderTrendChart(trend) {
+  const container = document.getElementById('tbTrendChart');
+  if (!container) return;
+
+  if (trend.length === 0 || trend.every(d => d.done === 0 && d.failed === 0)) {
+    container.innerHTML = '<div style="text-align:center;color:var(--text-muted);font-size:12px;width:100%;padding:20px;">No completions in the last 7 days</div>';
+    return;
+  }
+
+  // Find max value for scaling
+  const maxVal = Math.max(1, ...trend.map(d => Math.max(d.done, d.failed)));
+
+  container.innerHTML = trend.map(d => {
+    const doneH = Math.max(2, (d.done / maxVal) * 60);
+    const failH = Math.max(d.failed > 0 ? 2 : 0, (d.failed / maxVal) * 60);
+    const dayLabel = d.date.slice(5); // MM-DD
+    return `<div class="tb-trend-bar-group">
+      <div class="tb-trend-bars">
+        <div class="tb-trend-bar done" style="height:${doneH}px;" title="Done: ${d.done}"></div>
+        ${d.failed > 0 ? `<div class="tb-trend-bar failed" style="height:${failH}px;" title="Failed: ${d.failed}"></div>` : ''}
+      </div>
+      <span class="tb-trend-label">${dayLabel}</span>
+    </div>`;
+  }).join('');
+}
+
+/** Render the agent breakdown table. */
+function tbRenderAgentTable(agents) {
+  const tbody = document.getElementById('tbAgentTableBody');
+  if (!tbody) return;
+
+  if (agents.length === 0) {
+    tbody.innerHTML = '<tr><td colspan="5" style="text-align:center;color:var(--text-muted);padding:16px;">No agent data</td></tr>';
+    return;
+  }
+
+  tbody.innerHTML = agents.map(a => {
+    const rt = a.avgRuntimeMs != null ? tbDuration(a.avgRuntimeMs) : '—';
+    return `<tr>
+      <td style="color:var(--cyan);font-weight:500;">🤖 ${tbEsc(a.agentId)}</td>
+      <td style="color:${a.running > 0 ? 'var(--yellow)' : 'var(--text-muted)'};">${a.running}</td>
+      <td style="color:${a.done > 0 ? 'var(--green)' : 'var(--text-muted)'};">${a.done}</td>
+      <td style="color:${a.failed > 0 ? 'var(--red)' : 'var(--text-muted)'};">${a.failed}</td>
+      <td>${rt}</td>
+    </tr>`;
+  }).join('');
+}
+
 // ── Real-time SSE subscription (Issue #219) ─────────────────────────────────
 // Prefer SSE for live updates; fall back to 15s polling if unavailable.
 
@@ -7724,6 +8186,26 @@ function tbStartPollingFallback() {
 
 // Start SSE on load; falls back to polling automatically
 tbConnectSse();
+
+// Fetch metrics on initial load to populate stuck-task badges even when panel is closed
+(async function tbInitMetrics() {
+  try {
+    const res = await fetch('/api/task-board/metrics');
+    if (res.ok) {
+      tbMetricsData = await res.json();
+      // Populate stuck IDs for card badges
+      tbStuckIds = new Set((tbMetricsData.stuckTasks || []).map(s => s.id));
+      // Update stuck badge on toggle button
+      const stuckBadge = document.getElementById('tbMetricsStuckBadge');
+      if (stuckBadge && tbMetricsData.stuckCount > 0) {
+        stuckBadge.style.display = '';
+        stuckBadge.textContent = '⚠️ ' + tbMetricsData.stuckCount + ' stuck';
+      }
+      // Re-render to apply stuck badges
+      tbRenderBoard();
+    }
+  } catch {}
+})();
 </script>
 </body>
 </html>

--- a/dashboard/server/routes/task-board.ts
+++ b/dashboard/server/routes/task-board.ts
@@ -74,6 +74,229 @@ function saveTasks(dataDir: string, tasks: TaskCard[]): void {
   fs.writeFileSync(fp, JSON.stringify({ tasks, updatedAt: Date.now() }, null, 2));
 }
 
+// ─── Metrics & Stuck-Task Detection (Issue #219 — Task Metrics Dashboard) ────
+
+/** Default stuck-task timeout: 30 minutes. */
+const DEFAULT_STUCK_TIMEOUT_MS = 30 * 60 * 1000;
+
+/** A running task that exceeds the configured timeout threshold. */
+export interface StuckTask {
+  id: string;
+  title: string;
+  agentId: string | null;
+  priority: TaskPriority;
+  startedAt: number;
+  runningMs: number;
+  thresholdMs: number;
+  /** How far past the threshold (runningMs / thresholdMs). */
+  overshootRatio: number;
+}
+
+/** Computed task board metrics — derived from existing data, no schema changes. */
+export interface TaskBoardMetrics {
+  updatedAt: number;
+  /** Counts by status. */
+  statusCounts: Record<TaskStatus, number>;
+  total: number;
+  /** Throughput: tasks that reached done/failed in the given windows. */
+  throughput: {
+    last24h: number;
+    last7d: number;
+    last30d: number;
+  };
+  /** Average runtime of completed tasks (done/failed with runtimeMs). */
+  avgRuntimeMs: number | null;
+  /** Median runtime of completed tasks. */
+  medianRuntimeMs: number | null;
+  /** Success rate: done / (done + failed), null if no terminal tasks. */
+  successRate: number | null;
+  /** Per-day completion counts for the last 7 days (ISO date → count). */
+  completionTrend7d: Array<{ date: string; done: number; failed: number }>;
+  /** Per-agent breakdown of completed/running tasks. */
+  agentBreakdown: Array<{
+    agentId: string;
+    running: number;
+    done: number;
+    failed: number;
+    avgRuntimeMs: number | null;
+  }>;
+  /** Stuck tasks — running tasks exceeding the timeout threshold. */
+  stuckTasks: StuckTask[];
+  stuckCount: number;
+  stuckTimeoutMs: number;
+}
+
+/**
+ * Identify running tasks that exceed the given timeout threshold.
+ * Pure function — no side effects, bounded to the input array.
+ */
+export function computeStuckTasks(
+  tasks: TaskCard[],
+  timeoutMs: number = DEFAULT_STUCK_TIMEOUT_MS,
+  now: number = Date.now(),
+): StuckTask[] {
+  const stuck: StuckTask[] = [];
+  for (const t of tasks) {
+    if (t.status !== 'running' || !t.startedAt) continue;
+    const runningMs = now - t.startedAt;
+    if (runningMs > timeoutMs) {
+      stuck.push({
+        id: t.id,
+        title: t.title,
+        agentId: t.agentId,
+        priority: t.priority,
+        startedAt: t.startedAt,
+        runningMs,
+        thresholdMs: timeoutMs,
+        overshootRatio: runningMs / timeoutMs,
+      });
+    }
+  }
+  // Sort by overshoot descending (most stuck first)
+  stuck.sort((a, b) => b.overshootRatio - a.overshootRatio);
+  return stuck;
+}
+
+/**
+ * Compute comprehensive task board metrics from existing task data.
+ * All calculations are bounded (single pass + lightweight aggregations).
+ */
+export function computeMetrics(
+  tasks: TaskCard[],
+  opts: { stuckTimeoutMs?: number; now?: number } = {},
+): TaskBoardMetrics {
+  const now = opts.now ?? Date.now();
+  const stuckTimeoutMs = opts.stuckTimeoutMs ?? DEFAULT_STUCK_TIMEOUT_MS;
+
+  // Status counts
+  const statusCounts: Record<TaskStatus, number> = {
+    backlog: 0, queued: 0, running: 0, done: 0, failed: 0,
+  };
+  for (const t of tasks) {
+    statusCounts[t.status] = (statusCounts[t.status] ?? 0) + 1;
+  }
+
+  // Throughput windows
+  const ms24h = 24 * 60 * 60 * 1000;
+  const ms7d = 7 * ms24h;
+  const ms30d = 30 * ms24h;
+  let tp24h = 0, tp7d = 0, tp30d = 0;
+
+  // Runtime stats for completed tasks
+  const runtimes: number[] = [];
+
+  // Success rate
+  let doneCount = 0, failedCount = 0;
+
+  // Per-day completion trend (last 7 days)
+  const trendMap = new Map<string, { done: number; failed: number }>();
+  // Pre-fill 7 days
+  for (let i = 6; i >= 0; i--) {
+    const d = new Date(now - i * ms24h);
+    const key = d.toISOString().slice(0, 10);
+    trendMap.set(key, { done: 0, failed: 0 });
+  }
+
+  // Per-agent breakdown
+  const agentMap = new Map<string, { running: number; done: number; failed: number; runtimes: number[] }>();
+
+  for (const t of tasks) {
+    const aid = t.agentId ?? '_unassigned';
+    if (!agentMap.has(aid)) {
+      agentMap.set(aid, { running: 0, done: 0, failed: 0, runtimes: [] });
+    }
+    const ag = agentMap.get(aid)!;
+
+    if (t.status === 'running') ag.running++;
+
+    // Terminal tasks
+    if (t.status === 'done' || t.status === 'failed') {
+      if (t.status === 'done') { doneCount++; ag.done++; }
+      if (t.status === 'failed') { failedCount++; ag.failed++; }
+
+      // Throughput: use completedAt
+      if (t.completedAt) {
+        const age = now - t.completedAt;
+        if (age <= ms24h) tp24h++;
+        if (age <= ms7d) tp7d++;
+        if (age <= ms30d) tp30d++;
+
+        // Trend
+        const dateKey = new Date(t.completedAt).toISOString().slice(0, 10);
+        if (trendMap.has(dateKey)) {
+          const entry = trendMap.get(dateKey)!;
+          if (t.status === 'done') entry.done++;
+          else entry.failed++;
+        }
+      }
+
+      // Runtime
+      const rt = t.runtimeMs ?? (t.startedAt && t.completedAt ? t.completedAt - t.startedAt : null);
+      if (rt != null && rt >= 0) {
+        runtimes.push(rt);
+        ag.runtimes.push(rt);
+      }
+    }
+  }
+
+  // Average & median runtime
+  const avgRuntimeMs = runtimes.length > 0
+    ? Math.round(runtimes.reduce((s, v) => s + v, 0) / runtimes.length)
+    : null;
+  const medianRuntimeMs = runtimes.length > 0
+    ? (() => {
+        const sorted = [...runtimes].sort((a, b) => a - b);
+        const mid = Math.floor(sorted.length / 2);
+        return sorted.length % 2 !== 0
+          ? sorted[mid]
+          : Math.round((sorted[mid - 1] + sorted[mid]) / 2);
+      })()
+    : null;
+
+  // Success rate
+  const totalTerminal = doneCount + failedCount;
+  const successRate = totalTerminal > 0 ? Math.round((doneCount / totalTerminal) * 10000) / 10000 : null;
+
+  // Completion trend array
+  const completionTrend7d = [...trendMap.entries()].map(([date, v]) => ({
+    date,
+    done: v.done,
+    failed: v.failed,
+  }));
+
+  // Agent breakdown
+  const agentBreakdown = [...agentMap.entries()]
+    .filter(([id]) => id !== '_unassigned' || agentMap.size === 1) // include unassigned only if it's the only bucket
+    .map(([agentId, data]) => ({
+      agentId,
+      running: data.running,
+      done: data.done,
+      failed: data.failed,
+      avgRuntimeMs: data.runtimes.length > 0
+        ? Math.round(data.runtimes.reduce((s, v) => s + v, 0) / data.runtimes.length)
+        : null,
+    }))
+    .sort((a, b) => (b.done + b.failed + b.running) - (a.done + a.failed + a.running));
+
+  // Stuck tasks
+  const stuckTasks = computeStuckTasks(tasks, stuckTimeoutMs, now);
+
+  return {
+    updatedAt: now,
+    statusCounts,
+    total: tasks.length,
+    throughput: { last24h: tp24h, last7d: tp7d, last30d: tp30d },
+    avgRuntimeMs,
+    medianRuntimeMs,
+    successRate,
+    completionTrend7d,
+    agentBreakdown,
+    stuckTasks,
+    stuckCount: stuckTasks.length,
+    stuckTimeoutMs,
+  };
+}
+
 // ─── Derived data ────────────────────────────────────────────────────────────
 
 export function buildSummary(tasks: TaskCard[]): TaskBoardSummary {
@@ -435,6 +658,20 @@ export async function handleTaskBoard(
     const result = executeBatch(dataDir, body, deps.emitEvent);
     const status = result.error ? 400 : 200;
     sendJson(res, result, status);
+    return true;
+  }
+
+  // ── GET /api/task-board/metrics — Issue #219, Task Metrics Dashboard ───────
+  // Returns computed metrics: throughput, runtime stats, trends, stuck tasks.
+  // Optional query params:
+  //   ?stuckTimeoutMs=1800000 — override stuck-task timeout (default 30min)
+  if (url.startsWith('/api/task-board/metrics') && method === 'GET') {
+    const metricsParams = new URL(url, 'http://localhost').searchParams;
+    const stuckTimeoutMs = metricsParams.has('stuckTimeoutMs')
+      ? Math.max(1000, Math.min(Number(metricsParams.get('stuckTimeoutMs')) || DEFAULT_STUCK_TIMEOUT_MS, 86400000))
+      : undefined;
+    const tasks = loadTasks(dataDir);
+    sendJson(res, computeMetrics(tasks, { stuckTimeoutMs }));
     return true;
   }
 

--- a/dashboard/tests/unit/routes/task-board-metrics.test.ts
+++ b/dashboard/tests/unit/routes/task-board-metrics.test.ts
@@ -1,0 +1,383 @@
+/**
+ * Task Board Metrics & Stuck-Task Detection tests — Issue #219, Phase 7.
+ *
+ * Tests for:
+ * - computeMetrics() — KPIs, throughput, runtime stats, trend, agent breakdown
+ * - computeStuckTasks() — stuck-task identification and sorting
+ * - GET /api/task-board/metrics endpoint
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { mockRequest, mockResponse, parseJsonBody } from '../../helpers.js';
+import {
+  handleTaskBoard,
+  loadTasks,
+  computeMetrics,
+  computeStuckTasks,
+} from '../../../server/routes/task-board.js';
+import type { TaskBoardDeps, TaskCard, TaskStatus, TaskPriority } from '../../../server/types.js';
+
+const testDataDir = path.join('/tmp', 'test-task-board-metrics-' + process.pid);
+
+function createDeps(overrides: Partial<TaskBoardDeps> = {}): TaskBoardDeps {
+  return {
+    dataDir: testDataDir,
+    sendJson: (res, data, status = 200) => {
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+    },
+    readRequestBody: async () => '{}',
+    ...overrides,
+  };
+}
+
+function makeSampleCard(overrides: Partial<TaskCard> = {}): TaskCard {
+  return {
+    id: 'test-' + Math.random().toString(36).slice(2, 8),
+    agentId: 'oracle',
+    title: 'Test task',
+    description: 'A test task',
+    priority: 'medium',
+    status: 'backlog',
+    createdAt: Date.now(),
+    queuedAt: null,
+    startedAt: null,
+    completedAt: null,
+    resultSummary: null,
+    tokensUsed: null,
+    error: null,
+    costEstimate: null,
+    runtimeMs: null,
+    ...overrides,
+  };
+}
+
+function seedTasks(tasks: TaskCard[]): void {
+  fs.mkdirSync(testDataDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(testDataDir, 'task-board.json'),
+    JSON.stringify({ tasks, updatedAt: Date.now() }),
+  );
+}
+
+beforeEach(() => {
+  fs.mkdirSync(testDataDir, { recursive: true });
+  const fp = path.join(testDataDir, 'task-board.json');
+  if (fs.existsSync(fp)) fs.unlinkSync(fp);
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(testDataDir, { recursive: true, force: true });
+  } catch {}
+});
+
+// ─── computeStuckTasks ───────────────────────────────────────────────────────
+
+describe('computeStuckTasks', () => {
+  const NOW = 1700000000000;
+
+  it('returns empty array when no tasks are running', () => {
+    const tasks = [
+      makeSampleCard({ status: 'backlog' }),
+      makeSampleCard({ status: 'done' }),
+    ];
+    expect(computeStuckTasks(tasks, 30 * 60000, NOW)).toHaveLength(0);
+  });
+
+  it('returns empty when running tasks are within threshold', () => {
+    const tasks = [
+      makeSampleCard({
+        status: 'running',
+        startedAt: NOW - 10 * 60000, // 10 min ago
+      }),
+    ];
+    expect(computeStuckTasks(tasks, 30 * 60000, NOW)).toHaveLength(0);
+  });
+
+  it('identifies a running task exceeding the threshold', () => {
+    const tasks = [
+      makeSampleCard({
+        id: 'stuck-1',
+        status: 'running',
+        startedAt: NOW - 45 * 60000, // 45 min ago, threshold is 30 min
+        title: 'Stuck task',
+        agentId: 'nexus',
+        priority: 'high',
+      }),
+    ];
+    const stuck = computeStuckTasks(tasks, 30 * 60000, NOW);
+    expect(stuck).toHaveLength(1);
+    expect(stuck[0].id).toBe('stuck-1');
+    expect(stuck[0].runningMs).toBe(45 * 60000);
+    expect(stuck[0].thresholdMs).toBe(30 * 60000);
+    expect(stuck[0].overshootRatio).toBe(1.5);
+    expect(stuck[0].agentId).toBe('nexus');
+    expect(stuck[0].priority).toBe('high');
+  });
+
+  it('sorts by overshoot ratio descending', () => {
+    const tasks = [
+      makeSampleCard({ id: 'a', status: 'running', startedAt: NOW - 40 * 60000 }), // 40 min
+      makeSampleCard({ id: 'b', status: 'running', startedAt: NOW - 90 * 60000 }), // 90 min
+      makeSampleCard({ id: 'c', status: 'running', startedAt: NOW - 60 * 60000 }), // 60 min
+    ];
+    const stuck = computeStuckTasks(tasks, 30 * 60000, NOW);
+    expect(stuck).toHaveLength(3);
+    expect(stuck[0].id).toBe('b'); // most stuck
+    expect(stuck[1].id).toBe('c');
+    expect(stuck[2].id).toBe('a');
+  });
+
+  it('ignores running tasks without startedAt', () => {
+    const tasks = [
+      makeSampleCard({ status: 'running', startedAt: null }),
+    ];
+    expect(computeStuckTasks(tasks, 30 * 60000, NOW)).toHaveLength(0);
+  });
+
+  it('respects custom timeout', () => {
+    const tasks = [
+      makeSampleCard({
+        status: 'running',
+        startedAt: NOW - 5 * 60000, // 5 min ago
+      }),
+    ];
+    // 3 min timeout → should be stuck
+    expect(computeStuckTasks(tasks, 3 * 60000, NOW)).toHaveLength(1);
+    // 10 min timeout → not stuck
+    expect(computeStuckTasks(tasks, 10 * 60000, NOW)).toHaveLength(0);
+  });
+});
+
+// ─── computeMetrics ──────────────────────────────────────────────────────────
+
+describe('computeMetrics', () => {
+  const NOW = 1700000000000;
+  const HOUR = 3600000;
+  const DAY = 86400000;
+
+  it('returns zero metrics for empty task list', () => {
+    const m = computeMetrics([], { now: NOW });
+    expect(m.total).toBe(0);
+    expect(m.throughput.last24h).toBe(0);
+    expect(m.throughput.last7d).toBe(0);
+    expect(m.avgRuntimeMs).toBeNull();
+    expect(m.medianRuntimeMs).toBeNull();
+    expect(m.successRate).toBeNull();
+    expect(m.stuckCount).toBe(0);
+    expect(m.completionTrend7d).toHaveLength(7);
+    expect(m.agentBreakdown).toHaveLength(0);
+  });
+
+  it('counts status correctly', () => {
+    const tasks = [
+      makeSampleCard({ status: 'backlog' }),
+      makeSampleCard({ status: 'running' }),
+      makeSampleCard({ status: 'running' }),
+      makeSampleCard({ status: 'done' }),
+    ];
+    const m = computeMetrics(tasks, { now: NOW });
+    expect(m.statusCounts.backlog).toBe(1);
+    expect(m.statusCounts.running).toBe(2);
+    expect(m.statusCounts.done).toBe(1);
+    expect(m.total).toBe(4);
+  });
+
+  it('computes throughput for time windows', () => {
+    const tasks = [
+      makeSampleCard({ status: 'done', completedAt: NOW - 2 * HOUR }), // within 24h
+      makeSampleCard({ status: 'done', completedAt: NOW - 3 * DAY }), // within 7d
+      makeSampleCard({ status: 'failed', completedAt: NOW - 10 * DAY }), // within 30d
+      makeSampleCard({ status: 'done', completedAt: NOW - 60 * DAY }), // outside 30d
+    ];
+    const m = computeMetrics(tasks, { now: NOW });
+    expect(m.throughput.last24h).toBe(1);
+    expect(m.throughput.last7d).toBe(2);
+    expect(m.throughput.last30d).toBe(3);
+  });
+
+  it('computes average and median runtime', () => {
+    const tasks = [
+      makeSampleCard({ status: 'done', runtimeMs: 10000, completedAt: NOW - HOUR }),
+      makeSampleCard({ status: 'done', runtimeMs: 30000, completedAt: NOW - HOUR }),
+      makeSampleCard({ status: 'done', runtimeMs: 50000, completedAt: NOW - HOUR }),
+    ];
+    const m = computeMetrics(tasks, { now: NOW });
+    expect(m.avgRuntimeMs).toBe(30000); // (10+30+50)/3
+    expect(m.medianRuntimeMs).toBe(30000); // middle value
+  });
+
+  it('computes median for even number of runtimes', () => {
+    const tasks = [
+      makeSampleCard({ status: 'done', runtimeMs: 10000, completedAt: NOW - HOUR }),
+      makeSampleCard({ status: 'done', runtimeMs: 20000, completedAt: NOW - HOUR }),
+      makeSampleCard({ status: 'failed', runtimeMs: 30000, completedAt: NOW - HOUR }),
+      makeSampleCard({ status: 'done', runtimeMs: 40000, completedAt: NOW - HOUR }),
+    ];
+    const m = computeMetrics(tasks, { now: NOW });
+    expect(m.medianRuntimeMs).toBe(25000); // avg of 20000 and 30000
+  });
+
+  it('derives runtimeMs from startedAt/completedAt when not set', () => {
+    const tasks = [
+      makeSampleCard({
+        status: 'done',
+        startedAt: NOW - 60000,
+        completedAt: NOW - 10000,
+        runtimeMs: null,
+      }),
+    ];
+    const m = computeMetrics(tasks, { now: NOW });
+    expect(m.avgRuntimeMs).toBe(50000); // completedAt - startedAt
+  });
+
+  it('computes success rate', () => {
+    const tasks = [
+      makeSampleCard({ status: 'done', completedAt: NOW }),
+      makeSampleCard({ status: 'done', completedAt: NOW }),
+      makeSampleCard({ status: 'done', completedAt: NOW }),
+      makeSampleCard({ status: 'failed', completedAt: NOW }),
+    ];
+    const m = computeMetrics(tasks, { now: NOW });
+    expect(m.successRate).toBe(0.75);
+  });
+
+  it('populates 7-day trend with correct date keys', () => {
+    const m = computeMetrics([], { now: NOW });
+    expect(m.completionTrend7d).toHaveLength(7);
+    // Check that dates are in order
+    const dates = m.completionTrend7d.map(d => d.date);
+    for (let i = 1; i < dates.length; i++) {
+      expect(dates[i] > dates[i - 1]).toBe(true);
+    }
+  });
+
+  it('populates agent breakdown', () => {
+    const tasks = [
+      makeSampleCard({ agentId: 'nexus', status: 'done', runtimeMs: 10000, completedAt: NOW }),
+      makeSampleCard({ agentId: 'nexus', status: 'running', startedAt: NOW }),
+      makeSampleCard({ agentId: 'synth', status: 'failed', runtimeMs: 5000, completedAt: NOW }),
+    ];
+    const m = computeMetrics(tasks, { now: NOW });
+    expect(m.agentBreakdown.length).toBeGreaterThanOrEqual(2);
+
+    const nexus = m.agentBreakdown.find(a => a.agentId === 'nexus');
+    expect(nexus).toBeDefined();
+    expect(nexus!.done).toBe(1);
+    expect(nexus!.running).toBe(1);
+    expect(nexus!.avgRuntimeMs).toBe(10000);
+
+    const synth = m.agentBreakdown.find(a => a.agentId === 'synth');
+    expect(synth).toBeDefined();
+    expect(synth!.failed).toBe(1);
+  });
+
+  it('includes stuck tasks with default threshold', () => {
+    const tasks = [
+      makeSampleCard({
+        id: 'stuck-test',
+        status: 'running',
+        startedAt: NOW - 60 * 60000, // 1 hour, default threshold is 30 min
+      }),
+    ];
+    const m = computeMetrics(tasks, { now: NOW });
+    expect(m.stuckCount).toBe(1);
+    expect(m.stuckTasks[0].id).toBe('stuck-test');
+  });
+
+  it('uses custom stuck timeout', () => {
+    const tasks = [
+      makeSampleCard({
+        status: 'running',
+        startedAt: NOW - 10 * 60000, // 10 min
+      }),
+    ];
+    // 5 min timeout → stuck
+    const m1 = computeMetrics(tasks, { now: NOW, stuckTimeoutMs: 5 * 60000 });
+    expect(m1.stuckCount).toBe(1);
+
+    // 15 min timeout → not stuck
+    const m2 = computeMetrics(tasks, { now: NOW, stuckTimeoutMs: 15 * 60000 });
+    expect(m2.stuckCount).toBe(0);
+  });
+});
+
+// ─── GET /api/task-board/metrics endpoint ────────────────────────────────────
+
+describe('GET /api/task-board/metrics', () => {
+  it('returns 200 with metrics for empty board', async () => {
+    seedTasks([]);
+    const req = mockRequest({ url: '/api/task-board/metrics', method: 'GET' });
+    const res = mockResponse();
+    const deps = createDeps();
+
+    await handleTaskBoard(req, res, deps);
+
+    const body = parseJsonBody(res);
+    expect(res.statusCode ?? 200).toBe(200);
+    expect(body).toHaveProperty('total', 0);
+    expect(body).toHaveProperty('throughput');
+    expect(body).toHaveProperty('stuckTasks');
+    expect(body).toHaveProperty('completionTrend7d');
+    expect(body.completionTrend7d).toHaveLength(7);
+  });
+
+  it('returns metrics with task data', async () => {
+    const now = Date.now();
+    seedTasks([
+      makeSampleCard({ status: 'done', completedAt: now - 3600000, runtimeMs: 5000 }),
+      makeSampleCard({ status: 'running', startedAt: now - 3600000 * 2 }), // stuck (2h)
+      makeSampleCard({ status: 'backlog' }),
+    ]);
+
+    const req = mockRequest({ url: '/api/task-board/metrics', method: 'GET' });
+    const res = mockResponse();
+    const deps = createDeps();
+
+    await handleTaskBoard(req, res, deps);
+
+    const body = parseJsonBody(res);
+    expect(body.total).toBe(3);
+    expect(body.statusCounts.done).toBe(1);
+    expect(body.statusCounts.running).toBe(1);
+    expect(body.statusCounts.backlog).toBe(1);
+    expect(body.throughput.last24h).toBe(1);
+    expect(body.avgRuntimeMs).toBe(5000);
+    expect(body.stuckCount).toBe(1);
+  });
+
+  it('accepts stuckTimeoutMs query param', async () => {
+    const now = Date.now();
+    seedTasks([
+      makeSampleCard({
+        status: 'running',
+        startedAt: now - 10 * 60000, // 10 min
+      }),
+    ]);
+
+    // Default (30 min) → not stuck
+    const req1 = mockRequest({ url: '/api/task-board/metrics', method: 'GET' });
+    const res1 = mockResponse();
+    await handleTaskBoard(req1, res1, createDeps());
+    expect(parseJsonBody(res1).stuckCount).toBe(0);
+
+    // Custom 5 min → stuck
+    const req2 = mockRequest({ url: '/api/task-board/metrics?stuckTimeoutMs=300000', method: 'GET' });
+    const res2 = mockResponse();
+    await handleTaskBoard(req2, res2, createDeps());
+    expect(parseJsonBody(res2).stuckCount).toBe(1);
+  });
+
+  it('clamps stuckTimeoutMs within safe bounds', async () => {
+    seedTasks([]);
+    // Test that extremely small timeout is clamped to 1000ms
+    const req = mockRequest({ url: '/api/task-board/metrics?stuckTimeoutMs=100', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+    const body = parseJsonBody(res);
+    expect(body.stuckTimeoutMs).toBe(1000);
+  });
+});


### PR DESCRIPTION
## Summary
Refs #219 — Delivers the next bounded slice: task metrics visualization and stuck-task alerting.

### Backend (additive, no schema changes)
- `computeMetrics()`: derives KPIs from existing task data in a single bounded pass
  - Status counts, throughput (24h/7d/30d), avg/median runtime, success rate
  - 7-day completion trend (done/failed per day)
  - Per-agent breakdown (running/done/failed/avgRuntime)
- `computeStuckTasks()`: identifies running tasks exceeding configurable timeout
  - Default 30min threshold, configurable via `?stuckTimeoutMs` query param
  - Sorted by overshoot ratio (most stuck first)
  - Clamped to safe bounds [1s, 24h]
- `GET /api/task-board/metrics` endpoint serving all computed metrics

### Frontend (additive)
- Collapsible **📊 Task Metrics & Health** panel above Kanban board
  - KPI cards: throughput 24h/7d, avg/median runtime, success rate, stuck count
  - 7-day completion trend mini bar chart (done vs failed)
  - Agent breakdown table (running/done/failed/avgRuntime per agent)
  - Stuck-task alert panel with per-task detail
- **⚠️ Stuck** badge on toggle button visible even when panel is collapsed
- Pulsing **⚠️ Stuck** badge on individual Kanban cards for stuck tasks
- Auto-refreshes metrics when panel is open and board data changes
- Initial stuck-task fetch on page load for card badges

### Tests
- **21 new tests** covering metrics calculations, stuck-task detection, and API endpoint
- **238 total task-board tests pass** (all existing 217 + 21 new)
- TypeScript typecheck clean

### Risk Assessment
- **Low risk**: purely additive, no schema migration, no auth changes
- Metrics computed on-demand per request (bounded single pass over task array)
- Reversible: entire feature is contained in 3 files (route augmentation, test file, HTML additions)
- All pre-existing task-board tests continue to pass