### PR TITLE
feat(#219): Configurable alert-threshold evaluation for task-board metrics (Phase 9)

### DIFF
--- a/dashboard/client/index.html
+++ b/dashboard/client/index.html
@@ -1947,6 +1947,195 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
   overflow: visible;
 }
 
+/* ─── Alert Rules (Issue #219, Phase 9) ─────────────────────────────── */
+
+.tb-alerts-banner {
+  border-radius: 10px;
+  padding: 12px 16px;
+  margin-bottom: 16px;
+  display: none;
+}
+
+.tb-alerts-banner.active {
+  display: block;
+}
+
+.tb-alerts-banner.severity-warning {
+  background: rgba(245, 158, 11, 0.08);
+  border: 1px solid rgba(245, 158, 11, 0.3);
+}
+
+.tb-alerts-banner.severity-critical {
+  background: rgba(239, 68, 68, 0.08);
+  border: 1px solid rgba(239, 68, 68, 0.3);
+}
+
+.tb-alerts-banner-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+.tb-alerts-banner.severity-warning .tb-alerts-banner-header {
+  color: var(--yellow);
+}
+
+.tb-alerts-banner.severity-critical .tb-alerts-banner-header {
+  color: var(--red);
+}
+
+.tb-alert-rule-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 0;
+  font-size: 12px;
+  color: var(--text-secondary);
+}
+
+.tb-alert-rule-severity {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+}
+
+.tb-alert-rule-severity.warning {
+  background: rgba(245, 158, 11, 0.15);
+  color: var(--yellow);
+}
+
+.tb-alert-rule-severity.critical {
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--red);
+}
+
+.tb-alert-badge-toggle {
+  display: none;
+  margin-left: auto;
+  font-size: 11px;
+  padding: 2px 8px;
+  border-radius: 8px;
+  font-weight: 600;
+}
+
+.tb-alert-badge-toggle.warning {
+  display: inline-flex;
+  background: rgba(245, 158, 11, 0.15);
+  color: var(--yellow);
+}
+
+.tb-alert-badge-toggle.critical {
+  display: inline-flex;
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--red);
+  animation: tb-stuck-pulse 2s ease-in-out infinite;
+}
+
+.tb-alert-config-link {
+  font-size: 11px;
+  color: var(--text-muted);
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  margin-left: auto;
+}
+
+.tb-alert-config-link:hover {
+  color: var(--text-primary);
+}
+
+/* Alert config modal */
+.tb-alert-config-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.75);
+  z-index: 700;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(4px);
+}
+
+.tb-alert-config-overlay.active {
+  display: flex;
+}
+
+.tb-alert-config-panel {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  width: 92%;
+  max-width: 540px;
+  max-height: 85vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.5);
+  animation: tb-detail-in 0.25s ease;
+}
+
+.tb-alert-config-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.tb-alert-config-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 20px;
+}
+
+.tb-alert-config-rule {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px 14px;
+  margin-bottom: 10px;
+  background: var(--bg-card);
+}
+
+.tb-alert-config-rule-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.tb-alert-config-rule-name {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.tb-alert-config-thresholds {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.tb-alert-config-footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 20px;
+  border-top: 1px solid var(--border);
+  justify-content: flex-end;
+}
+
+/* ─── End Alert Rules ───────────────────────────────────────────────── */
+
 /* ─── End Task Metrics Dashboard ────────────────────────────────────── */
 
 /* ─── End Task Board ────────────────────────────────────────────────── */
@@ -3464,6 +3653,7 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
         <div class="tb-metrics-toggle" id="tbMetricsToggle" onclick="tbToggleMetrics()">
           <span class="tb-metrics-toggle-icon">▸</span>
           <span>📊 Task Metrics &amp; Health</span>
+          <span id="tbAlertBadgeToggle" class="tb-alert-badge-toggle"></span>
           <span id="tbMetricsStuckBadge" style="display:none;margin-left:auto;background:rgba(245,158,11,0.15);color:var(--yellow);font-size:11px;padding:2px 8px;border-radius:8px;font-weight:600;"></span>
         </div>
         <div class="tb-metrics-panel" id="tbMetricsPanel">
@@ -3471,6 +3661,16 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
           <div id="tbStuckAlert" class="tb-stuck-alert mb-24" style="display:none;">
             <span class="tb-stuck-alert-icon">⚠️</span>
             <div class="tb-stuck-alert-list" id="tbStuckAlertList"></div>
+          </div>
+
+          <!-- Alert rules banner (Phase 9) — shown when thresholds are breached -->
+          <div id="tbAlertsBanner" class="tb-alerts-banner mb-24">
+            <div class="tb-alerts-banner-header">
+              <span id="tbAlertsBannerIcon">🔔</span>
+              <span id="tbAlertsBannerTitle">Alerts</span>
+              <span class="tb-alert-config-link" onclick="tbOpenAlertConfig()">⚙️ Configure</span>
+            </div>
+            <div id="tbAlertsBannerRules"></div>
           </div>
 
           <!-- KPI row -->
@@ -3800,6 +4000,25 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
   </div>
 </div>
 <!-- ═══ End Task Detail Modal ═══════════════════════════════════════════ -->
+
+<!-- ═══ Alert Config Modal (Issue #219, Phase 9) ═══════════════════════ -->
+<div class="tb-alert-config-overlay" id="tbAlertConfigModal" onclick="if(event.target===this)tbCloseAlertConfig()">
+  <div class="tb-alert-config-panel">
+    <div class="tb-alert-config-header">
+      <span>🔔 Alert Thresholds</span>
+      <button onclick="tbCloseAlertConfig()" class="tb-detail-close" aria-label="Close alert config">✕</button>
+    </div>
+    <div class="tb-alert-config-body" id="tbAlertConfigBody">
+      <!-- Populated dynamically -->
+    </div>
+    <div class="tb-alert-config-footer">
+      <button onclick="tbResetAlertConfig()" class="tb-btn tb-btn-secondary" style="margin-right:auto;">Reset Defaults</button>
+      <button onclick="tbCloseAlertConfig()" class="tb-btn tb-btn-secondary">Cancel</button>
+      <button onclick="tbSaveAlertConfig()" class="tb-btn tb-btn-primary">Save</button>
+    </div>
+  </div>
+</div>
+<!-- ═══ End Alert Config Modal ═════════════════════════════════════════ -->
 
 <div class="status-bar">
   <div class="status-bar-section">
@@ -8058,6 +8277,9 @@ function tbRenderMetrics(m) {
   // Agent breakdown table
   tbRenderAgentTable(m.agentBreakdown || []);
 
+  // Alert rules evaluation (Phase 9)
+  tbRenderAlerts(m.alerts);
+
   // Re-render board to pick up stuck badges on cards
   tbRenderBoard();
 }
@@ -8234,6 +8456,210 @@ function tbRenderHistoryChart() {
     <div style="position:absolute;top:0;right:8px;font-size:10px;color:var(--text-muted);font-family:'JetBrains Mono',monospace;">${yMax}</div>
     <div style="position:absolute;bottom:20px;right:8px;font-size:10px;color:var(--text-muted);font-family:'JetBrains Mono',monospace;">${yMin}</div>
   `;
+}
+
+// ── Alert Rules (Issue #219, Phase 9) ────────────────────────────────────────
+// Renders alert banners/badges from the alerts data included in metrics response.
+// Also manages the alert config modal for threshold editing.
+
+let tbAlertConfigCache = null;
+
+const TB_ALERT_RULE_LABELS = {
+  stuckCount: '⏱ Stuck Tasks',
+  failedRate: '❌ Failed Rate',
+  backlogSize: '📋 Backlog Size',
+  avgRuntime: '⏱ Avg Runtime',
+  queueDepth: '⏳ Queue Depth',
+};
+
+const TB_ALERT_RULE_DESCRIPTIONS = {
+  stuckCount: 'Number of running tasks exceeding the stuck timeout',
+  failedRate: 'Percentage of terminal tasks that failed (1 - success rate)',
+  backlogSize: 'Number of tasks in the backlog column',
+  avgRuntime: 'Average runtime of completed tasks (ms)',
+  queueDepth: 'Number of tasks waiting in the queued column',
+};
+
+/** Render alert banners from the metrics response alerts data. */
+function tbRenderAlerts(alerts) {
+  const banner = document.getElementById('tbAlertsBanner');
+  const rulesEl = document.getElementById('tbAlertsBannerRules');
+  const badgeToggle = document.getElementById('tbAlertBadgeToggle');
+  const bannerIcon = document.getElementById('tbAlertsBannerIcon');
+  const bannerTitle = document.getElementById('tbAlertsBannerTitle');
+
+  if (!banner || !rulesEl || !alerts) {
+    if (banner) banner.classList.remove('active', 'severity-warning', 'severity-critical');
+    if (badgeToggle) { badgeToggle.className = 'tb-alert-badge-toggle'; badgeToggle.textContent = ''; }
+    return;
+  }
+
+  // Filter to only active (non-ok, enabled) alerts
+  const activeAlerts = (alerts.rules || []).filter(r => r.enabled && r.severity !== 'ok');
+
+  if (activeAlerts.length === 0) {
+    banner.classList.remove('active', 'severity-warning', 'severity-critical');
+    if (badgeToggle) { badgeToggle.className = 'tb-alert-badge-toggle'; badgeToggle.textContent = ''; }
+    return;
+  }
+
+  // Show banner
+  banner.classList.add('active');
+  banner.classList.remove('severity-warning', 'severity-critical');
+  banner.classList.add('severity-' + alerts.overallSeverity);
+
+  // Header
+  const critCount = alerts.severityCounts?.critical || 0;
+  const warnCount = alerts.severityCounts?.warning || 0;
+  if (bannerIcon) bannerIcon.textContent = alerts.overallSeverity === 'critical' ? '🚨' : '⚠️';
+  if (bannerTitle) {
+    const parts = [];
+    if (critCount > 0) parts.push(critCount + ' critical');
+    if (warnCount > 0) parts.push(warnCount + ' warning');
+    bannerTitle.textContent = parts.join(', ') + ' alert' + (activeAlerts.length !== 1 ? 's' : '');
+  }
+
+  // Rule items
+  rulesEl.innerHTML = activeAlerts.map(r => {
+    const icon = TB_ALERT_RULE_LABELS[r.rule] || r.label;
+    return `<div class="tb-alert-rule-item">
+      <span class="tb-alert-rule-severity ${r.severity}">${r.severity}</span>
+      <span>${tbEsc(r.message)}</span>
+    </div>`;
+  }).join('');
+
+  // Toggle button badge
+  if (badgeToggle) {
+    badgeToggle.className = 'tb-alert-badge-toggle ' + alerts.overallSeverity;
+    const emoji = alerts.overallSeverity === 'critical' ? '🚨' : '⚠️';
+    badgeToggle.textContent = emoji + ' ' + activeAlerts.length + ' alert' + (activeAlerts.length !== 1 ? 's' : '');
+  }
+}
+
+/** Open the alert config modal. */
+async function tbOpenAlertConfig() {
+  const overlay = document.getElementById('tbAlertConfigModal');
+  if (!overlay) return;
+  overlay.classList.add('active');
+
+  // Fetch current config
+  try {
+    const res = await fetch('/api/task-board/alerts/config');
+    if (!res.ok) throw new Error('fetch failed');
+    const data = await res.json();
+    tbAlertConfigCache = data.config;
+    tbRenderAlertConfigForm(data.config);
+  } catch (e) {
+    console.warn('[alert-config] fetch error', e);
+    tbRenderAlertConfigForm(null);
+  }
+}
+
+/** Close the alert config modal. */
+function tbCloseAlertConfig() {
+  const overlay = document.getElementById('tbAlertConfigModal');
+  if (overlay) overlay.classList.remove('active');
+}
+
+/** Render the alert config form. */
+function tbRenderAlertConfigForm(config) {
+  const body = document.getElementById('tbAlertConfigBody');
+  if (!body) return;
+
+  if (!config) {
+    body.innerHTML = '<div style="text-align:center;color:var(--text-muted);padding:20px;">Failed to load config</div>';
+    return;
+  }
+
+  const rules = ['stuckCount', 'failedRate', 'backlogSize', 'avgRuntime', 'queueDepth'];
+
+  body.innerHTML = rules.map(key => {
+    const rule = config[key] || { enabled: false, warning: 0, critical: 0 };
+    const label = TB_ALERT_RULE_LABELS[key] || key;
+    const desc = TB_ALERT_RULE_DESCRIPTIONS[key] || '';
+    const isRate = key === 'failedRate';
+    const isMs = key === 'avgRuntime';
+    const step = isRate ? '0.01' : (isMs ? '1000' : '1');
+    const warningDisplay = isRate ? (rule.warning * 100).toFixed(0) : (isMs ? (rule.warning / 1000).toFixed(0) : rule.warning);
+    const criticalDisplay = isRate ? (rule.critical * 100).toFixed(0) : (isMs ? (rule.critical / 1000).toFixed(0) : rule.critical);
+    const unit = isRate ? '%' : (isMs ? 's' : '');
+
+    return `<div class="tb-alert-config-rule">
+      <div class="tb-alert-config-rule-header">
+        <label style="display:flex;align-items:center;gap:6px;cursor:pointer;">
+          <input type="checkbox" id="tbAcEnabled_${key}" ${rule.enabled ? 'checked' : ''} style="cursor:pointer;">
+          <span class="tb-alert-config-rule-name">${label}</span>
+        </label>
+      </div>
+      <div style="font-size:11px;color:var(--text-muted);margin-bottom:8px;">${tbEsc(desc)}</div>
+      <div class="tb-alert-config-thresholds">
+        <div>
+          <label class="tb-label" style="color:var(--yellow);">⚠️ Warning${unit ? ' (' + unit + ')' : ''}</label>
+          <input type="number" id="tbAcWarning_${key}" class="tb-input" value="${warningDisplay}" min="0" step="${isRate ? '1' : step}" style="font-family:'JetBrains Mono',monospace;">
+        </div>
+        <div>
+          <label class="tb-label" style="color:var(--red);">🚨 Critical${unit ? ' (' + unit + ')' : ''}</label>
+          <input type="number" id="tbAcCritical_${key}" class="tb-input" value="${criticalDisplay}" min="0" step="${isRate ? '1' : step}" style="font-family:'JetBrains Mono',monospace;">
+        </div>
+      </div>
+    </div>`;
+  }).join('');
+}
+
+/** Save alert config from the form. */
+async function tbSaveAlertConfig() {
+  const rules = ['stuckCount', 'failedRate', 'backlogSize', 'avgRuntime', 'queueDepth'];
+  const config = {};
+
+  for (const key of rules) {
+    const enabled = document.getElementById('tbAcEnabled_' + key)?.checked ?? false;
+    let warning = parseFloat(document.getElementById('tbAcWarning_' + key)?.value ?? '0');
+    let critical = parseFloat(document.getElementById('tbAcCritical_' + key)?.value ?? '0');
+
+    // Convert display units back to storage units
+    if (key === 'failedRate') {
+      warning = warning / 100;
+      critical = critical / 100;
+    } else if (key === 'avgRuntime') {
+      warning = warning * 1000;
+      critical = critical * 1000;
+    }
+
+    config[key] = { enabled, warning, critical };
+  }
+
+  try {
+    const res = await fetch('/api/task-board/alerts/config', {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(config),
+    });
+    if (!res.ok) {
+      const err = await res.json();
+      tbShowToast('Failed to save: ' + (err.error || 'unknown'), 'error');
+      return;
+    }
+    tbShowToast('Alert config saved', 'success');
+    tbCloseAlertConfig();
+    // Refresh metrics to pick up new alert evaluation
+    tbRefreshMetrics();
+  } catch (e) {
+    tbShowToast('Network error: ' + e.message, 'error');
+  }
+}
+
+/** Reset alert config to defaults. */
+async function tbResetAlertConfig() {
+  // Default config matches server defaults
+  const defaults = {
+    stuckCount: { enabled: true, warning: 2, critical: 5 },
+    failedRate: { enabled: true, warning: 0.15, critical: 0.30 },
+    backlogSize: { enabled: true, warning: 20, critical: 50 },
+    avgRuntime: { enabled: false, warning: 300000, critical: 600000 },
+    queueDepth: { enabled: false, warning: 10, critical: 25 },
+  };
+  tbRenderAlertConfigForm(defaults);
+  tbShowToast('Form reset to defaults (click Save to apply)', 'info');
 }
 
 // ── Real-time SSE subscription (Issue #219) ─────────────────────────────────

--- a/dashboard/server/alert-rules.ts
+++ b/dashboard/server/alert-rules.ts
@@ -1,0 +1,444 @@
+/**
+ * Alert Rules — configurable threshold evaluation for Task Board metrics.
+ * Issue #219 — Phase 9: Metrics Alerting Rules Baseline.
+ *
+ * Evaluates task-board metrics against user-configurable thresholds and
+ * produces alert states. Computed on-demand during metrics API reads —
+ * no background daemons or persistent state beyond the config file.
+ *
+ * Alert severity levels:
+ *   - ok:       metric is within acceptable bounds
+ *   - warning:  metric has crossed the warning threshold
+ *   - critical: metric has crossed the critical threshold
+ *
+ * Config is persisted as a JSON file alongside other task-board data.
+ * Missing config falls back to sensible defaults.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+export type AlertSeverity = 'ok' | 'warning' | 'critical';
+
+/** A single alert rule threshold config. */
+export interface AlertThreshold {
+  /** Whether this rule is enabled. */
+  enabled: boolean;
+  /** Warning threshold value. */
+  warning: number;
+  /** Critical threshold value. */
+  critical: number;
+}
+
+/** Full alert rules configuration. */
+export interface AlertRulesConfig {
+  /**
+   * Stuck task count thresholds.
+   * Direction: alert when metric >= threshold.
+   */
+  stuckCount: AlertThreshold;
+  /**
+   * Failed task rate (0–1) thresholds.
+   * Direction: alert when failed rate >= threshold.
+   * Computed as: 1 - successRate.
+   */
+  failedRate: AlertThreshold;
+  /**
+   * Backlog size thresholds.
+   * Direction: alert when backlog count >= threshold.
+   */
+  backlogSize: AlertThreshold;
+  /**
+   * Average runtime (milliseconds) thresholds.
+   * Direction: alert when avgRuntimeMs >= threshold.
+   */
+  avgRuntime: AlertThreshold;
+  /**
+   * Queue depth (queued count) thresholds.
+   * Direction: alert when queued count >= threshold.
+   */
+  queueDepth: AlertThreshold;
+}
+
+/** Result of evaluating a single alert rule. */
+export interface AlertRuleResult {
+  /** Rule identifier matching the config key. */
+  rule: keyof AlertRulesConfig;
+  /** Human-readable label for display. */
+  label: string;
+  /** Whether the rule is enabled. */
+  enabled: boolean;
+  /** Current severity level. */
+  severity: AlertSeverity;
+  /** Current metric value. */
+  currentValue: number | null;
+  /** Warning threshold. */
+  warningThreshold: number;
+  /** Critical threshold. */
+  criticalThreshold: number;
+  /** Human-readable message. */
+  message: string;
+}
+
+/** Aggregated alert evaluation result. */
+export interface AlertEvaluation {
+  /** Timestamp of evaluation (ms since epoch). */
+  evaluatedAt: number;
+  /** Highest severity across all enabled rules. */
+  overallSeverity: AlertSeverity;
+  /** Count of rules at each severity level. */
+  severityCounts: Record<AlertSeverity, number>;
+  /** Per-rule results. */
+  rules: AlertRuleResult[];
+}
+
+/** Metrics input for alert evaluation (subset of TaskBoardMetrics). */
+export interface AlertMetricsInput {
+  statusCounts: Record<string, number>;
+  successRate: number | null;
+  stuckCount: number;
+  avgRuntimeMs: number | null;
+  total: number;
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const ALERT_CONFIG_FILENAME = 'task-board-alert-rules.json';
+
+/** Default alert configuration — conservative thresholds. */
+export const DEFAULT_ALERT_CONFIG: AlertRulesConfig = {
+  stuckCount: { enabled: true, warning: 2, critical: 5 },
+  failedRate: { enabled: true, warning: 0.15, critical: 0.30 },
+  backlogSize: { enabled: true, warning: 20, critical: 50 },
+  avgRuntime: { enabled: false, warning: 300000, critical: 600000 }, // 5min / 10min
+  queueDepth: { enabled: false, warning: 10, critical: 25 },
+};
+
+/** Valid rule keys for validation. */
+const VALID_RULE_KEYS: (keyof AlertRulesConfig)[] = [
+  'stuckCount',
+  'failedRate',
+  'backlogSize',
+  'avgRuntime',
+  'queueDepth',
+];
+
+/** Human-readable labels for each rule. */
+const RULE_LABELS: Record<keyof AlertRulesConfig, string> = {
+  stuckCount: 'Stuck Tasks',
+  failedRate: 'Failed Rate',
+  backlogSize: 'Backlog Size',
+  avgRuntime: 'Avg Runtime',
+  queueDepth: 'Queue Depth',
+};
+
+// ─── Config I/O ──────────────────────────────────────────────────────────────
+
+function configFilePath(dataDir: string): string {
+  return path.join(dataDir, ALERT_CONFIG_FILENAME);
+}
+
+/**
+ * Read alert rules config from disk.
+ * Returns defaults if file doesn't exist or is corrupt.
+ */
+export function readAlertConfig(dataDir: string): AlertRulesConfig {
+  try {
+    const fp = configFilePath(dataDir);
+    if (!fs.existsSync(fp)) return { ...DEFAULT_ALERT_CONFIG };
+    const raw = fs.readFileSync(fp, 'utf8');
+    const parsed = JSON.parse(raw);
+    return mergeWithDefaults(parsed);
+  } catch {
+    return { ...DEFAULT_ALERT_CONFIG };
+  }
+}
+
+/**
+ * Write alert rules config to disk atomically.
+ * Validates input before writing.
+ */
+export function writeAlertConfig(dataDir: string, config: AlertRulesConfig): void {
+  const fp = configFilePath(dataDir);
+  const dir = path.dirname(fp);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  const tmpFp = fp + '.tmp';
+  fs.writeFileSync(tmpFp, JSON.stringify(config, null, 2));
+  fs.renameSync(tmpFp, fp);
+}
+
+/**
+ * Merge partial user config with defaults.
+ * Ensures all keys are present and values are valid.
+ * Pure function for testability.
+ */
+export function mergeWithDefaults(
+  partial: Partial<Record<string, unknown>>,
+): AlertRulesConfig {
+  const result: AlertRulesConfig = { ...DEFAULT_ALERT_CONFIG };
+
+  for (const key of VALID_RULE_KEYS) {
+    const val = partial?.[key];
+    if (val && typeof val === 'object' && !Array.isArray(val)) {
+      const src = val as Record<string, unknown>;
+      const def = DEFAULT_ALERT_CONFIG[key];
+      result[key] = {
+        enabled: typeof src.enabled === 'boolean' ? src.enabled : def.enabled,
+        warning: typeof src.warning === 'number' && isFinite(src.warning) && src.warning >= 0
+          ? src.warning
+          : def.warning,
+        critical: typeof src.critical === 'number' && isFinite(src.critical) && src.critical >= 0
+          ? src.critical
+          : def.critical,
+      };
+    }
+  }
+
+  return result;
+}
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+/** Validation error returned when config update fails. */
+export interface AlertConfigValidationError {
+  field: string;
+  message: string;
+}
+
+/**
+ * Validate an alert rules config update.
+ * Returns an array of validation errors (empty = valid).
+ * Pure function for testability.
+ */
+export function validateAlertConfig(
+  input: unknown,
+): AlertConfigValidationError[] {
+  const errors: AlertConfigValidationError[] = [];
+
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    errors.push({ field: 'root', message: 'config must be a non-null object' });
+    return errors;
+  }
+
+  const obj = input as Record<string, unknown>;
+
+  for (const key of Object.keys(obj)) {
+    if (!VALID_RULE_KEYS.includes(key as keyof AlertRulesConfig)) {
+      errors.push({ field: key, message: `unknown rule key: ${key}` });
+      continue;
+    }
+
+    const ruleVal = obj[key];
+    if (!ruleVal || typeof ruleVal !== 'object' || Array.isArray(ruleVal)) {
+      errors.push({ field: key, message: `${key} must be an object` });
+      continue;
+    }
+
+    const rule = ruleVal as Record<string, unknown>;
+
+    if (rule.enabled !== undefined && typeof rule.enabled !== 'boolean') {
+      errors.push({ field: `${key}.enabled`, message: 'enabled must be a boolean' });
+    }
+
+    if (rule.warning !== undefined) {
+      if (typeof rule.warning !== 'number' || !isFinite(rule.warning) || rule.warning < 0) {
+        errors.push({ field: `${key}.warning`, message: 'warning must be a non-negative finite number' });
+      }
+    }
+
+    if (rule.critical !== undefined) {
+      if (typeof rule.critical !== 'number' || !isFinite(rule.critical) || rule.critical < 0) {
+        errors.push({ field: `${key}.critical`, message: 'critical must be a non-negative finite number' });
+      }
+    }
+
+    // For "upper bound" rules (alert when value >= threshold),
+    // critical should be >= warning
+    if (
+      typeof rule.warning === 'number' &&
+      typeof rule.critical === 'number' &&
+      rule.critical < rule.warning
+    ) {
+      errors.push({
+        field: `${key}`,
+        message: `critical threshold (${rule.critical}) must be >= warning threshold (${rule.warning})`,
+      });
+    }
+  }
+
+  return errors;
+}
+
+// ─── Alert Evaluation ────────────────────────────────────────────────────────
+
+/**
+ * Evaluate a single "upper bound" rule: alert when value >= threshold.
+ * Pure function.
+ */
+function evaluateUpperBound(
+  value: number | null,
+  threshold: AlertThreshold,
+): AlertSeverity {
+  if (!threshold.enabled || value === null) return 'ok';
+  if (value >= threshold.critical) return 'critical';
+  if (value >= threshold.warning) return 'warning';
+  return 'ok';
+}
+
+/**
+ * Get the highest severity from an array.
+ */
+function maxSeverity(severities: AlertSeverity[]): AlertSeverity {
+  if (severities.includes('critical')) return 'critical';
+  if (severities.includes('warning')) return 'warning';
+  return 'ok';
+}
+
+/**
+ * Format a metric value for display in alert messages.
+ */
+function fmtValue(rule: keyof AlertRulesConfig, value: number | null): string {
+  if (value === null) return 'N/A';
+  switch (rule) {
+    case 'failedRate':
+      return (value * 100).toFixed(1) + '%';
+    case 'avgRuntime':
+      return value >= 60000
+        ? (value / 60000).toFixed(1) + 'm'
+        : (value / 1000).toFixed(1) + 's';
+    default:
+      return String(Math.round(value));
+  }
+}
+
+/**
+ * Format a threshold value for display.
+ */
+function fmtThreshold(rule: keyof AlertRulesConfig, value: number): string {
+  switch (rule) {
+    case 'failedRate':
+      return (value * 100).toFixed(0) + '%';
+    case 'avgRuntime':
+      return value >= 60000
+        ? (value / 60000).toFixed(0) + 'm'
+        : (value / 1000).toFixed(0) + 's';
+    default:
+      return String(Math.round(value));
+  }
+}
+
+/**
+ * Build alert message for a rule result.
+ */
+function buildMessage(
+  rule: keyof AlertRulesConfig,
+  label: string,
+  severity: AlertSeverity,
+  value: number | null,
+  threshold: AlertThreshold,
+): string {
+  if (severity === 'ok') return `${label}: ${fmtValue(rule, value)} (OK)`;
+  const thresholdLabel = severity === 'critical' ? 'critical' : 'warning';
+  const thresholdVal = severity === 'critical' ? threshold.critical : threshold.warning;
+  return `${label}: ${fmtValue(rule, value)} exceeds ${thresholdLabel} threshold of ${fmtThreshold(rule, thresholdVal)}`;
+}
+
+/**
+ * Evaluate all alert rules against current metrics.
+ * This is the main entry point — called from the metrics API handler.
+ * Pure function (no side effects, no I/O).
+ */
+export function evaluateAlerts(
+  metrics: AlertMetricsInput,
+  config: AlertRulesConfig,
+  now: number = Date.now(),
+): AlertEvaluation {
+  const results: AlertRuleResult[] = [];
+
+  // 1. Stuck count
+  const stuckSeverity = evaluateUpperBound(metrics.stuckCount, config.stuckCount);
+  results.push({
+    rule: 'stuckCount',
+    label: RULE_LABELS.stuckCount,
+    enabled: config.stuckCount.enabled,
+    severity: stuckSeverity,
+    currentValue: metrics.stuckCount,
+    warningThreshold: config.stuckCount.warning,
+    criticalThreshold: config.stuckCount.critical,
+    message: buildMessage('stuckCount', RULE_LABELS.stuckCount, stuckSeverity, metrics.stuckCount, config.stuckCount),
+  });
+
+  // 2. Failed rate (computed from successRate)
+  const failedRate = metrics.successRate !== null ? 1 - metrics.successRate : null;
+  const failedSeverity = evaluateUpperBound(failedRate, config.failedRate);
+  results.push({
+    rule: 'failedRate',
+    label: RULE_LABELS.failedRate,
+    enabled: config.failedRate.enabled,
+    severity: failedSeverity,
+    currentValue: failedRate,
+    warningThreshold: config.failedRate.warning,
+    criticalThreshold: config.failedRate.critical,
+    message: buildMessage('failedRate', RULE_LABELS.failedRate, failedSeverity, failedRate, config.failedRate),
+  });
+
+  // 3. Backlog size
+  const backlogCount = metrics.statusCounts['backlog'] ?? 0;
+  const backlogSeverity = evaluateUpperBound(backlogCount, config.backlogSize);
+  results.push({
+    rule: 'backlogSize',
+    label: RULE_LABELS.backlogSize,
+    enabled: config.backlogSize.enabled,
+    severity: backlogSeverity,
+    currentValue: backlogCount,
+    warningThreshold: config.backlogSize.warning,
+    criticalThreshold: config.backlogSize.critical,
+    message: buildMessage('backlogSize', RULE_LABELS.backlogSize, backlogSeverity, backlogCount, config.backlogSize),
+  });
+
+  // 4. Average runtime
+  const avgSeverity = evaluateUpperBound(metrics.avgRuntimeMs, config.avgRuntime);
+  results.push({
+    rule: 'avgRuntime',
+    label: RULE_LABELS.avgRuntime,
+    enabled: config.avgRuntime.enabled,
+    severity: avgSeverity,
+    currentValue: metrics.avgRuntimeMs,
+    warningThreshold: config.avgRuntime.warning,
+    criticalThreshold: config.avgRuntime.critical,
+    message: buildMessage('avgRuntime', RULE_LABELS.avgRuntime, avgSeverity, metrics.avgRuntimeMs, config.avgRuntime),
+  });
+
+  // 5. Queue depth
+  const queueCount = metrics.statusCounts['queued'] ?? 0;
+  const queueSeverity = evaluateUpperBound(queueCount, config.queueDepth);
+  results.push({
+    rule: 'queueDepth',
+    label: RULE_LABELS.queueDepth,
+    enabled: config.queueDepth.enabled,
+    severity: queueSeverity,
+    currentValue: queueCount,
+    warningThreshold: config.queueDepth.warning,
+    criticalThreshold: config.queueDepth.critical,
+    message: buildMessage('queueDepth', RULE_LABELS.queueDepth, queueSeverity, queueCount, config.queueDepth),
+  });
+
+  // Compute overall severity (only from enabled rules)
+  const enabledSeverities = results.filter(r => r.enabled).map(r => r.severity);
+  const overallSeverity = maxSeverity(enabledSeverities);
+
+  // Severity counts
+  const severityCounts: Record<AlertSeverity, number> = { ok: 0, warning: 0, critical: 0 };
+  for (const r of results) {
+    if (r.enabled) severityCounts[r.severity]++;
+  }
+
+  return {
+    evaluatedAt: now,
+    overallSeverity,
+    severityCounts,
+    rules: results,
+  };
+}

--- a/dashboard/server/routes/index.ts
+++ b/dashboard/server/routes/index.ts
@@ -42,3 +42,20 @@ export {
 export type { SseSubscriptionFilter } from '../task-board-events.js';
 export { handleMemoryState } from './memory-state.js';
 export { handleSharedContext } from './shared-context.js';
+export {
+  readAlertConfig,
+  writeAlertConfig,
+  evaluateAlerts,
+  validateAlertConfig,
+  mergeWithDefaults,
+  DEFAULT_ALERT_CONFIG,
+} from '../alert-rules.js';
+export type {
+  AlertRulesConfig,
+  AlertThreshold,
+  AlertSeverity,
+  AlertRuleResult,
+  AlertEvaluation,
+  AlertMetricsInput,
+  AlertConfigValidationError,
+} from '../alert-rules.js';

--- a/dashboard/server/routes/task-board.ts
+++ b/dashboard/server/routes/task-board.ts
@@ -42,6 +42,19 @@ import {
   queryHistory,
 } from '../metrics-history.js';
 
+import {
+  readAlertConfig,
+  writeAlertConfig,
+  evaluateAlerts,
+  validateAlertConfig,
+  mergeWithDefaults,
+} from '../alert-rules.js';
+
+import type {
+  AlertRulesConfig,
+  AlertEvaluation,
+} from '../alert-rules.js';
+
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 const VALID_STATUSES: TaskStatus[] = ['backlog', 'queued', 'running', 'done', 'failed'];
@@ -133,6 +146,8 @@ export interface TaskBoardMetrics {
   stuckTasks: StuckTask[];
   stuckCount: number;
   stuckTimeoutMs: number;
+  /** Alert evaluation results (Phase 9). */
+  alerts?: AlertEvaluation;
 }
 
 /**
@@ -687,10 +702,42 @@ export async function handleTaskBoard(
     return true;
   }
 
+  // ── GET /api/task-board/alerts/config — Issue #219, Phase 9 ──────────────
+  // Read/write alert threshold configuration.
+  // GET: returns current config. PUT: updates config (validated).
+  if (url.startsWith('/api/task-board/alerts/config') && method === 'GET') {
+    const config = readAlertConfig(dataDir);
+    sendJson(res, { config });
+    return true;
+  }
+
+  if (url.startsWith('/api/task-board/alerts/config') && method === 'PUT') {
+    let body: unknown;
+    try {
+      const raw = await readRequestBody(req, { maxBytes: 8192 });
+      body = JSON.parse(raw);
+    } catch {
+      sendJson(res, { error: 'invalid JSON body' }, 400);
+      return true;
+    }
+
+    const errors = validateAlertConfig(body);
+    if (errors.length > 0) {
+      sendJson(res, { error: 'validation failed', errors }, 400);
+      return true;
+    }
+
+    const merged = mergeWithDefaults(body as Record<string, unknown>);
+    writeAlertConfig(dataDir, merged);
+    sendJson(res, { config: merged });
+    return true;
+  }
+
   // ── GET /api/task-board/metrics — Issue #219, Task Metrics Dashboard ───────
   // Returns computed metrics: throughput, runtime stats, trends, stuck tasks.
   // Optional query params:
   //   ?stuckTimeoutMs=1800000 — override stuck-task timeout (default 30min)
+  //   ?includeAlerts=true — include alert evaluation in response (Phase 9)
   // Side-effect (Phase 8): appends a snapshot to the metrics history file
   // if the cooldown interval has elapsed (no extra writes on rapid polling).
   if (url.startsWith('/api/task-board/metrics') && method === 'GET') {
@@ -700,6 +747,17 @@ export async function handleTaskBoard(
       : undefined;
     const tasks = loadTasks(dataDir);
     const metrics = computeMetrics(tasks, { stuckTimeoutMs });
+
+    // Alert evaluation (Phase 9): included by default, opt-out with ?includeAlerts=false
+    const includeAlerts = metricsParams.get('includeAlerts') !== 'false';
+    if (includeAlerts) {
+      try {
+        const alertConfig = readAlertConfig(dataDir);
+        metrics.alerts = evaluateAlerts(metrics, alertConfig);
+      } catch {
+        // Non-critical — don't break the metrics response
+      }
+    }
 
     // Piggyback: persist snapshot (bounded by 5-min cooldown)
     try {

--- a/dashboard/tests/unit/routes/task-board-alert-rules.test.ts
+++ b/dashboard/tests/unit/routes/task-board-alert-rules.test.ts
@@ -1,0 +1,644 @@
+/**
+ * Alert Rules tests — Issue #219, Phase 9: Metrics Alerting Rules Baseline.
+ *
+ * Tests for:
+ * - evaluateAlerts() — threshold evaluation correctness
+ * - validateAlertConfig() — config validation
+ * - mergeWithDefaults() — partial config merge
+ * - readAlertConfig() / writeAlertConfig() — config persistence
+ * - GET /api/task-board/alerts/config — read endpoint
+ * - PUT /api/task-board/alerts/config — write endpoint
+ * - GET /api/task-board/metrics — includes alerts in response
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { mockRequest, mockResponse, parseJsonBody } from '../../helpers.js';
+import {
+  handleTaskBoard,
+  loadTasks,
+} from '../../../server/routes/task-board.js';
+import {
+  evaluateAlerts,
+  validateAlertConfig,
+  mergeWithDefaults,
+  readAlertConfig,
+  writeAlertConfig,
+  DEFAULT_ALERT_CONFIG,
+} from '../../../server/alert-rules.js';
+import type {
+  AlertRulesConfig,
+  AlertMetricsInput,
+  AlertSeverity,
+} from '../../../server/alert-rules.js';
+import type { TaskBoardDeps, TaskCard } from '../../../server/types.js';
+
+const testDataDir = path.join('/tmp', 'test-alert-rules-' + process.pid);
+
+function createDeps(overrides: Partial<TaskBoardDeps> = {}): TaskBoardDeps {
+  return {
+    dataDir: testDataDir,
+    sendJson: (res, data, status = 200) => {
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+    },
+    readRequestBody: async () => '{}',
+    ...overrides,
+  };
+}
+
+function makeSampleCard(overrides: Partial<TaskCard> = {}): TaskCard {
+  return {
+    id: 'test-' + Math.random().toString(36).slice(2, 8),
+    agentId: 'oracle',
+    title: 'Test task',
+    description: 'A test task',
+    priority: 'medium',
+    status: 'backlog',
+    createdAt: Date.now(),
+    queuedAt: null,
+    startedAt: null,
+    completedAt: null,
+    resultSummary: null,
+    tokensUsed: null,
+    error: null,
+    costEstimate: null,
+    runtimeMs: null,
+    ...overrides,
+  };
+}
+
+function seedTasks(tasks: TaskCard[]): void {
+  fs.mkdirSync(testDataDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(testDataDir, 'task-board.json'),
+    JSON.stringify({ tasks, updatedAt: Date.now() }),
+  );
+}
+
+function metricsInput(overrides: Partial<AlertMetricsInput> = {}): AlertMetricsInput {
+  return {
+    statusCounts: { backlog: 0, queued: 0, running: 0, done: 0, failed: 0 },
+    successRate: null,
+    stuckCount: 0,
+    avgRuntimeMs: null,
+    total: 0,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  fs.mkdirSync(testDataDir, { recursive: true });
+  // Clean slate
+  for (const f of ['task-board.json', 'task-board-alert-rules.json']) {
+    const fp = path.join(testDataDir, f);
+    if (fs.existsSync(fp)) fs.unlinkSync(fp);
+  }
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(testDataDir, { recursive: true, force: true });
+  } catch {}
+});
+
+// ─── evaluateAlerts — threshold evaluation correctness ───────────────────────
+
+describe('evaluateAlerts', () => {
+  const NOW = 1700000000000;
+
+  it('returns all OK with default config and empty metrics', () => {
+    const result = evaluateAlerts(metricsInput(), DEFAULT_ALERT_CONFIG, NOW);
+    expect(result.overallSeverity).toBe('ok');
+    expect(result.rules).toHaveLength(5);
+    expect(result.rules.every(r => r.severity === 'ok')).toBe(true);
+    expect(result.severityCounts.ok).toBeGreaterThan(0);
+    expect(result.severityCounts.warning).toBe(0);
+    expect(result.severityCounts.critical).toBe(0);
+  });
+
+  it('fires warning when stuck count >= warning threshold', () => {
+    const metrics = metricsInput({ stuckCount: 3 });
+    const config: AlertRulesConfig = {
+      ...DEFAULT_ALERT_CONFIG,
+      stuckCount: { enabled: true, warning: 2, critical: 5 },
+    };
+    const result = evaluateAlerts(metrics, config, NOW);
+    const stuckRule = result.rules.find(r => r.rule === 'stuckCount')!;
+    expect(stuckRule.severity).toBe('warning');
+    expect(stuckRule.currentValue).toBe(3);
+    expect(result.overallSeverity).toBe('warning');
+  });
+
+  it('fires critical when stuck count >= critical threshold', () => {
+    const metrics = metricsInput({ stuckCount: 7 });
+    const config: AlertRulesConfig = {
+      ...DEFAULT_ALERT_CONFIG,
+      stuckCount: { enabled: true, warning: 2, critical: 5 },
+    };
+    const result = evaluateAlerts(metrics, config, NOW);
+    const stuckRule = result.rules.find(r => r.rule === 'stuckCount')!;
+    expect(stuckRule.severity).toBe('critical');
+    expect(result.overallSeverity).toBe('critical');
+  });
+
+  it('stays OK when stuck count < warning', () => {
+    const metrics = metricsInput({ stuckCount: 1 });
+    const result = evaluateAlerts(metrics, DEFAULT_ALERT_CONFIG, NOW);
+    const stuckRule = result.rules.find(r => r.rule === 'stuckCount')!;
+    expect(stuckRule.severity).toBe('ok');
+  });
+
+  it('fires warning when failed rate >= warning threshold', () => {
+    // successRate 0.8 => failedRate 0.2, warning threshold 0.15
+    const metrics = metricsInput({ successRate: 0.8 });
+    const config: AlertRulesConfig = {
+      ...DEFAULT_ALERT_CONFIG,
+      failedRate: { enabled: true, warning: 0.15, critical: 0.30 },
+    };
+    const result = evaluateAlerts(metrics, config, NOW);
+    const failedRule = result.rules.find(r => r.rule === 'failedRate')!;
+    expect(failedRule.severity).toBe('warning');
+    expect(failedRule.currentValue).toBeCloseTo(0.2);
+  });
+
+  it('fires critical when failed rate >= critical threshold', () => {
+    // successRate 0.6 => failedRate 0.4, critical threshold 0.30
+    const metrics = metricsInput({ successRate: 0.6 });
+    const config: AlertRulesConfig = {
+      ...DEFAULT_ALERT_CONFIG,
+      failedRate: { enabled: true, warning: 0.15, critical: 0.30 },
+    };
+    const result = evaluateAlerts(metrics, config, NOW);
+    const failedRule = result.rules.find(r => r.rule === 'failedRate')!;
+    expect(failedRule.severity).toBe('critical');
+  });
+
+  it('stays OK when no terminal tasks (successRate is null)', () => {
+    const metrics = metricsInput({ successRate: null });
+    const result = evaluateAlerts(metrics, DEFAULT_ALERT_CONFIG, NOW);
+    const failedRule = result.rules.find(r => r.rule === 'failedRate')!;
+    expect(failedRule.severity).toBe('ok');
+    expect(failedRule.currentValue).toBeNull();
+  });
+
+  it('fires warning when backlog >= warning threshold', () => {
+    const metrics = metricsInput({
+      statusCounts: { backlog: 25, queued: 0, running: 0, done: 0, failed: 0 },
+    });
+    const result = evaluateAlerts(metrics, DEFAULT_ALERT_CONFIG, NOW);
+    const backlogRule = result.rules.find(r => r.rule === 'backlogSize')!;
+    expect(backlogRule.severity).toBe('warning');
+    expect(backlogRule.currentValue).toBe(25);
+  });
+
+  it('fires critical when backlog >= critical threshold', () => {
+    const metrics = metricsInput({
+      statusCounts: { backlog: 55, queued: 0, running: 0, done: 0, failed: 0 },
+    });
+    const result = evaluateAlerts(metrics, DEFAULT_ALERT_CONFIG, NOW);
+    const backlogRule = result.rules.find(r => r.rule === 'backlogSize')!;
+    expect(backlogRule.severity).toBe('critical');
+  });
+
+  it('respects disabled rules', () => {
+    const metrics = metricsInput({ stuckCount: 100 });
+    const config: AlertRulesConfig = {
+      ...DEFAULT_ALERT_CONFIG,
+      stuckCount: { enabled: false, warning: 1, critical: 2 },
+    };
+    const result = evaluateAlerts(metrics, config, NOW);
+    const stuckRule = result.rules.find(r => r.rule === 'stuckCount')!;
+    expect(stuckRule.severity).toBe('ok');
+    expect(stuckRule.enabled).toBe(false);
+  });
+
+  it('disabled rules do not affect overall severity', () => {
+    const metrics = metricsInput({ stuckCount: 100 });
+    const config: AlertRulesConfig = {
+      ...DEFAULT_ALERT_CONFIG,
+      stuckCount: { enabled: false, warning: 1, critical: 2 },
+      failedRate: { enabled: false, warning: 0.01, critical: 0.01 },
+      backlogSize: { enabled: false, warning: 0, critical: 0 },
+      avgRuntime: { enabled: false, warning: 0, critical: 0 },
+      queueDepth: { enabled: false, warning: 0, critical: 0 },
+    };
+    const result = evaluateAlerts(metrics, config, NOW);
+    expect(result.overallSeverity).toBe('ok');
+  });
+
+  it('fires avgRuntime alert when enabled and exceeded', () => {
+    const metrics = metricsInput({ avgRuntimeMs: 400000 }); // 400s
+    const config: AlertRulesConfig = {
+      ...DEFAULT_ALERT_CONFIG,
+      avgRuntime: { enabled: true, warning: 300000, critical: 600000 },
+    };
+    const result = evaluateAlerts(metrics, config, NOW);
+    const rtRule = result.rules.find(r => r.rule === 'avgRuntime')!;
+    expect(rtRule.severity).toBe('warning');
+  });
+
+  it('fires queueDepth alert when enabled and exceeded', () => {
+    const metrics = metricsInput({
+      statusCounts: { backlog: 0, queued: 30, running: 0, done: 0, failed: 0 },
+    });
+    const config: AlertRulesConfig = {
+      ...DEFAULT_ALERT_CONFIG,
+      queueDepth: { enabled: true, warning: 10, critical: 25 },
+    };
+    const result = evaluateAlerts(metrics, config, NOW);
+    const queueRule = result.rules.find(r => r.rule === 'queueDepth')!;
+    expect(queueRule.severity).toBe('critical');
+  });
+
+  it('overall severity is the max across all enabled rules', () => {
+    const metrics = metricsInput({
+      stuckCount: 3,
+      successRate: 0.6,
+    });
+    const config: AlertRulesConfig = {
+      ...DEFAULT_ALERT_CONFIG,
+      stuckCount: { enabled: true, warning: 2, critical: 5 },
+      failedRate: { enabled: true, warning: 0.15, critical: 0.30 },
+    };
+    const result = evaluateAlerts(metrics, config, NOW);
+    // stuckCount=3 → warning, failedRate=0.4 → critical
+    expect(result.overallSeverity).toBe('critical');
+    expect(result.severityCounts.warning).toBeGreaterThanOrEqual(1);
+    expect(result.severityCounts.critical).toBeGreaterThanOrEqual(1);
+  });
+
+  it('exact threshold value triggers alert (>=)', () => {
+    const metrics = metricsInput({ stuckCount: 2 });
+    const config: AlertRulesConfig = {
+      ...DEFAULT_ALERT_CONFIG,
+      stuckCount: { enabled: true, warning: 2, critical: 5 },
+    };
+    const result = evaluateAlerts(metrics, config, NOW);
+    const stuckRule = result.rules.find(r => r.rule === 'stuckCount')!;
+    expect(stuckRule.severity).toBe('warning');
+  });
+
+  it('includes human-readable messages', () => {
+    const metrics = metricsInput({ stuckCount: 3 });
+    const config: AlertRulesConfig = {
+      ...DEFAULT_ALERT_CONFIG,
+      stuckCount: { enabled: true, warning: 2, critical: 5 },
+    };
+    const result = evaluateAlerts(metrics, config, NOW);
+    const stuckRule = result.rules.find(r => r.rule === 'stuckCount')!;
+    expect(stuckRule.message).toContain('Stuck Tasks');
+    expect(stuckRule.message).toContain('3');
+    expect(stuckRule.message).toContain('warning');
+    expect(stuckRule.message).toContain('2');
+  });
+
+  it('evaluatedAt timestamp is set correctly', () => {
+    const result = evaluateAlerts(metricsInput(), DEFAULT_ALERT_CONFIG, NOW);
+    expect(result.evaluatedAt).toBe(NOW);
+  });
+});
+
+// ─── validateAlertConfig — config validation ─────────────────────────────────
+
+describe('validateAlertConfig', () => {
+  it('returns empty array for valid config', () => {
+    const errors = validateAlertConfig({
+      stuckCount: { enabled: true, warning: 2, critical: 5 },
+      failedRate: { enabled: true, warning: 0.15, critical: 0.30 },
+    });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects non-object input', () => {
+    expect(validateAlertConfig(null)).toHaveLength(1);
+    expect(validateAlertConfig('string')).toHaveLength(1);
+    expect(validateAlertConfig(42)).toHaveLength(1);
+    expect(validateAlertConfig([])).toHaveLength(1);
+  });
+
+  it('rejects unknown rule keys', () => {
+    const errors = validateAlertConfig({ unknownRule: { enabled: true, warning: 1, critical: 2 } });
+    expect(errors).toHaveLength(1);
+    expect(errors[0].field).toBe('unknownRule');
+  });
+
+  it('rejects non-boolean enabled', () => {
+    const errors = validateAlertConfig({ stuckCount: { enabled: 'yes', warning: 2, critical: 5 } });
+    expect(errors.some(e => e.field === 'stuckCount.enabled')).toBe(true);
+  });
+
+  it('rejects negative thresholds', () => {
+    const errors = validateAlertConfig({ stuckCount: { enabled: true, warning: -1, critical: 5 } });
+    expect(errors.some(e => e.field === 'stuckCount.warning')).toBe(true);
+  });
+
+  it('rejects NaN thresholds', () => {
+    const errors = validateAlertConfig({ stuckCount: { enabled: true, warning: NaN, critical: 5 } });
+    expect(errors.some(e => e.field === 'stuckCount.warning')).toBe(true);
+  });
+
+  it('rejects Infinity thresholds', () => {
+    const errors = validateAlertConfig({ stuckCount: { enabled: true, warning: Infinity, critical: 5 } });
+    expect(errors.some(e => e.field === 'stuckCount.warning')).toBe(true);
+  });
+
+  it('rejects critical < warning', () => {
+    const errors = validateAlertConfig({ stuckCount: { enabled: true, warning: 10, critical: 5 } });
+    expect(errors.some(e => e.field === 'stuckCount')).toBe(true);
+  });
+
+  it('allows partial config (only some rules)', () => {
+    const errors = validateAlertConfig({ stuckCount: { enabled: true, warning: 2, critical: 5 } });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('allows empty object', () => {
+    const errors = validateAlertConfig({});
+    expect(errors).toHaveLength(0);
+  });
+});
+
+// ─── mergeWithDefaults — partial config merge ────────────────────────────────
+
+describe('mergeWithDefaults', () => {
+  it('returns full defaults for empty input', () => {
+    const result = mergeWithDefaults({});
+    expect(result).toEqual(DEFAULT_ALERT_CONFIG);
+  });
+
+  it('overrides specific rule values', () => {
+    const result = mergeWithDefaults({
+      stuckCount: { enabled: false, warning: 10, critical: 20 },
+    });
+    expect(result.stuckCount.enabled).toBe(false);
+    expect(result.stuckCount.warning).toBe(10);
+    expect(result.stuckCount.critical).toBe(20);
+    // Other rules should be defaults
+    expect(result.failedRate).toEqual(DEFAULT_ALERT_CONFIG.failedRate);
+  });
+
+  it('fills missing fields from defaults', () => {
+    const result = mergeWithDefaults({
+      stuckCount: { warning: 99 },
+    });
+    // enabled should come from default
+    expect(result.stuckCount.enabled).toBe(DEFAULT_ALERT_CONFIG.stuckCount.enabled);
+    expect(result.stuckCount.warning).toBe(99);
+    // critical from default
+    expect(result.stuckCount.critical).toBe(DEFAULT_ALERT_CONFIG.stuckCount.critical);
+  });
+
+  it('ignores invalid field types', () => {
+    const result = mergeWithDefaults({
+      stuckCount: { enabled: 'not-bool', warning: 'not-num', critical: -5 },
+    });
+    // Invalid values should fall back to defaults
+    expect(result.stuckCount.enabled).toBe(DEFAULT_ALERT_CONFIG.stuckCount.enabled);
+    expect(result.stuckCount.warning).toBe(DEFAULT_ALERT_CONFIG.stuckCount.warning);
+    expect(result.stuckCount.critical).toBe(DEFAULT_ALERT_CONFIG.stuckCount.critical);
+  });
+
+  it('ignores unknown keys', () => {
+    const result = mergeWithDefaults({
+      unknownRule: { enabled: true, warning: 1, critical: 2 },
+    });
+    expect(result).toEqual(DEFAULT_ALERT_CONFIG);
+    expect((result as any).unknownRule).toBeUndefined();
+  });
+});
+
+// ─── readAlertConfig / writeAlertConfig — persistence ────────────────────────
+
+describe('config persistence', () => {
+  it('returns defaults when file does not exist', () => {
+    const config = readAlertConfig(testDataDir);
+    expect(config).toEqual(DEFAULT_ALERT_CONFIG);
+  });
+
+  it('round-trips config through write/read', () => {
+    const custom: AlertRulesConfig = {
+      ...DEFAULT_ALERT_CONFIG,
+      stuckCount: { enabled: false, warning: 10, critical: 20 },
+    };
+    writeAlertConfig(testDataDir, custom);
+    const read = readAlertConfig(testDataDir);
+    expect(read.stuckCount.enabled).toBe(false);
+    expect(read.stuckCount.warning).toBe(10);
+    expect(read.stuckCount.critical).toBe(20);
+  });
+
+  it('returns defaults for corrupted file', () => {
+    const fp = path.join(testDataDir, 'task-board-alert-rules.json');
+    fs.writeFileSync(fp, 'not valid json!!!');
+    const config = readAlertConfig(testDataDir);
+    expect(config).toEqual(DEFAULT_ALERT_CONFIG);
+  });
+
+  it('creates directory if needed', () => {
+    const deepDir = path.join(testDataDir, 'deep', 'nested');
+    writeAlertConfig(deepDir, DEFAULT_ALERT_CONFIG);
+    const config = readAlertConfig(deepDir);
+    expect(config).toEqual(DEFAULT_ALERT_CONFIG);
+  });
+});
+
+// ─── GET /api/task-board/alerts/config endpoint ──────────────────────────────
+
+describe('GET /api/task-board/alerts/config', () => {
+  it('returns default config when no file exists', async () => {
+    seedTasks([]);
+    const req = mockRequest({ url: '/api/task-board/alerts/config', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    const body = parseJsonBody(res);
+    expect(res._statusCode).toBe(200);
+    expect(body).toHaveProperty('config');
+    expect(body.config).toHaveProperty('stuckCount');
+    expect(body.config).toHaveProperty('failedRate');
+    expect(body.config).toHaveProperty('backlogSize');
+    expect(body.config).toHaveProperty('avgRuntime');
+    expect(body.config).toHaveProperty('queueDepth');
+  });
+
+  it('returns saved config', async () => {
+    seedTasks([]);
+    const custom: AlertRulesConfig = {
+      ...DEFAULT_ALERT_CONFIG,
+      stuckCount: { enabled: false, warning: 99, critical: 999 },
+    };
+    writeAlertConfig(testDataDir, custom);
+
+    const req = mockRequest({ url: '/api/task-board/alerts/config', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    const body = parseJsonBody(res);
+    expect(body.config.stuckCount.enabled).toBe(false);
+    expect(body.config.stuckCount.warning).toBe(99);
+    expect(body.config.stuckCount.critical).toBe(999);
+  });
+});
+
+// ─── PUT /api/task-board/alerts/config endpoint ──────────────────────────────
+
+describe('PUT /api/task-board/alerts/config', () => {
+  it('saves valid config and returns merged result', async () => {
+    seedTasks([]);
+    const update = {
+      stuckCount: { enabled: false, warning: 10, critical: 20 },
+    };
+
+    const req = mockRequest({ url: '/api/task-board/alerts/config', method: 'PUT' });
+    const res = mockResponse();
+    const deps = createDeps({
+      readRequestBody: async () => JSON.stringify(update),
+    });
+
+    await handleTaskBoard(req, res, deps);
+
+    const body = parseJsonBody(res);
+    expect(res._statusCode).toBe(200);
+    expect(body.config.stuckCount.enabled).toBe(false);
+    expect(body.config.stuckCount.warning).toBe(10);
+    // Other rules should be defaults
+    expect(body.config.failedRate).toEqual(DEFAULT_ALERT_CONFIG.failedRate);
+
+    // Verify persisted
+    const persisted = readAlertConfig(testDataDir);
+    expect(persisted.stuckCount.enabled).toBe(false);
+  });
+
+  it('rejects invalid config with 400', async () => {
+    seedTasks([]);
+    const invalid = {
+      stuckCount: { enabled: true, warning: 10, critical: 5 }, // critical < warning
+    };
+
+    const req = mockRequest({ url: '/api/task-board/alerts/config', method: 'PUT' });
+    const res = mockResponse();
+    const deps = createDeps({
+      readRequestBody: async () => JSON.stringify(invalid),
+    });
+
+    await handleTaskBoard(req, res, deps);
+
+    const body = parseJsonBody(res);
+    expect(res._statusCode).toBe(400);
+    expect(body.error).toBe('validation failed');
+    expect(body.errors).toHaveLength(1);
+  });
+
+  it('rejects invalid JSON with 400', async () => {
+    seedTasks([]);
+    const req = mockRequest({ url: '/api/task-board/alerts/config', method: 'PUT' });
+    const res = mockResponse();
+    const deps = createDeps({
+      readRequestBody: async () => 'not json!!!',
+    });
+
+    await handleTaskBoard(req, res, deps);
+
+    expect(res._statusCode).toBe(400);
+    expect(parseJsonBody(res).error).toBe('invalid JSON body');
+  });
+
+  it('rejects unknown rule keys', async () => {
+    seedTasks([]);
+    const req = mockRequest({ url: '/api/task-board/alerts/config', method: 'PUT' });
+    const res = mockResponse();
+    const deps = createDeps({
+      readRequestBody: async () => JSON.stringify({ badKey: { enabled: true, warning: 1, critical: 2 } }),
+    });
+
+    await handleTaskBoard(req, res, deps);
+    expect(res._statusCode).toBe(400);
+  });
+});
+
+// ─── GET /api/task-board/metrics includes alerts ─────────────────────────────
+
+describe('GET /api/task-board/metrics — alert integration', () => {
+  it('includes alerts in metrics response by default', async () => {
+    seedTasks([]);
+    const req = mockRequest({ url: '/api/task-board/metrics', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    const body = parseJsonBody(res);
+    expect(body).toHaveProperty('alerts');
+    expect(body.alerts).toHaveProperty('overallSeverity');
+    expect(body.alerts).toHaveProperty('rules');
+    expect(body.alerts.rules).toHaveLength(5);
+  });
+
+  it('excludes alerts when includeAlerts=false', async () => {
+    seedTasks([]);
+    const req = mockRequest({ url: '/api/task-board/metrics?includeAlerts=false', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    const body = parseJsonBody(res);
+    expect(body.alerts).toBeUndefined();
+  });
+
+  it('evaluates alerts with task data correctly', async () => {
+    const now = Date.now();
+    // Create conditions that should trigger alerts:
+    // - 3 stuck tasks (default warning=2)
+    // - 0.6 success rate -> 0.4 failed rate (default critical=0.30)
+    seedTasks([
+      makeSampleCard({ status: 'running', startedAt: now - 3600000 * 2 }), // stuck
+      makeSampleCard({ status: 'running', startedAt: now - 3600000 * 2 }), // stuck
+      makeSampleCard({ status: 'running', startedAt: now - 3600000 * 2 }), // stuck
+      makeSampleCard({ status: 'done', completedAt: now - 1000 }),
+      makeSampleCard({ status: 'done', completedAt: now - 1000 }),
+      makeSampleCard({ status: 'done', completedAt: now - 1000 }),
+      makeSampleCard({ status: 'failed', completedAt: now - 1000 }),
+      makeSampleCard({ status: 'failed', completedAt: now - 1000 }),
+    ]);
+
+    const req = mockRequest({ url: '/api/task-board/metrics', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    const body = parseJsonBody(res);
+    expect(body.alerts.overallSeverity).toBe('critical');
+
+    const stuckRule = body.alerts.rules.find((r: any) => r.rule === 'stuckCount');
+    expect(stuckRule.severity).toBe('warning'); // 3 >= 2 (warning), < 5 (critical)
+
+    const failedRule = body.alerts.rules.find((r: any) => r.rule === 'failedRate');
+    expect(failedRule.severity).toBe('critical'); // 0.4 >= 0.30
+  });
+
+  it('uses custom config for alert evaluation', async () => {
+    const now = Date.now();
+    // Raise the thresholds so nothing triggers
+    const lenientConfig: AlertRulesConfig = {
+      stuckCount: { enabled: true, warning: 100, critical: 200 },
+      failedRate: { enabled: true, warning: 0.90, critical: 0.95 },
+      backlogSize: { enabled: true, warning: 1000, critical: 5000 },
+      avgRuntime: { enabled: false, warning: 300000, critical: 600000 },
+      queueDepth: { enabled: false, warning: 100, critical: 200 },
+    };
+    writeAlertConfig(testDataDir, lenientConfig);
+
+    seedTasks([
+      makeSampleCard({ status: 'running', startedAt: now - 3600000 * 2 }), // stuck
+      makeSampleCard({ status: 'running', startedAt: now - 3600000 * 2 }), // stuck
+      makeSampleCard({ status: 'running', startedAt: now - 3600000 * 2 }), // stuck
+      makeSampleCard({ status: 'failed', completedAt: now - 1000 }),
+      makeSampleCard({ status: 'done', completedAt: now - 1000 }),
+    ]);
+
+    const req = mockRequest({ url: '/api/task-board/metrics', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    const body = parseJsonBody(res);
+    expect(body.alerts.overallSeverity).toBe('ok'); // nothing triggers with lenient thresholds
+  });
+});


### PR DESCRIPTION
## Summary
Refs #219

Adds configurable alert rules that evaluate task-board metrics against user-defined thresholds. Alerts are computed on-demand during metrics API reads — no background daemons, no new dependencies.

## What's New

### Alert Rules Engine (`dashboard/server/alert-rules.ts`)
5 configurable threshold rules, each with enabled/disabled + warning + critical levels:
| Rule | Description | Default Warning | Default Critical | Default Enabled |
|------|-------------|-----------------|------------------|----------------|
| stuckCount | Running tasks exceeding stuck timeout | ≥2 | ≥5 | ✅ |
| failedRate | 1 - successRate | ≥15% | ≥30% | ✅ |
| backlogSize | Backlog column count | ≥20 | ≥50 | ✅ |
| avgRuntime | Avg completed task runtime | ≥5min | ≥10min | ❌ |
| queueDepth | Queued column count | ≥10 | ≥25 | ❌ |

### API Surface
- **GET /api/task-board/alerts/config** — read alert threshold config
- **PUT /api/task-board/alerts/config** — update config (validated, atomic write)
- **GET /api/task-board/metrics** — now includes `alerts` field with evaluation results (opt-out: `?includeAlerts=false`)

### Dashboard UI
- Alert banner in metrics panel (warning/critical severity with per-rule details)
- Alert badge on the metrics toggle button (visible when panel is collapsed)
- Config modal for editing thresholds (⚙️ Configure link in banner)

## Tests
- **46 new tests** covering threshold evaluation, config validation, merge logic, persistence, and API endpoints
- **317 total task-board tests** — all passing, zero regressions
- TypeScript: clean compile, no errors

## Risk Notes
- **Additive only**: new file + new optional field on existing metrics response
- **No schema changes** to task-board.json
- **No background processes**: evaluation happens during normal request/refresh paths
- **Reversible**: removing the `alerts` field from the response is the only breaking change; config file is standalone
- **Pre-existing failures**: 3 test files in shared-context.test.ts fail due to a better-sqlite3 native module issue (unrelated)