### PR TITLE
feat(#219): Alert history timeline — persistent event log + dashboard widget (Phase 10)

### DIFF
--- a/dashboard/client/index.html
+++ b/dashboard/client/index.html
@@ -2136,6 +2136,155 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
 
 /* ─── End Alert Rules ───────────────────────────────────────────────── */
 
+/* ─── Alert Timeline (Issue #219, Phase 10) ─────────────────────────── */
+
+.tb-alert-timeline {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px;
+  margin-top: 12px;
+}
+
+.tb-alert-timeline-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.tb-alert-timeline-header .title {
+  font-size: 13px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.tb-alert-timeline-header .subtitle {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-left: auto;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.tb-alert-timeline-bar {
+  display: flex;
+  width: 100%;
+  height: 20px;
+  border-radius: 4px;
+  overflow: hidden;
+  background: rgba(16, 185, 129, 0.1);
+  border: 1px solid var(--border);
+  margin-bottom: 8px;
+}
+
+.tb-alert-timeline-bar-segment {
+  height: 100%;
+  min-width: 2px;
+  transition: width 0.3s ease;
+}
+
+.tb-alert-timeline-bar-segment.severity-ok {
+  background: rgba(16, 185, 129, 0.25);
+}
+
+.tb-alert-timeline-bar-segment.severity-warning {
+  background: rgba(245, 158, 11, 0.5);
+}
+
+.tb-alert-timeline-bar-segment.severity-critical {
+  background: rgba(239, 68, 68, 0.5);
+}
+
+.tb-alert-timeline-stats {
+  display: flex;
+  gap: 16px;
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 10px;
+}
+
+.tb-alert-timeline-stats .stat-label {
+  color: var(--text-muted);
+}
+
+.tb-alert-timeline-stats .stat-value {
+  font-family: 'JetBrains Mono', monospace;
+  font-weight: 500;
+}
+
+.tb-alert-timeline-stats .stat-value.severity-ok { color: var(--green); }
+.tb-alert-timeline-stats .stat-value.severity-warning { color: var(--yellow); }
+.tb-alert-timeline-stats .stat-value.severity-critical { color: var(--red); }
+
+.tb-alert-timeline-events {
+  display: flex;
+  flex-direction: column;
+  gap: 0;
+  max-height: 180px;
+  overflow-y: auto;
+}
+
+.tb-alert-timeline-event {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 8px;
+  font-size: 11px;
+  border-bottom: 1px solid rgba(42, 42, 58, 0.5);
+}
+
+.tb-alert-timeline-event:last-child {
+  border-bottom: none;
+}
+
+.tb-alert-timeline-event-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  flex-shrink: 0;
+}
+
+.tb-alert-timeline-event-dot.severity-ok { background: var(--green); }
+.tb-alert-timeline-event-dot.severity-warning { background: var(--yellow); }
+.tb-alert-timeline-event-dot.severity-critical { background: var(--red); }
+
+.tb-alert-timeline-event-time {
+  font-family: 'JetBrains Mono', monospace;
+  color: var(--text-muted);
+  font-size: 10px;
+  flex-shrink: 0;
+  width: 52px;
+}
+
+.tb-alert-timeline-event-severity {
+  font-weight: 600;
+  font-size: 10px;
+  text-transform: uppercase;
+  padding: 1px 6px;
+  border-radius: 3px;
+  flex-shrink: 0;
+}
+
+.tb-alert-timeline-event-severity.ok { color: var(--green); background: rgba(16,185,129,0.1); }
+.tb-alert-timeline-event-severity.warning { color: var(--yellow); background: rgba(245,158,11,0.1); }
+.tb-alert-timeline-event-severity.critical { color: var(--red); background: rgba(239,68,68,0.1); }
+
+.tb-alert-timeline-event-msg {
+  color: var(--text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.tb-alert-timeline-empty {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 12px;
+  padding: 16px;
+}
+
+/* ─── End Alert Timeline ────────────────────────────────────────────── */
+
 /* ─── End Task Metrics Dashboard ────────────────────────────────────── */
 
 /* ─── End Task Board ────────────────────────────────────────────────── */
@@ -3671,6 +3820,25 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
               <span class="tb-alert-config-link" onclick="tbOpenAlertConfig()">⚙️ Configure</span>
             </div>
             <div id="tbAlertsBannerRules"></div>
+          </div>
+
+          <!-- Alert History Timeline (Phase 10) — compact recent alert transitions -->
+          <div id="tbAlertTimeline" class="tb-alert-timeline mb-24" style="display:none;">
+            <div class="tb-alert-timeline-header">
+              <span class="title">🕐 Alert Timeline</span>
+              <select id="tbTimelineWindow" onchange="tbFetchAlertTimeline()" style="padding:2px 6px;background:var(--bg-tertiary);border:1px solid var(--border);border-radius:4px;color:var(--text-primary);font-size:11px;font-family:inherit;">
+                <option value="3600000">Last 1h</option>
+                <option value="21600000" selected>Last 6h</option>
+                <option value="86400000">Last 24h</option>
+                <option value="172800000">Last 48h</option>
+              </select>
+              <span class="subtitle" id="tbTimelineSubtitle"></span>
+            </div>
+            <div id="tbTimelineBar" class="tb-alert-timeline-bar"></div>
+            <div id="tbTimelineStats" class="tb-alert-timeline-stats"></div>
+            <div id="tbTimelineEvents" class="tb-alert-timeline-events">
+              <div class="tb-alert-timeline-empty">No alert events recorded yet</div>
+            </div>
           </div>
 
           <!-- KPI row -->
@@ -7416,10 +7584,11 @@ async function tbRefresh() {
 
     tbRenderBoard();
 
-    // Also refresh metrics + history if the panel is open
+    // Also refresh metrics + history + timeline if the panel is open
     if (tbMetricsOpen) {
       tbRefreshMetrics();
       tbFetchHistory();
+      tbFetchAlertTimeline();
     }
   } catch (e) {
     console.error('[task-board] refresh error', e);
@@ -8199,6 +8368,7 @@ function tbToggleMetrics() {
   if (tbMetricsOpen) {
     tbRefreshMetrics();
     tbFetchHistory();
+    tbFetchAlertTimeline();
   }
 }
 
@@ -8660,6 +8830,128 @@ async function tbResetAlertConfig() {
   };
   tbRenderAlertConfigForm(defaults);
   tbShowToast('Form reset to defaults (click Save to apply)', 'info');
+}
+
+// ── Alert History Timeline (Issue #219, Phase 10) ────────────────────────────
+// Fetches alert timeline data and renders a compact visualization.
+
+let tbTimelineData = null;
+
+/** Fetch alert timeline data from the API. */
+async function tbFetchAlertTimeline() {
+  try {
+    const windowMs = document.getElementById('tbTimelineWindow')?.value || '21600000';
+    const res = await fetch('/api/task-board/alerts/timeline?sinceMs=' + windowMs + '&limit=100');
+    if (!res.ok) return;
+    tbTimelineData = await res.json();
+    tbRenderAlertTimeline(tbTimelineData);
+  } catch (e) {
+    console.warn('[alert-timeline] fetch error', e);
+  }
+}
+
+/** Render the alert timeline visualization. */
+function tbRenderAlertTimeline(data) {
+  const container = document.getElementById('tbAlertTimeline');
+  const barEl = document.getElementById('tbTimelineBar');
+  const statsEl = document.getElementById('tbTimelineStats');
+  const eventsEl = document.getElementById('tbTimelineEvents');
+  const subtitleEl = document.getElementById('tbTimelineSubtitle');
+
+  if (!container || !data) return;
+
+  // Always show the timeline container
+  container.style.display = '';
+
+  if (!data.events || data.events.length === 0) {
+    if (barEl) barEl.innerHTML = '';
+    if (statsEl) statsEl.innerHTML = '';
+    if (eventsEl) eventsEl.innerHTML = '<div class="tb-alert-timeline-empty">No alert events recorded yet</div>';
+    if (subtitleEl) subtitleEl.textContent = '';
+    return;
+  }
+
+  // Subtitle
+  if (subtitleEl) {
+    subtitleEl.textContent = data.returnedEvents + ' event' + (data.returnedEvents !== 1 ? 's' : '') +
+      (data.transitionCount > 0 ? ' · ' + data.transitionCount + ' transition' + (data.transitionCount !== 1 ? 's' : '') : '');
+  }
+
+  // Severity duration bar
+  if (barEl) {
+    const totalDuration = data.severityDurations.ok + data.severityDurations.warning + data.severityDurations.critical;
+    if (totalDuration > 0) {
+      const okPct = (data.severityDurations.ok / totalDuration * 100).toFixed(1);
+      const warnPct = (data.severityDurations.warning / totalDuration * 100).toFixed(1);
+      const critPct = (data.severityDurations.critical / totalDuration * 100).toFixed(1);
+      barEl.innerHTML = '';
+      if (data.severityDurations.ok > 0) barEl.innerHTML += '<div class="tb-alert-timeline-bar-segment severity-ok" style="width:' + okPct + '%" title="OK: ' + tbTimelineFmtDuration(data.severityDurations.ok) + '"></div>';
+      if (data.severityDurations.warning > 0) barEl.innerHTML += '<div class="tb-alert-timeline-bar-segment severity-warning" style="width:' + warnPct + '%" title="Warning: ' + tbTimelineFmtDuration(data.severityDurations.warning) + '"></div>';
+      if (data.severityDurations.critical > 0) barEl.innerHTML += '<div class="tb-alert-timeline-bar-segment severity-critical" style="width:' + critPct + '%" title="Critical: ' + tbTimelineFmtDuration(data.severityDurations.critical) + '"></div>';
+    } else {
+      barEl.innerHTML = '';
+    }
+  }
+
+  // Stats row
+  if (statsEl) {
+    const parts = [];
+    parts.push('<span class="stat-label">Current:</span> <span class="stat-value severity-' + data.currentSeverity + '">' + data.currentSeverity.toUpperCase() + '</span>');
+    if (data.lastTransitionAt) {
+      parts.push('<span class="stat-label">Last change:</span> <span class="stat-value">' + tbTimelineTimeAgo(data.lastTransitionAt) + '</span>');
+    }
+    const totalDur = data.severityDurations.ok + data.severityDurations.warning + data.severityDurations.critical;
+    if (totalDur > 0 && data.severityDurations.ok > 0) {
+      const okPct = (data.severityDurations.ok / totalDur * 100).toFixed(0);
+      parts.push('<span class="stat-label">OK:</span> <span class="stat-value severity-ok">' + okPct + '%</span>');
+    }
+    statsEl.innerHTML = parts.join(' &nbsp;·&nbsp; ');
+  }
+
+  // Event list (most recent first for readability)
+  if (eventsEl) {
+    const reversed = [...data.events].reverse();
+    // Show max 20 events in the compact view
+    const displayed = reversed.slice(0, 20);
+    eventsEl.innerHTML = displayed.map(function(ev) {
+      const time = tbTimelineFmtTime(ev.ts);
+      const msgs = (ev.activeMessages || []).join('; ');
+      const label = ev.overallSeverity === 'ok' ? 'All clear' : msgs || ev.overallSeverity;
+      return '<div class="tb-alert-timeline-event">' +
+        '<span class="tb-alert-timeline-event-dot severity-' + ev.overallSeverity + '"></span>' +
+        '<span class="tb-alert-timeline-event-time">' + time + '</span>' +
+        '<span class="tb-alert-timeline-event-severity ' + ev.overallSeverity + '">' + ev.overallSeverity + '</span>' +
+        '<span class="tb-alert-timeline-event-msg">' + tbEsc(label) + '</span>' +
+        '</div>';
+    }).join('');
+    if (reversed.length > 20) {
+      eventsEl.innerHTML += '<div style="text-align:center;color:var(--text-muted);font-size:10px;padding:4px;">+ ' + (reversed.length - 20) + ' more events</div>';
+    }
+  }
+}
+
+/** Format a duration (ms) into human-readable string. */
+function tbTimelineFmtDuration(ms) {
+  if (ms < 60000) return Math.round(ms / 1000) + 's';
+  if (ms < 3600000) return Math.round(ms / 60000) + 'm';
+  const h = Math.floor(ms / 3600000);
+  const m = Math.round((ms % 3600000) / 60000);
+  return h + 'h' + (m > 0 ? ' ' + m + 'm' : '');
+}
+
+/** Format a timestamp into compact HH:MM time. */
+function tbTimelineFmtTime(ts) {
+  const d = new Date(ts);
+  return d.toLocaleTimeString([], { hour: '2-digit', minute: '2-digit', hour12: false });
+}
+
+/** Format a timestamp into "X ago" relative time. */
+function tbTimelineTimeAgo(ts) {
+  const diff = Date.now() - ts;
+  if (diff < 60000) return 'just now';
+  if (diff < 3600000) return Math.round(diff / 60000) + 'm ago';
+  if (diff < 86400000) return Math.round(diff / 3600000) + 'h ago';
+  return Math.round(diff / 86400000) + 'd ago';
 }
 
 // ── Real-time SSE subscription (Issue #219) ─────────────────────────────────

--- a/dashboard/server/alert-history.ts
+++ b/dashboard/server/alert-history.ts
@@ -1,0 +1,370 @@
+/**
+ * Alert History — persistent event log for alert state transitions.
+ * Issue #219 — Phase 10: Alert History / Timeline Baseline.
+ *
+ * Records alert evaluation events as an append-only log with bounded
+ * retention. Designed for lightweight timeline display — not a full
+ * audit trail. No background daemons; events are appended inline
+ * during alert evaluation (piggybacked on metrics reads).
+ *
+ * Retention policy:
+ *   - Max events: 200 (configurable)
+ *   - Max age: 48 hours (configurable)
+ *   - Minimum interval between persisted events: 60 seconds (configurable)
+ *   - Deduplication: consecutive identical severity snapshots are collapsed
+ *
+ * File format: { version: 1, events: AlertHistoryEvent[] }
+ * File location: <dataDir>/task-board-alert-history.json
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import type { AlertSeverity, AlertEvaluation } from './alert-rules.js';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/**
+ * A single alert history event — a snapshot of alert evaluation state
+ * at a point in time. Records severity transitions for timeline rendering.
+ */
+export interface AlertHistoryEvent {
+  /** Timestamp of the event (ms since epoch). */
+  ts: number;
+  /** Overall severity at this point. */
+  overallSeverity: AlertSeverity;
+  /** Severity counts at this point. */
+  severityCounts: Record<AlertSeverity, number>;
+  /** Compact per-rule severity snapshot (rule → severity). */
+  ruleSeverities: Record<string, AlertSeverity>;
+  /** Human-readable messages for non-ok rules only (compact). */
+  activeMessages: string[];
+}
+
+/** On-disk file format. */
+export interface AlertHistoryFile {
+  version: 1;
+  events: AlertHistoryEvent[];
+}
+
+/** Configuration for the alert history store. */
+export interface AlertHistoryConfig {
+  /** Maximum number of events to retain. Default: 200. */
+  maxEvents?: number;
+  /** Maximum age of events in ms. Default: 48 hours. */
+  maxAgeMs?: number;
+  /** Minimum interval between persisted events in ms. Default: 60 seconds. */
+  minIntervalMs?: number;
+}
+
+/** Query options for reading alert history. */
+export interface AlertHistoryQuery {
+  /** Maximum number of events to return. Default: 50, max 200. */
+  limit?: number;
+  /** Only events newer than (now - sinceMs). */
+  sinceMs?: number;
+  /** Filter to only events with this minimum severity (warning or critical). */
+  minSeverity?: AlertSeverity;
+  /** Current time override (for testing). */
+  now?: number;
+}
+
+/** Timeline summary — compact overview for dashboard display. */
+export interface AlertTimelineSummary {
+  /** Total events in the query window. */
+  totalEvents: number;
+  /** Events returned (after limit). */
+  returnedEvents: number;
+  /** Current overall severity (from most recent event, or 'ok'). */
+  currentSeverity: AlertSeverity;
+  /** Timestamp of the last state change (severity transition). */
+  lastTransitionAt: number | null;
+  /** Time spent in each severity level (ms) within the query window. */
+  severityDurations: Record<AlertSeverity, number>;
+  /** Number of distinct severity transitions in the window. */
+  transitionCount: number;
+  /** The events themselves. */
+  events: AlertHistoryEvent[];
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const HISTORY_FILENAME = 'task-board-alert-history.json';
+const DEFAULT_MAX_EVENTS = 200;
+const DEFAULT_MAX_AGE_MS = 48 * 60 * 60 * 1000; // 48 hours
+const DEFAULT_MIN_INTERVAL_MS = 60 * 1000; // 60 seconds
+
+// ─── File I/O ────────────────────────────────────────────────────────────────
+
+function historyFilePath(dataDir: string): string {
+  return path.join(dataDir, HISTORY_FILENAME);
+}
+
+/**
+ * Read the alert history from disk.
+ * Returns an empty history if the file doesn't exist or is corrupt.
+ */
+export function readAlertHistory(dataDir: string): AlertHistoryFile {
+  try {
+    const fp = historyFilePath(dataDir);
+    if (!fs.existsSync(fp)) return { version: 1, events: [] };
+    const raw = fs.readFileSync(fp, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && parsed.version === 1 && Array.isArray(parsed.events)) {
+      return parsed as AlertHistoryFile;
+    }
+    return { version: 1, events: [] };
+  } catch {
+    return { version: 1, events: [] };
+  }
+}
+
+/**
+ * Write the alert history to disk atomically (write-rename pattern).
+ */
+function writeAlertHistory(dataDir: string, history: AlertHistoryFile): void {
+  const fp = historyFilePath(dataDir);
+  const dir = path.dirname(fp);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  const tmpFp = fp + '.tmp';
+  fs.writeFileSync(tmpFp, JSON.stringify(history, null, 2));
+  fs.renameSync(tmpFp, fp);
+}
+
+// ─── Core operations ─────────────────────────────────────────────────────────
+
+/**
+ * Create an AlertHistoryEvent from an AlertEvaluation.
+ * Extracts only the fields needed for timeline display.
+ * Pure function.
+ */
+export function createAlertEvent(
+  evaluation: AlertEvaluation,
+): AlertHistoryEvent {
+  const ruleSeverities: Record<string, AlertSeverity> = {};
+  const activeMessages: string[] = [];
+
+  for (const rule of evaluation.rules) {
+    if (rule.enabled) {
+      ruleSeverities[rule.rule] = rule.severity;
+      if (rule.severity !== 'ok') {
+        activeMessages.push(rule.message);
+      }
+    }
+  }
+
+  return {
+    ts: evaluation.evaluatedAt,
+    overallSeverity: evaluation.overallSeverity,
+    severityCounts: { ...evaluation.severityCounts },
+    ruleSeverities,
+    activeMessages,
+  };
+}
+
+/**
+ * Determine whether a new event represents a meaningful state change
+ * compared to the last recorded event. Used for deduplication —
+ * consecutive identical states are collapsed.
+ *
+ * A state change is detected when:
+ * - Overall severity changed
+ * - Any individual rule severity changed
+ * - Active messages changed (metric values crossed thresholds)
+ *
+ * Pure function.
+ */
+export function isStateChange(
+  newEvent: AlertHistoryEvent,
+  lastEvent: AlertHistoryEvent | undefined,
+): boolean {
+  if (!lastEvent) return true;
+
+  // Overall severity changed
+  if (newEvent.overallSeverity !== lastEvent.overallSeverity) return true;
+
+  // Check individual rule severities
+  const newRules = newEvent.ruleSeverities;
+  const lastRules = lastEvent.ruleSeverities;
+
+  const allKeys = new Set([...Object.keys(newRules), ...Object.keys(lastRules)]);
+  for (const key of allKeys) {
+    if (newRules[key] !== lastRules[key]) return true;
+  }
+
+  return false;
+}
+
+/**
+ * Prune events that exceed retention bounds.
+ * Returns a new array (does not mutate input).
+ * Pure function.
+ */
+export function pruneAlertHistory(
+  events: AlertHistoryEvent[],
+  opts: {
+    maxEvents?: number;
+    maxAgeMs?: number;
+    now?: number;
+  } = {},
+): AlertHistoryEvent[] {
+  const maxEvents = opts.maxEvents ?? DEFAULT_MAX_EVENTS;
+  const maxAgeMs = opts.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+  const now = opts.now ?? Date.now();
+
+  // Filter by age first
+  let result = events.filter((e) => now - e.ts <= maxAgeMs);
+
+  // Then cap by count (keep most recent)
+  if (result.length > maxEvents) {
+    result = result.slice(result.length - maxEvents);
+  }
+
+  return result;
+}
+
+/**
+ * Determine whether a new event should be recorded based on the cooldown
+ * interval since the last event.
+ * Pure function.
+ */
+export function shouldRecordEvent(
+  events: AlertHistoryEvent[],
+  opts: { minIntervalMs?: number; now?: number } = {},
+): boolean {
+  const minIntervalMs = opts.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS;
+  const now = opts.now ?? Date.now();
+
+  if (events.length === 0) return true;
+
+  const lastTs = events[events.length - 1].ts;
+  return now - lastTs >= minIntervalMs;
+}
+
+/**
+ * Append an alert evaluation to the history if:
+ * 1. The cooldown interval has elapsed, AND
+ * 2. The state has meaningfully changed (deduplication), OR
+ *    this is a state transition (always recorded regardless of cooldown).
+ *
+ * Returns true if an event was written, false if skipped.
+ *
+ * This is the main write entry point — called inline during metrics
+ * evaluation. No background daemon needed.
+ */
+export function maybeAppendAlertEvent(
+  dataDir: string,
+  evaluation: AlertEvaluation,
+  config: AlertHistoryConfig = {},
+): boolean {
+  const minIntervalMs = config.minIntervalMs ?? DEFAULT_MIN_INTERVAL_MS;
+  const maxEvents = config.maxEvents ?? DEFAULT_MAX_EVENTS;
+  const maxAgeMs = config.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+  const now = evaluation.evaluatedAt;
+
+  const history = readAlertHistory(dataDir);
+  const lastEvent = history.events.length > 0
+    ? history.events[history.events.length - 1]
+    : undefined;
+
+  const newEvent = createAlertEvent(evaluation);
+  const stateChanged = isStateChange(newEvent, lastEvent);
+
+  // Always record state transitions immediately.
+  // For non-transitions, respect the cooldown interval.
+  if (!stateChanged) {
+    if (!shouldRecordEvent(history.events, { minIntervalMs, now })) {
+      return false;
+    }
+  }
+
+  history.events.push(newEvent);
+
+  // Prune before writing to keep file bounded
+  history.events = pruneAlertHistory(history.events, { maxEvents, maxAgeMs, now });
+
+  writeAlertHistory(dataDir, history);
+  return true;
+}
+
+// ─── Query helpers ───────────────────────────────────────────────────────────
+
+/** Severity priority for filtering (higher = more severe). */
+const SEVERITY_PRIORITY: Record<AlertSeverity, number> = {
+  ok: 0,
+  warning: 1,
+  critical: 2,
+};
+
+/**
+ * Query alert history and compute a timeline summary.
+ * Supports filtering by time window, limit, and minimum severity.
+ *
+ * Returns events sorted oldest-first (chronological order)
+ * with summary statistics for dashboard display.
+ */
+export function queryAlertTimeline(
+  dataDir: string,
+  opts: AlertHistoryQuery = {},
+): AlertTimelineSummary {
+  const history = readAlertHistory(dataDir);
+  const now = opts.now ?? Date.now();
+  let events = history.events;
+
+  // Filter by time window
+  if (opts.sinceMs != null && opts.sinceMs > 0) {
+    const cutoff = now - opts.sinceMs;
+    events = events.filter((e) => e.ts >= cutoff);
+  }
+
+  // Filter by minimum severity
+  if (opts.minSeverity && opts.minSeverity !== 'ok') {
+    const minPriority = SEVERITY_PRIORITY[opts.minSeverity] ?? 0;
+    events = events.filter((e) => SEVERITY_PRIORITY[e.overallSeverity] >= minPriority);
+  }
+
+  const totalEvents = events.length;
+
+  // Apply limit (most recent N)
+  const limit = Math.max(1, Math.min(opts.limit ?? 50, 200));
+  if (events.length > limit) {
+    events = events.slice(events.length - limit);
+  }
+
+  // Compute summary
+  const currentSeverity = events.length > 0
+    ? events[events.length - 1].overallSeverity
+    : 'ok';
+
+  // Count transitions (consecutive events with different overall severity)
+  let transitionCount = 0;
+  let lastTransitionAt: number | null = null;
+  for (let i = 1; i < events.length; i++) {
+    if (events[i].overallSeverity !== events[i - 1].overallSeverity) {
+      transitionCount++;
+      lastTransitionAt = events[i].ts;
+    }
+  }
+
+  // If only one event and it's the first, mark it as the last transition
+  if (events.length === 1 && lastTransitionAt === null) {
+    lastTransitionAt = events[0].ts;
+  }
+
+  // Compute time spent in each severity level
+  const severityDurations: Record<AlertSeverity, number> = { ok: 0, warning: 0, critical: 0 };
+  for (let i = 0; i < events.length; i++) {
+    const nextTs = i < events.length - 1 ? events[i + 1].ts : now;
+    const duration = nextTs - events[i].ts;
+    severityDurations[events[i].overallSeverity] += duration;
+  }
+
+  return {
+    totalEvents,
+    returnedEvents: events.length,
+    currentSeverity,
+    lastTransitionAt,
+    severityDurations,
+    transitionCount,
+    events,
+  };
+}

--- a/dashboard/server/routes/index.ts
+++ b/dashboard/server/routes/index.ts
@@ -59,3 +59,19 @@ export type {
   AlertMetricsInput,
   AlertConfigValidationError,
 } from '../alert-rules.js';
+export {
+  readAlertHistory,
+  createAlertEvent,
+  isStateChange,
+  pruneAlertHistory,
+  shouldRecordEvent,
+  maybeAppendAlertEvent,
+  queryAlertTimeline,
+} from '../alert-history.js';
+export type {
+  AlertHistoryEvent,
+  AlertHistoryFile,
+  AlertHistoryConfig,
+  AlertHistoryQuery,
+  AlertTimelineSummary,
+} from '../alert-history.js';

--- a/dashboard/server/routes/task-board.ts
+++ b/dashboard/server/routes/task-board.ts
@@ -55,6 +55,11 @@ import type {
   AlertEvaluation,
 } from '../alert-rules.js';
 
+import {
+  maybeAppendAlertEvent,
+  queryAlertTimeline,
+} from '../alert-history.js';
+
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 const VALID_STATUSES: TaskStatus[] = ['backlog', 'queued', 'running', 'done', 'failed'];
@@ -733,6 +738,29 @@ export async function handleTaskBoard(
     return true;
   }
 
+  // ── GET /api/task-board/alerts/timeline — Issue #219, Phase 10 ─────────────
+  // Returns alert history timeline with summary statistics.
+  // Query params:
+  //   ?limit=50        — max events to return (default 50, max 200)
+  //   ?sinceMs=3600000 — only events within this window (default: all retained)
+  //   ?minSeverity=warning — filter to warning+ or critical+ events
+  if (url.startsWith('/api/task-board/alerts/timeline') && method === 'GET') {
+    const tlParams = new URL(url, 'http://localhost').searchParams;
+    const limit = Math.max(1, Math.min(Number(tlParams.get('limit')) || 50, 200));
+    const sinceMs = tlParams.has('sinceMs')
+      ? Math.max(0, Number(tlParams.get('sinceMs')) || 0)
+      : undefined;
+    const minSeverityRaw = tlParams.get('minSeverity');
+    const validSeverities = ['ok', 'warning', 'critical'];
+    const minSeverity = minSeverityRaw && validSeverities.includes(minSeverityRaw)
+      ? (minSeverityRaw as 'ok' | 'warning' | 'critical')
+      : undefined;
+
+    const timeline = queryAlertTimeline(dataDir, { limit, sinceMs, minSeverity });
+    sendJson(res, timeline);
+    return true;
+  }
+
   // ── GET /api/task-board/metrics — Issue #219, Task Metrics Dashboard ───────
   // Returns computed metrics: throughput, runtime stats, trends, stuck tasks.
   // Optional query params:
@@ -740,6 +768,7 @@ export async function handleTaskBoard(
   //   ?includeAlerts=true — include alert evaluation in response (Phase 9)
   // Side-effect (Phase 8): appends a snapshot to the metrics history file
   // if the cooldown interval has elapsed (no extra writes on rapid polling).
+  // Side-effect (Phase 10): appends alert event to history for timeline.
   if (url.startsWith('/api/task-board/metrics') && method === 'GET') {
     const metricsParams = new URL(url, 'http://localhost').searchParams;
     const stuckTimeoutMs = metricsParams.has('stuckTimeoutMs')
@@ -764,6 +793,15 @@ export async function handleTaskBoard(
       maybeAppendSnapshot(dataDir, metrics);
     } catch {
       // Non-critical — don't break the metrics response
+    }
+
+    // Piggyback (Phase 10): record alert event for timeline
+    if (metrics.alerts) {
+      try {
+        maybeAppendAlertEvent(dataDir, metrics.alerts);
+      } catch {
+        // Non-critical — don't break the metrics response
+      }
     }
 
     sendJson(res, metrics);

--- a/dashboard/tests/unit/routes/task-board-alert-history.test.ts
+++ b/dashboard/tests/unit/routes/task-board-alert-history.test.ts
@@ -1,0 +1,702 @@
+/**
+ * Alert History tests — Issue #219, Phase 10: Alert History / Timeline Baseline.
+ *
+ * Tests for:
+ * - createAlertEvent() — event creation from evaluation
+ * - isStateChange() — deduplication logic
+ * - pruneAlertHistory() — retention pruning
+ * - shouldRecordEvent() — cooldown logic
+ * - maybeAppendAlertEvent() — main write path
+ * - queryAlertTimeline() — timeline query with summary stats
+ * - readAlertHistory() — file I/O robustness
+ * - GET /api/task-board/alerts/timeline — API endpoint
+ * - Alert event recording via GET /api/task-board/metrics (piggyback)
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { mockRequest, mockResponse, parseJsonBody } from '../../helpers.js';
+import {
+  handleTaskBoard,
+} from '../../../server/routes/task-board.js';
+import {
+  readAlertHistory,
+  createAlertEvent,
+  isStateChange,
+  pruneAlertHistory,
+  shouldRecordEvent,
+  maybeAppendAlertEvent,
+  queryAlertTimeline,
+} from '../../../server/alert-history.js';
+import {
+  evaluateAlerts,
+  DEFAULT_ALERT_CONFIG,
+} from '../../../server/alert-rules.js';
+import type {
+  AlertEvaluation,
+  AlertMetricsInput,
+  AlertRulesConfig,
+} from '../../../server/alert-rules.js';
+import type { AlertHistoryEvent } from '../../../server/alert-history.js';
+import type { TaskBoardDeps, TaskCard } from '../../../server/types.js';
+
+const testDataDir = path.join('/tmp', 'test-alert-history-' + process.pid);
+
+function createDeps(overrides: Partial<TaskBoardDeps> = {}): TaskBoardDeps {
+  return {
+    dataDir: testDataDir,
+    sendJson: (res, data, status = 200) => {
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+    },
+    readRequestBody: async () => '{}',
+    ...overrides,
+  };
+}
+
+function makeSampleCard(overrides: Partial<TaskCard> = {}): TaskCard {
+  return {
+    id: 'test-' + Math.random().toString(36).slice(2, 8),
+    agentId: 'oracle',
+    title: 'Test task',
+    description: 'A test task',
+    priority: 'medium',
+    status: 'backlog',
+    createdAt: Date.now(),
+    queuedAt: null,
+    startedAt: null,
+    completedAt: null,
+    resultSummary: null,
+    tokensUsed: null,
+    error: null,
+    costEstimate: null,
+    runtimeMs: null,
+    ...overrides,
+  };
+}
+
+function seedTasks(tasks: TaskCard[]): void {
+  fs.mkdirSync(testDataDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(testDataDir, 'task-board.json'),
+    JSON.stringify({ tasks, updatedAt: Date.now() }),
+  );
+}
+
+function metricsInput(overrides: Partial<AlertMetricsInput> = {}): AlertMetricsInput {
+  return {
+    statusCounts: { backlog: 0, queued: 0, running: 0, done: 0, failed: 0 },
+    successRate: null,
+    stuckCount: 0,
+    avgRuntimeMs: null,
+    total: 0,
+    ...overrides,
+  };
+}
+
+function makeEvaluation(overrides: {
+  overallSeverity?: 'ok' | 'warning' | 'critical';
+  stuckCount?: number;
+  successRate?: number | null;
+  evaluatedAt?: number;
+} = {}): AlertEvaluation {
+  const metrics = metricsInput({
+    stuckCount: overrides.stuckCount ?? 0,
+    successRate: overrides.successRate ?? null,
+  });
+  return evaluateAlerts(
+    metrics,
+    DEFAULT_ALERT_CONFIG,
+    overrides.evaluatedAt ?? Date.now(),
+  );
+}
+
+beforeEach(() => {
+  fs.mkdirSync(testDataDir, { recursive: true });
+  // Clean slate
+  for (const f of ['task-board.json', 'task-board-alert-history.json', 'task-board-alert-rules.json']) {
+    const fp = path.join(testDataDir, f);
+    if (fs.existsSync(fp)) fs.unlinkSync(fp);
+  }
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(testDataDir, { recursive: true, force: true });
+  } catch {}
+});
+
+// ─── createAlertEvent — event creation ───────────────────────────────────────
+
+describe('createAlertEvent', () => {
+  it('creates event from OK evaluation', () => {
+    const evaluation = makeEvaluation({ evaluatedAt: 1700000000000 });
+    const event = createAlertEvent(evaluation);
+    expect(event.ts).toBe(1700000000000);
+    expect(event.overallSeverity).toBe('ok');
+    expect(event.activeMessages).toHaveLength(0);
+    expect(event.ruleSeverities).toBeDefined();
+  });
+
+  it('creates event from warning evaluation with messages', () => {
+    const evaluation = makeEvaluation({ stuckCount: 3, evaluatedAt: 1700000000000 });
+    const event = createAlertEvent(evaluation);
+    expect(event.overallSeverity).toBe('warning');
+    expect(event.activeMessages.length).toBeGreaterThan(0);
+    expect(event.activeMessages.some(m => m.includes('Stuck Tasks'))).toBe(true);
+    expect(event.ruleSeverities['stuckCount']).toBe('warning');
+  });
+
+  it('creates event from critical evaluation', () => {
+    const evaluation = makeEvaluation({ stuckCount: 10, evaluatedAt: 1700000000000 });
+    const event = createAlertEvent(evaluation);
+    expect(event.overallSeverity).toBe('critical');
+    expect(event.severityCounts.critical).toBeGreaterThan(0);
+  });
+
+  it('only includes enabled rules in ruleSeverities', () => {
+    const config: AlertRulesConfig = {
+      ...DEFAULT_ALERT_CONFIG,
+      avgRuntime: { enabled: false, warning: 300000, critical: 600000 },
+      queueDepth: { enabled: false, warning: 10, critical: 25 },
+    };
+    const evaluation = evaluateAlerts(metricsInput(), config, 1700000000000);
+    const event = createAlertEvent(evaluation);
+    // avgRuntime and queueDepth are disabled, should not appear
+    expect(event.ruleSeverities).not.toHaveProperty('avgRuntime');
+    expect(event.ruleSeverities).not.toHaveProperty('queueDepth');
+  });
+});
+
+// ─── isStateChange — deduplication logic ─────────────────────────────────────
+
+describe('isStateChange', () => {
+  it('returns true when no last event', () => {
+    const event = createAlertEvent(makeEvaluation());
+    expect(isStateChange(event, undefined)).toBe(true);
+  });
+
+  it('returns false for identical consecutive events', () => {
+    const eval1 = makeEvaluation({ evaluatedAt: 1700000000000 });
+    const eval2 = makeEvaluation({ evaluatedAt: 1700000060000 });
+    const event1 = createAlertEvent(eval1);
+    const event2 = createAlertEvent(eval2);
+    expect(isStateChange(event2, event1)).toBe(false);
+  });
+
+  it('returns true when overall severity changes', () => {
+    const event1 = createAlertEvent(makeEvaluation({ stuckCount: 0 }));
+    const event2 = createAlertEvent(makeEvaluation({ stuckCount: 3 }));
+    expect(isStateChange(event2, event1)).toBe(true);
+  });
+
+  it('returns true when individual rule severity changes', () => {
+    const event1 = createAlertEvent(makeEvaluation({ stuckCount: 3 })); // warning
+    const event2 = createAlertEvent(makeEvaluation({ stuckCount: 6 })); // critical
+    expect(isStateChange(event2, event1)).toBe(true);
+  });
+
+  it('returns false when values change but severities stay the same', () => {
+    // stuckCount 3 → warning, stuckCount 4 → still warning
+    const eval1 = makeEvaluation({ stuckCount: 3, evaluatedAt: 1700000000000 });
+    const eval2 = makeEvaluation({ stuckCount: 4, evaluatedAt: 1700000060000 });
+    const event1 = createAlertEvent(eval1);
+    const event2 = createAlertEvent(eval2);
+    expect(isStateChange(event2, event1)).toBe(false);
+  });
+});
+
+// ─── pruneAlertHistory — retention pruning ───────────────────────────────────
+
+describe('pruneAlertHistory', () => {
+  const NOW = 1700000000000;
+
+  function makeEvents(count: number, startTs: number = NOW - count * 60000): AlertHistoryEvent[] {
+    return Array.from({ length: count }, (_, i) => ({
+      ts: startTs + i * 60000,
+      overallSeverity: 'ok' as const,
+      severityCounts: { ok: 3, warning: 0, critical: 0 },
+      ruleSeverities: { stuckCount: 'ok' as const },
+      activeMessages: [],
+    }));
+  }
+
+  it('returns empty array for empty input', () => {
+    expect(pruneAlertHistory([], { now: NOW })).toEqual([]);
+  });
+
+  it('caps at maxEvents (keeps most recent)', () => {
+    const events = makeEvents(50);
+    const pruned = pruneAlertHistory(events, { maxEvents: 10, now: NOW });
+    expect(pruned).toHaveLength(10);
+    expect(pruned[0].ts).toBe(events[40].ts); // last 10
+    expect(pruned[9].ts).toBe(events[49].ts);
+  });
+
+  it('removes events older than maxAgeMs', () => {
+    const oldEvent: AlertHistoryEvent = {
+      ts: NOW - 100 * 60 * 60 * 1000, // 100 hours ago
+      overallSeverity: 'ok',
+      severityCounts: { ok: 3, warning: 0, critical: 0 },
+      ruleSeverities: {},
+      activeMessages: [],
+    };
+    const recentEvent: AlertHistoryEvent = {
+      ts: NOW - 1000,
+      overallSeverity: 'warning',
+      severityCounts: { ok: 2, warning: 1, critical: 0 },
+      ruleSeverities: { stuckCount: 'warning' },
+      activeMessages: ['test'],
+    };
+    const pruned = pruneAlertHistory([oldEvent, recentEvent], { maxAgeMs: 48 * 3600000, now: NOW });
+    expect(pruned).toHaveLength(1);
+    expect(pruned[0].overallSeverity).toBe('warning');
+  });
+
+  it('applies both age and count limits', () => {
+    const events = makeEvents(300, NOW - 300 * 60000); // 300 events, 1 per minute
+    const pruned = pruneAlertHistory(events, { maxEvents: 100, maxAgeMs: 2 * 3600000, now: NOW });
+    // 2h = 120 minutes of events pass age filter, then capped at 100
+    expect(pruned.length).toBeLessThanOrEqual(100);
+    // All should be within 2h
+    for (const e of pruned) {
+      expect(NOW - e.ts).toBeLessThanOrEqual(2 * 3600000);
+    }
+  });
+
+  it('does not mutate input array', () => {
+    const events = makeEvents(50);
+    const original = [...events];
+    pruneAlertHistory(events, { maxEvents: 5, now: NOW });
+    expect(events).toHaveLength(50);
+    expect(events).toEqual(original);
+  });
+});
+
+// ─── shouldRecordEvent — cooldown logic ──────────────────────────────────────
+
+describe('shouldRecordEvent', () => {
+  const NOW = 1700000000000;
+
+  it('returns true for empty history', () => {
+    expect(shouldRecordEvent([], { now: NOW })).toBe(true);
+  });
+
+  it('returns false if last event is too recent', () => {
+    const events: AlertHistoryEvent[] = [{
+      ts: NOW - 30000, // 30 seconds ago
+      overallSeverity: 'ok',
+      severityCounts: { ok: 3, warning: 0, critical: 0 },
+      ruleSeverities: {},
+      activeMessages: [],
+    }];
+    expect(shouldRecordEvent(events, { minIntervalMs: 60000, now: NOW })).toBe(false);
+  });
+
+  it('returns true if cooldown has elapsed', () => {
+    const events: AlertHistoryEvent[] = [{
+      ts: NOW - 120000, // 2 minutes ago
+      overallSeverity: 'ok',
+      severityCounts: { ok: 3, warning: 0, critical: 0 },
+      ruleSeverities: {},
+      activeMessages: [],
+    }];
+    expect(shouldRecordEvent(events, { minIntervalMs: 60000, now: NOW })).toBe(true);
+  });
+
+  it('uses default interval when not specified', () => {
+    const events: AlertHistoryEvent[] = [{
+      ts: NOW - 30000,
+      overallSeverity: 'ok',
+      severityCounts: { ok: 3, warning: 0, critical: 0 },
+      ruleSeverities: {},
+      activeMessages: [],
+    }];
+    // Default is 60 seconds, 30s ago should be too recent
+    expect(shouldRecordEvent(events, { now: NOW })).toBe(false);
+  });
+});
+
+// ─── maybeAppendAlertEvent — main write path ─────────────────────────────────
+
+describe('maybeAppendAlertEvent', () => {
+  const NOW = 1700000000000;
+
+  it('appends first event to empty history', () => {
+    const evaluation = makeEvaluation({ evaluatedAt: NOW });
+    const result = maybeAppendAlertEvent(testDataDir, evaluation);
+    expect(result).toBe(true);
+    const history = readAlertHistory(testDataDir);
+    expect(history.events).toHaveLength(1);
+    expect(history.events[0].ts).toBe(NOW);
+  });
+
+  it('skips duplicate state within cooldown', () => {
+    const eval1 = makeEvaluation({ evaluatedAt: NOW });
+    const eval2 = makeEvaluation({ evaluatedAt: NOW + 30000 }); // 30s later, same state
+    maybeAppendAlertEvent(testDataDir, eval1, { minIntervalMs: 60000 });
+    const result = maybeAppendAlertEvent(testDataDir, eval2, { minIntervalMs: 60000 });
+    expect(result).toBe(false);
+    expect(readAlertHistory(testDataDir).events).toHaveLength(1);
+  });
+
+  it('records state transitions immediately (bypasses cooldown)', () => {
+    const eval1 = makeEvaluation({ stuckCount: 0, evaluatedAt: NOW });
+    const eval2 = makeEvaluation({ stuckCount: 3, evaluatedAt: NOW + 10000 }); // 10s later, severity changed
+    maybeAppendAlertEvent(testDataDir, eval1, { minIntervalMs: 60000 });
+    const result = maybeAppendAlertEvent(testDataDir, eval2, { minIntervalMs: 60000 });
+    expect(result).toBe(true);
+    const history = readAlertHistory(testDataDir);
+    expect(history.events).toHaveLength(2);
+    expect(history.events[0].overallSeverity).toBe('ok');
+    expect(history.events[1].overallSeverity).toBe('warning');
+  });
+
+  it('records same state after cooldown elapses', () => {
+    const eval1 = makeEvaluation({ evaluatedAt: NOW });
+    const eval2 = makeEvaluation({ evaluatedAt: NOW + 120000 }); // 2min later, same state
+    maybeAppendAlertEvent(testDataDir, eval1, { minIntervalMs: 60000 });
+    const result = maybeAppendAlertEvent(testDataDir, eval2, { minIntervalMs: 60000 });
+    expect(result).toBe(true);
+    expect(readAlertHistory(testDataDir).events).toHaveLength(2);
+  });
+
+  it('prunes events on write', () => {
+    // Pre-seed with many events
+    const events: AlertHistoryEvent[] = Array.from({ length: 250 }, (_, i) => ({
+      ts: NOW - (250 - i) * 120000,
+      overallSeverity: 'ok' as const,
+      severityCounts: { ok: 3, warning: 0, critical: 0 },
+      ruleSeverities: { stuckCount: 'ok' as const },
+      activeMessages: [],
+    }));
+    fs.writeFileSync(
+      path.join(testDataDir, 'task-board-alert-history.json'),
+      JSON.stringify({ version: 1, events }),
+    );
+
+    const evaluation = makeEvaluation({ evaluatedAt: NOW });
+    maybeAppendAlertEvent(testDataDir, evaluation, { maxEvents: 100 });
+    const history = readAlertHistory(testDataDir);
+    expect(history.events.length).toBeLessThanOrEqual(100);
+  });
+
+  it('creates data directory if needed', () => {
+    const deepDir = path.join(testDataDir, 'deep', 'nested');
+    const evaluation = makeEvaluation({ evaluatedAt: NOW });
+    maybeAppendAlertEvent(deepDir, evaluation);
+    const history = readAlertHistory(deepDir);
+    expect(history.events).toHaveLength(1);
+  });
+});
+
+// ─── readAlertHistory — file I/O robustness ──────────────────────────────────
+
+describe('readAlertHistory', () => {
+  it('returns empty history when file does not exist', () => {
+    const history = readAlertHistory(testDataDir);
+    expect(history.version).toBe(1);
+    expect(history.events).toEqual([]);
+  });
+
+  it('returns empty history for corrupted file', () => {
+    fs.writeFileSync(
+      path.join(testDataDir, 'task-board-alert-history.json'),
+      'not valid json!!!',
+    );
+    const history = readAlertHistory(testDataDir);
+    expect(history.events).toEqual([]);
+  });
+
+  it('returns empty history for wrong version', () => {
+    fs.writeFileSync(
+      path.join(testDataDir, 'task-board-alert-history.json'),
+      JSON.stringify({ version: 99, events: [{ ts: 1 }] }),
+    );
+    const history = readAlertHistory(testDataDir);
+    expect(history.events).toEqual([]);
+  });
+
+  it('reads valid history file', () => {
+    const event: AlertHistoryEvent = {
+      ts: 1700000000000,
+      overallSeverity: 'warning',
+      severityCounts: { ok: 2, warning: 1, critical: 0 },
+      ruleSeverities: { stuckCount: 'warning' },
+      activeMessages: ['Stuck Tasks: 3'],
+    };
+    fs.writeFileSync(
+      path.join(testDataDir, 'task-board-alert-history.json'),
+      JSON.stringify({ version: 1, events: [event] }),
+    );
+    const history = readAlertHistory(testDataDir);
+    expect(history.events).toHaveLength(1);
+    expect(history.events[0].overallSeverity).toBe('warning');
+  });
+});
+
+// ─── queryAlertTimeline — timeline query with summary ────────────────────────
+
+describe('queryAlertTimeline', () => {
+  const NOW = 1700000000000;
+
+  function seedEvents(events: AlertHistoryEvent[]): void {
+    fs.writeFileSync(
+      path.join(testDataDir, 'task-board-alert-history.json'),
+      JSON.stringify({ version: 1, events }),
+    );
+  }
+
+  it('returns empty summary when no events', () => {
+    const result = queryAlertTimeline(testDataDir, { now: NOW });
+    expect(result.totalEvents).toBe(0);
+    expect(result.returnedEvents).toBe(0);
+    expect(result.currentSeverity).toBe('ok');
+    expect(result.events).toEqual([]);
+    expect(result.transitionCount).toBe(0);
+  });
+
+  it('returns events in chronological order', () => {
+    seedEvents([
+      { ts: NOW - 3000, overallSeverity: 'ok', severityCounts: { ok: 3, warning: 0, critical: 0 }, ruleSeverities: {}, activeMessages: [] },
+      { ts: NOW - 2000, overallSeverity: 'warning', severityCounts: { ok: 2, warning: 1, critical: 0 }, ruleSeverities: {}, activeMessages: [] },
+      { ts: NOW - 1000, overallSeverity: 'ok', severityCounts: { ok: 3, warning: 0, critical: 0 }, ruleSeverities: {}, activeMessages: [] },
+    ]);
+    const result = queryAlertTimeline(testDataDir, { now: NOW });
+    expect(result.events).toHaveLength(3);
+    expect(result.events[0].ts).toBe(NOW - 3000);
+    expect(result.events[2].ts).toBe(NOW - 1000);
+  });
+
+  it('respects limit parameter', () => {
+    seedEvents(Array.from({ length: 100 }, (_, i) => ({
+      ts: NOW - (100 - i) * 1000,
+      overallSeverity: 'ok' as const,
+      severityCounts: { ok: 3, warning: 0, critical: 0 },
+      ruleSeverities: {},
+      activeMessages: [],
+    })));
+    const result = queryAlertTimeline(testDataDir, { limit: 10, now: NOW });
+    expect(result.returnedEvents).toBe(10);
+    expect(result.totalEvents).toBe(100);
+  });
+
+  it('filters by sinceMs', () => {
+    seedEvents([
+      { ts: NOW - 7200000, overallSeverity: 'warning', severityCounts: { ok: 2, warning: 1, critical: 0 }, ruleSeverities: {}, activeMessages: [] },
+      { ts: NOW - 1800000, overallSeverity: 'ok', severityCounts: { ok: 3, warning: 0, critical: 0 }, ruleSeverities: {}, activeMessages: [] },
+    ]);
+    const result = queryAlertTimeline(testDataDir, { sinceMs: 3600000, now: NOW }); // last 1h
+    expect(result.totalEvents).toBe(1); // only the recent one
+    expect(result.events[0].overallSeverity).toBe('ok');
+  });
+
+  it('filters by minSeverity', () => {
+    seedEvents([
+      { ts: NOW - 3000, overallSeverity: 'ok', severityCounts: { ok: 3, warning: 0, critical: 0 }, ruleSeverities: {}, activeMessages: [] },
+      { ts: NOW - 2000, overallSeverity: 'warning', severityCounts: { ok: 2, warning: 1, critical: 0 }, ruleSeverities: {}, activeMessages: ['test'] },
+      { ts: NOW - 1000, overallSeverity: 'critical', severityCounts: { ok: 1, warning: 0, critical: 2 }, ruleSeverities: {}, activeMessages: ['crit'] },
+    ]);
+    const result = queryAlertTimeline(testDataDir, { minSeverity: 'warning', now: NOW });
+    expect(result.returnedEvents).toBe(2);
+    expect(result.events.every(e => e.overallSeverity !== 'ok')).toBe(true);
+  });
+
+  it('computes currentSeverity from most recent event', () => {
+    seedEvents([
+      { ts: NOW - 2000, overallSeverity: 'warning', severityCounts: { ok: 2, warning: 1, critical: 0 }, ruleSeverities: {}, activeMessages: [] },
+      { ts: NOW - 1000, overallSeverity: 'critical', severityCounts: { ok: 1, warning: 0, critical: 2 }, ruleSeverities: {}, activeMessages: [] },
+    ]);
+    const result = queryAlertTimeline(testDataDir, { now: NOW });
+    expect(result.currentSeverity).toBe('critical');
+  });
+
+  it('counts severity transitions correctly', () => {
+    seedEvents([
+      { ts: NOW - 4000, overallSeverity: 'ok', severityCounts: { ok: 3, warning: 0, critical: 0 }, ruleSeverities: {}, activeMessages: [] },
+      { ts: NOW - 3000, overallSeverity: 'warning', severityCounts: { ok: 2, warning: 1, critical: 0 }, ruleSeverities: {}, activeMessages: [] },
+      { ts: NOW - 2000, overallSeverity: 'warning', severityCounts: { ok: 2, warning: 1, critical: 0 }, ruleSeverities: {}, activeMessages: [] },
+      { ts: NOW - 1000, overallSeverity: 'ok', severityCounts: { ok: 3, warning: 0, critical: 0 }, ruleSeverities: {}, activeMessages: [] },
+    ]);
+    const result = queryAlertTimeline(testDataDir, { now: NOW });
+    expect(result.transitionCount).toBe(2); // ok→warning, warning→ok
+  });
+
+  it('computes severity durations', () => {
+    seedEvents([
+      { ts: NOW - 6000, overallSeverity: 'ok', severityCounts: { ok: 3, warning: 0, critical: 0 }, ruleSeverities: {}, activeMessages: [] },
+      { ts: NOW - 3000, overallSeverity: 'warning', severityCounts: { ok: 2, warning: 1, critical: 0 }, ruleSeverities: {}, activeMessages: [] },
+    ]);
+    const result = queryAlertTimeline(testDataDir, { now: NOW });
+    // ok: 6000-3000 = 3000ms, warning: 3000-0 = 3000ms
+    expect(result.severityDurations.ok).toBe(3000);
+    expect(result.severityDurations.warning).toBe(3000);
+    expect(result.severityDurations.critical).toBe(0);
+  });
+
+  it('sets lastTransitionAt to the most recent transition', () => {
+    seedEvents([
+      { ts: NOW - 4000, overallSeverity: 'ok', severityCounts: { ok: 3, warning: 0, critical: 0 }, ruleSeverities: {}, activeMessages: [] },
+      { ts: NOW - 2000, overallSeverity: 'warning', severityCounts: { ok: 2, warning: 1, critical: 0 }, ruleSeverities: {}, activeMessages: [] },
+      { ts: NOW - 1000, overallSeverity: 'ok', severityCounts: { ok: 3, warning: 0, critical: 0 }, ruleSeverities: {}, activeMessages: [] },
+    ]);
+    const result = queryAlertTimeline(testDataDir, { now: NOW });
+    expect(result.lastTransitionAt).toBe(NOW - 1000);
+  });
+
+  it('clamps limit to max 200', () => {
+    seedEvents(Array.from({ length: 250 }, (_, i) => ({
+      ts: NOW - (250 - i) * 1000,
+      overallSeverity: 'ok' as const,
+      severityCounts: { ok: 3, warning: 0, critical: 0 },
+      ruleSeverities: {},
+      activeMessages: [],
+    })));
+    const result = queryAlertTimeline(testDataDir, { limit: 999, now: NOW });
+    expect(result.returnedEvents).toBeLessThanOrEqual(200);
+  });
+});
+
+// ─── GET /api/task-board/alerts/timeline — API endpoint ──────────────────────
+
+describe('GET /api/task-board/alerts/timeline', () => {
+  it('returns empty timeline when no history exists', async () => {
+    seedTasks([]);
+    const req = mockRequest({ url: '/api/task-board/alerts/timeline', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    const body = parseJsonBody(res);
+    expect(res._statusCode).toBe(200);
+    expect(body.totalEvents).toBe(0);
+    expect(body.events).toEqual([]);
+    expect(body.currentSeverity).toBe('ok');
+  });
+
+  it('returns timeline with events', async () => {
+    seedTasks([]);
+    const NOW = Date.now();
+    // Seed some alert history events
+    const events: AlertHistoryEvent[] = [
+      { ts: NOW - 5000, overallSeverity: 'ok', severityCounts: { ok: 3, warning: 0, critical: 0 }, ruleSeverities: {}, activeMessages: [] },
+      { ts: NOW - 3000, overallSeverity: 'warning', severityCounts: { ok: 2, warning: 1, critical: 0 }, ruleSeverities: { stuckCount: 'warning' }, activeMessages: ['Stuck Tasks: 3'] },
+    ];
+    fs.writeFileSync(
+      path.join(testDataDir, 'task-board-alert-history.json'),
+      JSON.stringify({ version: 1, events }),
+    );
+
+    const req = mockRequest({ url: '/api/task-board/alerts/timeline', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    const body = parseJsonBody(res);
+    expect(body.totalEvents).toBe(2);
+    expect(body.events).toHaveLength(2);
+    expect(body.currentSeverity).toBe('warning');
+    expect(body.transitionCount).toBe(1);
+  });
+
+  it('respects limit query param', async () => {
+    seedTasks([]);
+    const NOW = Date.now();
+    const events = Array.from({ length: 50 }, (_, i) => ({
+      ts: NOW - (50 - i) * 1000,
+      overallSeverity: 'ok' as const,
+      severityCounts: { ok: 3, warning: 0, critical: 0 },
+      ruleSeverities: {},
+      activeMessages: [],
+    }));
+    fs.writeFileSync(
+      path.join(testDataDir, 'task-board-alert-history.json'),
+      JSON.stringify({ version: 1, events }),
+    );
+
+    const req = mockRequest({ url: '/api/task-board/alerts/timeline?limit=5', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    const body = parseJsonBody(res);
+    expect(body.returnedEvents).toBe(5);
+    expect(body.totalEvents).toBe(50);
+  });
+
+  it('respects sinceMs query param', async () => {
+    seedTasks([]);
+    const NOW = Date.now();
+    const events = [
+      { ts: NOW - 7200000, overallSeverity: 'warning' as const, severityCounts: { ok: 2, warning: 1, critical: 0 }, ruleSeverities: {}, activeMessages: [] },
+      { ts: NOW - 1800000, overallSeverity: 'ok' as const, severityCounts: { ok: 3, warning: 0, critical: 0 }, ruleSeverities: {}, activeMessages: [] },
+    ];
+    fs.writeFileSync(
+      path.join(testDataDir, 'task-board-alert-history.json'),
+      JSON.stringify({ version: 1, events }),
+    );
+
+    const req = mockRequest({ url: '/api/task-board/alerts/timeline?sinceMs=3600000', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    const body = parseJsonBody(res);
+    expect(body.totalEvents).toBe(1);
+    expect(body.events[0].overallSeverity).toBe('ok');
+  });
+
+  it('respects minSeverity query param', async () => {
+    seedTasks([]);
+    const NOW = Date.now();
+    const events = [
+      { ts: NOW - 3000, overallSeverity: 'ok' as const, severityCounts: { ok: 3, warning: 0, critical: 0 }, ruleSeverities: {}, activeMessages: [] },
+      { ts: NOW - 2000, overallSeverity: 'warning' as const, severityCounts: { ok: 2, warning: 1, critical: 0 }, ruleSeverities: {}, activeMessages: ['test'] },
+    ];
+    fs.writeFileSync(
+      path.join(testDataDir, 'task-board-alert-history.json'),
+      JSON.stringify({ version: 1, events }),
+    );
+
+    const req = mockRequest({ url: '/api/task-board/alerts/timeline?minSeverity=warning', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    const body = parseJsonBody(res);
+    expect(body.totalEvents).toBe(1);
+    expect(body.events[0].overallSeverity).toBe('warning');
+  });
+});
+
+// ─── Alert event recording via GET /api/task-board/metrics (piggyback) ───────
+
+describe('GET /api/task-board/metrics — alert history recording', () => {
+  it('records alert event on metrics fetch', async () => {
+    seedTasks([
+      makeSampleCard({ status: 'running', startedAt: Date.now() - 3600000 * 2 }),
+      makeSampleCard({ status: 'running', startedAt: Date.now() - 3600000 * 2 }),
+      makeSampleCard({ status: 'running', startedAt: Date.now() - 3600000 * 2 }),
+    ]);
+
+    const req = mockRequest({ url: '/api/task-board/metrics', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    // Verify metrics response includes alerts
+    const body = parseJsonBody(res);
+    expect(body.alerts).toBeDefined();
+    expect(body.alerts.overallSeverity).toBe('warning');
+
+    // Verify alert history was written
+    const history = readAlertHistory(testDataDir);
+    expect(history.events.length).toBeGreaterThanOrEqual(1);
+    expect(history.events[0].overallSeverity).toBe('warning');
+  });
+
+  it('does not record when alerts are excluded', async () => {
+    seedTasks([]);
+    const req = mockRequest({ url: '/api/task-board/metrics?includeAlerts=false', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    const history = readAlertHistory(testDataDir);
+    expect(history.events).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Refs #219

### What
Alert history/timeline baseline — **Phase 10** of the task-board metrics + alerting system.

### Delivered Scope
1. **Alert event persistence store** (`dashboard/server/alert-history.ts`)
   - Append-only JSON log with bounded retention (200 events, 48h max age)
   - Deduplication: consecutive identical severity states collapsed
   - State transitions bypass cooldown (always recorded immediately)
   - Atomic write-rename file I/O (matches existing patterns)

2. **API endpoint**: `GET /api/task-board/alerts/timeline`
   - Query params: `limit`, `sinceMs`, `minSeverity`
   - Returns timeline summary: severity durations, transition count, current severity, event list

3. **Dashboard UI widget** (compact timeline in metrics panel)
   - Severity duration bar (color-coded OK/warning/critical segments)
   - Current status + last transition time
   - Scrollable event list (most recent first, max 20 visible)
   - Time window selector (1h / 6h / 24h / 48h)

4. **Automatic recording**: alert events piggybacked on metrics API reads
   - Same non-blocking pattern as metrics history snapshots
   - Bounded: 60s min interval, pruned on each write

### Tests — 45 new
| Area | Tests |
|------|-------|
| `createAlertEvent` | Event creation from evaluation |
| `isStateChange` | Deduplication correctness |
| `pruneAlertHistory` | Retention pruning (age + count) |
| `shouldRecordEvent` | Cooldown logic |
| `maybeAppendAlertEvent` | Write path + transition bypass |
| `readAlertHistory` | File I/O robustness (corrupt/missing/wrong version) |
| `queryAlertTimeline` | Time window, limit, minSeverity, transitions, durations |
| API endpoint | GET timeline with params |
| Integration | Alert recording via metrics piggyback |

### Test Results
- **362/362** task-board tests pass (10 test files, 0 failures)
- `tsc --noEmit` clean
- Pre-existing failures (38) in `shared-context.test.ts` and `memory-state.test.ts` due to `better-sqlite3` native module issue — unrelated to this PR

### Risk Assessment
- **Low risk**: Additive-only, no changes to existing file schemas
- All new code wrapped in try/catch in metrics handler (non-breaking fallback)
- File I/O follows same atomic write-rename pattern as metrics-history
- Dashboard UI purely additive (new panel, existing rendering untouched)
- Fully reversible: deleting the history file resets to clean state

### Files Changed (5)
- `dashboard/server/alert-history.ts` — **NEW**: Event store + query engine
- `dashboard/server/routes/task-board.ts` — Timeline API route + metrics piggyback
- `dashboard/server/routes/index.ts` — Barrel export
- `dashboard/client/index.html` — Timeline CSS + HTML + JavaScript
- `dashboard/tests/unit/routes/task-board-alert-history.test.ts` — **NEW**: 45 tests