### PR TITLE
feat(#219): Persistent task metrics history — time-series baseline (Phase 8)

### DIFF
--- a/dashboard/client/index.html
+++ b/dashboard/client/index.html
@@ -1938,6 +1938,15 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
   }
 }
 
+/* Metrics history chart (Phase 8) */
+#tbHistoryChart svg {
+  display: block;
+}
+
+#tbHistoryChart {
+  overflow: visible;
+}
+
 /* ─── End Task Metrics Dashboard ────────────────────────────────────── */
 
 /* ─── End Task Board ────────────────────────────────────────────────── */
@@ -3525,6 +3534,33 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
                     <tr><td colspan="5" style="text-align:center;color:var(--text-muted);padding:16px;">No agent data</td></tr>
                   </tbody>
                 </table>
+              </div>
+            </div>
+          </div>
+
+          <!-- Metrics History Trend (Issue #219, Phase 8) -->
+          <div style="margin-top:20px;">
+            <div class="tb-metrics-section-title">📈 Metrics History (Time-Series)</div>
+            <div style="background:var(--bg-card);border:1px solid var(--border);border-radius:10px;padding:14px;">
+              <div style="display:flex;gap:8px;margin-bottom:12px;align-items:center;">
+                <select id="tbHistoryMetric" onchange="tbRenderHistoryChart()" style="padding:4px 8px;background:var(--bg-tertiary);border:1px solid var(--border);border-radius:6px;color:var(--text-primary);font-size:12px;font-family:inherit;">
+                  <option value="total">Total Tasks</option>
+                  <option value="throughput24h">Throughput (24h)</option>
+                  <option value="successRate" selected>Success Rate</option>
+                  <option value="avgRuntimeMs">Avg Runtime</option>
+                  <option value="stuckCount">Stuck Tasks</option>
+                  <option value="running">Running</option>
+                </select>
+                <select id="tbHistoryWindow" onchange="tbFetchHistory()" style="padding:4px 8px;background:var(--bg-tertiary);border:1px solid var(--border);border-radius:6px;color:var(--text-primary);font-size:12px;font-family:inherit;">
+                  <option value="3600000">Last 1h</option>
+                  <option value="21600000">Last 6h</option>
+                  <option value="86400000" selected>Last 24h</option>
+                  <option value="604800000">Last 7d</option>
+                </select>
+                <span id="tbHistoryPointCount" style="font-size:11px;color:var(--text-muted);font-family:'JetBrains Mono',monospace;margin-left:auto;"></span>
+              </div>
+              <div id="tbHistoryChart" style="height:100px;position:relative;">
+                <div style="text-align:center;color:var(--text-muted);font-size:12px;padding:30px;">No history data yet — snapshots are recorded every 5 minutes</div>
               </div>
             </div>
           </div>
@@ -7161,8 +7197,11 @@ async function tbRefresh() {
 
     tbRenderBoard();
 
-    // Also refresh metrics if the panel is open
-    if (tbMetricsOpen) tbRefreshMetrics();
+    // Also refresh metrics + history if the panel is open
+    if (tbMetricsOpen) {
+      tbRefreshMetrics();
+      tbFetchHistory();
+    }
   } catch (e) {
     console.error('[task-board] refresh error', e);
   }
@@ -7938,7 +7977,10 @@ function tbToggleMetrics() {
   const panel = document.getElementById('tbMetricsPanel');
   if (toggle) toggle.classList.toggle('open', tbMetricsOpen);
   if (panel) panel.classList.toggle('open', tbMetricsOpen);
-  if (tbMetricsOpen) tbRefreshMetrics();
+  if (tbMetricsOpen) {
+    tbRefreshMetrics();
+    tbFetchHistory();
+  }
 }
 
 /** Fetch metrics from the API and render all panels. */
@@ -8067,6 +8109,131 @@ function tbRenderAgentTable(agents) {
       <td>${rt}</td>
     </tr>`;
   }).join('');
+}
+
+// ── Metrics History (Issue #219, Phase 8) ────────────────────────────────────
+// Fetch and render persisted metrics time-series for trend visualization.
+
+let tbHistoryData = [];
+
+async function tbFetchHistory() {
+  try {
+    const windowMs = document.getElementById('tbHistoryWindow')?.value || '86400000';
+    const res = await fetch(`/api/task-board/metrics/history?sinceMs=${windowMs}&limit=200`);
+    if (!res.ok) return;
+    const data = await res.json();
+    tbHistoryData = data.snapshots || [];
+    const countEl = document.getElementById('tbHistoryPointCount');
+    if (countEl) countEl.textContent = tbHistoryData.length + ' points';
+    tbRenderHistoryChart();
+  } catch (e) {
+    console.warn('[task-board] history fetch error', e);
+  }
+}
+
+function tbRenderHistoryChart() {
+  const container = document.getElementById('tbHistoryChart');
+  if (!container) return;
+  const metric = document.getElementById('tbHistoryMetric')?.value || 'successRate';
+  const points = tbHistoryData;
+
+  if (!points || points.length < 2) {
+    container.innerHTML = '<div style="text-align:center;color:var(--text-muted);font-size:12px;padding:30px;">Not enough data points yet — snapshots are recorded every 5 minutes</div>';
+    return;
+  }
+
+  // Extract values based on selected metric
+  const values = points.map(p => {
+    switch (metric) {
+      case 'total': return p.total;
+      case 'throughput24h': return p.throughput?.last24h ?? 0;
+      case 'successRate': return p.successRate != null ? p.successRate * 100 : null;
+      case 'avgRuntimeMs': return p.avgRuntimeMs != null ? p.avgRuntimeMs / 1000 : null;
+      case 'stuckCount': return p.stuckCount ?? 0;
+      case 'running': return p.statusCounts?.running ?? 0;
+      default: return 0;
+    }
+  });
+
+  // Filter out nulls for y-axis computation
+  const numericValues = values.filter(v => v !== null);
+  if (numericValues.length < 2) {
+    container.innerHTML = '<div style="text-align:center;color:var(--text-muted);font-size:12px;padding:30px;">Not enough non-null data points for ' + metric + '</div>';
+    return;
+  }
+
+  const minVal = Math.min(...numericValues);
+  const maxVal = Math.max(...numericValues);
+  const range = maxVal - minVal || 1;
+  const h = 80;
+  const w = container.clientWidth || 400;
+  const padTop = 10;
+  const padBottom = 10;
+
+  // Build SVG polyline
+  const stepX = w / (points.length - 1);
+  let pathPoints = [];
+  let lastValid = null;
+
+  for (let i = 0; i < points.length; i++) {
+    const v = values[i];
+    if (v === null) continue;
+    const x = i * stepX;
+    const y = padTop + h - padBottom - ((v - minVal) / range) * (h - padTop - padBottom);
+    pathPoints.push(`${x.toFixed(1)},${y.toFixed(1)}`);
+    lastValid = { x, y, v, ts: points[i].ts };
+  }
+
+  // Format label based on metric
+  function fmtVal(v) {
+    if (metric === 'successRate') return v.toFixed(1) + '%';
+    if (metric === 'avgRuntimeMs') return v.toFixed(1) + 's';
+    return Math.round(v).toString();
+  }
+
+  // Y-axis labels
+  const yMin = fmtVal(minVal);
+  const yMax = fmtVal(maxVal);
+
+  // Time labels (first and last)
+  const firstTs = new Date(points[0].ts);
+  const lastTs = new Date(points[points.length - 1].ts);
+  const tfmt = (d) => d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' });
+
+  // Color based on metric
+  const colors = {
+    total: '#6366f1',
+    throughput24h: '#10b981',
+    successRate: '#10b981',
+    avgRuntimeMs: '#f59e0b',
+    stuckCount: '#ef4444',
+    running: '#3b82f6',
+  };
+  const lineColor = colors[metric] || '#6366f1';
+
+  // Fill area under line
+  const fillPoints = [...pathPoints];
+  if (fillPoints.length > 0) {
+    const lastX = fillPoints[fillPoints.length - 1].split(',')[0];
+    const firstX = fillPoints[0].split(',')[0];
+    fillPoints.push(`${lastX},${h}`);
+    fillPoints.push(`${firstX},${h}`);
+  }
+
+  container.innerHTML = `
+    <svg width="100%" height="${h}" viewBox="0 0 ${w} ${h}" preserveAspectRatio="none" style="overflow:visible;">
+      ${fillPoints.length > 2 ? `<polygon points="${fillPoints.join(' ')}" fill="${lineColor}" fill-opacity="0.08"/>` : ''}
+      <polyline points="${pathPoints.join(' ')}" fill="none" stroke="${lineColor}" stroke-width="2" stroke-linejoin="round" stroke-linecap="round"/>
+      ${lastValid ? `<circle cx="${lastValid.x.toFixed(1)}" cy="${lastValid.y.toFixed(1)}" r="3" fill="${lineColor}" stroke="var(--bg-card)" stroke-width="1.5"/>` : ''}
+    </svg>
+    <div style="display:flex;justify-content:space-between;font-size:10px;color:var(--text-muted);font-family:'JetBrains Mono',monospace;margin-top:4px;">
+      <span>${tfmt(firstTs)}</span>
+      <span style="color:${lineColor};font-weight:600;">${lastValid ? fmtVal(lastValid.v) : '—'}</span>
+      <span>${tfmt(lastTs)}</span>
+    </div>
+    <div style="position:absolute;top:0;right:8px;font-size:10px;color:var(--text-muted);font-family:'JetBrains Mono',monospace;">${yMax}</div>
+    <div style="position:absolute;bottom:20px;right:8px;font-size:10px;color:var(--text-muted);font-family:'JetBrains Mono',monospace;">${yMin}</div>
+  `;
 }
 
 // ── Real-time SSE subscription (Issue #219) ─────────────────────────────────

--- a/dashboard/server/metrics-history.ts
+++ b/dashboard/server/metrics-history.ts
@@ -1,0 +1,243 @@
+/**
+ * Metrics History — persistent time-series snapshots for Task Board metrics.
+ * Issue #219 — Phase 8: Persistent task metrics history / time-series baseline.
+ *
+ * Lightweight, additive-only JSON file storage with bounded retention.
+ * No background daemons — snapshots are appended on-demand (piggyback on
+ * metrics API reads, with a minimum cooldown between writes).
+ *
+ * Retention policy:
+ *   - Max points: 500 (configurable)
+ *   - Max age: 7 days (configurable)
+ *   - Minimum interval between snapshots: 5 minutes (configurable)
+ *
+ * File format: { version: 1, snapshots: MetricsSnapshot[] }
+ * File location: <dataDir>/task-board-metrics-history.json
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import type { TaskStatus, TaskPriority } from './types.js';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/** A compact metrics snapshot stored in the history file. */
+export interface MetricsSnapshot {
+  /** Timestamp of the snapshot (ms since epoch). */
+  ts: number;
+  /** Counts by status. */
+  statusCounts: Record<TaskStatus, number>;
+  /** Total task count at snapshot time. */
+  total: number;
+  /** Throughput windows at snapshot time. */
+  throughput: { last24h: number; last7d: number; last30d: number };
+  /** Average runtime of completed tasks (ms), null if none. */
+  avgRuntimeMs: number | null;
+  /** Median runtime (ms), null if none. */
+  medianRuntimeMs: number | null;
+  /** Success rate (0-1), null if no terminal tasks. */
+  successRate: number | null;
+  /** Number of stuck tasks at snapshot time. */
+  stuckCount: number;
+}
+
+/** On-disk file format. */
+export interface MetricsHistoryFile {
+  version: 1;
+  snapshots: MetricsSnapshot[];
+}
+
+/** Configuration for the metrics history store. */
+export interface MetricsHistoryConfig {
+  /** Maximum number of snapshots to retain. Default: 500. */
+  maxPoints?: number;
+  /** Maximum age of snapshots in ms. Default: 7 days. */
+  maxAgeMs?: number;
+  /** Minimum interval between snapshots in ms. Default: 5 minutes. */
+  minIntervalMs?: number;
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const DEFAULT_MAX_POINTS = 500;
+const DEFAULT_MAX_AGE_MS = 7 * 24 * 60 * 60 * 1000; // 7 days
+const DEFAULT_MIN_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+
+const HISTORY_FILENAME = 'task-board-metrics-history.json';
+
+// ─── File I/O ────────────────────────────────────────────────────────────────
+
+function historyFilePath(dataDir: string): string {
+  return path.join(dataDir, HISTORY_FILENAME);
+}
+
+/**
+ * Read the metrics history from disk.
+ * Returns an empty history if the file doesn't exist or is corrupt.
+ * Bounded read: the file is bounded by retention caps.
+ */
+export function readHistory(dataDir: string): MetricsHistoryFile {
+  try {
+    const fp = historyFilePath(dataDir);
+    if (!fs.existsSync(fp)) return { version: 1, snapshots: [] };
+    const raw = fs.readFileSync(fp, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && parsed.version === 1 && Array.isArray(parsed.snapshots)) {
+      return parsed as MetricsHistoryFile;
+    }
+    return { version: 1, snapshots: [] };
+  } catch {
+    return { version: 1, snapshots: [] };
+  }
+}
+
+/**
+ * Write the metrics history to disk atomically (write-rename pattern).
+ */
+function writeHistory(dataDir: string, history: MetricsHistoryFile): void {
+  const fp = historyFilePath(dataDir);
+  const dir = path.dirname(fp);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  const tmpFp = fp + '.tmp';
+  fs.writeFileSync(tmpFp, JSON.stringify(history, null, 2));
+  fs.renameSync(tmpFp, fp);
+}
+
+// ─── Core operations ─────────────────────────────────────────────────────────
+
+/**
+ * Prune snapshots that exceed retention bounds.
+ * Returns a new array (does not mutate input).
+ * Pure function for testability.
+ */
+export function pruneSnapshots(
+  snapshots: MetricsSnapshot[],
+  opts: {
+    maxPoints?: number;
+    maxAgeMs?: number;
+    now?: number;
+  } = {},
+): MetricsSnapshot[] {
+  const maxPoints = opts.maxPoints ?? DEFAULT_MAX_POINTS;
+  const maxAgeMs = opts.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+  const now = opts.now ?? Date.now();
+
+  // Filter by age first
+  let result = snapshots.filter((s) => now - s.ts <= maxAgeMs);
+
+  // Then cap by count (keep most recent)
+  if (result.length > maxPoints) {
+    result = result.slice(result.length - maxPoints);
+  }
+
+  return result;
+}
+
+/**
+ * Determine whether a new snapshot should be recorded based on the cooldown
+ * interval since the last snapshot.
+ */
+export function shouldSnapshot(
+  snapshots: MetricsSnapshot[],
+  opts: { minIntervalMs?: number; now?: number } = {},
+): boolean {
+  const minIntervalMs = opts.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS;
+  const now = opts.now ?? Date.now();
+
+  if (snapshots.length === 0) return true;
+
+  const lastTs = snapshots[snapshots.length - 1].ts;
+  return now - lastTs >= minIntervalMs;
+}
+
+/**
+ * Create a compact snapshot from full metrics data.
+ * Extracts only the fields needed for time-series display.
+ */
+export function createSnapshot(metrics: {
+  updatedAt: number;
+  statusCounts: Record<TaskStatus, number>;
+  total: number;
+  throughput: { last24h: number; last7d: number; last30d: number };
+  avgRuntimeMs: number | null;
+  medianRuntimeMs: number | null;
+  successRate: number | null;
+  stuckCount: number;
+}): MetricsSnapshot {
+  return {
+    ts: metrics.updatedAt,
+    statusCounts: { ...metrics.statusCounts },
+    total: metrics.total,
+    throughput: { ...metrics.throughput },
+    avgRuntimeMs: metrics.avgRuntimeMs,
+    medianRuntimeMs: metrics.medianRuntimeMs,
+    successRate: metrics.successRate,
+    stuckCount: metrics.stuckCount,
+  };
+}
+
+/**
+ * Append a snapshot to the history file if the cooldown has elapsed.
+ * Applies retention pruning before writing.
+ * Returns true if a snapshot was written, false if skipped (cooldown).
+ *
+ * This is the main entry point for the write path — called from the
+ * metrics API handler as a side-effect (no background daemon needed).
+ */
+export function maybeAppendSnapshot(
+  dataDir: string,
+  metrics: Parameters<typeof createSnapshot>[0],
+  config: MetricsHistoryConfig = {},
+): boolean {
+  const minIntervalMs = config.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS;
+  const maxPoints = config.maxPoints ?? DEFAULT_MAX_POINTS;
+  const maxAgeMs = config.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+  const now = metrics.updatedAt;
+
+  const history = readHistory(dataDir);
+
+  if (!shouldSnapshot(history.snapshots, { minIntervalMs, now })) {
+    return false;
+  }
+
+  const snapshot = createSnapshot(metrics);
+  history.snapshots.push(snapshot);
+
+  // Prune before writing to keep file bounded
+  history.snapshots = pruneSnapshots(history.snapshots, { maxPoints, maxAgeMs, now });
+
+  writeHistory(dataDir, history);
+  return true;
+}
+
+// ─── Query helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Read recent history points. Supports filtering by:
+ *   - limit: max number of most-recent points to return
+ *   - sinceMs: only points newer than (now - sinceMs)
+ *
+ * Returns snapshots sorted oldest-first (chronological order).
+ */
+export function queryHistory(
+  dataDir: string,
+  opts: { limit?: number; sinceMs?: number; now?: number } = {},
+): MetricsSnapshot[] {
+  const history = readHistory(dataDir);
+  const now = opts.now ?? Date.now();
+  let snapshots = history.snapshots;
+
+  // Filter by time window
+  if (opts.sinceMs != null && opts.sinceMs > 0) {
+    const cutoff = now - opts.sinceMs;
+    snapshots = snapshots.filter((s) => s.ts >= cutoff);
+  }
+
+  // Apply limit (most recent N)
+  const limit = opts.limit ?? 100;
+  if (snapshots.length > limit) {
+    snapshots = snapshots.slice(snapshots.length - limit);
+  }
+
+  return snapshots;
+}

--- a/dashboard/server/routes/index.ts
+++ b/dashboard/server/routes/index.ts
@@ -16,6 +16,19 @@ export { handleAgentDiagnostics } from './agent-diagnostics.js';
 export { handleChangelog } from './changelog.js';
 export { handleTaskBoard } from './task-board.js';
 export {
+  maybeAppendSnapshot,
+  queryHistory,
+  readHistory,
+  pruneSnapshots,
+  shouldSnapshot,
+  createSnapshot,
+} from '../metrics-history.js';
+export type {
+  MetricsSnapshot,
+  MetricsHistoryFile,
+  MetricsHistoryConfig,
+} from '../metrics-history.js';
+export {
   emitTaskEvent,
   broadcastTaskEvent,
   addClient,

--- a/dashboard/server/routes/task-board.ts
+++ b/dashboard/server/routes/task-board.ts
@@ -10,6 +10,10 @@
  *
  * Data is persisted as a single JSON file on disk (consistent with
  * the rest of the dashboard's filesystem-based storage).
+ *
+ * Phase 8 (Issue #219): Metrics history persistence — snapshots are
+ * appended on each metrics API read (with cooldown) and queryable via
+ * GET /api/task-board/metrics/history.
  */
 
 import fs from 'node:fs';
@@ -32,6 +36,11 @@ import {
   clientCount,
   parseSubscriptionFilter,
 } from '../task-board-events.js';
+
+import {
+  maybeAppendSnapshot,
+  queryHistory,
+} from '../metrics-history.js';
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -661,17 +670,45 @@ export async function handleTaskBoard(
     return true;
   }
 
+  // ── GET /api/task-board/metrics/history — Issue #219, Phase 8 ───────────────
+  // Returns persisted metrics snapshots for time-series charting.
+  // Query params:
+  //   ?limit=50       — max number of most-recent points (default 100, max 500)
+  //   ?sinceMs=86400000 — only points within this window (default: all retained)
+  // Note: this route MUST be checked before the general /metrics route below.
+  if (url.startsWith('/api/task-board/metrics/history') && method === 'GET') {
+    const histParams = new URL(url, 'http://localhost').searchParams;
+    const limit = Math.max(1, Math.min(Number(histParams.get('limit')) || 100, 500));
+    const sinceMs = histParams.has('sinceMs')
+      ? Math.max(0, Number(histParams.get('sinceMs')) || 0)
+      : undefined;
+    const snapshots = queryHistory(dataDir, { limit, sinceMs });
+    sendJson(res, { snapshots, count: snapshots.length });
+    return true;
+  }
+
   // ── GET /api/task-board/metrics — Issue #219, Task Metrics Dashboard ───────
   // Returns computed metrics: throughput, runtime stats, trends, stuck tasks.
   // Optional query params:
   //   ?stuckTimeoutMs=1800000 — override stuck-task timeout (default 30min)
+  // Side-effect (Phase 8): appends a snapshot to the metrics history file
+  // if the cooldown interval has elapsed (no extra writes on rapid polling).
   if (url.startsWith('/api/task-board/metrics') && method === 'GET') {
     const metricsParams = new URL(url, 'http://localhost').searchParams;
     const stuckTimeoutMs = metricsParams.has('stuckTimeoutMs')
       ? Math.max(1000, Math.min(Number(metricsParams.get('stuckTimeoutMs')) || DEFAULT_STUCK_TIMEOUT_MS, 86400000))
       : undefined;
     const tasks = loadTasks(dataDir);
-    sendJson(res, computeMetrics(tasks, { stuckTimeoutMs }));
+    const metrics = computeMetrics(tasks, { stuckTimeoutMs });
+
+    // Piggyback: persist snapshot (bounded by 5-min cooldown)
+    try {
+      maybeAppendSnapshot(dataDir, metrics);
+    } catch {
+      // Non-critical — don't break the metrics response
+    }
+
+    sendJson(res, metrics);
     return true;
   }
 

--- a/dashboard/tests/unit/routes/task-board-metrics-history.test.ts
+++ b/dashboard/tests/unit/routes/task-board-metrics-history.test.ts
@@ -1,0 +1,561 @@
+/**
+ * Task Board Metrics History — persistence, pruning, and API tests.
+ * Issue #219, Phase 8: Persistent task metrics history / time-series baseline.
+ *
+ * Tests for:
+ * - readHistory / writeHistory (via maybeAppendSnapshot)
+ * - pruneSnapshots (retention by count and age)
+ * - shouldSnapshot (cooldown logic)
+ * - createSnapshot (compact extraction)
+ * - maybeAppendSnapshot (end-to-end write path)
+ * - queryHistory (read with limit/sinceMs filters)
+ * - GET /api/task-board/metrics/history endpoint
+ * - Snapshot side-effect on GET /api/task-board/metrics
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { mockRequest, mockResponse, parseJsonBody } from '../../helpers.js';
+import {
+  handleTaskBoard,
+  computeMetrics,
+} from '../../../server/routes/task-board.js';
+import {
+  readHistory,
+  pruneSnapshots,
+  shouldSnapshot,
+  createSnapshot,
+  maybeAppendSnapshot,
+  queryHistory,
+} from '../../../server/metrics-history.js';
+import type { MetricsSnapshot, MetricsHistoryFile } from '../../../server/metrics-history.js';
+import type { TaskBoardDeps, TaskCard, TaskStatus } from '../../../server/types.js';
+
+const testDataDir = path.join('/tmp', 'test-metrics-history-' + process.pid);
+
+function createDeps(overrides: Partial<TaskBoardDeps> = {}): TaskBoardDeps {
+  return {
+    dataDir: testDataDir,
+    sendJson: (res, data, status = 200) => {
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+    },
+    readRequestBody: async () => '{}',
+    ...overrides,
+  };
+}
+
+function makeSampleCard(overrides: Partial<TaskCard> = {}): TaskCard {
+  return {
+    id: 'test-' + Math.random().toString(36).slice(2, 8),
+    agentId: 'oracle',
+    title: 'Test task',
+    description: 'A test task',
+    priority: 'medium',
+    status: 'backlog',
+    createdAt: Date.now(),
+    queuedAt: null,
+    startedAt: null,
+    completedAt: null,
+    resultSummary: null,
+    tokensUsed: null,
+    error: null,
+    costEstimate: null,
+    runtimeMs: null,
+    ...overrides,
+  };
+}
+
+function seedTasks(tasks: TaskCard[]): void {
+  fs.mkdirSync(testDataDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(testDataDir, 'task-board.json'),
+    JSON.stringify({ tasks, updatedAt: Date.now() }),
+  );
+}
+
+function seedHistory(snapshots: MetricsSnapshot[]): void {
+  fs.mkdirSync(testDataDir, { recursive: true });
+  const data: MetricsHistoryFile = { version: 1, snapshots };
+  fs.writeFileSync(
+    path.join(testDataDir, 'task-board-metrics-history.json'),
+    JSON.stringify(data),
+  );
+}
+
+function makeSnapshot(overrides: Partial<MetricsSnapshot> = {}): MetricsSnapshot {
+  return {
+    ts: Date.now(),
+    statusCounts: { backlog: 0, queued: 0, running: 0, done: 0, failed: 0 },
+    total: 0,
+    throughput: { last24h: 0, last7d: 0, last30d: 0 },
+    avgRuntimeMs: null,
+    medianRuntimeMs: null,
+    successRate: null,
+    stuckCount: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  fs.mkdirSync(testDataDir, { recursive: true });
+  for (const f of ['task-board.json', 'task-board-metrics-history.json']) {
+    const fp = path.join(testDataDir, f);
+    if (fs.existsSync(fp)) fs.unlinkSync(fp);
+  }
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(testDataDir, { recursive: true, force: true });
+  } catch {}
+});
+
+// ─── readHistory ─────────────────────────────────────────────────────────────
+
+describe('readHistory', () => {
+  it('returns empty history when file does not exist', () => {
+    const h = readHistory(testDataDir);
+    expect(h.version).toBe(1);
+    expect(h.snapshots).toHaveLength(0);
+  });
+
+  it('reads valid history file', () => {
+    const snap = makeSnapshot({ ts: 1000, total: 5 });
+    seedHistory([snap]);
+    const h = readHistory(testDataDir);
+    expect(h.snapshots).toHaveLength(1);
+    expect(h.snapshots[0].total).toBe(5);
+    expect(h.snapshots[0].ts).toBe(1000);
+  });
+
+  it('returns empty history for corrupt file', () => {
+    fs.writeFileSync(
+      path.join(testDataDir, 'task-board-metrics-history.json'),
+      'NOT JSON',
+    );
+    const h = readHistory(testDataDir);
+    expect(h.snapshots).toHaveLength(0);
+  });
+
+  it('returns empty history for wrong version', () => {
+    fs.writeFileSync(
+      path.join(testDataDir, 'task-board-metrics-history.json'),
+      JSON.stringify({ version: 99, snapshots: [{ ts: 1 }] }),
+    );
+    const h = readHistory(testDataDir);
+    expect(h.snapshots).toHaveLength(0);
+  });
+});
+
+// ─── pruneSnapshots ──────────────────────────────────────────────────────────
+
+describe('pruneSnapshots', () => {
+  const NOW = 1700000000000;
+
+  it('returns empty for empty input', () => {
+    expect(pruneSnapshots([], { now: NOW })).toHaveLength(0);
+  });
+
+  it('prunes snapshots older than maxAgeMs', () => {
+    const snapshots = [
+      makeSnapshot({ ts: NOW - 10 * 86400000 }), // 10 days old — pruned
+      makeSnapshot({ ts: NOW - 5 * 86400000 }),  // 5 days old — kept
+      makeSnapshot({ ts: NOW - 1 * 86400000 }),  // 1 day old — kept
+    ];
+    const result = pruneSnapshots(snapshots, { maxAgeMs: 7 * 86400000, now: NOW });
+    expect(result).toHaveLength(2);
+    expect(result[0].ts).toBe(NOW - 5 * 86400000);
+  });
+
+  it('caps to maxPoints (keeps most recent)', () => {
+    const snapshots = Array.from({ length: 10 }, (_, i) =>
+      makeSnapshot({ ts: NOW - (10 - i) * 60000 }),
+    );
+    const result = pruneSnapshots(snapshots, { maxPoints: 3, now: NOW, maxAgeMs: 86400000 });
+    expect(result).toHaveLength(3);
+    // Should keep the 3 most recent
+    expect(result[0].ts).toBe(snapshots[7].ts);
+    expect(result[2].ts).toBe(snapshots[9].ts);
+  });
+
+  it('applies both age and count limits', () => {
+    const snapshots = [
+      makeSnapshot({ ts: NOW - 8 * 86400000 }), // too old
+      ...Array.from({ length: 5 }, (_, i) =>
+        makeSnapshot({ ts: NOW - (5 - i) * 3600000 }),
+      ),
+    ];
+    const result = pruneSnapshots(snapshots, {
+      maxAgeMs: 7 * 86400000,
+      maxPoints: 3,
+      now: NOW,
+    });
+    expect(result).toHaveLength(3); // 1 removed by age, then capped to 3
+  });
+
+  it('does not mutate input array', () => {
+    const snapshots = [
+      makeSnapshot({ ts: NOW - 10 * 86400000 }),
+      makeSnapshot({ ts: NOW }),
+    ];
+    const orig = [...snapshots];
+    pruneSnapshots(snapshots, { maxAgeMs: 86400000, now: NOW });
+    expect(snapshots).toEqual(orig);
+  });
+});
+
+// ─── shouldSnapshot ──────────────────────────────────────────────────────────
+
+describe('shouldSnapshot', () => {
+  const NOW = 1700000000000;
+
+  it('returns true for empty snapshot list', () => {
+    expect(shouldSnapshot([], { now: NOW })).toBe(true);
+  });
+
+  it('returns false if last snapshot is within cooldown', () => {
+    const snapshots = [makeSnapshot({ ts: NOW - 60000 })]; // 1 min ago
+    expect(shouldSnapshot(snapshots, { minIntervalMs: 300000, now: NOW })).toBe(false);
+  });
+
+  it('returns true if last snapshot is beyond cooldown', () => {
+    const snapshots = [makeSnapshot({ ts: NOW - 600000 })]; // 10 min ago
+    expect(shouldSnapshot(snapshots, { minIntervalMs: 300000, now: NOW })).toBe(true);
+  });
+
+  it('uses last element for comparison', () => {
+    const snapshots = [
+      makeSnapshot({ ts: NOW - 600000 }), // old
+      makeSnapshot({ ts: NOW - 30000 }),   // recent (last)
+    ];
+    expect(shouldSnapshot(snapshots, { minIntervalMs: 300000, now: NOW })).toBe(false);
+  });
+});
+
+// ─── createSnapshot ──────────────────────────────────────────────────────────
+
+describe('createSnapshot', () => {
+  it('extracts correct fields from full metrics', () => {
+    const metrics = {
+      updatedAt: 1700000000000,
+      statusCounts: { backlog: 2, queued: 1, running: 3, done: 5, failed: 1 } as Record<TaskStatus, number>,
+      total: 12,
+      throughput: { last24h: 3, last7d: 10, last30d: 25 },
+      avgRuntimeMs: 45000,
+      medianRuntimeMs: 30000,
+      successRate: 0.833,
+      stuckCount: 1,
+      // Fields that should NOT be in snapshot
+      completionTrend7d: [],
+      agentBreakdown: [],
+      stuckTasks: [],
+      stuckTimeoutMs: 1800000,
+    };
+    const snap = createSnapshot(metrics);
+    expect(snap.ts).toBe(1700000000000);
+    expect(snap.total).toBe(12);
+    expect(snap.statusCounts.running).toBe(3);
+    expect(snap.throughput.last24h).toBe(3);
+    expect(snap.avgRuntimeMs).toBe(45000);
+    expect(snap.successRate).toBe(0.833);
+    expect(snap.stuckCount).toBe(1);
+    // Ensure no extraneous fields
+    expect(snap).not.toHaveProperty('completionTrend7d');
+    expect(snap).not.toHaveProperty('agentBreakdown');
+    expect(snap).not.toHaveProperty('stuckTasks');
+  });
+
+  it('does not share references with input', () => {
+    const statusCounts = { backlog: 1, queued: 0, running: 0, done: 0, failed: 0 } as Record<TaskStatus, number>;
+    const throughput = { last24h: 1, last7d: 2, last30d: 3 };
+    const snap = createSnapshot({
+      updatedAt: Date.now(),
+      statusCounts,
+      total: 1,
+      throughput,
+      avgRuntimeMs: null,
+      medianRuntimeMs: null,
+      successRate: null,
+      stuckCount: 0,
+    });
+    // Mutate originals — snapshot should be unaffected
+    statusCounts.backlog = 999;
+    throughput.last24h = 999;
+    expect(snap.statusCounts.backlog).toBe(1);
+    expect(snap.throughput.last24h).toBe(1);
+  });
+});
+
+// ─── maybeAppendSnapshot ─────────────────────────────────────────────────────
+
+describe('maybeAppendSnapshot', () => {
+  const NOW = 1700000000000;
+
+  function makeMetrics(overrides: Partial<ReturnType<typeof computeMetrics>> = {}) {
+    return {
+      updatedAt: NOW,
+      statusCounts: { backlog: 0, queued: 0, running: 0, done: 0, failed: 0 } as Record<TaskStatus, number>,
+      total: 0,
+      throughput: { last24h: 0, last7d: 0, last30d: 0 },
+      avgRuntimeMs: null,
+      medianRuntimeMs: null,
+      successRate: null,
+      stuckCount: 0,
+      completionTrend7d: [],
+      agentBreakdown: [],
+      stuckTasks: [],
+      stuckTimeoutMs: 1800000,
+      ...overrides,
+    };
+  }
+
+  it('writes first snapshot to empty history', () => {
+    const metrics = makeMetrics({ total: 5 });
+    const written = maybeAppendSnapshot(testDataDir, metrics, { minIntervalMs: 300000 });
+    expect(written).toBe(true);
+    const h = readHistory(testDataDir);
+    expect(h.snapshots).toHaveLength(1);
+    expect(h.snapshots[0].total).toBe(5);
+  });
+
+  it('skips write if cooldown has not elapsed', () => {
+    // Seed with a recent snapshot
+    seedHistory([makeSnapshot({ ts: NOW - 60000 })]);
+    const metrics = makeMetrics({ updatedAt: NOW, total: 10 });
+    const written = maybeAppendSnapshot(testDataDir, metrics, { minIntervalMs: 300000 });
+    expect(written).toBe(false);
+    const h = readHistory(testDataDir);
+    expect(h.snapshots).toHaveLength(1); // no new snapshot
+  });
+
+  it('writes if cooldown has elapsed', () => {
+    seedHistory([makeSnapshot({ ts: NOW - 600000 })]); // 10 min ago
+    const metrics = makeMetrics({ updatedAt: NOW, total: 10 });
+    const written = maybeAppendSnapshot(testDataDir, metrics, { minIntervalMs: 300000 });
+    expect(written).toBe(true);
+    const h = readHistory(testDataDir);
+    expect(h.snapshots).toHaveLength(2);
+  });
+
+  it('prunes old snapshots on write', () => {
+    // Seed with 5 snapshots, all old
+    const oldSnapshots = Array.from({ length: 5 }, (_, i) =>
+      makeSnapshot({ ts: NOW - (10 + i) * 86400000 }), // 10-14 days old
+    );
+    seedHistory(oldSnapshots);
+    const metrics = makeMetrics({ updatedAt: NOW });
+    const written = maybeAppendSnapshot(testDataDir, metrics, {
+      minIntervalMs: 0, // no cooldown
+      maxAgeMs: 7 * 86400000,
+    });
+    expect(written).toBe(true);
+    const h = readHistory(testDataDir);
+    // All 5 old snapshots pruned, only the new one remains
+    expect(h.snapshots).toHaveLength(1);
+    expect(h.snapshots[0].ts).toBe(NOW);
+  });
+
+  it('caps total snapshots to maxPoints', () => {
+    const existing = Array.from({ length: 10 }, (_, i) =>
+      makeSnapshot({ ts: NOW - (10 - i) * 300000 }),
+    );
+    seedHistory(existing);
+    const metrics = makeMetrics({ updatedAt: NOW });
+    maybeAppendSnapshot(testDataDir, metrics, {
+      minIntervalMs: 0,
+      maxPoints: 5,
+      maxAgeMs: 86400000,
+    });
+    const h = readHistory(testDataDir);
+    expect(h.snapshots.length).toBeLessThanOrEqual(5);
+  });
+
+  it('creates dataDir if it does not exist', () => {
+    const newDir = path.join(testDataDir, 'nested', 'dir');
+    const metrics = makeMetrics({ updatedAt: NOW });
+    maybeAppendSnapshot(newDir, metrics, { minIntervalMs: 0 });
+    expect(fs.existsSync(path.join(newDir, 'task-board-metrics-history.json'))).toBe(true);
+  });
+});
+
+// ─── queryHistory ────────────────────────────────────────────────────────────
+
+describe('queryHistory', () => {
+  const NOW = 1700000000000;
+
+  it('returns empty array when no history file exists', () => {
+    const result = queryHistory(testDataDir, { now: NOW });
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns all snapshots within default limit', () => {
+    const snaps = Array.from({ length: 5 }, (_, i) =>
+      makeSnapshot({ ts: NOW - (5 - i) * 300000 }),
+    );
+    seedHistory(snaps);
+    const result = queryHistory(testDataDir, { now: NOW });
+    expect(result).toHaveLength(5);
+    // Should be in chronological order (oldest first)
+    expect(result[0].ts).toBeLessThan(result[4].ts);
+  });
+
+  it('respects limit parameter', () => {
+    const snaps = Array.from({ length: 20 }, (_, i) =>
+      makeSnapshot({ ts: NOW - (20 - i) * 300000 }),
+    );
+    seedHistory(snaps);
+    const result = queryHistory(testDataDir, { limit: 5, now: NOW });
+    expect(result).toHaveLength(5);
+    // Should be the 5 most recent
+    expect(result[0].ts).toBe(snaps[15].ts);
+  });
+
+  it('filters by sinceMs', () => {
+    const snaps = [
+      makeSnapshot({ ts: NOW - 3600000 * 3 }), // 3 hours ago
+      makeSnapshot({ ts: NOW - 3600000 }),       // 1 hour ago
+      makeSnapshot({ ts: NOW - 60000 }),          // 1 min ago
+    ];
+    seedHistory(snaps);
+    const result = queryHistory(testDataDir, {
+      sinceMs: 2 * 3600000, // last 2 hours
+      now: NOW,
+    });
+    expect(result).toHaveLength(2);
+    expect(result[0].ts).toBe(NOW - 3600000);
+  });
+
+  it('combines limit and sinceMs', () => {
+    const snaps = Array.from({ length: 10 }, (_, i) =>
+      makeSnapshot({ ts: NOW - (10 - i) * 60000 }),
+    );
+    seedHistory(snaps);
+    const result = queryHistory(testDataDir, {
+      sinceMs: 5 * 60000, // last 5 min
+      limit: 2,
+      now: NOW,
+    });
+    expect(result).toHaveLength(2);
+  });
+});
+
+// ─── GET /api/task-board/metrics/history endpoint ────────────────────────────
+
+describe('GET /api/task-board/metrics/history', () => {
+  const NOW = 1700000000000;
+
+  it('returns empty snapshots array when no history', async () => {
+    seedTasks([]);
+    const req = mockRequest({ url: '/api/task-board/metrics/history', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+    const body = parseJsonBody(res);
+    expect(res._statusCode).toBe(200);
+    expect(body).toHaveProperty('snapshots');
+    expect(body).toHaveProperty('count', 0);
+    expect(body.snapshots).toHaveLength(0);
+  });
+
+  it('returns persisted snapshots', async () => {
+    seedTasks([]);
+    seedHistory([
+      makeSnapshot({ ts: NOW - 600000, total: 3 }),
+      makeSnapshot({ ts: NOW - 300000, total: 5 }),
+      makeSnapshot({ ts: NOW, total: 7 }),
+    ]);
+    const req = mockRequest({ url: '/api/task-board/metrics/history', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+    const body = parseJsonBody(res);
+    expect(body.count).toBe(3);
+    expect(body.snapshots).toHaveLength(3);
+    expect(body.snapshots[0].total).toBe(3);
+    expect(body.snapshots[2].total).toBe(7);
+  });
+
+  it('respects limit query param', async () => {
+    seedTasks([]);
+    const snaps = Array.from({ length: 20 }, (_, i) =>
+      makeSnapshot({ ts: NOW - (20 - i) * 300000 }),
+    );
+    seedHistory(snaps);
+    const req = mockRequest({ url: '/api/task-board/metrics/history?limit=5', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+    const body = parseJsonBody(res);
+    expect(body.count).toBe(5);
+    expect(body.snapshots).toHaveLength(5);
+  });
+
+  it('respects sinceMs query param', async () => {
+    seedTasks([]);
+    // Use real timestamps relative to actual Date.now() so the API handler
+    // (which defaults to Date.now()) filters correctly.
+    const realNow = Date.now();
+    seedHistory([
+      makeSnapshot({ ts: realNow - 7200000 }), // 2h ago
+      makeSnapshot({ ts: realNow - 1800000 }), // 30 min ago
+      makeSnapshot({ ts: realNow }),
+    ]);
+    const req = mockRequest({ url: `/api/task-board/metrics/history?sinceMs=3600000`, method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+    const body = parseJsonBody(res);
+    expect(body.count).toBe(2); // 30 min + now
+  });
+
+  it('clamps limit to 500 max', async () => {
+    seedTasks([]);
+    seedHistory([makeSnapshot({ ts: NOW })]);
+    const req = mockRequest({ url: '/api/task-board/metrics/history?limit=9999', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+    // Should not error — just clamped
+    const body = parseJsonBody(res);
+    expect(body.count).toBe(1);
+  });
+});
+
+// ─── Snapshot side-effect on GET /api/task-board/metrics ─────────────────────
+
+describe('Metrics API snapshot side-effect', () => {
+  it('persists a snapshot when metrics are fetched', async () => {
+    seedTasks([
+      makeSampleCard({ status: 'done', completedAt: Date.now() - 3600000, runtimeMs: 5000 }),
+      makeSampleCard({ status: 'running', startedAt: Date.now() }),
+    ]);
+
+    const req = mockRequest({ url: '/api/task-board/metrics', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    // Verify metrics response is still correct
+    const body = parseJsonBody(res);
+    expect(body.total).toBe(2);
+
+    // Verify a snapshot was written
+    const h = readHistory(testDataDir);
+    expect(h.snapshots.length).toBeGreaterThanOrEqual(1);
+    expect(h.snapshots[h.snapshots.length - 1].total).toBe(2);
+  });
+
+  it('does not duplicate snapshot on rapid successive calls', async () => {
+    seedTasks([makeSampleCard({ status: 'backlog' })]);
+
+    // First call — should write
+    const req1 = mockRequest({ url: '/api/task-board/metrics', method: 'GET' });
+    const res1 = mockResponse();
+    await handleTaskBoard(req1, res1, createDeps());
+
+    // Second call immediately — should NOT write (cooldown)
+    const req2 = mockRequest({ url: '/api/task-board/metrics', method: 'GET' });
+    const res2 = mockResponse();
+    await handleTaskBoard(req2, res2, createDeps());
+
+    const h = readHistory(testDataDir);
+    // Only 1 snapshot despite 2 API calls
+    expect(h.snapshots).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Summary
Refs #219

Adds additive persistence layer for periodic task-board metrics snapshots with bounded retention, a query API for charting, and dashboard trend visualization.

## What's New

### 1. Metrics History Persistence (`dashboard/server/metrics-history.ts`)
- **MetricsSnapshot** type — compact subset of TaskBoardMetrics (ts, statusCounts, total, throughput, avgRuntimeMs, medianRuntimeMs, successRate, stuckCount)
- **JSON file storage** with atomic write-rename pattern
- **Retention policy**: max 500 points, max 7 days, 5-minute cooldown between writes
- Pure functions for testability: `pruneSnapshots`, `shouldSnapshot`, `createSnapshot`
- `maybeAppendSnapshot` — main write entry point (bounded, idempotent)
- `queryHistory` — read with `limit` and `sinceMs` filters

### 2. API Surface
- **`GET /api/task-board/metrics/history`** — query persisted snapshots
  - `?limit=50` — max recent points (default 100, max 500)
  - `?sinceMs=86400000` — time window filter
  - Response: `{ snapshots: MetricsSnapshot[], count: number }`
- **`GET /api/task-board/metrics`** — enhanced with snapshot side-effect
  - Piggybacks snapshot write on each read (5-min cooldown)
  - Non-critical: wrapped in try/catch, won't break metrics response

### 3. Dashboard Integration
- **Metrics History trend chart** in the task metrics panel
  - SVG polyline chart with area fill
  - Metric selector: Total Tasks, Throughput (24h), Success Rate, Avg Runtime, Stuck Tasks, Running
  - Time window selector: 1h, 6h, 24h, 7d
  - Auto-fetches on metrics panel open and board refresh
  - Color-coded by metric type, responsive

## Tests — 33 new (all passing)
| Suite | Tests |
|-------|-------|
| readHistory | 4 (empty, valid, corrupt, wrong version) |
| pruneSnapshots | 5 (age, count, combined, immutability) |
| shouldSnapshot | 4 (empty, within/beyond cooldown, last element) |
| createSnapshot | 2 (field extraction, reference isolation) |
| maybeAppendSnapshot | 6 (first write, cooldown skip/elapsed, prune, cap, mkdir) |
| queryHistory | 5 (empty, all, limit, sinceMs, combined) |
| API endpoint | 5 (empty, persisted, limit, sinceMs, clamp) |
| Side-effect | 2 (snapshot written, no duplicate on rapid calls) |

Full regression: **271/271** task-board tests passing, **607/607** other dashboard tests passing (38 pre-existing better-sqlite3 native module failures excluded).

Typecheck: ✅ clean (`tsc --noEmit`)

## Risk Assessment
- **LOW**: Additive only — no schema changes, no background daemons
- File bounded: max 500 points × ~200 bytes ≈ 100KB max file size
- Cooldown prevents write amplification on rapid polling
- Non-critical try/catch on snapshot side-effect
- **Fully reversible**: delete `task-board-metrics-history.json` to reset
- No auth changes — inherits existing middleware posture