### PR TITLE
feat(#219): Alert webhook delivery — external notification for severity transitions (Phase 11)

### DIFF
--- a/dashboard/server/alert-webhook.ts
+++ b/dashboard/server/alert-webhook.ts
@@ -1,0 +1,672 @@
+/**
+ * Alert Webhook Delivery — external notification for alert state transitions.
+ * Issue #219 — Phase 11: Webhook Notification Baseline.
+ *
+ * Delivers webhook HTTP POST notifications when alert severity transitions
+ * occur (e.g., ok→warning, warning→critical, critical→ok). Designed as a
+ * lightweight, bounded, non-blocking delivery mechanism:
+ *
+ * - Config persisted as JSON alongside other task-board data
+ * - Disabled by default — explicit opt-in required
+ * - Bounded retry with exponential backoff (max 3 attempts)
+ * - Request timeout prevents blocking the metrics evaluation path
+ * - Secrets (webhook URLs) are never logged in full
+ * - Fire-and-forget: delivery failures do not affect alert evaluation
+ *
+ * Delivery is triggered inline during alert evaluation (piggybacked on
+ * metrics API reads, same pattern as alert-history.ts). No new daemons.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import type { AlertSeverity, AlertEvaluation, AlertRuleResult } from './alert-rules.js';
+import type { AlertHistoryEvent } from './alert-history.js';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/** A single webhook target configuration. */
+export interface WebhookTarget {
+  /** Unique identifier for this target. */
+  id: string;
+  /** Display name for dashboard UI. */
+  name: string;
+  /** Target URL — must be HTTPS (or HTTP for localhost in dev). */
+  url: string;
+  /** Whether this target is enabled. */
+  enabled: boolean;
+  /** Optional shared secret for HMAC-SHA256 signature header. */
+  secret?: string;
+  /**
+   * Minimum severity to trigger notification on this target.
+   * Default: 'warning' (notifies on warning and critical transitions).
+   */
+  minSeverity?: AlertSeverity;
+}
+
+/** Full webhook configuration. */
+export interface WebhookConfig {
+  /** Global enable/disable flag. When false, no webhooks are sent. */
+  enabled: boolean;
+  /** Webhook targets. */
+  targets: WebhookTarget[];
+  /**
+   * Cooldown between webhook deliveries per target in ms.
+   * Prevents flood during rapid state changes. Default: 60000 (1 min).
+   */
+  cooldownMs?: number;
+  /**
+   * Request timeout in ms. Default: 10000 (10 seconds).
+   */
+  timeoutMs?: number;
+  /**
+   * Maximum retry attempts on failure. Default: 3.
+   */
+  maxRetries?: number;
+}
+
+/** Payload sent to webhook targets. */
+export interface WebhookPayload {
+  /** Event type identifier. */
+  event: 'alert.transition';
+  /** Timestamp of the transition (ms since epoch). */
+  timestamp: number;
+  /** ISO 8601 timestamp string. */
+  timestampISO: string;
+  /** Previous overall severity (null if first evaluation). */
+  previousSeverity: AlertSeverity | null;
+  /** New overall severity. */
+  currentSeverity: AlertSeverity;
+  /** Human-readable transition description. */
+  transitionLabel: string;
+  /** Full alert evaluation snapshot. */
+  evaluation: {
+    evaluatedAt: number;
+    overallSeverity: AlertSeverity;
+    severityCounts: Record<AlertSeverity, number>;
+    rules: Array<{
+      rule: string;
+      label: string;
+      enabled: boolean;
+      severity: AlertSeverity;
+      currentValue: number | null;
+      warningThreshold: number;
+      criticalThreshold: number;
+      message: string;
+    }>;
+  };
+  /** Source identifier. */
+  source: 'ventureos-dashboard';
+  /** Schema version for forward compatibility. */
+  schemaVersion: 1;
+}
+
+/** Result of a single webhook delivery attempt. */
+export interface WebhookDeliveryResult {
+  targetId: string;
+  targetName: string;
+  success: boolean;
+  statusCode: number | null;
+  attempts: number;
+  error: string | null;
+  durationMs: number;
+}
+
+/** Delivery state tracked per-target (in-memory, non-persistent). */
+export interface WebhookDeliveryState {
+  /** Last successful delivery timestamp per target ID. */
+  lastDeliveryAt: Record<string, number>;
+  /** Last known severity (for transition detection). */
+  lastSeverity: AlertSeverity | null;
+}
+
+/** Validation error for webhook config. */
+export interface WebhookConfigValidationError {
+  field: string;
+  message: string;
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const WEBHOOK_CONFIG_FILENAME = 'task-board-webhook-config.json';
+const DEFAULT_COOLDOWN_MS = 60_000; // 1 minute
+const DEFAULT_TIMEOUT_MS = 10_000; // 10 seconds
+const DEFAULT_MAX_RETRIES = 3;
+const MAX_TARGETS = 5;
+const MAX_URL_LENGTH = 2048;
+const MAX_NAME_LENGTH = 100;
+const MAX_SECRET_LENGTH = 256;
+
+/** Severity priority for filtering. */
+const SEVERITY_PRIORITY: Record<AlertSeverity, number> = {
+  ok: 0,
+  warning: 1,
+  critical: 2,
+};
+
+// ─── In-memory delivery state (non-persistent, resets on restart) ────────────
+
+let deliveryState: WebhookDeliveryState = {
+  lastDeliveryAt: {},
+  lastSeverity: null,
+};
+
+/** Reset delivery state (for testing). */
+export function resetDeliveryState(): void {
+  deliveryState = {
+    lastDeliveryAt: {},
+    lastSeverity: null,
+  };
+}
+
+/** Get current delivery state (for testing/inspection). */
+export function getDeliveryState(): Readonly<WebhookDeliveryState> {
+  return deliveryState;
+}
+
+// ─── Default config ──────────────────────────────────────────────────────────
+
+export const DEFAULT_WEBHOOK_CONFIG: WebhookConfig = {
+  enabled: false,
+  targets: [],
+  cooldownMs: DEFAULT_COOLDOWN_MS,
+  timeoutMs: DEFAULT_TIMEOUT_MS,
+  maxRetries: DEFAULT_MAX_RETRIES,
+};
+
+// ─── Config I/O ──────────────────────────────────────────────────────────────
+
+function configFilePath(dataDir: string): string {
+  return path.join(dataDir, WEBHOOK_CONFIG_FILENAME);
+}
+
+/**
+ * Read webhook config from disk.
+ * Returns defaults if file doesn't exist or is corrupt.
+ */
+export function readWebhookConfig(dataDir: string): WebhookConfig {
+  try {
+    const fp = configFilePath(dataDir);
+    if (!fs.existsSync(fp)) return { ...DEFAULT_WEBHOOK_CONFIG, targets: [] };
+    const raw = fs.readFileSync(fp, 'utf8');
+    const parsed = JSON.parse(raw);
+    return sanitizeConfig(parsed);
+  } catch {
+    return { ...DEFAULT_WEBHOOK_CONFIG, targets: [] };
+  }
+}
+
+/**
+ * Write webhook config to disk atomically.
+ */
+export function writeWebhookConfig(dataDir: string, config: WebhookConfig): void {
+  const fp = configFilePath(dataDir);
+  const dir = path.dirname(fp);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  // Strip secrets from disk representation? No — we need them for signing.
+  // But we DO redact in API responses (see route handler).
+  const tmpFp = fp + '.tmp';
+  fs.writeFileSync(tmpFp, JSON.stringify(config, null, 2));
+  fs.renameSync(tmpFp, fp);
+}
+
+/**
+ * Sanitize/normalize a parsed config object.
+ * Fills missing fields with defaults, validates types.
+ * Pure function.
+ */
+export function sanitizeConfig(raw: unknown): WebhookConfig {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ...DEFAULT_WEBHOOK_CONFIG, targets: [] };
+  }
+
+  const obj = raw as Record<string, unknown>;
+
+  const enabled = typeof obj.enabled === 'boolean' ? obj.enabled : false;
+  const cooldownMs = typeof obj.cooldownMs === 'number' && isFinite(obj.cooldownMs) && obj.cooldownMs >= 0
+    ? obj.cooldownMs
+    : DEFAULT_COOLDOWN_MS;
+  const timeoutMs = typeof obj.timeoutMs === 'number' && isFinite(obj.timeoutMs) && obj.timeoutMs >= 1000
+    ? Math.min(obj.timeoutMs, 30000)
+    : DEFAULT_TIMEOUT_MS;
+  const maxRetries = typeof obj.maxRetries === 'number' && isFinite(obj.maxRetries) && obj.maxRetries >= 0
+    ? Math.min(Math.floor(obj.maxRetries), 5)
+    : DEFAULT_MAX_RETRIES;
+
+  const targets: WebhookTarget[] = [];
+  if (Array.isArray(obj.targets)) {
+    for (const t of obj.targets.slice(0, MAX_TARGETS)) {
+      if (t && typeof t === 'object' && !Array.isArray(t)) {
+        const tObj = t as Record<string, unknown>;
+        if (typeof tObj.id === 'string' && typeof tObj.url === 'string') {
+          targets.push({
+            id: tObj.id.slice(0, 64),
+            name: typeof tObj.name === 'string' ? tObj.name.slice(0, MAX_NAME_LENGTH) : tObj.id.slice(0, MAX_NAME_LENGTH),
+            url: tObj.url.slice(0, MAX_URL_LENGTH),
+            enabled: typeof tObj.enabled === 'boolean' ? tObj.enabled : false,
+            secret: typeof tObj.secret === 'string' ? tObj.secret.slice(0, MAX_SECRET_LENGTH) : undefined,
+            minSeverity: typeof tObj.minSeverity === 'string' && ['ok', 'warning', 'critical'].includes(tObj.minSeverity)
+              ? (tObj.minSeverity as AlertSeverity)
+              : 'warning',
+          });
+        }
+      }
+    }
+  }
+
+  return { enabled, targets, cooldownMs, timeoutMs, maxRetries };
+}
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+/**
+ * Validate webhook config input (for PUT requests).
+ * Returns array of errors (empty = valid).
+ * Pure function.
+ */
+export function validateWebhookConfig(input: unknown): WebhookConfigValidationError[] {
+  const errors: WebhookConfigValidationError[] = [];
+
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    errors.push({ field: 'root', message: 'config must be a non-null object' });
+    return errors;
+  }
+
+  const obj = input as Record<string, unknown>;
+
+  if (obj.enabled !== undefined && typeof obj.enabled !== 'boolean') {
+    errors.push({ field: 'enabled', message: 'enabled must be a boolean' });
+  }
+
+  if (obj.cooldownMs !== undefined) {
+    if (typeof obj.cooldownMs !== 'number' || !isFinite(obj.cooldownMs) || obj.cooldownMs < 0) {
+      errors.push({ field: 'cooldownMs', message: 'cooldownMs must be a non-negative finite number' });
+    }
+  }
+
+  if (obj.timeoutMs !== undefined) {
+    if (typeof obj.timeoutMs !== 'number' || !isFinite(obj.timeoutMs) || obj.timeoutMs < 1000 || obj.timeoutMs > 30000) {
+      errors.push({ field: 'timeoutMs', message: 'timeoutMs must be between 1000 and 30000' });
+    }
+  }
+
+  if (obj.maxRetries !== undefined) {
+    if (typeof obj.maxRetries !== 'number' || !isFinite(obj.maxRetries) || obj.maxRetries < 0 || obj.maxRetries > 5) {
+      errors.push({ field: 'maxRetries', message: 'maxRetries must be between 0 and 5' });
+    }
+  }
+
+  if (obj.targets !== undefined) {
+    if (!Array.isArray(obj.targets)) {
+      errors.push({ field: 'targets', message: 'targets must be an array' });
+    } else {
+      if (obj.targets.length > MAX_TARGETS) {
+        errors.push({ field: 'targets', message: `maximum ${MAX_TARGETS} targets allowed` });
+      }
+
+      const seenIds = new Set<string>();
+      for (let i = 0; i < obj.targets.length; i++) {
+        const t = obj.targets[i];
+        const prefix = `targets[${i}]`;
+
+        if (!t || typeof t !== 'object' || Array.isArray(t)) {
+          errors.push({ field: prefix, message: 'target must be an object' });
+          continue;
+        }
+
+        const tObj = t as Record<string, unknown>;
+
+        if (typeof tObj.id !== 'string' || tObj.id.trim().length === 0) {
+          errors.push({ field: `${prefix}.id`, message: 'id is required and must be a non-empty string' });
+        } else if (seenIds.has(tObj.id)) {
+          errors.push({ field: `${prefix}.id`, message: `duplicate target id: ${tObj.id}` });
+        } else {
+          seenIds.add(tObj.id);
+        }
+
+        if (typeof tObj.url !== 'string' || tObj.url.trim().length === 0) {
+          errors.push({ field: `${prefix}.url`, message: 'url is required and must be a non-empty string' });
+        } else {
+          try {
+            const parsed = new URL(tObj.url);
+            const isLocalhost = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1' || parsed.hostname === '::1';
+            if (parsed.protocol !== 'https:' && !(parsed.protocol === 'http:' && isLocalhost)) {
+              errors.push({ field: `${prefix}.url`, message: 'url must use HTTPS (HTTP allowed only for localhost)' });
+            }
+          } catch {
+            errors.push({ field: `${prefix}.url`, message: 'url must be a valid URL' });
+          }
+
+          if (tObj.url.length > MAX_URL_LENGTH) {
+            errors.push({ field: `${prefix}.url`, message: `url must be ≤ ${MAX_URL_LENGTH} characters` });
+          }
+        }
+
+        if (tObj.name !== undefined && typeof tObj.name !== 'string') {
+          errors.push({ field: `${prefix}.name`, message: 'name must be a string' });
+        }
+
+        if (tObj.enabled !== undefined && typeof tObj.enabled !== 'boolean') {
+          errors.push({ field: `${prefix}.enabled`, message: 'enabled must be a boolean' });
+        }
+
+        if (tObj.secret !== undefined && typeof tObj.secret !== 'string') {
+          errors.push({ field: `${prefix}.secret`, message: 'secret must be a string' });
+        }
+
+        if (tObj.minSeverity !== undefined) {
+          if (typeof tObj.minSeverity !== 'string' || !['ok', 'warning', 'critical'].includes(tObj.minSeverity)) {
+            errors.push({ field: `${prefix}.minSeverity`, message: 'minSeverity must be ok, warning, or critical' });
+          }
+        }
+      }
+    }
+  }
+
+  return errors;
+}
+
+// ─── Redaction (for API responses) ───────────────────────────────────────────
+
+/**
+ * Redact secrets from a webhook config for safe API responses.
+ * Replaces secret values with a boolean indicator.
+ * Pure function.
+ */
+export function redactConfig(config: WebhookConfig): WebhookConfig & { targets: Array<Omit<WebhookTarget, 'secret'> & { hasSecret: boolean }> } {
+  return {
+    ...config,
+    targets: config.targets.map((t) => {
+      const { secret, ...rest } = t;
+      return { ...rest, hasSecret: !!secret };
+    }),
+  };
+}
+
+// ─── URL masking for logs ────────────────────────────────────────────────────
+
+/**
+ * Mask a webhook URL for safe logging.
+ * Shows protocol + host, masks the path.
+ */
+export function maskUrl(url: string): string {
+  try {
+    const parsed = new URL(url);
+    return `${parsed.protocol}//${parsed.host}/***`;
+  } catch {
+    return '***invalid-url***';
+  }
+}
+
+// ─── Payload construction ────────────────────────────────────────────────────
+
+/**
+ * Build the webhook payload for an alert transition.
+ * Pure function.
+ */
+export function buildWebhookPayload(
+  evaluation: AlertEvaluation,
+  previousSeverity: AlertSeverity | null,
+): WebhookPayload {
+  const now = evaluation.evaluatedAt;
+  const current = evaluation.overallSeverity;
+  const prev = previousSeverity;
+
+  let transitionLabel: string;
+  if (prev === null) {
+    transitionLabel = `Initial evaluation: ${current}`;
+  } else if (prev === current) {
+    transitionLabel = `Severity unchanged: ${current}`;
+  } else {
+    const direction = SEVERITY_PRIORITY[current] > SEVERITY_PRIORITY[prev] ? 'escalated' : 'de-escalated';
+    transitionLabel = `Alert ${direction}: ${prev} → ${current}`;
+  }
+
+  return {
+    event: 'alert.transition',
+    timestamp: now,
+    timestampISO: new Date(now).toISOString(),
+    previousSeverity: prev,
+    currentSeverity: current,
+    transitionLabel,
+    evaluation: {
+      evaluatedAt: evaluation.evaluatedAt,
+      overallSeverity: evaluation.overallSeverity,
+      severityCounts: { ...evaluation.severityCounts },
+      rules: evaluation.rules.map((r) => ({
+        rule: r.rule,
+        label: r.label,
+        enabled: r.enabled,
+        severity: r.severity,
+        currentValue: r.currentValue,
+        warningThreshold: r.warningThreshold,
+        criticalThreshold: r.criticalThreshold,
+        message: r.message,
+      })),
+    },
+    source: 'ventureos-dashboard',
+    schemaVersion: 1,
+  };
+}
+
+// ─── HMAC Signing ────────────────────────────────────────────────────────────
+
+/**
+ * Compute HMAC-SHA256 signature for a payload body.
+ * Returns hex-encoded digest.
+ */
+export async function computeSignature(body: string, secret: string): Promise<string> {
+  // Use dynamic import so we don't add a top-level dependency issue
+  const { createHmac } = await import('node:crypto');
+  return createHmac('sha256', secret).update(body).digest('hex');
+}
+
+// ─── HTTP Delivery ───────────────────────────────────────────────────────────
+
+/**
+ * Deliver a webhook payload to a single target with retry/backoff.
+ * Non-blocking — catches all errors and returns a result.
+ *
+ * Retry strategy: exponential backoff starting at 1s, capped at 3 attempts.
+ * Each attempt has a bounded timeout.
+ */
+export async function deliverWebhook(
+  target: WebhookTarget,
+  payload: WebhookPayload,
+  opts: { timeoutMs?: number; maxRetries?: number } = {},
+): Promise<WebhookDeliveryResult> {
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
+  const body = JSON.stringify(payload);
+  const startMs = Date.now();
+
+  let lastError: string | null = null;
+  let lastStatusCode: number | null = null;
+  let attempts = 0;
+
+  for (let attempt = 0; attempt < maxRetries; attempt++) {
+    attempts++;
+
+    // Exponential backoff: 0, 1s, 2s (only between retries)
+    if (attempt > 0) {
+      const delayMs = Math.min(1000 * Math.pow(2, attempt - 1), 4000);
+      await new Promise((resolve) => setTimeout(resolve, delayMs));
+    }
+
+    try {
+      const headers: Record<string, string> = {
+        'Content-Type': 'application/json',
+        'User-Agent': 'VentureOS-Dashboard/1.0',
+        'X-VentureOS-Event': 'alert.transition',
+      };
+
+      // Add HMAC signature if secret is configured
+      if (target.secret) {
+        const signature = await computeSignature(body, target.secret);
+        headers['X-VentureOS-Signature'] = `sha256=${signature}`;
+      }
+
+      const controller = new AbortController();
+      const timer = setTimeout(() => controller.abort(), timeoutMs);
+
+      try {
+        const response = await fetch(target.url, {
+          method: 'POST',
+          headers,
+          body,
+          signal: controller.signal,
+        });
+
+        clearTimeout(timer);
+        lastStatusCode = response.status;
+
+        if (response.ok) {
+          return {
+            targetId: target.id,
+            targetName: target.name,
+            success: true,
+            statusCode: response.status,
+            attempts,
+            error: null,
+            durationMs: Date.now() - startMs,
+          };
+        }
+
+        // Non-retryable status codes (client errors)
+        if (response.status >= 400 && response.status < 500) {
+          lastError = `HTTP ${response.status}`;
+          break; // Don't retry client errors
+        }
+
+        lastError = `HTTP ${response.status}`;
+      } catch (fetchErr: unknown) {
+        clearTimeout(timer);
+        if (fetchErr instanceof Error) {
+          lastError = fetchErr.name === 'AbortError'
+            ? `timeout after ${timeoutMs}ms`
+            : fetchErr.message;
+        } else {
+          lastError = 'unknown fetch error';
+        }
+      }
+    } catch (outerErr: unknown) {
+      lastError = outerErr instanceof Error ? outerErr.message : 'unknown error';
+    }
+  }
+
+  return {
+    targetId: target.id,
+    targetName: target.name,
+    success: false,
+    statusCode: lastStatusCode,
+    attempts,
+    error: lastError,
+    durationMs: Date.now() - startMs,
+  };
+}
+
+// ─── Transition Detection & Dispatch ─────────────────────────────────────────
+
+/**
+ * Determine if the current evaluation represents a severity transition
+ * compared to the previously known state.
+ * Pure function.
+ */
+export function isTransition(
+  current: AlertSeverity,
+  previous: AlertSeverity | null,
+): boolean {
+  if (previous === null) return true; // First evaluation
+  return current !== previous;
+}
+
+/**
+ * Determine which targets should receive a notification based on
+ * the transition severity and per-target minSeverity filter + cooldown.
+ * Pure function.
+ */
+export function selectTargets(
+  targets: WebhookTarget[],
+  currentSeverity: AlertSeverity,
+  state: WebhookDeliveryState,
+  cooldownMs: number,
+  now: number,
+): WebhookTarget[] {
+  return targets.filter((t) => {
+    if (!t.enabled) return false;
+
+    // Check severity filter
+    const minPriority = SEVERITY_PRIORITY[t.minSeverity ?? 'warning'];
+    if (SEVERITY_PRIORITY[currentSeverity] < minPriority) return false;
+
+    // Check cooldown
+    const lastDelivery = state.lastDeliveryAt[t.id] ?? 0;
+    if (now - lastDelivery < cooldownMs) return false;
+
+    return true;
+  });
+}
+
+/**
+ * Main entry point: check for alert transitions and dispatch webhooks.
+ *
+ * Called inline during metrics evaluation (same pattern as alert-history).
+ * Non-blocking — fires delivery promises and does not await them in the
+ * critical path (unless the caller explicitly awaits the return).
+ *
+ * Returns a promise that resolves to delivery results (for testing/logging).
+ * In production, the caller can fire-and-forget.
+ */
+export async function maybeDeliverWebhooks(
+  dataDir: string,
+  evaluation: AlertEvaluation,
+  opts: { now?: number } = {},
+): Promise<WebhookDeliveryResult[]> {
+  const now = opts.now ?? evaluation.evaluatedAt;
+  const config = readWebhookConfig(dataDir);
+
+  // Global kill switch
+  if (!config.enabled) return [];
+
+  // No targets configured
+  if (config.targets.length === 0) return [];
+
+  const currentSeverity = evaluation.overallSeverity;
+  const previousSeverity = deliveryState.lastSeverity;
+
+  // Only deliver on actual transitions
+  if (!isTransition(currentSeverity, previousSeverity)) return [];
+
+  // Update tracked severity immediately (before async delivery)
+  deliveryState.lastSeverity = currentSeverity;
+
+  const cooldownMs = config.cooldownMs ?? DEFAULT_COOLDOWN_MS;
+  const eligibleTargets = selectTargets(
+    config.targets,
+    currentSeverity,
+    deliveryState,
+    cooldownMs,
+    now,
+  );
+
+  if (eligibleTargets.length === 0) return [];
+
+  const payload = buildWebhookPayload(evaluation, previousSeverity);
+  const deliveryOpts = {
+    timeoutMs: config.timeoutMs ?? DEFAULT_TIMEOUT_MS,
+    maxRetries: config.maxRetries ?? DEFAULT_MAX_RETRIES,
+  };
+
+  // Deliver to all eligible targets concurrently
+  const results = await Promise.all(
+    eligibleTargets.map(async (target) => {
+      const result = await deliverWebhook(target, payload, deliveryOpts);
+      // Update last delivery timestamp on success
+      if (result.success) {
+        deliveryState.lastDeliveryAt[target.id] = now;
+      }
+      return result;
+    }),
+  );
+
+  return results;
+}

--- a/dashboard/server/routes/index.ts
+++ b/dashboard/server/routes/index.ts
@@ -75,3 +75,28 @@ export type {
   AlertHistoryQuery,
   AlertTimelineSummary,
 } from '../alert-history.js';
+export {
+  readWebhookConfig,
+  writeWebhookConfig,
+  validateWebhookConfig,
+  sanitizeConfig as sanitizeWebhookConfig,
+  redactConfig as redactWebhookConfig,
+  buildWebhookPayload,
+  deliverWebhook,
+  maybeDeliverWebhooks,
+  isTransition,
+  selectTargets,
+  resetDeliveryState,
+  getDeliveryState,
+  maskUrl,
+  computeSignature,
+  DEFAULT_WEBHOOK_CONFIG,
+} from '../alert-webhook.js';
+export type {
+  WebhookConfig,
+  WebhookTarget,
+  WebhookPayload,
+  WebhookDeliveryResult,
+  WebhookDeliveryState,
+  WebhookConfigValidationError,
+} from '../alert-webhook.js';

--- a/dashboard/server/routes/task-board.ts
+++ b/dashboard/server/routes/task-board.ts
@@ -60,6 +60,15 @@ import {
   queryAlertTimeline,
 } from '../alert-history.js';
 
+import {
+  readWebhookConfig,
+  writeWebhookConfig,
+  validateWebhookConfig,
+  sanitizeConfig as sanitizeWebhookConfig,
+  redactConfig as redactWebhookConfig,
+  maybeDeliverWebhooks,
+} from '../alert-webhook.js';
+
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 const VALID_STATUSES: TaskStatus[] = ['backlog', 'queued', 'running', 'done', 'failed'];
@@ -761,6 +770,38 @@ export async function handleTaskBoard(
     return true;
   }
 
+  // ── GET /api/task-board/webhooks/config — Issue #219, Phase 11 ──────────────
+  // Read/write webhook notification configuration.
+  // GET: returns current config (secrets redacted).
+  // PUT: updates config (validated).
+  if (url.startsWith('/api/task-board/webhooks/config') && method === 'GET') {
+    const config = readWebhookConfig(dataDir);
+    sendJson(res, { config: redactWebhookConfig(config) });
+    return true;
+  }
+
+  if (url.startsWith('/api/task-board/webhooks/config') && method === 'PUT') {
+    let body: unknown;
+    try {
+      const raw = await readRequestBody(req, { maxBytes: 8192 });
+      body = JSON.parse(raw);
+    } catch {
+      sendJson(res, { error: 'invalid JSON body' }, 400);
+      return true;
+    }
+
+    const errors = validateWebhookConfig(body);
+    if (errors.length > 0) {
+      sendJson(res, { error: 'validation failed', errors }, 400);
+      return true;
+    }
+
+    const sanitized = sanitizeWebhookConfig(body);
+    writeWebhookConfig(dataDir, sanitized);
+    sendJson(res, { config: redactWebhookConfig(sanitized) });
+    return true;
+  }
+
   // ── GET /api/task-board/metrics — Issue #219, Task Metrics Dashboard ───────
   // Returns computed metrics: throughput, runtime stats, trends, stuck tasks.
   // Optional query params:
@@ -799,6 +840,17 @@ export async function handleTaskBoard(
     if (metrics.alerts) {
       try {
         maybeAppendAlertEvent(dataDir, metrics.alerts);
+      } catch {
+        // Non-critical — don't break the metrics response
+      }
+    }
+
+    // Piggyback (Phase 11): fire webhook notifications on severity transitions.
+    // Fire-and-forget — delivery is async and non-blocking.
+    if (metrics.alerts) {
+      try {
+        // Intentionally not awaited — delivery runs in background
+        void maybeDeliverWebhooks(dataDir, metrics.alerts);
       } catch {
         // Non-critical — don't break the metrics response
       }

--- a/dashboard/tests/unit/routes/task-board-webhook.test.ts
+++ b/dashboard/tests/unit/routes/task-board-webhook.test.ts
@@ -1,0 +1,961 @@
+/**
+ * Alert Webhook tests — Issue #219, Phase 11: Webhook Notification Baseline.
+ *
+ * Tests for:
+ * - validateWebhookConfig() — config validation
+ * - sanitizeConfig() — config normalization
+ * - readWebhookConfig() / writeWebhookConfig() — config persistence
+ * - redactConfig() — secret redaction for API responses
+ * - maskUrl() — URL masking for logs
+ * - buildWebhookPayload() — payload construction & schema
+ * - computeSignature() — HMAC-SHA256 signing
+ * - isTransition() — transition detection
+ * - selectTargets() — target selection with cooldown + severity filter
+ * - deliverWebhook() — HTTP delivery with retry/backoff
+ * - maybeDeliverWebhooks() — full dispatch pipeline
+ * - GET /api/task-board/webhooks/config — read endpoint
+ * - PUT /api/task-board/webhooks/config — write endpoint
+ * - Webhook trigger via GET /api/task-board/metrics — piggyback delivery
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { mockRequest, mockResponse, parseJsonBody } from '../../helpers.js';
+import {
+  handleTaskBoard,
+} from '../../../server/routes/task-board.js';
+import {
+  readWebhookConfig,
+  writeWebhookConfig,
+  validateWebhookConfig,
+  sanitizeConfig,
+  redactConfig,
+  buildWebhookPayload,
+  deliverWebhook,
+  maybeDeliverWebhooks,
+  isTransition,
+  selectTargets,
+  resetDeliveryState,
+  getDeliveryState,
+  maskUrl,
+  computeSignature,
+  DEFAULT_WEBHOOK_CONFIG,
+} from '../../../server/alert-webhook.js';
+import {
+  evaluateAlerts,
+  DEFAULT_ALERT_CONFIG,
+} from '../../../server/alert-rules.js';
+import type {
+  AlertEvaluation,
+  AlertMetricsInput,
+  AlertSeverity,
+} from '../../../server/alert-rules.js';
+import type {
+  WebhookConfig,
+  WebhookTarget,
+  WebhookDeliveryState,
+} from '../../../server/alert-webhook.js';
+import type { TaskBoardDeps, TaskCard } from '../../../server/types.js';
+
+const testDataDir = path.join('/tmp', 'test-webhook-' + process.pid);
+
+function createDeps(overrides: Partial<TaskBoardDeps> = {}): TaskBoardDeps {
+  return {
+    dataDir: testDataDir,
+    sendJson: (res, data, status = 200) => {
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+    },
+    readRequestBody: async () => '{}',
+    ...overrides,
+  };
+}
+
+function makeSampleCard(overrides: Partial<TaskCard> = {}): TaskCard {
+  return {
+    id: 'test-' + Math.random().toString(36).slice(2, 8),
+    agentId: 'oracle',
+    title: 'Test task',
+    description: 'A test task',
+    priority: 'medium',
+    status: 'backlog',
+    createdAt: Date.now(),
+    queuedAt: null,
+    startedAt: null,
+    completedAt: null,
+    resultSummary: null,
+    tokensUsed: null,
+    error: null,
+    costEstimate: null,
+    runtimeMs: null,
+    ...overrides,
+  };
+}
+
+function seedTasks(tasks: TaskCard[]): void {
+  fs.mkdirSync(testDataDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(testDataDir, 'task-board.json'),
+    JSON.stringify({ tasks, updatedAt: Date.now() }),
+  );
+}
+
+function metricsInput(overrides: Partial<AlertMetricsInput> = {}): AlertMetricsInput {
+  return {
+    statusCounts: { backlog: 5, queued: 2, running: 1, done: 10, failed: 2 },
+    successRate: 0.8,
+    stuckCount: 0,
+    avgRuntimeMs: 60000,
+    total: 20,
+    ...overrides,
+  };
+}
+
+function makeEvaluation(overrides: Partial<AlertEvaluation> = {}): AlertEvaluation {
+  return evaluateAlerts(metricsInput(), DEFAULT_ALERT_CONFIG, Date.now(), ...[] as never[]) ?? {
+    evaluatedAt: Date.now(),
+    overallSeverity: 'ok' as AlertSeverity,
+    severityCounts: { ok: 5, warning: 0, critical: 0 },
+    rules: [],
+    ...overrides,
+  };
+}
+
+function makeTarget(overrides: Partial<WebhookTarget> = {}): WebhookTarget {
+  return {
+    id: 'test-target',
+    name: 'Test Target',
+    url: 'https://example.com/webhook',
+    enabled: true,
+    minSeverity: 'warning',
+    ...overrides,
+  };
+}
+
+function makeConfig(overrides: Partial<WebhookConfig> = {}): WebhookConfig {
+  return {
+    enabled: true,
+    targets: [makeTarget()],
+    cooldownMs: 60000,
+    timeoutMs: 10000,
+    maxRetries: 3,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  fs.mkdirSync(testDataDir, { recursive: true });
+  resetDeliveryState();
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(testDataDir, { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup errors
+  }
+  vi.restoreAllMocks();
+});
+
+// ─── validateWebhookConfig ───────────────────────────────────────────────────
+
+describe('validateWebhookConfig', () => {
+  it('accepts a valid minimal config', () => {
+    const errors = validateWebhookConfig({ enabled: false, targets: [] });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('accepts a valid config with targets', () => {
+    const errors = validateWebhookConfig({
+      enabled: true,
+      targets: [{
+        id: 'slack',
+        name: 'Slack',
+        url: 'https://hooks.slack.com/services/xxx',
+        enabled: true,
+      }],
+    });
+    expect(errors).toHaveLength(0);
+  });
+
+  it('rejects non-object input', () => {
+    expect(validateWebhookConfig(null)).toHaveLength(1);
+    expect(validateWebhookConfig('string')).toHaveLength(1);
+    expect(validateWebhookConfig([])).toHaveLength(1);
+    expect(validateWebhookConfig(42)).toHaveLength(1);
+  });
+
+  it('rejects invalid enabled type', () => {
+    const errors = validateWebhookConfig({ enabled: 'yes' });
+    expect(errors.some(e => e.field === 'enabled')).toBe(true);
+  });
+
+  it('rejects invalid cooldownMs', () => {
+    const errors = validateWebhookConfig({ cooldownMs: -1 });
+    expect(errors.some(e => e.field === 'cooldownMs')).toBe(true);
+  });
+
+  it('rejects invalid timeoutMs range', () => {
+    expect(validateWebhookConfig({ timeoutMs: 500 }).some(e => e.field === 'timeoutMs')).toBe(true);
+    expect(validateWebhookConfig({ timeoutMs: 50000 }).some(e => e.field === 'timeoutMs')).toBe(true);
+  });
+
+  it('rejects invalid maxRetries', () => {
+    expect(validateWebhookConfig({ maxRetries: -1 }).some(e => e.field === 'maxRetries')).toBe(true);
+    expect(validateWebhookConfig({ maxRetries: 10 }).some(e => e.field === 'maxRetries')).toBe(true);
+  });
+
+  it('rejects too many targets', () => {
+    const targets = Array.from({ length: 6 }, (_, i) => ({
+      id: `t${i}`, name: `T${i}`, url: `https://example.com/${i}`, enabled: true,
+    }));
+    const errors = validateWebhookConfig({ targets });
+    expect(errors.some(e => e.field === 'targets')).toBe(true);
+  });
+
+  it('rejects duplicate target ids', () => {
+    const targets = [
+      { id: 'dup', name: 'A', url: 'https://example.com/a', enabled: true },
+      { id: 'dup', name: 'B', url: 'https://example.com/b', enabled: true },
+    ];
+    const errors = validateWebhookConfig({ targets });
+    expect(errors.some(e => e.message.includes('duplicate'))).toBe(true);
+  });
+
+  it('rejects HTTP URLs for non-localhost', () => {
+    const errors = validateWebhookConfig({
+      targets: [{ id: 'bad', url: 'http://external.com/hook', enabled: true }],
+    });
+    expect(errors.some(e => e.message.includes('HTTPS'))).toBe(true);
+  });
+
+  it('allows HTTP for localhost', () => {
+    const errors = validateWebhookConfig({
+      targets: [{ id: 'local', url: 'http://localhost:3000/hook', enabled: true }],
+    });
+    const urlErrors = errors.filter(e => e.field.includes('url'));
+    expect(urlErrors).toHaveLength(0);
+  });
+
+  it('allows HTTP for 127.0.0.1', () => {
+    const errors = validateWebhookConfig({
+      targets: [{ id: 'local', url: 'http://127.0.0.1:9090/hook', enabled: true }],
+    });
+    const urlErrors = errors.filter(e => e.field.includes('url'));
+    expect(urlErrors).toHaveLength(0);
+  });
+
+  it('rejects invalid URL', () => {
+    const errors = validateWebhookConfig({
+      targets: [{ id: 'bad', url: 'not-a-url', enabled: true }],
+    });
+    expect(errors.some(e => e.message.includes('valid URL'))).toBe(true);
+  });
+
+  it('rejects target without id', () => {
+    const errors = validateWebhookConfig({
+      targets: [{ url: 'https://example.com', enabled: true }],
+    });
+    expect(errors.some(e => e.field.includes('.id'))).toBe(true);
+  });
+
+  it('rejects target without url', () => {
+    const errors = validateWebhookConfig({
+      targets: [{ id: 'no-url', enabled: true }],
+    });
+    expect(errors.some(e => e.field.includes('.url'))).toBe(true);
+  });
+
+  it('rejects invalid minSeverity', () => {
+    const errors = validateWebhookConfig({
+      targets: [{ id: 't', url: 'https://example.com', minSeverity: 'extreme' }],
+    });
+    expect(errors.some(e => e.field.includes('minSeverity'))).toBe(true);
+  });
+
+  it('accepts valid minSeverity values', () => {
+    for (const sev of ['ok', 'warning', 'critical']) {
+      const errors = validateWebhookConfig({
+        targets: [{ id: 't', url: 'https://example.com', enabled: true, minSeverity: sev }],
+      });
+      const sevErrors = errors.filter(e => e.field.includes('minSeverity'));
+      expect(sevErrors).toHaveLength(0);
+    }
+  });
+});
+
+// ─── sanitizeConfig ──────────────────────────────────────────────────────────
+
+describe('sanitizeConfig', () => {
+  it('returns defaults for null/undefined', () => {
+    expect(sanitizeConfig(null)).toEqual(DEFAULT_WEBHOOK_CONFIG);
+    expect(sanitizeConfig(undefined)).toEqual(DEFAULT_WEBHOOK_CONFIG);
+  });
+
+  it('sanitizes a valid config', () => {
+    const result = sanitizeConfig({
+      enabled: true,
+      targets: [{ id: 'a', url: 'https://x.com', enabled: true }],
+      cooldownMs: 30000,
+    });
+    expect(result.enabled).toBe(true);
+    expect(result.targets).toHaveLength(1);
+    expect(result.cooldownMs).toBe(30000);
+  });
+
+  it('caps maxRetries at 5', () => {
+    const result = sanitizeConfig({ maxRetries: 100 });
+    expect(result.maxRetries).toBe(5);
+  });
+
+  it('caps timeoutMs at 30000', () => {
+    const result = sanitizeConfig({ timeoutMs: 99999 });
+    expect(result.timeoutMs).toBe(30000);
+  });
+
+  it('caps targets at 5', () => {
+    const targets = Array.from({ length: 10 }, (_, i) => ({
+      id: `t${i}`, url: `https://x.com/${i}`, enabled: true,
+    }));
+    const result = sanitizeConfig({ targets });
+    expect(result.targets).toHaveLength(5);
+  });
+
+  it('defaults minSeverity to warning', () => {
+    const result = sanitizeConfig({
+      targets: [{ id: 'a', url: 'https://x.com', enabled: true }],
+    });
+    expect(result.targets[0].minSeverity).toBe('warning');
+  });
+});
+
+// ─── Config I/O ──────────────────────────────────────────────────────────────
+
+describe('readWebhookConfig / writeWebhookConfig', () => {
+  it('returns defaults when no file exists', () => {
+    const config = readWebhookConfig(testDataDir);
+    expect(config.enabled).toBe(false);
+    expect(config.targets).toHaveLength(0);
+  });
+
+  it('round-trips a config to disk', () => {
+    const config = makeConfig();
+    writeWebhookConfig(testDataDir, config);
+    const read = readWebhookConfig(testDataDir);
+    expect(read.enabled).toBe(true);
+    expect(read.targets).toHaveLength(1);
+    expect(read.targets[0].id).toBe('test-target');
+  });
+
+  it('returns defaults for corrupt file', () => {
+    fs.writeFileSync(path.join(testDataDir, 'task-board-webhook-config.json'), '{corrupt');
+    const config = readWebhookConfig(testDataDir);
+    expect(config.enabled).toBe(false);
+  });
+});
+
+// ─── redactConfig ────────────────────────────────────────────────────────────
+
+describe('redactConfig', () => {
+  it('replaces secret with hasSecret flag', () => {
+    const config = makeConfig({
+      targets: [makeTarget({ secret: 'my-super-secret' })],
+    });
+    const redacted = redactConfig(config);
+    expect((redacted.targets[0] as Record<string, unknown>).secret).toBeUndefined();
+    expect(redacted.targets[0].hasSecret).toBe(true);
+  });
+
+  it('sets hasSecret to false when no secret', () => {
+    const config = makeConfig({
+      targets: [makeTarget()],
+    });
+    const redacted = redactConfig(config);
+    expect(redacted.targets[0].hasSecret).toBe(false);
+  });
+});
+
+// ─── maskUrl ─────────────────────────────────────────────────────────────────
+
+describe('maskUrl', () => {
+  it('masks the path of a valid URL', () => {
+    expect(maskUrl('https://hooks.slack.com/services/xxx/yyy')).toBe('https://hooks.slack.com/***');
+  });
+
+  it('handles invalid URLs gracefully', () => {
+    expect(maskUrl('not-a-url')).toBe('***invalid-url***');
+  });
+});
+
+// ─── buildWebhookPayload ─────────────────────────────────────────────────────
+
+describe('buildWebhookPayload', () => {
+  it('builds a valid payload with correct schema', () => {
+    const evaluation = makeEvaluation();
+    const payload = buildWebhookPayload(evaluation, null);
+
+    expect(payload.event).toBe('alert.transition');
+    expect(payload.source).toBe('ventureos-dashboard');
+    expect(payload.schemaVersion).toBe(1);
+    expect(payload.timestamp).toBe(evaluation.evaluatedAt);
+    expect(payload.timestampISO).toBeTruthy();
+    expect(payload.previousSeverity).toBeNull();
+    expect(payload.currentSeverity).toBe(evaluation.overallSeverity);
+    expect(payload.evaluation).toBeDefined();
+    expect(payload.evaluation.rules).toBeInstanceOf(Array);
+  });
+
+  it('labels escalation correctly', () => {
+    const config = {
+      ...DEFAULT_ALERT_CONFIG,
+      stuckCount: { enabled: true, warning: 1, critical: 3 },
+    };
+    const evaluation = evaluateAlerts(metricsInput({ stuckCount: 5 }), config);
+    const payload = buildWebhookPayload(evaluation, 'ok');
+    expect(payload.transitionLabel).toContain('escalated');
+    expect(payload.transitionLabel).toContain('ok → critical');
+  });
+
+  it('labels de-escalation correctly', () => {
+    const evaluation = makeEvaluation();
+    const payload = buildWebhookPayload(evaluation, 'critical');
+    expect(payload.transitionLabel).toContain('de-escalated');
+  });
+
+  it('labels initial evaluation', () => {
+    const evaluation = makeEvaluation();
+    const payload = buildWebhookPayload(evaluation, null);
+    expect(payload.transitionLabel).toContain('Initial evaluation');
+  });
+
+  it('includes all evaluation rule details', () => {
+    const evaluation = makeEvaluation();
+    const payload = buildWebhookPayload(evaluation, null);
+    expect(payload.evaluation.rules.length).toBeGreaterThan(0);
+    for (const rule of payload.evaluation.rules) {
+      expect(rule).toHaveProperty('rule');
+      expect(rule).toHaveProperty('label');
+      expect(rule).toHaveProperty('severity');
+      expect(rule).toHaveProperty('message');
+    }
+  });
+});
+
+// ─── computeSignature ────────────────────────────────────────────────────────
+
+describe('computeSignature', () => {
+  it('produces a hex string', async () => {
+    const sig = await computeSignature('{"test": true}', 'secret123');
+    expect(sig).toMatch(/^[0-9a-f]+$/);
+    expect(sig.length).toBe(64); // SHA-256 = 32 bytes = 64 hex chars
+  });
+
+  it('produces different signatures for different secrets', async () => {
+    const body = '{"test": true}';
+    const sig1 = await computeSignature(body, 'secret1');
+    const sig2 = await computeSignature(body, 'secret2');
+    expect(sig1).not.toBe(sig2);
+  });
+
+  it('produces same signature for same inputs', async () => {
+    const body = '{"test": true}';
+    const sig1 = await computeSignature(body, 'same-secret');
+    const sig2 = await computeSignature(body, 'same-secret');
+    expect(sig1).toBe(sig2);
+  });
+});
+
+// ─── isTransition ────────────────────────────────────────────────────────────
+
+describe('isTransition', () => {
+  it('returns true for first evaluation (null → any)', () => {
+    expect(isTransition('ok', null)).toBe(true);
+    expect(isTransition('warning', null)).toBe(true);
+    expect(isTransition('critical', null)).toBe(true);
+  });
+
+  it('returns true when severity changes', () => {
+    expect(isTransition('warning', 'ok')).toBe(true);
+    expect(isTransition('critical', 'warning')).toBe(true);
+    expect(isTransition('ok', 'critical')).toBe(true);
+  });
+
+  it('returns false when severity is unchanged', () => {
+    expect(isTransition('ok', 'ok')).toBe(false);
+    expect(isTransition('warning', 'warning')).toBe(false);
+    expect(isTransition('critical', 'critical')).toBe(false);
+  });
+});
+
+// ─── selectTargets ───────────────────────────────────────────────────────────
+
+describe('selectTargets', () => {
+  const now = Date.now();
+  const emptyState: WebhookDeliveryState = { lastDeliveryAt: {}, lastSeverity: null };
+
+  it('selects enabled targets matching severity', () => {
+    const targets = [
+      makeTarget({ id: 'a', enabled: true, minSeverity: 'warning' }),
+      makeTarget({ id: 'b', enabled: false, minSeverity: 'warning' }),
+    ];
+    const selected = selectTargets(targets, 'warning', emptyState, 60000, now);
+    expect(selected).toHaveLength(1);
+    expect(selected[0].id).toBe('a');
+  });
+
+  it('filters by minSeverity', () => {
+    const targets = [
+      makeTarget({ id: 'warn-only', minSeverity: 'warning' }),
+      makeTarget({ id: 'crit-only', minSeverity: 'critical' }),
+    ];
+    const selected = selectTargets(targets, 'warning', emptyState, 60000, now);
+    expect(selected).toHaveLength(1);
+    expect(selected[0].id).toBe('warn-only');
+  });
+
+  it('includes targets when severity exceeds minSeverity', () => {
+    const targets = [
+      makeTarget({ id: 'warn', minSeverity: 'warning' }),
+    ];
+    const selected = selectTargets(targets, 'critical', emptyState, 60000, now);
+    expect(selected).toHaveLength(1);
+  });
+
+  it('excludes targets with ok severity when minSeverity is warning', () => {
+    const targets = [makeTarget({ id: 'a', minSeverity: 'warning' })];
+    const selected = selectTargets(targets, 'ok', emptyState, 60000, now);
+    expect(selected).toHaveLength(0);
+  });
+
+  it('respects cooldown period', () => {
+    const targets = [makeTarget({ id: 'a' })];
+    const state: WebhookDeliveryState = {
+      lastDeliveryAt: { a: now - 30000 }, // 30s ago
+      lastSeverity: 'ok',
+    };
+    // Cooldown is 60s, last delivery was 30s ago → should be excluded
+    const selected = selectTargets(targets, 'warning', state, 60000, now);
+    expect(selected).toHaveLength(0);
+  });
+
+  it('includes targets past cooldown', () => {
+    const targets = [makeTarget({ id: 'a' })];
+    const state: WebhookDeliveryState = {
+      lastDeliveryAt: { a: now - 120000 }, // 2 min ago
+      lastSeverity: 'ok',
+    };
+    const selected = selectTargets(targets, 'warning', state, 60000, now);
+    expect(selected).toHaveLength(1);
+  });
+
+  it('includes targets with minSeverity ok for any transition', () => {
+    const targets = [makeTarget({ id: 'all', minSeverity: 'ok' })];
+    const selected = selectTargets(targets, 'ok', emptyState, 60000, now);
+    expect(selected).toHaveLength(1);
+  });
+});
+
+// ─── deliverWebhook ──────────────────────────────────────────────────────────
+
+describe('deliverWebhook', () => {
+  it('returns success for 200 response', async () => {
+    // Mock fetch to return 200
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const target = makeTarget();
+    const payload = buildWebhookPayload(makeEvaluation(), null);
+    const result = await deliverWebhook(target, payload, { maxRetries: 1 });
+
+    expect(result.success).toBe(true);
+    expect(result.statusCode).toBe(200);
+    expect(result.attempts).toBe(1);
+    expect(result.error).toBeNull();
+    expect(result.targetId).toBe('test-target');
+    expect(result.durationMs).toBeGreaterThanOrEqual(0);
+  });
+
+  it('retries on 500 errors', async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({ ok: false, status: 500 })
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const target = makeTarget();
+    const payload = buildWebhookPayload(makeEvaluation(), null);
+    const result = await deliverWebhook(target, payload, { maxRetries: 3, timeoutMs: 5000 });
+
+    expect(result.success).toBe(true);
+    expect(result.attempts).toBe(2);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry on 4xx errors', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: false, status: 404 });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const target = makeTarget();
+    const payload = buildWebhookPayload(makeEvaluation(), null);
+    const result = await deliverWebhook(target, payload, { maxRetries: 3, timeoutMs: 5000 });
+
+    expect(result.success).toBe(false);
+    expect(result.statusCode).toBe(404);
+    expect(result.attempts).toBe(1);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+  });
+
+  it('handles network errors with retry', async () => {
+    const mockFetch = vi.fn()
+      .mockRejectedValueOnce(new Error('ECONNREFUSED'))
+      .mockResolvedValueOnce({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const target = makeTarget();
+    const payload = buildWebhookPayload(makeEvaluation(), null);
+    const result = await deliverWebhook(target, payload, { maxRetries: 2, timeoutMs: 5000 });
+
+    expect(result.success).toBe(true);
+    expect(result.attempts).toBe(2);
+  });
+
+  it('returns failure after exhausting retries', async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error('network down'));
+    vi.stubGlobal('fetch', mockFetch);
+
+    const target = makeTarget();
+    const payload = buildWebhookPayload(makeEvaluation(), null);
+    const result = await deliverWebhook(target, payload, { maxRetries: 2, timeoutMs: 5000 });
+
+    expect(result.success).toBe(false);
+    expect(result.attempts).toBe(2);
+    expect(result.error).toBe('network down');
+  });
+
+  it('sends correct headers', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const target = makeTarget();
+    const payload = buildWebhookPayload(makeEvaluation(), null);
+    await deliverWebhook(target, payload, { maxRetries: 1 });
+
+    const call = mockFetch.mock.calls[0];
+    expect(call[1].headers['Content-Type']).toBe('application/json');
+    expect(call[1].headers['User-Agent']).toBe('VentureOS-Dashboard/1.0');
+    expect(call[1].headers['X-VentureOS-Event']).toBe('alert.transition');
+  });
+
+  it('sends HMAC signature header when secret is configured', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const target = makeTarget({ secret: 'test-secret' });
+    const payload = buildWebhookPayload(makeEvaluation(), null);
+    await deliverWebhook(target, payload, { maxRetries: 1 });
+
+    const call = mockFetch.mock.calls[0];
+    expect(call[1].headers['X-VentureOS-Signature']).toMatch(/^sha256=[0-9a-f]{64}$/);
+  });
+
+  it('does not send signature header without secret', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const target = makeTarget();
+    const payload = buildWebhookPayload(makeEvaluation(), null);
+    await deliverWebhook(target, payload, { maxRetries: 1 });
+
+    const call = mockFetch.mock.calls[0];
+    expect(call[1].headers['X-VentureOS-Signature']).toBeUndefined();
+  });
+
+  it('sends valid JSON payload', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const target = makeTarget();
+    const evaluation = makeEvaluation();
+    const payload = buildWebhookPayload(evaluation, 'ok');
+    await deliverWebhook(target, payload, { maxRetries: 1 });
+
+    const call = mockFetch.mock.calls[0];
+    const sentBody = JSON.parse(call[1].body);
+    expect(sentBody.event).toBe('alert.transition');
+    expect(sentBody.schemaVersion).toBe(1);
+    expect(sentBody.source).toBe('ventureos-dashboard');
+  });
+});
+
+// ─── maybeDeliverWebhooks ────────────────────────────────────────────────────
+
+describe('maybeDeliverWebhooks', () => {
+  it('returns empty when webhooks are disabled', async () => {
+    writeWebhookConfig(testDataDir, { ...DEFAULT_WEBHOOK_CONFIG, enabled: false });
+    const evaluation = makeEvaluation();
+    const results = await maybeDeliverWebhooks(testDataDir, evaluation);
+    expect(results).toHaveLength(0);
+  });
+
+  it('returns empty when no targets configured', async () => {
+    writeWebhookConfig(testDataDir, { ...DEFAULT_WEBHOOK_CONFIG, enabled: true, targets: [] });
+    const evaluation = makeEvaluation();
+    const results = await maybeDeliverWebhooks(testDataDir, evaluation);
+    expect(results).toHaveLength(0);
+  });
+
+  it('returns empty when no transition detected', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', mockFetch);
+
+    writeWebhookConfig(testDataDir, makeConfig());
+
+    // First call — transition from null → ok
+    const eval1 = makeEvaluation();
+    await maybeDeliverWebhooks(testDataDir, eval1);
+
+    // Second call — same severity, no transition
+    const eval2 = makeEvaluation();
+    const results = await maybeDeliverWebhooks(testDataDir, eval2);
+    expect(results).toHaveLength(0);
+  });
+
+  it('delivers on first evaluation (null → severity)', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', mockFetch);
+
+    writeWebhookConfig(testDataDir, makeConfig({
+      targets: [makeTarget({ minSeverity: 'ok' })],
+    }));
+
+    const evaluation = makeEvaluation();
+    const results = await maybeDeliverWebhooks(testDataDir, evaluation);
+    expect(results).toHaveLength(1);
+    expect(results[0].success).toBe(true);
+  });
+
+  it('delivers on severity escalation', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const now = Date.now();
+
+    // Configure with minSeverity: ok + zero cooldown so both transitions fire
+    writeWebhookConfig(testDataDir, makeConfig({
+      targets: [makeTarget({ minSeverity: 'ok' })],
+      cooldownMs: 0,
+    }));
+
+    // All-ok config: high thresholds so nothing triggers
+    const allOkConfig = {
+      ...DEFAULT_ALERT_CONFIG,
+      stuckCount: { enabled: true, warning: 100, critical: 200 },
+      failedRate: { enabled: true, warning: 0.99, critical: 1.0 },
+      backlogSize: { enabled: true, warning: 1000, critical: 2000 },
+      avgRuntime: { enabled: false, warning: 999999, critical: 999999 },
+      queueDepth: { enabled: false, warning: 999, critical: 999 },
+    };
+
+    // First call — initial evaluation at ok severity (null → ok transition)
+    const okEval = evaluateAlerts(metricsInput({ stuckCount: 0 }), allOkConfig, now);
+    expect(okEval.overallSeverity).toBe('ok');
+    await maybeDeliverWebhooks(testDataDir, okEval, { now });
+
+    // Verify first delivery happened
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Now escalate to warning (ok → warning transition)
+    const warningConfig = {
+      ...allOkConfig,
+      stuckCount: { enabled: true, warning: 1, critical: 5 },
+    };
+    const warningEval = evaluateAlerts(metricsInput({ stuckCount: 3 }), warningConfig, now + 1);
+    expect(warningEval.overallSeverity).toBe('warning');
+    const results = await maybeDeliverWebhooks(testDataDir, warningEval, { now: now + 1 });
+    expect(results).toHaveLength(1);
+    expect(results[0].success).toBe(true);
+
+    // Verify the payload has escalation label
+    const lastCallBody = JSON.parse(mockFetch.mock.calls[1][1].body);
+    expect(lastCallBody.transitionLabel).toContain('escalated');
+  });
+
+  it('updates delivery state on success', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', mockFetch);
+
+    const now = Date.now();
+    writeWebhookConfig(testDataDir, makeConfig({
+      targets: [makeTarget({ id: 'tracked', minSeverity: 'ok' })],
+    }));
+
+    const evaluation = makeEvaluation();
+    await maybeDeliverWebhooks(testDataDir, evaluation, { now });
+
+    const state = getDeliveryState();
+    expect(state.lastSeverity).toBe(evaluation.overallSeverity);
+    expect(state.lastDeliveryAt['tracked']).toBe(now);
+  });
+
+  it('delivers to multiple targets concurrently', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', mockFetch);
+
+    writeWebhookConfig(testDataDir, makeConfig({
+      targets: [
+        makeTarget({ id: 'a', minSeverity: 'ok' }),
+        makeTarget({ id: 'b', minSeverity: 'ok' }),
+      ],
+    }));
+
+    const evaluation = makeEvaluation();
+    const results = await maybeDeliverWebhooks(testDataDir, evaluation);
+    expect(results).toHaveLength(2);
+    expect(results.every(r => r.success)).toBe(true);
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});
+
+// ─── API Routes ──────────────────────────────────────────────────────────────
+
+describe('GET /api/task-board/webhooks/config', () => {
+  it('returns default config when no file exists', async () => {
+    const req = mockRequest({ url: '/api/task-board/webhooks/config' });
+    const res = mockResponse();
+    const deps = createDeps();
+
+    const handled = await handleTaskBoard(req, res, deps);
+    expect(handled).toBe(true);
+    expect(res._statusCode).toBe(200);
+
+    const body = parseJsonBody<{ config: WebhookConfig }>(res);
+    expect(body.config.enabled).toBe(false);
+    expect(body.config.targets).toHaveLength(0);
+  });
+
+  it('returns persisted config with secrets redacted', async () => {
+    writeWebhookConfig(testDataDir, makeConfig({
+      targets: [makeTarget({ secret: 'super-secret' })],
+    }));
+
+    const req = mockRequest({ url: '/api/task-board/webhooks/config' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    const body = parseJsonBody<{ config: Record<string, unknown> }>(res);
+    expect((body.config.targets as Array<Record<string, unknown>>)[0].hasSecret).toBe(true);
+    expect((body.config.targets as Array<Record<string, unknown>>)[0].secret).toBeUndefined();
+  });
+});
+
+describe('PUT /api/task-board/webhooks/config', () => {
+  it('writes valid config and returns redacted', async () => {
+    const input = {
+      enabled: true,
+      targets: [{
+        id: 'slack',
+        name: 'Slack',
+        url: 'https://hooks.slack.com/hook',
+        enabled: true,
+        secret: 'my-secret',
+      }],
+    };
+
+    const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+    const res = mockResponse();
+    const deps = createDeps({
+      readRequestBody: async () => JSON.stringify(input),
+    });
+
+    await handleTaskBoard(req, res, deps);
+    expect(res._statusCode).toBe(200);
+
+    const body = parseJsonBody<{ config: Record<string, unknown> }>(res);
+    expect(body.config.enabled).toBe(true);
+    expect((body.config.targets as Array<Record<string, unknown>>)[0].hasSecret).toBe(true);
+
+    // Verify persisted on disk (with secret intact)
+    const onDisk = readWebhookConfig(testDataDir);
+    expect(onDisk.targets[0].secret).toBe('my-secret');
+  });
+
+  it('rejects invalid config with 400', async () => {
+    const input = {
+      enabled: 'not-boolean',
+      targets: [{ url: 'not-a-url' }],
+    };
+
+    const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+    const res = mockResponse();
+    const deps = createDeps({
+      readRequestBody: async () => JSON.stringify(input),
+    });
+
+    await handleTaskBoard(req, res, deps);
+    expect(res._statusCode).toBe(400);
+
+    const body = parseJsonBody<{ error: string; errors: unknown[] }>(res);
+    expect(body.error).toBe('validation failed');
+    expect(body.errors.length).toBeGreaterThan(0);
+  });
+
+  it('rejects invalid JSON with 400', async () => {
+    const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+    const res = mockResponse();
+    const deps = createDeps({
+      readRequestBody: async () => '{invalid',
+    });
+
+    await handleTaskBoard(req, res, deps);
+    expect(res._statusCode).toBe(400);
+  });
+});
+
+// ─── Failure isolation ───────────────────────────────────────────────────────
+
+describe('failure isolation', () => {
+  it('webhook delivery failure does not affect alert evaluation', async () => {
+    // Simulate a config that would trigger delivery, but fetch fails
+    const mockFetch = vi.fn().mockRejectedValue(new Error('network error'));
+    vi.stubGlobal('fetch', mockFetch);
+
+    writeWebhookConfig(testDataDir, makeConfig({
+      targets: [makeTarget({ minSeverity: 'ok' })],
+    }));
+
+    const evaluation = makeEvaluation();
+    // This should not throw
+    const results = await maybeDeliverWebhooks(testDataDir, evaluation);
+    expect(results).toHaveLength(1);
+    expect(results[0].success).toBe(false);
+    expect(results[0].error).toBe('network error');
+  });
+
+  it('corrupt webhook config does not crash', () => {
+    fs.writeFileSync(
+      path.join(testDataDir, 'task-board-webhook-config.json'),
+      'not-json-at-all',
+    );
+    const config = readWebhookConfig(testDataDir);
+    expect(config.enabled).toBe(false);
+    expect(config.targets).toHaveLength(0);
+  });
+});
+
+// ─── Delivery state management ───────────────────────────────────────────────
+
+describe('delivery state', () => {
+  it('resetDeliveryState clears all state', () => {
+    // Modify state
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', mockFetch);
+
+    resetDeliveryState();
+    const state = getDeliveryState();
+    expect(state.lastSeverity).toBeNull();
+    expect(Object.keys(state.lastDeliveryAt)).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary

Adds generic webhook notification delivery for alert severity transitions. Refs #219

## Delivered Scope

- **Webhook config surface**: JSON-persisted config with targets, secrets, enable/disable flags, cooldown, timeout, and retry settings. API: `GET/PUT /api/task-board/webhooks/config` (secrets redacted in responses).
- **Transition-triggered delivery**: Webhooks fire only on severity transitions (ok→warning, warning→critical, critical→ok, etc.). No notification on steady-state — prevents flood.
- **Bounded retry with backoff**: Max 3 attempts, exponential backoff (1s, 2s), 10s timeout per attempt. Client errors (4xx) are not retried.
- **HMAC-SHA256 signing**: Optional shared secret produces `X-VentureOS-Signature` header for payload verification.
- **Security posture**: Secrets never appear in API responses (redacted to boolean). URL masking for logs. HTTPS enforced (HTTP only for localhost).
- **Strict validation**: URL format, HTTPS requirement, target count cap (5), duplicate ID detection, severity enum validation, timeout/retry bounds.
- **Fire-and-forget integration**: Delivery is async and non-blocking — failures never affect metrics evaluation or alert history recording.

## Test Evidence

- **72 new tests** covering: config validation, sanitization, persistence, redaction, payload schema, HMAC signing, transition detection, target selection with cooldown/severity filters, HTTP delivery with retry/backoff, full dispatch pipeline, API endpoints, failure isolation.
- **Full dashboard regression**: 770/808 pass (38 pre-existing failures in `memory-state` and `shared-context` from `better-sqlite3` native module issue — unrelated).
- **Typecheck**: Clean (`tsc --noEmit` passes).

## Files Changed

| File | Change |
|------|--------|
| `dashboard/server/alert-webhook.ts` | NEW — core webhook module (~500 LOC) |
| `dashboard/tests/unit/routes/task-board-webhook.test.ts` | NEW — 72 tests (~800 LOC) |
| `dashboard/server/routes/task-board.ts` | MOD — webhook config routes + delivery trigger |
| `dashboard/server/routes/index.ts` | MOD — barrel exports |

## Risk Notes

- **Additive only** — no existing code modified beyond import + 2 route additions + 1 fire-and-forget call.
- **Disabled by default** (`enabled: false`, empty targets array). Zero operational impact until explicitly configured.
- In-memory delivery state resets on server restart (intentional for this baseline slice).
- Webhook URLs persisted on disk (same pattern as alert-rules config).

## Webhook Payload Schema (v1)

```json
{
  "event": "alert.transition",
  "timestamp": 1708234567890,
  "timestampISO": "2026-02-18T10:30:00.000Z",
  "previousSeverity": "ok",
  "currentSeverity": "warning",
  "transitionLabel": "Alert escalated: ok → warning",
  "evaluation": { "overallSeverity": "warning", "rules": [...] },
  "source": "ventureos-dashboard",
  "schemaVersion": 1
}
```

Refs #219