### PR TITLE
feat(#219): Webhook delivery history — persistent log + API + dashboard UI (Phase 13)

### DIFF
--- a/dashboard/client/index.html
+++ b/dashboard/client/index.html
@@ -2405,6 +2405,205 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
 
 /* ─── End Webhook Config ────────────────────────────────────────────── */
 
+/* ─── Webhook Delivery History (Issue #219, Phase 13) ────────────────── */
+
+.tb-delivery-history-link {
+  font-size: 11px;
+  color: var(--text-muted);
+  cursor: pointer;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+  margin-left: 6px;
+}
+
+.tb-delivery-history-link:hover {
+  color: var(--text-primary);
+}
+
+.tb-delivery-overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0, 0, 0, 0.75);
+  z-index: 700;
+  align-items: center;
+  justify-content: center;
+  backdrop-filter: blur(4px);
+}
+
+.tb-delivery-overlay.active {
+  display: flex;
+}
+
+.tb-delivery-panel {
+  background: var(--bg-secondary);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  width: 94%;
+  max-width: 760px;
+  max-height: 88vh;
+  display: flex;
+  flex-direction: column;
+  box-shadow: 0 24px 64px rgba(0, 0, 0, 0.5);
+  animation: tb-detail-in 0.25s ease;
+}
+
+.tb-delivery-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 16px 20px;
+  border-bottom: 1px solid var(--border);
+  font-size: 16px;
+  font-weight: 700;
+}
+
+.tb-delivery-header .tb-delivery-controls {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tb-delivery-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 16px 20px;
+}
+
+.tb-delivery-summary {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.tb-delivery-summary-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 12px;
+  text-align: center;
+}
+
+.tb-delivery-summary-card .value {
+  font-size: 20px;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.tb-delivery-summary-card .label {
+  font-size: 10px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-top: 2px;
+}
+
+.tb-delivery-summary-card .value.success { color: var(--green); }
+.tb-delivery-summary-card .value.failure { color: var(--red); }
+.tb-delivery-summary-card .value.neutral { color: var(--text-primary); }
+
+.tb-delivery-filters {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.tb-delivery-filters select,
+.tb-delivery-filters input {
+  padding: 4px 8px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-primary);
+  font-size: 11px;
+  font-family: inherit;
+}
+
+.tb-delivery-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12px;
+}
+
+.tb-delivery-table th {
+  text-align: left;
+  font-size: 10px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  padding: 6px 8px;
+  border-bottom: 1px solid var(--border);
+  font-weight: 600;
+}
+
+.tb-delivery-table td {
+  padding: 8px 8px;
+  border-bottom: 1px solid rgba(42, 42, 58, 0.5);
+  vertical-align: middle;
+}
+
+.tb-delivery-table tr:hover td {
+  background: rgba(99, 102, 241, 0.05);
+}
+
+.tb-delivery-status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-right: 6px;
+}
+
+.tb-delivery-status-dot.success { background: var(--green); box-shadow: 0 0 6px var(--green-glow); }
+.tb-delivery-status-dot.failure { background: var(--red); }
+
+.tb-delivery-badge {
+  font-size: 10px;
+  padding: 2px 6px;
+  border-radius: 4px;
+  font-weight: 600;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.tb-delivery-badge.http-2xx { background: rgba(16, 185, 129, 0.15); color: var(--green); }
+.tb-delivery-badge.http-4xx { background: rgba(245, 158, 11, 0.15); color: var(--yellow); }
+.tb-delivery-badge.http-5xx { background: rgba(239, 68, 68, 0.15); color: var(--red); }
+.tb-delivery-badge.http-none { background: rgba(113, 113, 122, 0.15); color: var(--text-muted); }
+
+.tb-delivery-error-text {
+  color: var(--red);
+  font-size: 11px;
+  font-family: 'JetBrains Mono', monospace;
+  max-width: 200px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tb-delivery-empty {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 12px;
+  padding: 32px 16px;
+  border: 1px dashed var(--border);
+  border-radius: 10px;
+}
+
+.tb-delivery-footer {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 12px 20px;
+  border-top: 1px solid var(--border);
+  justify-content: space-between;
+  font-size: 11px;
+  color: var(--text-muted);
+}
+
+/* ─── End Webhook Delivery History ──────────────────────────────────── */
+
 /* ─── Alert Timeline (Issue #219, Phase 10) ─────────────────────────── */
 
 .tb-alert-timeline {
@@ -4088,6 +4287,7 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
               <span id="tbAlertsBannerTitle">Alerts</span>
               <span class="tb-alert-config-link" onclick="tbOpenAlertConfig()">⚙️ Configure</span>
               <span class="tb-webhook-config-link" onclick="tbOpenWebhookConfig()">🔗 Webhooks</span>
+              <span class="tb-delivery-history-link" onclick="tbOpenDeliveryHistory()">📊 Deliveries</span>
             </div>
             <div id="tbAlertsBannerRules"></div>
           </div>
@@ -4476,6 +4676,27 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
   </div>
 </div>
 <!-- ═══ End Webhook Config Modal ══════════════════════════════════════ -->
+
+<!-- ═══ Webhook Delivery History Modal (Issue #219, Phase 13) ═══════ -->
+<div class="tb-delivery-overlay" id="tbDeliveryHistoryModal" onclick="if(event.target===this)tbCloseDeliveryHistory()">
+  <div class="tb-delivery-panel">
+    <div class="tb-delivery-header">
+      <span>📊 Webhook Delivery History</span>
+      <div class="tb-delivery-controls">
+        <button onclick="tbRefreshDeliveryHistory()" class="tb-btn tb-btn-secondary" style="font-size:11px;padding:4px 10px;">↻ Refresh</button>
+        <button onclick="tbCloseDeliveryHistory()" class="tb-detail-close" aria-label="Close delivery history">✕</button>
+      </div>
+    </div>
+    <div class="tb-delivery-body" id="tbDeliveryHistoryBody">
+      <!-- Populated dynamically -->
+    </div>
+    <div class="tb-delivery-footer">
+      <span id="tbDeliveryFooterInfo"></span>
+      <span>Retention: 200 events / 48h</span>
+    </div>
+  </div>
+</div>
+<!-- ═══ End Webhook Delivery History Modal ════════════════════════════ -->
 
 <div class="status-bar">
   <div class="status-bar-section">
@@ -9561,6 +9782,168 @@ function tbResetWebhookConfig() {
   };
   tbRenderWebhookConfigForm(defaults);
   tbShowToast('Form reset to defaults (click Save to apply)', 'info');
+}
+
+// ── Webhook Delivery History UI (Issue #219, Phase 13) ──────────────────────
+// Dashboard modal for viewing recent webhook delivery attempts/results.
+// Integrates with GET /api/task-board/webhooks/deliveries endpoint.
+// Never displays raw secrets — URLs are pre-masked by the server.
+
+let tbDeliveryHistoryCache = null;
+
+/** Open the delivery history modal and fetch data. */
+async function tbOpenDeliveryHistory() {
+  const overlay = document.getElementById('tbDeliveryHistoryModal');
+  if (!overlay) return;
+  overlay.classList.add('active');
+  await tbFetchDeliveryHistory();
+}
+
+/** Close the delivery history modal. */
+function tbCloseDeliveryHistory() {
+  const overlay = document.getElementById('tbDeliveryHistoryModal');
+  if (overlay) overlay.classList.remove('active');
+}
+
+/** Refresh delivery history data. */
+async function tbRefreshDeliveryHistory() {
+  await tbFetchDeliveryHistory();
+}
+
+/** Fetch delivery history from the API with current filter state. */
+async function tbFetchDeliveryHistory() {
+  const body = document.getElementById('tbDeliveryHistoryBody');
+  if (body) body.innerHTML = '<div style="text-align:center;color:var(--text-muted);padding:30px;">Loading…</div>';
+
+  try {
+    const params = new URLSearchParams();
+    const windowEl = document.getElementById('tbDeliveryWindow');
+    const statusEl = document.getElementById('tbDeliveryStatusFilter');
+    const targetEl = document.getElementById('tbDeliveryTargetFilter');
+
+    if (windowEl && windowEl.value) params.set('sinceMs', windowEl.value);
+    if (statusEl && statusEl.value) params.set('status', statusEl.value);
+    if (targetEl && targetEl.value) params.set('targetId', targetEl.value);
+    params.set('limit', '100');
+
+    const res = await fetch('/api/task-board/webhooks/deliveries?' + params.toString());
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    const data = await res.json();
+    tbDeliveryHistoryCache = data;
+    tbRenderDeliveryHistory(data);
+  } catch (e) {
+    console.warn('[delivery-history] fetch error', e);
+    if (body) body.innerHTML = '<div style="text-align:center;color:var(--red);padding:30px;">Failed to load delivery history: ' + tbEsc(e.message) + '</div>';
+  }
+}
+
+/** Render the delivery history panel contents. */
+function tbRenderDeliveryHistory(data) {
+  const body = document.getElementById('tbDeliveryHistoryBody');
+  if (!body || !data) return;
+
+  const events = data.events || [];
+  const summary = data.summary || {};
+  let html = '';
+
+  // Summary cards
+  html += '<div class="tb-delivery-summary">';
+  html += '  <div class="tb-delivery-summary-card"><div class="value neutral">' + (summary.total || 0) + '</div><div class="label">Total</div></div>';
+  html += '  <div class="tb-delivery-summary-card"><div class="value success">' + (summary.succeeded || 0) + '</div><div class="label">Succeeded</div></div>';
+  html += '  <div class="tb-delivery-summary-card"><div class="value failure">' + (summary.failed || 0) + '</div><div class="label">Failed</div></div>';
+  html += '  <div class="tb-delivery-summary-card"><div class="value neutral">' + (summary.avgDurationMs != null ? summary.avgDurationMs + 'ms' : '—') + '</div><div class="label">Avg Latency</div></div>';
+  html += '</div>';
+
+  // Filters
+  html += '<div class="tb-delivery-filters">';
+
+  // Time window
+  html += '  <select id="tbDeliveryWindow" onchange="tbFetchDeliveryHistory()">';
+  html += '    <option value="3600000">Last 1h</option>';
+  html += '    <option value="21600000" selected>Last 6h</option>';
+  html += '    <option value="86400000">Last 24h</option>';
+  html += '    <option value="172800000">Last 48h</option>';
+  html += '    <option value="">All retained</option>';
+  html += '  </select>';
+
+  // Status filter
+  html += '  <select id="tbDeliveryStatusFilter" onchange="tbFetchDeliveryHistory()">';
+  html += '    <option value="">All statuses</option>';
+  html += '    <option value="success">Success only</option>';
+  html += '    <option value="failure">Failures only</option>';
+  html += '  </select>';
+
+  // Target filter (dynamically from summary)
+  var targetIds = summary.targetIds || [];
+  html += '  <select id="tbDeliveryTargetFilter" onchange="tbFetchDeliveryHistory()">';
+  html += '    <option value="">All targets</option>';
+  for (var i = 0; i < targetIds.length; i++) {
+    html += '    <option value="' + tbEsc(targetIds[i]) + '">' + tbEsc(targetIds[i]) + '</option>';
+  }
+  html += '  </select>';
+
+  html += '</div>';
+
+  // Events table
+  if (events.length === 0) {
+    html += '<div class="tb-delivery-empty">No webhook delivery events found for the selected window.</div>';
+  } else {
+    html += '<table class="tb-delivery-table">';
+    html += '<thead><tr>';
+    html += '  <th>Status</th>';
+    html += '  <th>Target</th>';
+    html += '  <th>HTTP</th>';
+    html += '  <th>Latency</th>';
+    html += '  <th>Attempts</th>';
+    html += '  <th>Severity</th>';
+    html += '  <th>Time</th>';
+    html += '  <th>Error</th>';
+    html += '</tr></thead>';
+    html += '<tbody>';
+
+    for (var j = 0; j < events.length; j++) {
+      var ev = events[j];
+      var statusClass = ev.success ? 'success' : 'failure';
+      var statusLabel = ev.success ? 'OK' : 'FAIL';
+      var httpBadge = 'http-none';
+      var httpText = '—';
+      if (ev.statusCode != null) {
+        httpText = '' + ev.statusCode;
+        if (ev.statusCode >= 200 && ev.statusCode < 300) httpBadge = 'http-2xx';
+        else if (ev.statusCode >= 400 && ev.statusCode < 500) httpBadge = 'http-4xx';
+        else if (ev.statusCode >= 500) httpBadge = 'http-5xx';
+      }
+
+      var sevColor = ev.triggerSeverity === 'critical' ? 'var(--red)' : ev.triggerSeverity === 'warning' ? 'var(--yellow)' : 'var(--green)';
+      var timeAgo = tbRelTime(ev.ts);
+
+      html += '<tr>';
+      html += '  <td><span class="tb-delivery-status-dot ' + statusClass + '"></span>' + statusLabel + '</td>';
+      html += '  <td title="' + tbEsc(ev.maskedUrl) + '">' + tbEsc(ev.targetName || ev.targetId) + '</td>';
+      html += '  <td><span class="tb-delivery-badge ' + httpBadge + '">' + httpText + '</span></td>';
+      html += '  <td style="font-family:\'JetBrains Mono\',monospace;font-size:11px;">' + ev.durationMs + 'ms</td>';
+      html += '  <td style="text-align:center;">' + ev.attempts + '</td>';
+      html += '  <td style="color:' + sevColor + ';font-size:11px;">';
+      if (ev.previousSeverity) {
+        html += tbEsc(ev.previousSeverity) + ' → ';
+      }
+      html += tbEsc(ev.triggerSeverity);
+      html += '</td>';
+      html += '  <td style="font-size:11px;color:var(--text-muted);" title="' + new Date(ev.ts).toISOString() + '">' + timeAgo + '</td>';
+      html += '  <td>' + (ev.error ? '<span class="tb-delivery-error-text" title="' + tbEsc(ev.error) + '">' + tbEsc(ev.error) + '</span>' : '<span style="color:var(--text-muted);">—</span>') + '</td>';
+      html += '</tr>';
+    }
+
+    html += '</tbody></table>';
+  }
+
+  body.innerHTML = html;
+
+  // Update footer
+  var footer = document.getElementById('tbDeliveryFooterInfo');
+  if (footer) {
+    footer.textContent = 'Showing ' + events.length + ' event' + (events.length !== 1 ? 's' : '');
+  }
 }
 
 // ── Real-time SSE subscription (Issue #219) ─────────────────────────────────

--- a/dashboard/server/alert-webhook.ts
+++ b/dashboard/server/alert-webhook.ts
@@ -21,6 +21,7 @@ import fs from 'node:fs';
 import path from 'node:path';
 import type { AlertSeverity, AlertEvaluation, AlertRuleResult } from './alert-rules.js';
 import type { AlertHistoryEvent } from './alert-history.js';
+import { appendDeliveryEvents } from './webhook-delivery-history.js';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -667,6 +668,21 @@ export async function maybeDeliverWebhooks(
       return result;
     }),
   );
+
+  // Record delivery events to persistent history (Phase 13).
+  // Fire-and-forget — history recording failures must not affect delivery results.
+  try {
+    const targetMap = new Map(eligibleTargets.map((t) => [t.id, t]));
+    const contexts = results.map((r) => ({
+      url: targetMap.get(r.targetId)?.url ?? '',
+      triggerSeverity: currentSeverity,
+      previousSeverity: previousSeverity,
+      ts: now,
+    }));
+    appendDeliveryEvents(dataDir, results, contexts);
+  } catch {
+    // Non-critical — delivery history recording failure is swallowed
+  }
 
   return results;
 }

--- a/dashboard/server/routes/index.ts
+++ b/dashboard/server/routes/index.ts
@@ -100,3 +100,19 @@ export type {
   WebhookDeliveryState,
   WebhookConfigValidationError,
 } from '../alert-webhook.js';
+export {
+  readDeliveryHistory,
+  appendDeliveryEvents,
+  queryDeliveryHistory,
+  pruneDeliveryEvents,
+  createDeliveryEvent,
+  truncateError,
+} from '../webhook-delivery-history.js';
+export type {
+  WebhookDeliveryEvent,
+  WebhookDeliveryHistoryFile,
+  WebhookDeliveryHistoryConfig,
+  DeliveryHistoryQuery,
+  DeliveryHistorySummary,
+  DeliveryHistoryResponse,
+} from '../webhook-delivery-history.js';

--- a/dashboard/server/routes/task-board.ts
+++ b/dashboard/server/routes/task-board.ts
@@ -69,6 +69,10 @@ import {
   maybeDeliverWebhooks,
 } from '../alert-webhook.js';
 
+import {
+  queryDeliveryHistory,
+} from '../webhook-delivery-history.js';
+
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 const VALID_STATUSES: TaskStatus[] = ['backlog', 'queued', 'running', 'done', 'failed'];
@@ -817,6 +821,28 @@ export async function handleTaskBoard(
 
     writeWebhookConfig(dataDir, sanitized);
     sendJson(res, { config: redactWebhookConfig(sanitized) });
+    return true;
+  }
+
+  // ── GET /api/task-board/webhooks/deliveries — Issue #219, Phase 13 ─────────
+  // Returns recent webhook delivery events with summary statistics.
+  // Query params:
+  //   ?limit=50        — max events to return (default 50, max 200)
+  //   ?sinceMs=3600000 — only events within this time window (default: all retained)
+  //   ?targetId=slack  — filter by target ID
+  //   ?status=success  — filter: 'success' or 'failure'
+  if (url.startsWith('/api/task-board/webhooks/deliveries') && method === 'GET') {
+    const dlvParams = new URL(url, 'http://localhost').searchParams;
+    const limit = Math.max(1, Math.min(Number(dlvParams.get('limit')) || 50, 200));
+    const sinceMs = dlvParams.has('sinceMs')
+      ? Math.max(0, Number(dlvParams.get('sinceMs')) || 0)
+      : undefined;
+    const targetId = dlvParams.get('targetId') || undefined;
+    const statusRaw = dlvParams.get('status');
+    const status = statusRaw === 'success' || statusRaw === 'failure' ? statusRaw : undefined;
+
+    const result = queryDeliveryHistory(dataDir, { limit, sinceMs, targetId, status });
+    sendJson(res, result);
     return true;
   }
 

--- a/dashboard/server/webhook-delivery-history.ts
+++ b/dashboard/server/webhook-delivery-history.ts
@@ -1,0 +1,338 @@
+/**
+ * Webhook Delivery History — persistent log of webhook delivery attempts.
+ * Issue #219 — Phase 13: Webhook Delivery Status/History UI Baseline.
+ *
+ * Records each webhook delivery attempt (success or failure) as an append-only
+ * log with bounded retention. Designed for dashboard display and debugging —
+ * not a full audit trail.
+ *
+ * Key design decisions:
+ *   - Append-only JSON file (same pattern as alert-history.ts)
+ *   - Bounded retention: max 200 events, max 48h age (configurable)
+ *   - No secrets stored — URLs are masked, payloads omitted
+ *   - Inline recording: appended during webhook delivery (no background jobs)
+ *   - Error summaries are truncated (max 200 chars)
+ *
+ * File format: { version: 1, events: WebhookDeliveryEvent[] }
+ * File location: <dataDir>/task-board-webhook-delivery-history.json
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { maskUrl } from './alert-webhook.js';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/** A single recorded webhook delivery attempt. */
+export interface WebhookDeliveryEvent {
+  /** Unique event ID (monotonic counter within file). */
+  id: number;
+  /** Timestamp of the delivery attempt start (ms since epoch). */
+  ts: number;
+  /** Target ID from webhook config. */
+  targetId: string;
+  /** Target display name. */
+  targetName: string;
+  /** Whether delivery ultimately succeeded. */
+  success: boolean;
+  /** HTTP status code (null if network error). */
+  statusCode: number | null;
+  /** Total number of attempts (including retries). */
+  attempts: number;
+  /** Total delivery duration in ms (including retries). */
+  durationMs: number;
+  /** Error summary, truncated. Null on success. */
+  error: string | null;
+  /** Masked URL for debugging (protocol + host only). */
+  maskedUrl: string;
+  /** Alert severity that triggered the delivery. */
+  triggerSeverity: string;
+  /** Previous severity (the transition source). */
+  previousSeverity: string | null;
+}
+
+/** On-disk file format. */
+export interface WebhookDeliveryHistoryFile {
+  version: 1;
+  events: WebhookDeliveryEvent[];
+  /** Monotonic counter for unique event IDs. */
+  nextId: number;
+}
+
+/** Configuration for delivery history retention. */
+export interface WebhookDeliveryHistoryConfig {
+  /** Maximum number of events to retain. Default: 200. */
+  maxEvents?: number;
+  /** Maximum age of events in ms. Default: 48 hours. */
+  maxAgeMs?: number;
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const DEFAULT_MAX_EVENTS = 200;
+const DEFAULT_MAX_AGE_MS = 48 * 60 * 60 * 1000; // 48 hours
+const MAX_ERROR_LENGTH = 200;
+const HISTORY_FILENAME = 'task-board-webhook-delivery-history.json';
+
+// ─── File I/O ────────────────────────────────────────────────────────────────
+
+function historyFilePath(dataDir: string): string {
+  return path.join(dataDir, HISTORY_FILENAME);
+}
+
+/**
+ * Read delivery history from disk.
+ * Returns empty history if file doesn't exist or is corrupt.
+ */
+export function readDeliveryHistory(dataDir: string): WebhookDeliveryHistoryFile {
+  try {
+    const fp = historyFilePath(dataDir);
+    if (!fs.existsSync(fp)) return { version: 1, events: [], nextId: 1 };
+    const raw = fs.readFileSync(fp, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && parsed.version === 1 && Array.isArray(parsed.events)) {
+      return {
+        version: 1,
+        events: parsed.events,
+        nextId: typeof parsed.nextId === 'number' ? parsed.nextId : parsed.events.length + 1,
+      };
+    }
+    return { version: 1, events: [], nextId: 1 };
+  } catch {
+    return { version: 1, events: [], nextId: 1 };
+  }
+}
+
+/**
+ * Write delivery history to disk atomically (write-rename pattern).
+ */
+function writeDeliveryHistory(dataDir: string, history: WebhookDeliveryHistoryFile): void {
+  const fp = historyFilePath(dataDir);
+  const dir = path.dirname(fp);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  const tmpFp = fp + '.tmp';
+  fs.writeFileSync(tmpFp, JSON.stringify(history, null, 2));
+  fs.renameSync(tmpFp, fp);
+}
+
+// ─── Core Operations ─────────────────────────────────────────────────────────
+
+/**
+ * Truncate an error string to bounded length.
+ * Pure function.
+ */
+export function truncateError(error: string | null): string | null {
+  if (!error) return null;
+  if (error.length <= MAX_ERROR_LENGTH) return error;
+  return error.slice(0, MAX_ERROR_LENGTH - 3) + '...';
+}
+
+/**
+ * Prune events that exceed retention bounds.
+ * Returns a new array (does not mutate input).
+ * Pure function.
+ */
+export function pruneDeliveryEvents(
+  events: WebhookDeliveryEvent[],
+  opts: {
+    maxEvents?: number;
+    maxAgeMs?: number;
+    now?: number;
+  } = {},
+): WebhookDeliveryEvent[] {
+  const maxEvents = opts.maxEvents ?? DEFAULT_MAX_EVENTS;
+  const maxAgeMs = opts.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+  const now = opts.now ?? Date.now();
+
+  // Filter by age first
+  let result = events.filter((e) => now - e.ts <= maxAgeMs);
+
+  // Then cap by count (keep most recent)
+  if (result.length > maxEvents) {
+    result = result.slice(result.length - maxEvents);
+  }
+
+  return result;
+}
+
+/**
+ * Create a delivery event from a WebhookDeliveryResult.
+ * Masks the URL and truncates errors — never stores raw secrets.
+ */
+export function createDeliveryEvent(
+  result: {
+    targetId: string;
+    targetName: string;
+    success: boolean;
+    statusCode: number | null;
+    attempts: number;
+    error: string | null;
+    durationMs: number;
+  },
+  context: {
+    url: string;
+    triggerSeverity: string;
+    previousSeverity: string | null;
+    ts?: number;
+  },
+  nextId: number,
+): WebhookDeliveryEvent {
+  return {
+    id: nextId,
+    ts: context.ts ?? Date.now(),
+    targetId: result.targetId,
+    targetName: result.targetName,
+    success: result.success,
+    statusCode: result.statusCode,
+    attempts: result.attempts,
+    durationMs: result.durationMs,
+    error: truncateError(result.error),
+    maskedUrl: maskUrl(context.url),
+    triggerSeverity: context.triggerSeverity,
+    previousSeverity: context.previousSeverity,
+  };
+}
+
+/**
+ * Append one or more delivery events to the history file.
+ * Applies retention pruning before writing.
+ * Returns the number of events recorded.
+ *
+ * This is the main write entry point — called from the webhook delivery
+ * pipeline after each dispatch round completes.
+ */
+export function appendDeliveryEvents(
+  dataDir: string,
+  results: Array<{
+    targetId: string;
+    targetName: string;
+    success: boolean;
+    statusCode: number | null;
+    attempts: number;
+    error: string | null;
+    durationMs: number;
+  }>,
+  contexts: Array<{
+    url: string;
+    triggerSeverity: string;
+    previousSeverity: string | null;
+    ts?: number;
+  }>,
+  config: WebhookDeliveryHistoryConfig = {},
+): number {
+  if (results.length === 0) return 0;
+
+  const maxEvents = config.maxEvents ?? DEFAULT_MAX_EVENTS;
+  const maxAgeMs = config.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+  const now = Date.now();
+
+  const history = readDeliveryHistory(dataDir);
+  let nextId = history.nextId;
+
+  for (let i = 0; i < results.length; i++) {
+    const ctx = contexts[Math.min(i, contexts.length - 1)];
+    const event = createDeliveryEvent(results[i], ctx, nextId++);
+    history.events.push(event);
+  }
+
+  // Prune before writing
+  history.events = pruneDeliveryEvents(history.events, { maxEvents, maxAgeMs, now });
+  history.nextId = nextId;
+
+  writeDeliveryHistory(dataDir, history);
+  return results.length;
+}
+
+// ─── Query Helpers ───────────────────────────────────────────────────────────
+
+/** Query options for delivery history. */
+export interface DeliveryHistoryQuery {
+  /** Max events to return (default 50, max 200). */
+  limit?: number;
+  /** Only events within this time window from now (ms). */
+  sinceMs?: number;
+  /** Filter by target ID. */
+  targetId?: string;
+  /** Filter by success status: 'success' | 'failure'. */
+  status?: 'success' | 'failure';
+  /** Current time override (for testing). */
+  now?: number;
+}
+
+/** Summary statistics for a delivery history query. */
+export interface DeliveryHistorySummary {
+  total: number;
+  succeeded: number;
+  failed: number;
+  avgDurationMs: number | null;
+  /** Distinct target IDs that appear in the results. */
+  targetIds: string[];
+}
+
+/** Query result shape for the API endpoint. */
+export interface DeliveryHistoryResponse {
+  events: WebhookDeliveryEvent[];
+  count: number;
+  summary: DeliveryHistorySummary;
+}
+
+/**
+ * Query recent delivery events with optional filters.
+ * Returns events sorted most-recent-first (reverse chronological).
+ */
+export function queryDeliveryHistory(
+  dataDir: string,
+  opts: DeliveryHistoryQuery = {},
+): DeliveryHistoryResponse {
+  const history = readDeliveryHistory(dataDir);
+  const now = opts.now ?? Date.now();
+  let events = history.events;
+
+  // Filter by time window
+  if (opts.sinceMs != null && opts.sinceMs > 0) {
+    const cutoff = now - opts.sinceMs;
+    events = events.filter((e) => e.ts >= cutoff);
+  }
+
+  // Filter by target ID
+  if (opts.targetId) {
+    events = events.filter((e) => e.targetId === opts.targetId);
+  }
+
+  // Filter by success/failure
+  if (opts.status === 'success') {
+    events = events.filter((e) => e.success);
+  } else if (opts.status === 'failure') {
+    events = events.filter((e) => !e.success);
+  }
+
+  // Apply limit (most recent N) — events are stored chronologically
+  const limit = Math.max(1, Math.min(opts.limit ?? 50, 200));
+  if (events.length > limit) {
+    events = events.slice(events.length - limit);
+  }
+
+  // Reverse to most-recent-first for display
+  events = [...events].reverse();
+
+  // Compute summary
+  const succeeded = events.filter((e) => e.success).length;
+  const failed = events.length - succeeded;
+  const durations = events.map((e) => e.durationMs);
+  const avgDurationMs = durations.length > 0
+    ? Math.round(durations.reduce((s, v) => s + v, 0) / durations.length)
+    : null;
+  const targetIds = [...new Set(events.map((e) => e.targetId))];
+
+  return {
+    events,
+    count: events.length,
+    summary: {
+      total: events.length,
+      succeeded,
+      failed,
+      avgDurationMs,
+      targetIds,
+    },
+  };
+}

--- a/dashboard/tests/unit/routes/task-board-webhook-delivery-history.test.ts
+++ b/dashboard/tests/unit/routes/task-board-webhook-delivery-history.test.ts
@@ -1,0 +1,765 @@
+/**
+ * Webhook Delivery History tests — Issue #219, Phase 13.
+ *
+ * Tests for:
+ * - readDeliveryHistory() / appendDeliveryEvents() — persistence
+ * - pruneDeliveryEvents() — bounded retention (count + age)
+ * - createDeliveryEvent() — event construction, URL masking, error truncation
+ * - truncateError() — bounded error messages
+ * - queryDeliveryHistory() — query with filters + summary statistics
+ * - GET /api/task-board/webhooks/deliveries — API endpoint
+ * - Integration: delivery recording via maybeDeliverWebhooks()
+ * - Failure-path recording (network errors, HTTP errors)
+ * - Secret safety — no raw URLs or secrets in stored events
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { mockRequest, mockResponse, parseJsonBody } from '../../helpers.js';
+import {
+  handleTaskBoard,
+} from '../../../server/routes/task-board.js';
+import {
+  readDeliveryHistory,
+  appendDeliveryEvents,
+  queryDeliveryHistory,
+  pruneDeliveryEvents,
+  createDeliveryEvent,
+  truncateError,
+} from '../../../server/webhook-delivery-history.js';
+import type {
+  WebhookDeliveryEvent,
+  WebhookDeliveryHistoryFile,
+  DeliveryHistoryResponse,
+} from '../../../server/webhook-delivery-history.js';
+import {
+  writeWebhookConfig,
+  resetDeliveryState,
+  maybeDeliverWebhooks,
+} from '../../../server/alert-webhook.js';
+import {
+  evaluateAlerts,
+  DEFAULT_ALERT_CONFIG,
+} from '../../../server/alert-rules.js';
+import type {
+  AlertMetricsInput,
+} from '../../../server/alert-rules.js';
+import type { TaskBoardDeps, TaskCard } from '../../../server/types.js';
+
+const testDataDir = path.join('/tmp', 'test-delivery-history-' + process.pid);
+
+function createDeps(overrides: Partial<TaskBoardDeps> = {}): TaskBoardDeps {
+  return {
+    dataDir: testDataDir,
+    sendJson: (res, data, status = 200) => {
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+    },
+    readRequestBody: async () => '{}',
+    ...overrides,
+  };
+}
+
+function metricsInput(overrides: Partial<AlertMetricsInput> = {}): AlertMetricsInput {
+  return {
+    statusCounts: { backlog: 5, queued: 2, running: 1, done: 10, failed: 2 },
+    successRate: 0.8,
+    stuckCount: 0,
+    avgRuntimeMs: 60000,
+    total: 20,
+    ...overrides,
+  };
+}
+
+function sampleResult(overrides: Partial<{
+  targetId: string;
+  targetName: string;
+  success: boolean;
+  statusCode: number | null;
+  attempts: number;
+  error: string | null;
+  durationMs: number;
+}> = {}) {
+  return {
+    targetId: 'test-target',
+    targetName: 'Test Target',
+    success: true,
+    statusCode: 200,
+    attempts: 1,
+    error: null,
+    durationMs: 150,
+    ...overrides,
+  };
+}
+
+function sampleContext(overrides: Partial<{
+  url: string;
+  triggerSeverity: string;
+  previousSeverity: string | null;
+  ts: number;
+}> = {}) {
+  return {
+    url: 'https://hooks.example.com/webhook/secret-path',
+    triggerSeverity: 'warning',
+    previousSeverity: 'ok' as string | null,
+    ts: Date.now(),
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  fs.mkdirSync(testDataDir, { recursive: true });
+  resetDeliveryState();
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(testDataDir, { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup errors
+  }
+  vi.restoreAllMocks();
+});
+
+// ─── truncateError ───────────────────────────────────────────────────────────
+
+describe('truncateError', () => {
+  it('returns null for null input', () => {
+    expect(truncateError(null)).toBeNull();
+  });
+
+  it('returns short errors unchanged', () => {
+    expect(truncateError('connection refused')).toBe('connection refused');
+  });
+
+  it('truncates long errors with ellipsis', () => {
+    const longError = 'x'.repeat(300);
+    const result = truncateError(longError);
+    expect(result!.length).toBe(200);
+    expect(result!.endsWith('...')).toBe(true);
+  });
+
+  it('preserves errors at exactly the limit', () => {
+    const exactError = 'a'.repeat(200);
+    expect(truncateError(exactError)).toBe(exactError);
+  });
+});
+
+// ─── createDeliveryEvent ─────────────────────────────────────────────────────
+
+describe('createDeliveryEvent', () => {
+  it('creates event with all fields populated', () => {
+    const result = sampleResult();
+    const ctx = sampleContext({ ts: 1000000 });
+    const event = createDeliveryEvent(result, ctx, 42);
+
+    expect(event.id).toBe(42);
+    expect(event.ts).toBe(1000000);
+    expect(event.targetId).toBe('test-target');
+    expect(event.targetName).toBe('Test Target');
+    expect(event.success).toBe(true);
+    expect(event.statusCode).toBe(200);
+    expect(event.attempts).toBe(1);
+    expect(event.durationMs).toBe(150);
+    expect(event.error).toBeNull();
+    expect(event.triggerSeverity).toBe('warning');
+    expect(event.previousSeverity).toBe('ok');
+  });
+
+  it('masks the URL — never stores full path', () => {
+    const ctx = sampleContext({ url: 'https://hooks.slack.com/services/T00/B00/xxxx' });
+    const event = createDeliveryEvent(sampleResult(), ctx, 1);
+
+    expect(event.maskedUrl).toBe('https://hooks.slack.com/***');
+    expect(event.maskedUrl).not.toContain('services');
+    expect(event.maskedUrl).not.toContain('xxxx');
+  });
+
+  it('truncates long error strings', () => {
+    const result = sampleResult({
+      success: false,
+      error: 'E'.repeat(500),
+    });
+    const event = createDeliveryEvent(result, sampleContext(), 1);
+    expect(event.error!.length).toBe(200);
+  });
+
+  it('records failure details correctly', () => {
+    const result = sampleResult({
+      success: false,
+      statusCode: 503,
+      attempts: 3,
+      error: 'Service Unavailable',
+      durationMs: 12500,
+    });
+    const event = createDeliveryEvent(result, sampleContext(), 1);
+
+    expect(event.success).toBe(false);
+    expect(event.statusCode).toBe(503);
+    expect(event.attempts).toBe(3);
+    expect(event.error).toBe('Service Unavailable');
+    expect(event.durationMs).toBe(12500);
+  });
+
+  it('handles null status code (network error)', () => {
+    const result = sampleResult({
+      success: false,
+      statusCode: null,
+      error: 'ECONNREFUSED',
+    });
+    const event = createDeliveryEvent(result, sampleContext(), 1);
+    expect(event.statusCode).toBeNull();
+    expect(event.error).toBe('ECONNREFUSED');
+  });
+});
+
+// ─── pruneDeliveryEvents ─────────────────────────────────────────────────────
+
+describe('pruneDeliveryEvents', () => {
+  function makeEvents(count: number, startTs: number = Date.now()): WebhookDeliveryEvent[] {
+    return Array.from({ length: count }, (_, i) => ({
+      id: i + 1,
+      ts: startTs - (count - i - 1) * 1000,
+      targetId: 'target',
+      targetName: 'Target',
+      success: true,
+      statusCode: 200,
+      attempts: 1,
+      durationMs: 100,
+      error: null,
+      maskedUrl: 'https://example.com/***',
+      triggerSeverity: 'warning',
+      previousSeverity: 'ok',
+    }));
+  }
+
+  it('keeps events within bounds', () => {
+    const events = makeEvents(10);
+    const pruned = pruneDeliveryEvents(events, { maxEvents: 200, maxAgeMs: 48 * 3600 * 1000 });
+    expect(pruned).toHaveLength(10);
+  });
+
+  it('caps at maxEvents (keeps most recent)', () => {
+    const events = makeEvents(300);
+    const pruned = pruneDeliveryEvents(events, { maxEvents: 200 });
+    expect(pruned).toHaveLength(200);
+    // Should keep the most recent 200
+    expect(pruned[0].id).toBe(101);
+    expect(pruned[199].id).toBe(300);
+  });
+
+  it('removes events older than maxAgeMs', () => {
+    const now = Date.now();
+    const events = [
+      ...makeEvents(3, now - 100 * 3600 * 1000), // 100h ago — too old
+      ...makeEvents(5, now),                      // recent
+    ];
+    // Re-assign ids
+    events.forEach((e, i) => e.id = i + 1);
+
+    const pruned = pruneDeliveryEvents(events, {
+      maxAgeMs: 48 * 3600 * 1000,
+      now,
+    });
+    expect(pruned).toHaveLength(5);
+  });
+
+  it('applies both age and count constraints', () => {
+    const now = Date.now();
+    const events = makeEvents(250, now);
+    const pruned = pruneDeliveryEvents(events, {
+      maxEvents: 200,
+      maxAgeMs: 48 * 3600 * 1000,
+      now,
+    });
+    expect(pruned).toHaveLength(200);
+  });
+
+  it('returns empty for empty input', () => {
+    expect(pruneDeliveryEvents([])).toHaveLength(0);
+  });
+});
+
+// ─── readDeliveryHistory / appendDeliveryEvents ──────────────────────────────
+
+describe('readDeliveryHistory / appendDeliveryEvents', () => {
+  it('returns empty history when no file exists', () => {
+    const history = readDeliveryHistory(testDataDir);
+    expect(history.version).toBe(1);
+    expect(history.events).toHaveLength(0);
+    expect(history.nextId).toBe(1);
+  });
+
+  it('appends events and persists to disk', () => {
+    const count = appendDeliveryEvents(
+      testDataDir,
+      [sampleResult(), sampleResult({ targetId: 'b', success: false, statusCode: 500, error: 'Internal Server Error' })],
+      [sampleContext(), sampleContext({ url: 'https://other.com/hook' })],
+    );
+    expect(count).toBe(2);
+
+    const history = readDeliveryHistory(testDataDir);
+    expect(history.events).toHaveLength(2);
+    expect(history.events[0].id).toBe(1);
+    expect(history.events[1].id).toBe(2);
+    expect(history.nextId).toBe(3);
+  });
+
+  it('assigns monotonically increasing IDs across multiple appends', () => {
+    appendDeliveryEvents(testDataDir, [sampleResult()], [sampleContext()]);
+    appendDeliveryEvents(testDataDir, [sampleResult()], [sampleContext()]);
+    appendDeliveryEvents(testDataDir, [sampleResult()], [sampleContext()]);
+
+    const history = readDeliveryHistory(testDataDir);
+    expect(history.events).toHaveLength(3);
+    expect(history.events[0].id).toBe(1);
+    expect(history.events[1].id).toBe(2);
+    expect(history.events[2].id).toBe(3);
+  });
+
+  it('prunes on append when exceeding maxEvents', () => {
+    // Fill with 199 events
+    for (let i = 0; i < 199; i++) {
+      appendDeliveryEvents(testDataDir, [sampleResult()], [sampleContext()]);
+    }
+
+    // Append 10 more — should prune to 200
+    const batch = Array.from({ length: 10 }, () => sampleResult());
+    const ctxBatch = Array.from({ length: 10 }, () => sampleContext());
+    appendDeliveryEvents(testDataDir, batch, ctxBatch, { maxEvents: 200 });
+
+    const history = readDeliveryHistory(testDataDir);
+    expect(history.events.length).toBeLessThanOrEqual(200);
+  });
+
+  it('returns defaults for corrupt file', () => {
+    const fp = path.join(testDataDir, 'task-board-webhook-delivery-history.json');
+    fs.writeFileSync(fp, '{corrupt');
+    const history = readDeliveryHistory(testDataDir);
+    expect(history.version).toBe(1);
+    expect(history.events).toHaveLength(0);
+  });
+
+  it('returns 0 when no results provided', () => {
+    const count = appendDeliveryEvents(testDataDir, [], []);
+    expect(count).toBe(0);
+  });
+});
+
+// ─── queryDeliveryHistory ────────────────────────────────────────────────────
+
+describe('queryDeliveryHistory', () => {
+  function seedEvents(events: Partial<WebhookDeliveryEvent>[]): void {
+    const history: WebhookDeliveryHistoryFile = {
+      version: 1,
+      events: events.map((e, i) => ({
+        id: i + 1,
+        ts: Date.now() - (events.length - i) * 60000,
+        targetId: 'target-a',
+        targetName: 'Target A',
+        success: true,
+        statusCode: 200,
+        attempts: 1,
+        durationMs: 100,
+        error: null,
+        maskedUrl: 'https://example.com/***',
+        triggerSeverity: 'warning',
+        previousSeverity: 'ok',
+        ...e,
+      })),
+      nextId: events.length + 1,
+    };
+    fs.writeFileSync(
+      path.join(testDataDir, 'task-board-webhook-delivery-history.json'),
+      JSON.stringify(history),
+    );
+  }
+
+  it('returns empty result when no events exist', () => {
+    const result = queryDeliveryHistory(testDataDir);
+    expect(result.events).toHaveLength(0);
+    expect(result.count).toBe(0);
+    expect(result.summary.total).toBe(0);
+  });
+
+  it('returns events in reverse chronological order (most recent first)', () => {
+    const now = Date.now();
+    seedEvents([
+      { ts: now - 3000, targetId: 'a' },
+      { ts: now - 2000, targetId: 'b' },
+      { ts: now - 1000, targetId: 'c' },
+    ]);
+
+    const result = queryDeliveryHistory(testDataDir);
+    expect(result.events[0].targetId).toBe('c');
+    expect(result.events[2].targetId).toBe('a');
+  });
+
+  it('respects limit parameter', () => {
+    seedEvents(Array.from({ length: 20 }, (_, i) => ({ targetId: 't' + i })));
+
+    const result = queryDeliveryHistory(testDataDir, { limit: 5 });
+    expect(result.events).toHaveLength(5);
+    expect(result.count).toBe(5);
+  });
+
+  it('caps limit at 200', () => {
+    const result = queryDeliveryHistory(testDataDir, { limit: 999 });
+    // Should not throw, just returns whatever is available (capped)
+    expect(result.count).toBeLessThanOrEqual(200);
+  });
+
+  it('filters by sinceMs time window', () => {
+    const now = Date.now();
+    seedEvents([
+      { ts: now - 7200000 }, // 2h ago
+      { ts: now - 1800000 }, // 30min ago
+      { ts: now - 600000 },  // 10min ago
+    ]);
+
+    const result = queryDeliveryHistory(testDataDir, { sinceMs: 3600000, now }); // last 1h
+    expect(result.events).toHaveLength(2);
+  });
+
+  it('filters by targetId', () => {
+    seedEvents([
+      { targetId: 'slack' },
+      { targetId: 'discord' },
+      { targetId: 'slack' },
+    ]);
+
+    const result = queryDeliveryHistory(testDataDir, { targetId: 'slack' });
+    expect(result.events).toHaveLength(2);
+    expect(result.events.every(e => e.targetId === 'slack')).toBe(true);
+  });
+
+  it('filters by status: success', () => {
+    seedEvents([
+      { success: true },
+      { success: false, error: 'timeout' },
+      { success: true },
+    ]);
+
+    const result = queryDeliveryHistory(testDataDir, { status: 'success' });
+    expect(result.events).toHaveLength(2);
+    expect(result.events.every(e => e.success)).toBe(true);
+  });
+
+  it('filters by status: failure', () => {
+    seedEvents([
+      { success: true },
+      { success: false, error: 'timeout' },
+      { success: false, error: 'refused' },
+    ]);
+
+    const result = queryDeliveryHistory(testDataDir, { status: 'failure' });
+    expect(result.events).toHaveLength(2);
+    expect(result.events.every(e => !e.success)).toBe(true);
+  });
+
+  it('computes summary statistics', () => {
+    seedEvents([
+      { success: true, durationMs: 100, targetId: 'a' },
+      { success: true, durationMs: 200, targetId: 'b' },
+      { success: false, durationMs: 5000, targetId: 'a', error: 'timeout' },
+    ]);
+
+    const result = queryDeliveryHistory(testDataDir);
+    expect(result.summary.total).toBe(3);
+    expect(result.summary.succeeded).toBe(2);
+    expect(result.summary.failed).toBe(1);
+    expect(result.summary.avgDurationMs).toBeGreaterThan(0);
+    expect(result.summary.targetIds).toContain('a');
+    expect(result.summary.targetIds).toContain('b');
+  });
+
+  it('returns null avgDurationMs when no events', () => {
+    const result = queryDeliveryHistory(testDataDir);
+    expect(result.summary.avgDurationMs).toBeNull();
+  });
+});
+
+// ─── API Routes ──────────────────────────────────────────────────────────────
+
+describe('GET /api/task-board/webhooks/deliveries', () => {
+  function seedTasks(tasks: TaskCard[]): void {
+    fs.mkdirSync(testDataDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(testDataDir, 'task-board.json'),
+      JSON.stringify({ tasks, updatedAt: Date.now() }),
+    );
+  }
+
+  it('returns empty result when no history exists', async () => {
+    seedTasks([]); // ensure data dir is set up
+    const req = mockRequest({ url: '/api/task-board/webhooks/deliveries' });
+    const res = mockResponse();
+    const deps = createDeps();
+
+    const handled = await handleTaskBoard(req, res, deps);
+    expect(handled).toBe(true);
+    expect(res._statusCode).toBe(200);
+
+    const body = parseJsonBody<DeliveryHistoryResponse>(res);
+    expect(body.events).toHaveLength(0);
+    expect(body.count).toBe(0);
+    expect(body.summary.total).toBe(0);
+  });
+
+  it('returns persisted delivery events', async () => {
+    appendDeliveryEvents(
+      testDataDir,
+      [
+        sampleResult(),
+        sampleResult({ success: false, statusCode: 500, error: 'Internal Server Error' }),
+      ],
+      [
+        sampleContext(),
+        sampleContext(),
+      ],
+    );
+
+    const req = mockRequest({ url: '/api/task-board/webhooks/deliveries' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    expect(res._statusCode).toBe(200);
+    const body = parseJsonBody<DeliveryHistoryResponse>(res);
+    expect(body.events).toHaveLength(2);
+    expect(body.summary.succeeded).toBe(1);
+    expect(body.summary.failed).toBe(1);
+  });
+
+  it('respects query params: limit', async () => {
+    // Seed 10 events
+    for (let i = 0; i < 10; i++) {
+      appendDeliveryEvents(testDataDir, [sampleResult()], [sampleContext()]);
+    }
+
+    const req = mockRequest({ url: '/api/task-board/webhooks/deliveries?limit=3' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    const body = parseJsonBody<DeliveryHistoryResponse>(res);
+    expect(body.events).toHaveLength(3);
+  });
+
+  it('respects query params: status filter', async () => {
+    appendDeliveryEvents(
+      testDataDir,
+      [
+        sampleResult({ success: true }),
+        sampleResult({ success: false, error: 'fail' }),
+      ],
+      [sampleContext(), sampleContext()],
+    );
+
+    const req = mockRequest({ url: '/api/task-board/webhooks/deliveries?status=failure' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    const body = parseJsonBody<DeliveryHistoryResponse>(res);
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0].success).toBe(false);
+  });
+
+  it('respects query params: targetId filter', async () => {
+    appendDeliveryEvents(
+      testDataDir,
+      [
+        sampleResult({ targetId: 'slack' }),
+        sampleResult({ targetId: 'discord' }),
+      ],
+      [sampleContext(), sampleContext()],
+    );
+
+    const req = mockRequest({ url: '/api/task-board/webhooks/deliveries?targetId=slack' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    const body = parseJsonBody<DeliveryHistoryResponse>(res);
+    expect(body.events).toHaveLength(1);
+    expect(body.events[0].targetId).toBe('slack');
+  });
+});
+
+// ─── Integration: delivery recording via maybeDeliverWebhooks ────────────────
+
+describe('delivery history recording integration', () => {
+  it('records successful delivery to history', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal('fetch', mockFetch);
+
+    writeWebhookConfig(testDataDir, {
+      enabled: true,
+      targets: [{
+        id: 'test',
+        name: 'Test',
+        url: 'https://example.com/webhook',
+        enabled: true,
+        minSeverity: 'ok',
+      }],
+      cooldownMs: 0,
+      timeoutMs: 5000,
+      maxRetries: 1,
+    });
+
+    const evaluation = evaluateAlerts(metricsInput(), DEFAULT_ALERT_CONFIG);
+    await maybeDeliverWebhooks(testDataDir, evaluation);
+
+    const history = readDeliveryHistory(testDataDir);
+    expect(history.events.length).toBeGreaterThanOrEqual(1);
+
+    const event = history.events[0];
+    expect(event.success).toBe(true);
+    expect(event.statusCode).toBe(200);
+    expect(event.targetId).toBe('test');
+    expect(event.maskedUrl).toBe('https://example.com/***');
+    // Must not contain the full URL
+    expect(event.maskedUrl).not.toContain('/webhook');
+  });
+
+  it('records failed delivery to history', async () => {
+    const mockFetch = vi.fn().mockRejectedValue(new Error('ECONNREFUSED'));
+    vi.stubGlobal('fetch', mockFetch);
+
+    writeWebhookConfig(testDataDir, {
+      enabled: true,
+      targets: [{
+        id: 'failing',
+        name: 'Failing Target',
+        url: 'https://failing.example.com/hook',
+        enabled: true,
+        minSeverity: 'ok',
+      }],
+      cooldownMs: 0,
+      timeoutMs: 5000,
+      maxRetries: 1,
+    });
+
+    const evaluation = evaluateAlerts(metricsInput(), DEFAULT_ALERT_CONFIG);
+    await maybeDeliverWebhooks(testDataDir, evaluation);
+
+    const history = readDeliveryHistory(testDataDir);
+    expect(history.events.length).toBeGreaterThanOrEqual(1);
+
+    const event = history.events[0];
+    expect(event.success).toBe(false);
+    expect(event.error).toBe('ECONNREFUSED');
+    expect(event.targetId).toBe('failing');
+  });
+
+  it('records delivery to multiple targets', async () => {
+    const mockFetch = vi.fn()
+      .mockResolvedValueOnce({ ok: true, status: 200 })
+      .mockResolvedValueOnce({ ok: false, status: 502 });
+    vi.stubGlobal('fetch', mockFetch);
+
+    writeWebhookConfig(testDataDir, {
+      enabled: true,
+      targets: [
+        { id: 'a', name: 'A', url: 'https://a.com/hook', enabled: true, minSeverity: 'ok' },
+        { id: 'b', name: 'B', url: 'https://b.com/hook', enabled: true, minSeverity: 'ok' },
+      ],
+      cooldownMs: 0,
+      timeoutMs: 5000,
+      maxRetries: 1,
+    });
+
+    const evaluation = evaluateAlerts(metricsInput(), DEFAULT_ALERT_CONFIG);
+    await maybeDeliverWebhooks(testDataDir, evaluation);
+
+    const history = readDeliveryHistory(testDataDir);
+    expect(history.events.length).toBe(2);
+
+    const [evA, evB] = history.events;
+    expect(evA.targetId).toBe('a');
+    expect(evA.success).toBe(true);
+    expect(evB.targetId).toBe('b');
+    expect(evB.success).toBe(false);
+  });
+});
+
+// ─── Secret safety ───────────────────────────────────────────────────────────
+
+describe('secret safety', () => {
+  it('never stores full webhook URLs in history', () => {
+    const secretUrl = 'https://hooks.slack.com/services/T00/B00/xoxb-secret-token-value';
+    appendDeliveryEvents(
+      testDataDir,
+      [sampleResult()],
+      [sampleContext({ url: secretUrl })],
+    );
+
+    // Read raw file to verify
+    const fp = path.join(testDataDir, 'task-board-webhook-delivery-history.json');
+    const raw = fs.readFileSync(fp, 'utf8');
+
+    // Raw file must NOT contain the secret URL parts
+    expect(raw).not.toContain('xoxb-secret-token-value');
+    expect(raw).not.toContain('/services/T00');
+    expect(raw).not.toContain('/B00/');
+
+    // Should contain masked URL
+    expect(raw).toContain('hooks.slack.com/***');
+  });
+
+  it('never stores webhook secrets in history events', () => {
+    // The event creation path doesn't receive secrets, but verify
+    // the on-disk format has no secret-like fields
+    appendDeliveryEvents(
+      testDataDir,
+      [sampleResult()],
+      [sampleContext()],
+    );
+
+    const fp = path.join(testDataDir, 'task-board-webhook-delivery-history.json');
+    const raw = fs.readFileSync(fp, 'utf8');
+    const parsed = JSON.parse(raw);
+
+    for (const event of parsed.events) {
+      expect(event).not.toHaveProperty('secret');
+      expect(event).not.toHaveProperty('url');
+      // Only maskedUrl should exist
+      expect(event).toHaveProperty('maskedUrl');
+    }
+  });
+
+  it('query response never includes raw URLs', () => {
+    appendDeliveryEvents(
+      testDataDir,
+      [sampleResult()],
+      [sampleContext({ url: 'https://secret-webhook.com/path/to/secret' })],
+    );
+
+    const result = queryDeliveryHistory(testDataDir);
+    for (const event of result.events) {
+      expect(event.maskedUrl).not.toContain('/path/to/secret');
+      expect(event.maskedUrl).toBe('https://secret-webhook.com/***');
+    }
+  });
+});
+
+// ─── Failure isolation ───────────────────────────────────────────────────────
+
+describe('failure isolation', () => {
+  it('corrupt history file does not crash on read', () => {
+    const fp = path.join(testDataDir, 'task-board-webhook-delivery-history.json');
+    fs.writeFileSync(fp, 'not-json-at-all');
+    const history = readDeliveryHistory(testDataDir);
+    expect(history.version).toBe(1);
+    expect(history.events).toHaveLength(0);
+  });
+
+  it('corrupt history file does not block new appends', () => {
+    const fp = path.join(testDataDir, 'task-board-webhook-delivery-history.json');
+    fs.writeFileSync(fp, '!!!corrupt!!!');
+
+    // Should not throw — reads defaults, appends new event
+    appendDeliveryEvents(testDataDir, [sampleResult()], [sampleContext()]);
+
+    const history = readDeliveryHistory(testDataDir);
+    expect(history.events).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
## Refs #219 — Webhook Delivery Status/History UI Baseline (Phase 13)

### What
Adds bounded, additive webhook delivery history tracking with API endpoint and dashboard UI.

### Backend
- **`webhook-delivery-history.ts`**: Append-only delivery event log with bounded retention (200 events / 48h), monotonic IDs, and automatic pruning
- **Events capture**: target ID/name, success/failure, HTTP status code, attempt count, latency, error summary, severity transition context
- **URL masking**: Full webhook URLs are never stored — only `protocol://host/***`
- **Error truncation**: Error strings capped at 200 chars
- **Integration**: Events recorded inline during `maybeDeliverWebhooks()` dispatch (fire-and-forget, non-blocking). History recording failure is swallowed.

### API
- **`GET /api/task-board/webhooks/deliveries`** — query recent delivery events
  - Query params: `?limit=50&sinceMs=3600000&targetId=slack&status=success|failure`
  - Response: events array + summary (total/succeeded/failed/avgDurationMs/targetIds)

### Dashboard UI
- **📊 Deliveries** link in alerts banner (next to 🔗 Webhooks)
- Modal with summary cards (total, succeeded, failed, avg latency)
- Filterable table: status dot, target name, HTTP badge, latency, attempts, severity transition, time, error
- Dropdown filters: time window, status, target
- Color-coded: green/red status dots, 2xx/4xx/5xx HTTP badges

### Secret Safety
- Raw webhook URLs are **never** stored or displayed (masked to `protocol://host/***`)
- No secret/auth fields in delivery events
- Verified in tests: raw file contents scanned for leaked URLs/secrets

### Tests (43 new — all passing)
| Category | Count | Coverage |
|---|---|---|
| `truncateError` | 4 | Null, short, long, exact limit |
| `createDeliveryEvent` | 5 | Field mapping, URL masking, error truncation, failure, null status |
| `pruneDeliveryEvents` | 5 | Within bounds, maxEvents cap, maxAgeMs, combined, empty |
| `readDeliveryHistory` / `appendDeliveryEvents` | 6 | Persistence, monotonic IDs, pruning, corrupt file, empty |
| `queryDeliveryHistory` | 8 | Filters (sinceMs, targetId, status), limit, summary stats, ordering |
| API endpoint | 5 | Empty state, populated, limit/status/targetId params |
| Integration recording | 3 | Success, failure, multi-target recording via dispatch pipeline |
| Secret safety | 3 | No raw URLs in file, no secret fields, masked in query response |
| Failure isolation | 2 | Corrupt file read, corrupt file append recovery |

### Risk Notes
- **Additive only**: New file + new endpoint + new UI panel. No schema changes to existing data.
- **Reversible**: Removing the history file and reverting these changes restores previous state completely.
- **Non-blocking**: Delivery history recording failure is swallowed in a try/catch — will never affect webhook delivery or alert evaluation.
- **Bounded storage**: 200 events max + 48h age limit prevents unbounded growth.
- **Pre-existing test failures**: 38 failures in `memory-state.test.ts` and `shared-context.test.ts` are all `better-sqlite3` native module errors (pre-existing, unrelated to this PR).

### Files Changed
- `dashboard/server/webhook-delivery-history.ts` — **new** core module
- `dashboard/server/alert-webhook.ts` — integration: record events after delivery
- `dashboard/server/routes/task-board.ts` — new API endpoint
- `dashboard/server/routes/index.ts` — barrel exports
- `dashboard/client/index.html` — CSS + modal HTML + JavaScript
- `dashboard/tests/unit/routes/task-board-webhook-delivery-history.test.ts` — **new** test suite