### PR TITLE
feat(#219): Webhook health stats — per-target health aggregation + dashboard UI (Phase 15)

### DIFF
--- a/dashboard/client/index.html
+++ b/dashboard/client/index.html
@@ -2670,6 +2670,224 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
 
 /* ─── End Webhook Delivery History ──────────────────────────────────── */
 
+/* ─── Webhook Health Stats (Issue #219, Phase 15) ────────────────────── */
+
+.tb-health-section {
+  margin-bottom: 20px;
+}
+
+.tb-health-section-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 12px;
+}
+
+.tb-health-section-header .title {
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--text-primary);
+}
+
+.tb-health-section-header .subtitle {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-left: auto;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.tb-health-overall {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 10px;
+  margin-bottom: 16px;
+}
+
+.tb-health-overall-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 12px 14px;
+  text-align: center;
+}
+
+.tb-health-overall-card .value {
+  font-size: 22px;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.tb-health-overall-card .label {
+  font-size: 10px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  margin-top: 2px;
+}
+
+.tb-health-target-cards {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.tb-health-target-card {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px 16px;
+  transition: border-color 0.2s;
+}
+
+.tb-health-target-card:hover {
+  border-color: rgba(99, 102, 241, 0.4);
+}
+
+.tb-health-target-card.healthy {
+  border-left: 3px solid var(--green);
+}
+
+.tb-health-target-card.degraded {
+  border-left: 3px solid var(--yellow);
+}
+
+.tb-health-target-card.unhealthy {
+  border-left: 3px solid var(--red);
+}
+
+.tb-health-target-card.unknown {
+  border-left: 3px solid var(--text-muted);
+}
+
+.tb-health-target-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+}
+
+.tb-health-target-name {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.tb-health-target-url {
+  font-size: 10px;
+  color: var(--text-muted);
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.tb-health-status-badge {
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 2px 8px;
+  border-radius: 6px;
+  margin-left: auto;
+}
+
+.tb-health-status-badge.healthy {
+  background: rgba(16, 185, 129, 0.15);
+  color: var(--green);
+}
+
+.tb-health-status-badge.degraded {
+  background: rgba(245, 158, 11, 0.15);
+  color: var(--yellow);
+}
+
+.tb-health-status-badge.unhealthy {
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--red);
+}
+
+.tb-health-status-badge.unknown {
+  background: rgba(113, 113, 122, 0.15);
+  color: var(--text-muted);
+}
+
+.tb-health-target-stats {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 8px;
+}
+
+.tb-health-stat {
+  text-align: center;
+}
+
+.tb-health-stat .value {
+  font-size: 16px;
+  font-weight: 700;
+  font-family: 'JetBrains Mono', monospace;
+  color: var(--text-primary);
+}
+
+.tb-health-stat .label {
+  font-size: 9px;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+  margin-top: 1px;
+}
+
+.tb-health-target-timestamps {
+  display: flex;
+  gap: 16px;
+  margin-top: 8px;
+  font-size: 10px;
+  color: var(--text-muted);
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.tb-health-target-timestamps .ts-ok {
+  color: var(--green);
+}
+
+.tb-health-target-timestamps .ts-fail {
+  color: var(--red);
+}
+
+.tb-health-empty {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 12px;
+  padding: 24px 16px;
+  border: 1px dashed var(--border);
+  border-radius: 10px;
+}
+
+.tb-health-progress-bar {
+  width: 100%;
+  height: 6px;
+  background: rgba(239, 68, 68, 0.2);
+  border-radius: 3px;
+  overflow: hidden;
+  margin-top: 8px;
+}
+
+.tb-health-progress-fill {
+  height: 100%;
+  border-radius: 3px;
+  transition: width 0.4s ease;
+}
+
+.tb-health-progress-fill.healthy {
+  background: var(--green);
+}
+
+.tb-health-progress-fill.degraded {
+  background: var(--yellow);
+}
+
+.tb-health-progress-fill.unhealthy {
+  background: var(--red);
+}
+
+/* ─── End Webhook Health Stats ───────────────────────────────────────── */
+
 /* ─── Alert Timeline (Issue #219, Phase 10) ─────────────────────────── */
 
 .tb-alert-timeline {
@@ -4744,12 +4962,16 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
 </div>
 <!-- ═══ End Webhook Config Modal ══════════════════════════════════════ -->
 
-<!-- ═══ Webhook Delivery History Modal (Issue #219, Phase 13) ═══════ -->
+<!-- ═══ Webhook Delivery History Modal (Issue #219, Phase 13 + Phase 15 Health Stats) ═══════ -->
 <div class="tb-delivery-overlay" id="tbDeliveryHistoryModal" onclick="if(event.target===this)tbCloseDeliveryHistory()">
   <div class="tb-delivery-panel">
     <div class="tb-delivery-header">
       <span>📊 Webhook Delivery History</span>
       <div class="tb-delivery-controls">
+        <div class="tab-bar" style="margin-bottom:0;">
+          <button class="tab-btn active" id="tbDeliveryTabHistory" onclick="tbSwitchDeliveryTab('history')">📋 History</button>
+          <button class="tab-btn" id="tbDeliveryTabHealth" onclick="tbSwitchDeliveryTab('health')">💚 Health</button>
+        </div>
         <button onclick="tbSendTestPingFromDeliveries()" class="tb-webhook-test-btn" id="tbDeliveryTestBtn" style="font-size:11px;padding:4px 10px;">🔔 Send Test Ping</button>
         <button onclick="tbRefreshDeliveryHistory()" class="tb-btn tb-btn-secondary" style="font-size:11px;padding:4px 10px;">↻ Refresh</button>
         <button onclick="tbCloseDeliveryHistory()" class="tb-detail-close" aria-label="Close delivery history">✕</button>
@@ -4757,6 +4979,9 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
     </div>
     <div class="tb-delivery-body" id="tbDeliveryHistoryBody">
       <!-- Populated dynamically -->
+    </div>
+    <div class="tb-delivery-body" id="tbDeliveryHealthBody" style="display:none;">
+      <!-- Health stats populated dynamically -->
     </div>
     <div class="tb-delivery-footer">
       <span id="tbDeliveryFooterInfo"></span>
@@ -10009,9 +10234,13 @@ function tbCloseDeliveryHistory() {
   if (overlay) overlay.classList.remove('active');
 }
 
-/** Refresh delivery history data. */
+/** Refresh delivery history data (and health stats if on that tab). */
 async function tbRefreshDeliveryHistory() {
-  await tbFetchDeliveryHistory();
+  if (tbCurrentDeliveryTab === 'health') {
+    await tbFetchHealthStats();
+  } else {
+    await tbFetchDeliveryHistory();
+  }
 }
 
 /** Fetch delivery history from the API with current filter state. */
@@ -10188,6 +10417,167 @@ async function tbSendTestPingFromDeliveries() {
   } finally {
     if (btn) { btn.disabled = false; btn.textContent = '🔔 Send Test Ping'; }
   }
+}
+
+// ── Webhook Health Stats UI (Issue #219, Phase 15) ──────────────────────────
+// Per-target health dashboard tab within the delivery history modal.
+// Aggregates from delivery history — no new persistence.
+
+let tbHealthStatsCache = null;
+let tbCurrentDeliveryTab = 'history';
+
+/** Switch between History and Health tabs in the delivery modal. */
+function tbSwitchDeliveryTab(tab) {
+  tbCurrentDeliveryTab = tab;
+  var historyBody = document.getElementById('tbDeliveryHistoryBody');
+  var healthBody = document.getElementById('tbDeliveryHealthBody');
+  var tabHistory = document.getElementById('tbDeliveryTabHistory');
+  var tabHealth = document.getElementById('tbDeliveryTabHealth');
+
+  if (tab === 'health') {
+    if (historyBody) historyBody.style.display = 'none';
+    if (healthBody) healthBody.style.display = 'block';
+    if (tabHistory) tabHistory.classList.remove('active');
+    if (tabHealth) tabHealth.classList.add('active');
+    tbFetchHealthStats();
+  } else {
+    if (historyBody) historyBody.style.display = 'block';
+    if (healthBody) healthBody.style.display = 'none';
+    if (tabHistory) tabHistory.classList.add('active');
+    if (tabHealth) tabHealth.classList.remove('active');
+  }
+}
+
+/** Fetch webhook health stats from the API. */
+async function tbFetchHealthStats() {
+  var body = document.getElementById('tbDeliveryHealthBody');
+  if (!body) return;
+  body.innerHTML = '<div style="text-align:center;color:var(--text-muted);padding:30px;">Loading health stats…</div>';
+
+  try {
+    var windowSel = document.getElementById('tbHealthWindowSelect');
+    var windowMs = windowSel ? windowSel.value : '86400000';
+    var params = new URLSearchParams();
+    if (windowMs) params.set('windowMs', windowMs);
+
+    var res = await fetch('/api/task-board/webhooks/health?' + params.toString());
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+    var data = await res.json();
+    tbHealthStatsCache = data;
+    tbRenderHealthStats(data);
+  } catch (e) {
+    console.warn('[webhook-health] fetch error', e);
+    body.innerHTML = '<div style="text-align:center;color:var(--red);padding:30px;">Failed to load health stats: ' + tbEsc(e.message) + '</div>';
+  }
+}
+
+/** Format a success rate as a percentage string. */
+function tbFmtRate(rate) {
+  if (rate === null || rate === undefined) return '—';
+  return (rate * 100).toFixed(1) + '%';
+}
+
+/** Format a timestamp as a relative time, or "—" if null. */
+function tbFmtTs(ts) {
+  if (!ts) return '—';
+  return tbRelTime(ts);
+}
+
+/** Render the health stats panel. */
+function tbRenderHealthStats(data) {
+  var body = document.getElementById('tbDeliveryHealthBody');
+  if (!body || !data) return;
+
+  var targets = data.targets || [];
+  var summary = data.summary || {};
+  var html = '';
+
+  // Window selector
+  html += '<div class="tb-health-section">';
+  html += '<div class="tb-health-section-header">';
+  html += '  <span class="title">🩺 Target Health Overview</span>';
+  html += '  <select id="tbHealthWindowSelect" onchange="tbFetchHealthStats()" style="padding:4px 8px;background:var(--bg-tertiary);border:1px solid var(--border);border-radius:6px;color:var(--text-primary);font-size:11px;font-family:inherit;">';
+  html += '    <option value="3600000"' + (data.windowMs === 3600000 ? ' selected' : '') + '>Last 1h</option>';
+  html += '    <option value="21600000"' + (data.windowMs === 21600000 ? ' selected' : '') + '>Last 6h</option>';
+  html += '    <option value="86400000"' + (data.windowMs === 86400000 ? ' selected' : '') + '>Last 24h</option>';
+  html += '    <option value="172800000"' + (data.windowMs === 172800000 ? ' selected' : '') + '>Last 48h</option>';
+  html += '  </select>';
+  html += '  <span class="subtitle">Computed ' + new Date(data.computedAt).toLocaleTimeString() + '</span>';
+  html += '</div>';
+
+  // Overall summary cards
+  var rateColor = summary.overallSuccessRate === null ? 'var(--text-muted)' :
+    summary.overallSuccessRate >= 0.9 ? 'var(--green)' :
+    summary.overallSuccessRate >= 0.5 ? 'var(--yellow)' : 'var(--red)';
+
+  html += '<div class="tb-health-overall">';
+  html += '  <div class="tb-health-overall-card"><div class="value" style="color:var(--text-primary);">' + (summary.totalDeliveries || 0) + '</div><div class="label">Total Deliveries</div></div>';
+  html += '  <div class="tb-health-overall-card"><div class="value" style="color:' + rateColor + ';">' + tbFmtRate(summary.overallSuccessRate) + '</div><div class="label">Success Rate</div></div>';
+  html += '  <div class="tb-health-overall-card"><div class="value" style="color:var(--text-primary);">' + (summary.overallAvgLatencyMs != null ? summary.overallAvgLatencyMs + 'ms' : '—') + '</div><div class="label">Avg Latency</div></div>';
+  html += '  <div class="tb-health-overall-card"><div class="value" style="color:var(--text-primary);">';
+  html += '    <span style="color:var(--green);">' + (summary.healthyCount || 0) + '</span>';
+  html += '    <span style="color:var(--text-muted);font-size:14px;">/</span>';
+  if (summary.degradedCount) html += '    <span style="color:var(--yellow);">' + summary.degradedCount + '</span><span style="color:var(--text-muted);font-size:14px;">/</span>';
+  if (summary.unhealthyCount) html += '    <span style="color:var(--red);">' + summary.unhealthyCount + '</span><span style="color:var(--text-muted);font-size:14px;">/</span>';
+  html += '    <span style="color:var(--text-muted);">' + (summary.targetCount || 0) + '</span>';
+  html += '  </div><div class="label">Targets (Healthy/Total)</div></div>';
+  html += '</div>';
+
+  // Per-target cards
+  if (targets.length === 0) {
+    html += '<div class="tb-health-empty">No webhook delivery data found in the selected window.</div>';
+  } else {
+    html += '<div class="tb-health-target-cards">';
+
+    for (var i = 0; i < targets.length; i++) {
+      var t = targets[i];
+      var tRateColor = t.successRate === null ? 'var(--text-muted)' :
+        t.successRate >= 0.9 ? 'var(--green)' :
+        t.successRate >= 0.5 ? 'var(--yellow)' : 'var(--red)';
+      var pctWidth = t.successRate !== null ? (t.successRate * 100).toFixed(1) : '0';
+      var progressClass = t.healthStatus === 'healthy' ? 'healthy' : t.healthStatus === 'degraded' ? 'degraded' : t.healthStatus === 'unhealthy' ? 'unhealthy' : 'healthy';
+
+      html += '<div class="tb-health-target-card ' + tbEsc(t.healthStatus) + '">';
+
+      // Header row
+      html += '  <div class="tb-health-target-header">';
+      html += '    <span class="tb-health-target-name">' + tbEsc(t.targetName) + '</span>';
+      if (t.maskedUrl) {
+        html += '    <span class="tb-health-target-url">' + tbEsc(t.maskedUrl) + '</span>';
+      }
+      html += '    <span class="tb-health-status-badge ' + tbEsc(t.healthStatus) + '">' + tbEsc(t.healthStatus) + '</span>';
+      html += '  </div>';
+
+      // Stats row
+      html += '  <div class="tb-health-target-stats">';
+      html += '    <div class="tb-health-stat"><div class="value" style="color:' + tRateColor + ';">' + tbFmtRate(t.successRate) + '</div><div class="label">Success Rate</div></div>';
+      html += '    <div class="tb-health-stat"><div class="value" style="color:var(--green);">' + t.successCount + '</div><div class="label">Successes</div></div>';
+      html += '    <div class="tb-health-stat"><div class="value" style="color:' + (t.failureCount > 0 ? 'var(--red)' : 'var(--text-muted)') + ';">' + t.failureCount + '</div><div class="label">Failures</div></div>';
+      html += '    <div class="tb-health-stat"><div class="value">' + (t.avgLatencyMs != null ? t.avgLatencyMs + '<span style="font-size:11px;color:var(--text-muted);">ms</span>' : '—') + '</div><div class="label">Avg Latency</div></div>';
+      html += '  </div>';
+
+      // Success rate progress bar
+      html += '  <div class="tb-health-progress-bar">';
+      html += '    <div class="tb-health-progress-fill ' + progressClass + '" style="width:' + pctWidth + '%;"></div>';
+      html += '  </div>';
+
+      // Timestamps
+      html += '  <div class="tb-health-target-timestamps">';
+      html += '    <span>Last success: <span class="ts-ok">' + tbFmtTs(t.lastSuccessTs) + '</span></span>';
+      html += '    <span>Last failure: <span class="ts-fail">' + tbFmtTs(t.lastFailureTs) + '</span></span>';
+      if (t.lastStatusCode !== null) {
+        html += '    <span>Last HTTP: <span style="font-weight:600;">' + t.lastStatusCode + '</span></span>';
+      }
+      html += '  </div>';
+
+      html += '</div>'; // end target card
+    }
+
+    html += '</div>'; // end target cards container
+  }
+
+  html += '</div>'; // end health section
+  body.innerHTML = html;
 }
 
 // ── Real-time SSE subscription (Issue #219) ─────────────────────────────────

--- a/dashboard/server/routes/index.ts
+++ b/dashboard/server/routes/index.ts
@@ -106,6 +106,18 @@ export type {
   WebhookConfigValidationError,
 } from '../alert-webhook.js';
 export {
+  computeWebhookHealth,
+  aggregateTargetHealth,
+  computeHealthSummary,
+  classifyHealth,
+} from '../webhook-health-stats.js';
+export type {
+  WebhookTargetHealthStats,
+  WebhookHealthSummary,
+  WebhookHealthResponse,
+  WebhookHealthQuery,
+} from '../webhook-health-stats.js';
+export {
   readDeliveryHistory,
   appendDeliveryEvents,
   queryDeliveryHistory,

--- a/dashboard/server/routes/task-board.ts
+++ b/dashboard/server/routes/task-board.ts
@@ -74,6 +74,10 @@ import {
   queryDeliveryHistory,
 } from '../webhook-delivery-history.js';
 
+import {
+  computeWebhookHealth,
+} from '../webhook-health-stats.js';
+
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 const VALID_STATUSES: TaskStatus[] = ['backlog', 'queued', 'running', 'done', 'failed'];
@@ -864,6 +868,23 @@ export async function handleTaskBoard(
       sendJson(res, { error: `Test delivery failed: ${msg}`, results: [] }, 500);
     }
 
+    return true;
+  }
+
+  // ── GET /api/task-board/webhooks/health — Issue #219, Phase 15 ───────────
+  // Returns per-target webhook health stats aggregated from delivery history.
+  // Query params:
+  //   ?windowMs=86400000  — aggregation window (default 24h, max 48h)
+  //   ?targetId=slack     — filter to a specific target
+  if (url.startsWith('/api/task-board/webhooks/health') && method === 'GET') {
+    const healthParams = new URL(url, 'http://localhost').searchParams;
+    const windowMs = healthParams.has('windowMs')
+      ? Math.max(1000, Math.min(Number(healthParams.get('windowMs')) || 86400000, 172800000))
+      : undefined;
+    const targetId = healthParams.get('targetId') || undefined;
+
+    const result = computeWebhookHealth(dataDir, { windowMs, targetId });
+    sendJson(res, result);
     return true;
   }
 

--- a/dashboard/server/webhook-health-stats.ts
+++ b/dashboard/server/webhook-health-stats.ts
@@ -1,0 +1,312 @@
+/**
+ * Webhook Health Stats — per-target health aggregation from delivery history.
+ * Issue #219 — Phase 15: Webhook Health/Per-Target Statistics Dashboard.
+ *
+ * Computes per-target health metrics by aggregating from the existing
+ * webhook delivery history (append-only log). No new persistence layer —
+ * all stats are derived on-read from the bounded history file.
+ *
+ * Key design decisions:
+ *   - Pure read-only aggregation over existing delivery events
+ *   - No schema migrations — uses WebhookDeliveryEvent[] as input
+ *   - Bounded query window (default 24h, max 48h to match history retention)
+ *   - Single-pass aggregation for O(n) performance
+ *   - Results include per-target breakdown + overall summary
+ *
+ * Stats per target:
+ *   - successCount / failureCount / totalCount
+ *   - successRate (0–1, null if no deliveries)
+ *   - avgLatencyMs (null if no deliveries)
+ *   - lastSuccessTs / lastFailureTs (null if none)
+ *   - lastStatusCode (most recent HTTP status, null if none)
+ */
+
+import { readDeliveryHistory } from './webhook-delivery-history.js';
+import type { WebhookDeliveryEvent } from './webhook-delivery-history.js';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/** Health stats for a single webhook target. */
+export interface WebhookTargetHealthStats {
+  /** Target ID. */
+  targetId: string;
+  /** Target display name (from most recent event). */
+  targetName: string;
+  /** Number of successful deliveries in the window. */
+  successCount: number;
+  /** Number of failed deliveries in the window. */
+  failureCount: number;
+  /** Total delivery attempts in the window. */
+  totalCount: number;
+  /** Success rate (0–1). Null if no deliveries. */
+  successRate: number | null;
+  /** Average delivery latency in ms. Null if no deliveries. */
+  avgLatencyMs: number | null;
+  /** Timestamp of last successful delivery. Null if none. */
+  lastSuccessTs: number | null;
+  /** Timestamp of last failed delivery. Null if none. */
+  lastFailureTs: number | null;
+  /** Most recent HTTP status code. Null if none. */
+  lastStatusCode: number | null;
+  /** Masked URL from most recent event. */
+  maskedUrl: string | null;
+  /** Health status derived from success rate thresholds. */
+  healthStatus: 'healthy' | 'degraded' | 'unhealthy' | 'unknown';
+}
+
+/** Overall webhook health summary across all targets. */
+export interface WebhookHealthSummary {
+  /** Total deliveries across all targets in the window. */
+  totalDeliveries: number;
+  /** Total successes. */
+  totalSuccesses: number;
+  /** Total failures. */
+  totalFailures: number;
+  /** Overall success rate across all targets. Null if no deliveries. */
+  overallSuccessRate: number | null;
+  /** Overall average latency. Null if no deliveries. */
+  overallAvgLatencyMs: number | null;
+  /** Number of targets with health data. */
+  targetCount: number;
+  /** Number of healthy targets. */
+  healthyCount: number;
+  /** Number of degraded targets. */
+  degradedCount: number;
+  /** Number of unhealthy targets. */
+  unhealthyCount: number;
+}
+
+/** Full health stats response shape. */
+export interface WebhookHealthResponse {
+  /** Per-target health stats, sorted by totalCount descending. */
+  targets: WebhookTargetHealthStats[];
+  /** Overall summary. */
+  summary: WebhookHealthSummary;
+  /** Time window used for aggregation (ms). */
+  windowMs: number;
+  /** Current time used for computation. */
+  computedAt: number;
+}
+
+/** Query options for health stats. */
+export interface WebhookHealthQuery {
+  /** Time window in ms (default: 24h, max: 48h). */
+  windowMs?: number;
+  /** Filter to a specific target ID. */
+  targetId?: string;
+  /** Current time override (for testing). */
+  now?: number;
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const DEFAULT_WINDOW_MS = 24 * 60 * 60 * 1000;  // 24 hours
+const MAX_WINDOW_MS = 48 * 60 * 60 * 1000;       // 48 hours (matches retention)
+
+/** Success rate thresholds for health status classification. */
+const HEALTH_THRESHOLD_DEGRADED = 0.9;   // below 90% → degraded
+const HEALTH_THRESHOLD_UNHEALTHY = 0.5;  // below 50% → unhealthy
+
+// ─── Core Aggregation ────────────────────────────────────────────────────────
+
+/**
+ * Classify health status from a success rate.
+ * Pure function.
+ */
+export function classifyHealth(
+  successRate: number | null,
+  totalCount: number,
+): 'healthy' | 'degraded' | 'unhealthy' | 'unknown' {
+  if (totalCount === 0 || successRate === null) return 'unknown';
+  if (successRate >= HEALTH_THRESHOLD_DEGRADED) return 'healthy';
+  if (successRate >= HEALTH_THRESHOLD_UNHEALTHY) return 'degraded';
+  return 'unhealthy';
+}
+
+/**
+ * Aggregate per-target health stats from a list of delivery events.
+ * Single-pass O(n) aggregation. Pure function — no side effects.
+ *
+ * Events should already be filtered to the desired time window.
+ */
+export function aggregateTargetHealth(
+  events: WebhookDeliveryEvent[],
+): WebhookTargetHealthStats[] {
+  // Accumulate per-target
+  const map = new Map<string, {
+    targetId: string;
+    targetName: string;
+    successCount: number;
+    failureCount: number;
+    totalLatency: number;
+    lastSuccessTs: number | null;
+    lastFailureTs: number | null;
+    lastTs: number;
+    lastStatusCode: number | null;
+    maskedUrl: string | null;
+  }>();
+
+  for (const ev of events) {
+    let acc = map.get(ev.targetId);
+    if (!acc) {
+      acc = {
+        targetId: ev.targetId,
+        targetName: ev.targetName,
+        successCount: 0,
+        failureCount: 0,
+        totalLatency: 0,
+        lastSuccessTs: null,
+        lastFailureTs: null,
+        lastTs: 0,
+        lastStatusCode: null,
+        maskedUrl: null,
+      };
+      map.set(ev.targetId, acc);
+    }
+
+    if (ev.success) {
+      acc.successCount++;
+      if (acc.lastSuccessTs === null || ev.ts > acc.lastSuccessTs) {
+        acc.lastSuccessTs = ev.ts;
+      }
+    } else {
+      acc.failureCount++;
+      if (acc.lastFailureTs === null || ev.ts > acc.lastFailureTs) {
+        acc.lastFailureTs = ev.ts;
+      }
+    }
+
+    acc.totalLatency += ev.durationMs;
+
+    // Track most recent event for name/url/status
+    if (ev.ts > acc.lastTs) {
+      acc.lastTs = ev.ts;
+      acc.targetName = ev.targetName;
+      acc.maskedUrl = ev.maskedUrl;
+      acc.lastStatusCode = ev.statusCode;
+    }
+  }
+
+  // Convert to result
+  const results: WebhookTargetHealthStats[] = [];
+  for (const acc of map.values()) {
+    const totalCount = acc.successCount + acc.failureCount;
+    const successRate = totalCount > 0
+      ? Math.round((acc.successCount / totalCount) * 10000) / 10000
+      : null;
+    const avgLatencyMs = totalCount > 0
+      ? Math.round(acc.totalLatency / totalCount)
+      : null;
+
+    results.push({
+      targetId: acc.targetId,
+      targetName: acc.targetName,
+      successCount: acc.successCount,
+      failureCount: acc.failureCount,
+      totalCount,
+      successRate,
+      avgLatencyMs,
+      lastSuccessTs: acc.lastSuccessTs,
+      lastFailureTs: acc.lastFailureTs,
+      lastStatusCode: acc.lastStatusCode,
+      maskedUrl: acc.maskedUrl,
+      healthStatus: classifyHealth(successRate, totalCount),
+    });
+  }
+
+  // Sort by totalCount descending (most active targets first)
+  results.sort((a, b) => b.totalCount - a.totalCount);
+
+  return results;
+}
+
+/**
+ * Compute overall summary from per-target stats.
+ * Pure function.
+ */
+export function computeHealthSummary(
+  targets: WebhookTargetHealthStats[],
+): WebhookHealthSummary {
+  let totalDeliveries = 0;
+  let totalSuccesses = 0;
+  let totalFailures = 0;
+  let totalLatencySum = 0;
+  let latencyCount = 0;
+  let healthyCount = 0;
+  let degradedCount = 0;
+  let unhealthyCount = 0;
+
+  for (const t of targets) {
+    totalDeliveries += t.totalCount;
+    totalSuccesses += t.successCount;
+    totalFailures += t.failureCount;
+
+    if (t.avgLatencyMs !== null) {
+      totalLatencySum += t.avgLatencyMs * t.totalCount;
+      latencyCount += t.totalCount;
+    }
+
+    if (t.healthStatus === 'healthy') healthyCount++;
+    else if (t.healthStatus === 'degraded') degradedCount++;
+    else if (t.healthStatus === 'unhealthy') unhealthyCount++;
+  }
+
+  const overallSuccessRate = totalDeliveries > 0
+    ? Math.round((totalSuccesses / totalDeliveries) * 10000) / 10000
+    : null;
+
+  const overallAvgLatencyMs = latencyCount > 0
+    ? Math.round(totalLatencySum / latencyCount)
+    : null;
+
+  return {
+    totalDeliveries,
+    totalSuccesses,
+    totalFailures,
+    overallSuccessRate,
+    overallAvgLatencyMs,
+    targetCount: targets.length,
+    healthyCount,
+    degradedCount,
+    unhealthyCount,
+  };
+}
+
+/**
+ * Main entry point: compute webhook health stats from delivery history.
+ *
+ * Reads the persisted delivery history, filters to the query window,
+ * and aggregates per-target health metrics. Bounded to O(n) where n is
+ * the number of retained events (max 200).
+ */
+export function computeWebhookHealth(
+  dataDir: string,
+  opts: WebhookHealthQuery = {},
+): WebhookHealthResponse {
+  const now = opts.now ?? Date.now();
+  const windowMs = Math.max(1000, Math.min(opts.windowMs ?? DEFAULT_WINDOW_MS, MAX_WINDOW_MS));
+  const cutoff = now - windowMs;
+
+  // Read all events from history
+  const history = readDeliveryHistory(dataDir);
+  let events = history.events;
+
+  // Filter by time window
+  events = events.filter((e) => e.ts >= cutoff);
+
+  // Filter by target ID if specified
+  if (opts.targetId) {
+    events = events.filter((e) => e.targetId === opts.targetId);
+  }
+
+  // Aggregate
+  const targets = aggregateTargetHealth(events);
+  const summary = computeHealthSummary(targets);
+
+  return {
+    targets,
+    summary,
+    windowMs,
+    computedAt: now,
+  };
+}

--- a/dashboard/tests/unit/routes/task-board-webhook-health-stats.test.ts
+++ b/dashboard/tests/unit/routes/task-board-webhook-health-stats.test.ts
@@ -1,0 +1,513 @@
+/**
+ * Webhook Health Stats tests — Issue #219, Phase 15.
+ *
+ * Tests for:
+ * - classifyHealth() — health status classification from success rate
+ * - aggregateTargetHealth() — single-pass per-target aggregation
+ * - computeHealthSummary() — overall summary computation
+ * - computeWebhookHealth() — full pipeline from disk to response
+ * - GET /api/task-board/webhooks/health — API endpoint shape + filters
+ * - Edge cases: empty history, single target, all failures, all successes
+ * - Bounded query window enforcement
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { mockRequest, mockResponse, parseJsonBody } from '../../helpers.js';
+import { handleTaskBoard } from '../../../server/routes/task-board.js';
+import {
+  classifyHealth,
+  aggregateTargetHealth,
+  computeHealthSummary,
+  computeWebhookHealth,
+} from '../../../server/webhook-health-stats.js';
+import type {
+  WebhookTargetHealthStats,
+  WebhookHealthResponse,
+} from '../../../server/webhook-health-stats.js';
+import type {
+  WebhookDeliveryEvent,
+  WebhookDeliveryHistoryFile,
+} from '../../../server/webhook-delivery-history.js';
+import { appendDeliveryEvents } from '../../../server/webhook-delivery-history.js';
+import type { TaskBoardDeps } from '../../../server/types.js';
+
+const testDataDir = path.join('/tmp', 'test-webhook-health-' + process.pid);
+
+function createDeps(overrides: Partial<TaskBoardDeps> = {}): TaskBoardDeps {
+  return {
+    dataDir: testDataDir,
+    sendJson: (res, data, status = 200) => {
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+    },
+    readRequestBody: async () => '{}',
+    ...overrides,
+  };
+}
+
+function makeEvent(overrides: Partial<WebhookDeliveryEvent> = {}): WebhookDeliveryEvent {
+  return {
+    id: 1,
+    ts: Date.now(),
+    targetId: 'target-a',
+    targetName: 'Target A',
+    success: true,
+    statusCode: 200,
+    attempts: 1,
+    durationMs: 150,
+    error: null,
+    maskedUrl: 'https://example.com/***',
+    triggerSeverity: 'warning',
+    previousSeverity: 'ok',
+    ...overrides,
+  };
+}
+
+function seedHistory(events: Partial<WebhookDeliveryEvent>[]): void {
+  const history: WebhookDeliveryHistoryFile = {
+    version: 1,
+    events: events.map((e, i) => makeEvent({ id: i + 1, ...e })),
+    nextId: events.length + 1,
+  };
+  fs.mkdirSync(testDataDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(testDataDir, 'task-board-webhook-delivery-history.json'),
+    JSON.stringify(history),
+  );
+}
+
+beforeEach(() => {
+  fs.mkdirSync(testDataDir, { recursive: true });
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(testDataDir, { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup errors
+  }
+});
+
+// ─── classifyHealth ──────────────────────────────────────────────────────────
+
+describe('classifyHealth', () => {
+  it('returns "unknown" when totalCount is 0', () => {
+    expect(classifyHealth(null, 0)).toBe('unknown');
+  });
+
+  it('returns "unknown" when successRate is null', () => {
+    expect(classifyHealth(null, 5)).toBe('unknown');
+  });
+
+  it('returns "healthy" when rate >= 0.9', () => {
+    expect(classifyHealth(0.95, 10)).toBe('healthy');
+    expect(classifyHealth(0.9, 10)).toBe('healthy');
+    expect(classifyHealth(1.0, 10)).toBe('healthy');
+  });
+
+  it('returns "degraded" when 0.5 <= rate < 0.9', () => {
+    expect(classifyHealth(0.89, 10)).toBe('degraded');
+    expect(classifyHealth(0.5, 10)).toBe('degraded');
+    expect(classifyHealth(0.7, 10)).toBe('degraded');
+  });
+
+  it('returns "unhealthy" when rate < 0.5', () => {
+    expect(classifyHealth(0.49, 10)).toBe('unhealthy');
+    expect(classifyHealth(0.0, 10)).toBe('unhealthy');
+    expect(classifyHealth(0.1, 10)).toBe('unhealthy');
+  });
+});
+
+// ─── aggregateTargetHealth ───────────────────────────────────────────────────
+
+describe('aggregateTargetHealth', () => {
+  it('returns empty array for empty events', () => {
+    expect(aggregateTargetHealth([])).toHaveLength(0);
+  });
+
+  it('aggregates a single target correctly', () => {
+    const now = Date.now();
+    const events = [
+      makeEvent({ targetId: 'a', success: true, durationMs: 100, ts: now - 3000 }),
+      makeEvent({ targetId: 'a', success: true, durationMs: 200, ts: now - 2000 }),
+      makeEvent({ targetId: 'a', success: false, durationMs: 5000, ts: now - 1000, error: 'timeout', statusCode: null }),
+    ];
+
+    const results = aggregateTargetHealth(events);
+    expect(results).toHaveLength(1);
+
+    const t = results[0];
+    expect(t.targetId).toBe('a');
+    expect(t.successCount).toBe(2);
+    expect(t.failureCount).toBe(1);
+    expect(t.totalCount).toBe(3);
+    expect(t.successRate).toBeCloseTo(0.6667, 3);
+    expect(t.avgLatencyMs).toBe(Math.round((100 + 200 + 5000) / 3));
+    expect(t.lastSuccessTs).toBe(now - 2000);
+    expect(t.lastFailureTs).toBe(now - 1000);
+  });
+
+  it('aggregates multiple targets independently', () => {
+    const now = Date.now();
+    const events = [
+      makeEvent({ targetId: 'slack', targetName: 'Slack', success: true, durationMs: 100, ts: now }),
+      makeEvent({ targetId: 'discord', targetName: 'Discord', success: false, durationMs: 200, ts: now, error: 'fail' }),
+      makeEvent({ targetId: 'slack', targetName: 'Slack', success: true, durationMs: 150, ts: now }),
+    ];
+
+    const results = aggregateTargetHealth(events);
+    expect(results).toHaveLength(2);
+
+    // Sorted by totalCount desc — slack has 2, discord has 1
+    expect(results[0].targetId).toBe('slack');
+    expect(results[0].successCount).toBe(2);
+    expect(results[0].failureCount).toBe(0);
+    expect(results[0].successRate).toBe(1.0);
+
+    expect(results[1].targetId).toBe('discord');
+    expect(results[1].successCount).toBe(0);
+    expect(results[1].failureCount).toBe(1);
+    expect(results[1].successRate).toBe(0.0);
+    expect(results[1].healthStatus).toBe('unhealthy');
+  });
+
+  it('uses most recent event for targetName and maskedUrl', () => {
+    const now = Date.now();
+    const events = [
+      makeEvent({ targetId: 'x', targetName: 'Old Name', maskedUrl: 'https://old.com/***', ts: now - 5000 }),
+      makeEvent({ targetId: 'x', targetName: 'New Name', maskedUrl: 'https://new.com/***', ts: now }),
+    ];
+
+    const results = aggregateTargetHealth(events);
+    expect(results[0].targetName).toBe('New Name');
+    expect(results[0].maskedUrl).toBe('https://new.com/***');
+  });
+
+  it('classifies health status based on success rate', () => {
+    const now = Date.now();
+
+    // 100% success → healthy
+    const healthyEvents = Array.from({ length: 10 }, (_, i) =>
+      makeEvent({ targetId: 'h', success: true, ts: now - i * 1000 }),
+    );
+    const healthy = aggregateTargetHealth(healthyEvents);
+    expect(healthy[0].healthStatus).toBe('healthy');
+
+    // 70% success → degraded
+    const degradedEvents = [
+      ...Array.from({ length: 7 }, (_, i) => makeEvent({ targetId: 'd', success: true, ts: now - i * 1000 })),
+      ...Array.from({ length: 3 }, (_, i) => makeEvent({ targetId: 'd', success: false, error: 'err', ts: now - (7 + i) * 1000 })),
+    ];
+    const degraded = aggregateTargetHealth(degradedEvents);
+    expect(degraded[0].healthStatus).toBe('degraded');
+
+    // 20% success → unhealthy
+    const unhealthyEvents = [
+      ...Array.from({ length: 2 }, (_, i) => makeEvent({ targetId: 'u', success: true, ts: now - i * 1000 })),
+      ...Array.from({ length: 8 }, (_, i) => makeEvent({ targetId: 'u', success: false, error: 'err', ts: now - (2 + i) * 1000 })),
+    ];
+    const unhealthy = aggregateTargetHealth(unhealthyEvents);
+    expect(unhealthy[0].healthStatus).toBe('unhealthy');
+  });
+
+  it('tracks lastStatusCode from the most recent event', () => {
+    const now = Date.now();
+    const events = [
+      makeEvent({ targetId: 'a', statusCode: 200, ts: now - 2000 }),
+      makeEvent({ targetId: 'a', statusCode: 502, ts: now - 1000 }),
+    ];
+    const results = aggregateTargetHealth(events);
+    expect(results[0].lastStatusCode).toBe(502);
+  });
+});
+
+// ─── computeHealthSummary ────────────────────────────────────────────────────
+
+describe('computeHealthSummary', () => {
+  it('returns zeroes for empty targets array', () => {
+    const summary = computeHealthSummary([]);
+    expect(summary.totalDeliveries).toBe(0);
+    expect(summary.totalSuccesses).toBe(0);
+    expect(summary.totalFailures).toBe(0);
+    expect(summary.overallSuccessRate).toBeNull();
+    expect(summary.overallAvgLatencyMs).toBeNull();
+    expect(summary.targetCount).toBe(0);
+  });
+
+  it('computes overall stats from multiple targets', () => {
+    const targets: WebhookTargetHealthStats[] = [
+      {
+        targetId: 'a', targetName: 'A', successCount: 8, failureCount: 2,
+        totalCount: 10, successRate: 0.8, avgLatencyMs: 100,
+        lastSuccessTs: null, lastFailureTs: null, lastStatusCode: 200,
+        maskedUrl: null, healthStatus: 'degraded',
+      },
+      {
+        targetId: 'b', targetName: 'B', successCount: 5, failureCount: 0,
+        totalCount: 5, successRate: 1.0, avgLatencyMs: 200,
+        lastSuccessTs: null, lastFailureTs: null, lastStatusCode: 200,
+        maskedUrl: null, healthStatus: 'healthy',
+      },
+    ];
+
+    const summary = computeHealthSummary(targets);
+    expect(summary.totalDeliveries).toBe(15);
+    expect(summary.totalSuccesses).toBe(13);
+    expect(summary.totalFailures).toBe(2);
+    // Weighted average: (8+5) / 15
+    expect(summary.overallSuccessRate).toBeCloseTo(0.8667, 3);
+    // Weighted avg latency: (100*10 + 200*5) / 15 = 2000/15 ≈ 133
+    expect(summary.overallAvgLatencyMs).toBe(Math.round((100 * 10 + 200 * 5) / 15));
+    expect(summary.targetCount).toBe(2);
+    expect(summary.healthyCount).toBe(1);
+    expect(summary.degradedCount).toBe(1);
+    expect(summary.unhealthyCount).toBe(0);
+  });
+});
+
+// ─── computeWebhookHealth (integration) ──────────────────────────────────────
+
+describe('computeWebhookHealth', () => {
+  it('returns empty result when no history exists', () => {
+    const result = computeWebhookHealth(testDataDir);
+    expect(result.targets).toHaveLength(0);
+    expect(result.summary.totalDeliveries).toBe(0);
+    expect(result.windowMs).toBe(86400000); // default 24h
+    expect(result.computedAt).toBeGreaterThan(0);
+  });
+
+  it('aggregates from persisted delivery history', () => {
+    const now = Date.now();
+    seedHistory([
+      { targetId: 'slack', targetName: 'Slack', success: true, durationMs: 100, ts: now - 1000 },
+      { targetId: 'slack', targetName: 'Slack', success: false, durationMs: 5000, ts: now - 500, error: 'timeout' },
+      { targetId: 'discord', targetName: 'Discord', success: true, durationMs: 200, ts: now - 2000 },
+    ]);
+
+    const result = computeWebhookHealth(testDataDir, { now });
+    expect(result.targets).toHaveLength(2);
+    expect(result.summary.totalDeliveries).toBe(3);
+    expect(result.summary.totalSuccesses).toBe(2);
+    expect(result.summary.totalFailures).toBe(1);
+
+    const slack = result.targets.find((t) => t.targetId === 'slack');
+    expect(slack).toBeDefined();
+    expect(slack!.successCount).toBe(1);
+    expect(slack!.failureCount).toBe(1);
+    expect(slack!.successRate).toBe(0.5);
+    expect(slack!.healthStatus).toBe('degraded');
+  });
+
+  it('respects windowMs — excludes old events', () => {
+    const now = Date.now();
+    seedHistory([
+      { targetId: 'a', success: true, durationMs: 100, ts: now - 7200000 }, // 2h ago
+      { targetId: 'a', success: true, durationMs: 100, ts: now - 1800000 }, // 30min ago
+      { targetId: 'a', success: false, durationMs: 100, ts: now - 600000, error: 'fail' }, // 10min ago
+    ]);
+
+    // 1h window — should only include the 30min and 10min events
+    const result = computeWebhookHealth(testDataDir, { windowMs: 3600000, now });
+    expect(result.targets).toHaveLength(1);
+    expect(result.targets[0].totalCount).toBe(2);
+    expect(result.windowMs).toBe(3600000);
+  });
+
+  it('caps windowMs at 48h max', () => {
+    const result = computeWebhookHealth(testDataDir, { windowMs: 999999999 });
+    expect(result.windowMs).toBe(172800000); // 48h
+  });
+
+  it('filters by targetId', () => {
+    const now = Date.now();
+    seedHistory([
+      { targetId: 'slack', success: true, ts: now },
+      { targetId: 'discord', success: true, ts: now },
+    ]);
+
+    const result = computeWebhookHealth(testDataDir, { targetId: 'slack', now });
+    expect(result.targets).toHaveLength(1);
+    expect(result.targets[0].targetId).toBe('slack');
+  });
+
+  it('handles all-success scenario correctly', () => {
+    const now = Date.now();
+    seedHistory(
+      Array.from({ length: 10 }, (_, i) => ({
+        targetId: 't1',
+        targetName: 'T1',
+        success: true,
+        durationMs: 100 + i * 10,
+        ts: now - i * 1000,
+      })),
+    );
+
+    const result = computeWebhookHealth(testDataDir, { now });
+    expect(result.targets[0].successRate).toBe(1.0);
+    expect(result.targets[0].healthStatus).toBe('healthy');
+    expect(result.targets[0].failureCount).toBe(0);
+    expect(result.targets[0].lastFailureTs).toBeNull();
+  });
+
+  it('handles all-failure scenario correctly', () => {
+    const now = Date.now();
+    seedHistory(
+      Array.from({ length: 5 }, (_, i) => ({
+        targetId: 't1',
+        targetName: 'T1',
+        success: false,
+        durationMs: 5000,
+        error: 'ECONNREFUSED',
+        ts: now - i * 1000,
+      })),
+    );
+
+    const result = computeWebhookHealth(testDataDir, { now });
+    expect(result.targets[0].successRate).toBe(0.0);
+    expect(result.targets[0].healthStatus).toBe('unhealthy');
+    expect(result.targets[0].successCount).toBe(0);
+    expect(result.targets[0].lastSuccessTs).toBeNull();
+  });
+
+  it('handles corrupt history file gracefully', () => {
+    fs.writeFileSync(
+      path.join(testDataDir, 'task-board-webhook-delivery-history.json'),
+      '{corrupt}',
+    );
+    const result = computeWebhookHealth(testDataDir);
+    expect(result.targets).toHaveLength(0);
+    expect(result.summary.totalDeliveries).toBe(0);
+  });
+});
+
+// ─── API Route: GET /api/task-board/webhooks/health ──────────────────────────
+
+describe('GET /api/task-board/webhooks/health', () => {
+  it('returns correct response shape with empty history', async () => {
+    const req = mockRequest({ url: '/api/task-board/webhooks/health' });
+    const res = mockResponse();
+    const handled = await handleTaskBoard(req, res, createDeps());
+
+    expect(handled).toBe(true);
+    expect(res._statusCode).toBe(200);
+
+    const body = parseJsonBody<WebhookHealthResponse>(res);
+    expect(body).toHaveProperty('targets');
+    expect(body).toHaveProperty('summary');
+    expect(body).toHaveProperty('windowMs');
+    expect(body).toHaveProperty('computedAt');
+    expect(Array.isArray(body.targets)).toBe(true);
+    expect(body.summary).toHaveProperty('totalDeliveries');
+    expect(body.summary).toHaveProperty('overallSuccessRate');
+    expect(body.summary).toHaveProperty('overallAvgLatencyMs');
+    expect(body.summary).toHaveProperty('targetCount');
+    expect(body.summary).toHaveProperty('healthyCount');
+    expect(body.summary).toHaveProperty('degradedCount');
+    expect(body.summary).toHaveProperty('unhealthyCount');
+  });
+
+  it('returns per-target health stats from persisted data', async () => {
+    const now = Date.now();
+    seedHistory([
+      { targetId: 'slack', targetName: 'Slack', success: true, durationMs: 100, ts: now - 1000 },
+      { targetId: 'slack', targetName: 'Slack', success: true, durationMs: 200, ts: now - 500 },
+      { targetId: 'discord', targetName: 'Discord', success: false, durationMs: 5000, ts: now - 2000, error: 'refused' },
+    ]);
+
+    const req = mockRequest({ url: '/api/task-board/webhooks/health' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    const body = parseJsonBody<WebhookHealthResponse>(res);
+    expect(body.targets).toHaveLength(2);
+    expect(body.summary.totalDeliveries).toBe(3);
+
+    const slack = body.targets.find((t) => t.targetId === 'slack');
+    expect(slack).toBeDefined();
+    expect(slack!.successCount).toBe(2);
+    expect(slack!.successRate).toBe(1.0);
+    expect(slack!.healthStatus).toBe('healthy');
+
+    const discord = body.targets.find((t) => t.targetId === 'discord');
+    expect(discord).toBeDefined();
+    expect(discord!.failureCount).toBe(1);
+    expect(discord!.successRate).toBe(0.0);
+    expect(discord!.healthStatus).toBe('unhealthy');
+  });
+
+  it('respects windowMs query param', async () => {
+    const now = Date.now();
+    seedHistory([
+      { targetId: 'a', success: true, ts: now - 7200000 }, // 2h ago
+      { targetId: 'a', success: true, ts: now - 600000 },  // 10min ago
+    ]);
+
+    const req = mockRequest({ url: '/api/task-board/webhooks/health?windowMs=3600000' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    const body = parseJsonBody<WebhookHealthResponse>(res);
+    expect(body.windowMs).toBe(3600000);
+    // Only the 10min event should be in the window
+    expect(body.summary.totalDeliveries).toBe(1);
+  });
+
+  it('respects targetId query param', async () => {
+    const now = Date.now();
+    seedHistory([
+      { targetId: 'slack', success: true, ts: now },
+      { targetId: 'discord', success: true, ts: now },
+    ]);
+
+    const req = mockRequest({ url: '/api/task-board/webhooks/health?targetId=slack' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    const body = parseJsonBody<WebhookHealthResponse>(res);
+    expect(body.targets).toHaveLength(1);
+    expect(body.targets[0].targetId).toBe('slack');
+  });
+
+  it('per-target stats shape has all expected fields', async () => {
+    const now = Date.now();
+    seedHistory([
+      { targetId: 'x', targetName: 'X', success: true, durationMs: 120, ts: now, statusCode: 200, maskedUrl: 'https://x.com/***' },
+    ]);
+
+    const req = mockRequest({ url: '/api/task-board/webhooks/health' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    const body = parseJsonBody<WebhookHealthResponse>(res);
+    const t = body.targets[0];
+    expect(t).toHaveProperty('targetId');
+    expect(t).toHaveProperty('targetName');
+    expect(t).toHaveProperty('successCount');
+    expect(t).toHaveProperty('failureCount');
+    expect(t).toHaveProperty('totalCount');
+    expect(t).toHaveProperty('successRate');
+    expect(t).toHaveProperty('avgLatencyMs');
+    expect(t).toHaveProperty('lastSuccessTs');
+    expect(t).toHaveProperty('lastFailureTs');
+    expect(t).toHaveProperty('lastStatusCode');
+    expect(t).toHaveProperty('maskedUrl');
+    expect(t).toHaveProperty('healthStatus');
+  });
+
+  it('does not expose any secret data in response', async () => {
+    const now = Date.now();
+    seedHistory([
+      { targetId: 'a', success: true, ts: now, maskedUrl: 'https://hooks.slack.com/***' },
+    ]);
+
+    const req = mockRequest({ url: '/api/task-board/webhooks/health' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    const raw = res._body;
+    expect(raw).not.toContain('secret');
+    expect(raw).toContain('https://hooks.slack.com/***');
+  });
+});


### PR DESCRIPTION
## Summary

Adds per-target webhook health statistics derived from existing delivery history. No new persistence layer — all stats are computed on-read from the bounded delivery event log (max 200 events / 48h).

## What's New

### Aggregation Module (`webhook-health-stats.ts`)
- Pure O(n) single-pass aggregation over `WebhookDeliveryEvent[]`
- Per-target metrics: success/failure counts, success rate, avg latency, last success/failure timestamps, health classification
- Health classification thresholds: ≥90% healthy, ≥50% degraded, <50% unhealthy
- Overall summary: total deliveries, weighted success rate, weighted avg latency, target health breakdown

### API Endpoint
- `GET /api/task-board/webhooks/health` — returns per-target health stats + overall summary
- Query params: `windowMs` (default 24h, max 48h), `targetId` (optional filter)
- Response shape: `{ targets: WebhookTargetHealthStats[], summary: WebhookHealthSummary, windowMs, computedAt }`

### Dashboard UI
- New **Health** tab added to the Delivery History modal (alongside existing History tab)
- Overall summary cards: total deliveries, success rate, avg latency, healthy/total targets
- Per-target health cards with:
  - Color-coded health status badges (healthy/degraded/unhealthy/unknown)
  - Success rate progress bar
  - Success/failure counts, avg latency
  - Last success/failure timestamps
  - Left border color matches health status
- Configurable time window selector (1h / 6h / 24h / 48h)

### Tests (27 new)
- `classifyHealth()` — health status classification boundary cases
- `aggregateTargetHealth()` — single/multi target, most-recent field tracking, health classification
- `computeHealthSummary()` — weighted averages, empty input
- `computeWebhookHealth()` — full pipeline from disk, window enforcement, target filter, all-success/all-failure, corrupt file
- API route — response shape, per-target stats, query params, secret safety

## Evidence

```
✓ 27 new tests passing
✓ 559 total task-board tests passing (0 regressions)
✓ TypeScript: clean `tsc --noEmit`
```

## Risk Assessment

| Risk | Level | Mitigation |
|------|-------|------------|
| Performance on large history | **Low** | History capped at 200 events; single-pass O(n) |
| Secret exposure | **None** | Only pre-masked URLs from delivery events; no raw URLs ever stored |
| Breaking existing UI | **None** | New tab added to modal; existing History tab unchanged |
| Schema migration | **None** | Read-only aggregation over existing data format |

## Scope

- ✅ Per-target webhook health aggregation
- ✅ API endpoint with bounded query window
- ✅ Dashboard UI health tab
- ✅ Tests for aggregation, API, and edge cases
- ❌ No provider-specific integrations
- ❌ No queue daemon changes  
- ❌ No schema migrations

Refs #219