### PR TITLE
feat(#219): Webhook delivery history export — CSV/JSON download (Phase 17)

### DIFF
--- a/dashboard/client/index.html
+++ b/dashboard/client/index.html
@@ -2668,6 +2668,38 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
   color: var(--text-muted);
 }
 
+/* Export buttons (Phase 17) */
+.tb-export-controls {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+}
+
+.tb-export-btn {
+  padding: 3px 10px;
+  font-size: 11px;
+  font-weight: 600;
+  font-family: inherit;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-tertiary);
+  color: var(--text-secondary);
+  cursor: pointer;
+  transition: all 0.15s;
+  white-space: nowrap;
+}
+
+.tb-export-btn:hover {
+  border-color: var(--accent);
+  color: var(--text-primary);
+  background: var(--bg-card);
+}
+
+.tb-export-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
 /* ─── End Webhook Delivery History ──────────────────────────────────── */
 
 /* ─── Webhook Health Stats (Issue #219, Phase 15) ────────────────────── */
@@ -5247,6 +5279,10 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
     </div>
     <div class="tb-delivery-footer">
       <span id="tbDeliveryFooterInfo"></span>
+      <div class="tb-export-controls" id="tbExportControls">
+        <button class="tb-export-btn" onclick="tbExportCurrentTab('csv')" title="Download as CSV">📥 CSV</button>
+        <button class="tb-export-btn" onclick="tbExportCurrentTab('json')" title="Download as JSON">📥 JSON</button>
+      </div>
       <span>Retention: 200 events / 48h</span>
     </div>
   </div>
@@ -11042,6 +11078,84 @@ function tbRenderRetryActivity(data) {
   var footer = document.getElementById('tbDeliveryFooterInfo');
   if (footer) {
     footer.textContent = 'Showing ' + events.length + ' retried deliver' + (events.length !== 1 ? 'ies' : 'y');
+  }
+}
+
+// ── Delivery/Retry Export (Issue #219, Phase 17) ────────────────────────────
+// Download delivery history or retry activity as CSV/JSON file.
+// Uses the same filter state from the active tab. Triggers browser download
+// via a dynamically created <a> element with a blob: URL.
+
+/**
+ * Export current tab data as CSV or JSON.
+ * Reads current filter state and triggers a file download via the export API.
+ */
+function tbExportCurrentTab(format) {
+  var tab = tbCurrentDeliveryTab || 'history';
+  var params = new URLSearchParams();
+  params.set('format', format);
+  params.set('limit', '200');
+
+  if (tab === 'retries') {
+    // Read retry filters
+    var retryWindowSel = document.getElementById('tbRetryWindowSelect');
+    var retryTargetSel = document.getElementById('tbRetryTargetFilter');
+    if (retryWindowSel && retryWindowSel.value) params.set('sinceMs', retryWindowSel.value);
+    if (retryTargetSel && retryTargetSel.value) params.set('targetId', retryTargetSel.value);
+
+    tbTriggerExportDownload('/api/task-board/webhooks/retries/export?' + params.toString(), format);
+  } else {
+    // Read delivery filters (default tab = history)
+    var windowEl = document.getElementById('tbDeliveryWindow');
+    var statusEl = document.getElementById('tbDeliveryStatusFilter');
+    var targetEl = document.getElementById('tbDeliveryTargetFilter');
+    if (windowEl && windowEl.value) params.set('sinceMs', windowEl.value);
+    if (statusEl && statusEl.value) params.set('status', statusEl.value);
+    if (targetEl && targetEl.value) params.set('targetId', targetEl.value);
+
+    tbTriggerExportDownload('/api/task-board/webhooks/deliveries/export?' + params.toString(), format);
+  }
+}
+
+/**
+ * Trigger a file download from an export API URL.
+ * Fetches the content, creates a Blob, and triggers download via <a> click.
+ */
+async function tbTriggerExportDownload(url, format) {
+  // Disable export buttons while downloading
+  var btns = document.querySelectorAll('.tb-export-btn');
+  btns.forEach(function(b) { b.disabled = true; });
+
+  try {
+    var res = await fetch(url);
+    if (!res.ok) throw new Error('HTTP ' + res.status);
+
+    // Extract filename from Content-Disposition header if available
+    var disposition = res.headers.get('Content-Disposition') || '';
+    var filenameMatch = disposition.match(/filename="?([^";\s]+)"?/);
+    var filename = filenameMatch ? filenameMatch[1] : ('webhook-export.' + format);
+
+    var blob = await res.blob();
+    var blobUrl = URL.createObjectURL(blob);
+    var a = document.createElement('a');
+    a.href = blobUrl;
+    a.download = filename;
+    a.style.display = 'none';
+    document.body.appendChild(a);
+    a.click();
+
+    // Cleanup
+    setTimeout(function() {
+      document.body.removeChild(a);
+      URL.revokeObjectURL(blobUrl);
+    }, 100);
+
+    tbShowToast('Exported ' + (res.headers.get('X-Export-Count') || '') + ' events as ' + format.toUpperCase(), 'success');
+  } catch (e) {
+    console.warn('[export] download error', e);
+    tbShowToast('Export failed: ' + e.message, 'error');
+  } finally {
+    btns.forEach(function(b) { b.disabled = false; });
   }
 }
 

--- a/dashboard/server/routes/index.ts
+++ b/dashboard/server/routes/index.ts
@@ -125,6 +125,12 @@ export {
   pruneDeliveryEvents,
   createDeliveryEvent,
   truncateError,
+  exportDeliveryHistory,
+  exportRetryActivity,
+  deliveryEventsToCsv,
+  deliveryEventsToJson,
+  csvEscape,
+  EXPORT_MAX_EVENTS,
 } from '../webhook-delivery-history.js';
 export type {
   WebhookDeliveryEvent,
@@ -137,4 +143,8 @@ export type {
   RetryActivityQuery,
   RetryTargetSummary,
   RetryActivityResponse,
+  ExportFormat,
+  DeliveryExportQuery,
+  RetryExportQuery,
+  ExportResult,
 } from '../webhook-delivery-history.js';

--- a/dashboard/server/routes/task-board.ts
+++ b/dashboard/server/routes/task-board.ts
@@ -73,7 +73,10 @@ import {
 import {
   queryDeliveryHistory,
   queryRetryActivity,
+  exportDeliveryHistory,
+  exportRetryActivity,
 } from '../webhook-delivery-history.js';
+import type { ExportFormat } from '../webhook-delivery-history.js';
 
 import {
   computeWebhookHealth,
@@ -889,6 +892,33 @@ export async function handleTaskBoard(
     return true;
   }
 
+  // ── GET /api/task-board/webhooks/retries/export — Issue #219, Phase 17 ────
+  // Export retry activity as CSV or JSON file download.
+  // Query params: same as /retries + ?format=csv|json (default json)
+  // Bounded: max 200 events per export. Secret-safe: URLs pre-masked.
+  if (url.startsWith('/api/task-board/webhooks/retries/export') && method === 'GET') {
+    const retryExportParams = new URL(url, 'http://localhost').searchParams;
+    const format = (retryExportParams.get('format') === 'csv' ? 'csv' : 'json') as ExportFormat;
+    const limit = retryExportParams.has('limit')
+      ? Math.max(1, Math.min(Number(retryExportParams.get('limit')) || 200, 200))
+      : 200;
+    const sinceMs = retryExportParams.has('sinceMs')
+      ? Math.max(0, Number(retryExportParams.get('sinceMs')) || 0)
+      : undefined;
+    const targetId = retryExportParams.get('targetId') || undefined;
+
+    const result = exportRetryActivity(dataDir, { format, limit, sinceMs, targetId });
+
+    res.writeHead(200, {
+      'Content-Type': result.contentType,
+      'Content-Disposition': `attachment; filename="${result.filename}"`,
+      'Cache-Control': 'no-store',
+      'X-Export-Count': String(result.count),
+    });
+    res.end(result.content);
+    return true;
+  }
+
   // ── GET /api/task-board/webhooks/retries — Issue #219, Phase 16 ──────────
   // Returns retry activity: deliveries that required multiple attempts,
   // per-attempt breakdown, and per-target retry summaries.
@@ -906,6 +936,35 @@ export async function handleTaskBoard(
 
     const result = queryRetryActivity(dataDir, { limit, sinceMs, targetId });
     sendJson(res, result);
+    return true;
+  }
+
+  // ── GET /api/task-board/webhooks/deliveries/export — Issue #219, Phase 17 ──
+  // Export delivery history as CSV or JSON file download.
+  // Query params: same as /deliveries + ?format=csv|json (default json)
+  // Bounded: max 200 events per export. Secret-safe: URLs pre-masked.
+  if (url.startsWith('/api/task-board/webhooks/deliveries/export') && method === 'GET') {
+    const exportParams = new URL(url, 'http://localhost').searchParams;
+    const format = (exportParams.get('format') === 'csv' ? 'csv' : 'json') as ExportFormat;
+    const limit = exportParams.has('limit')
+      ? Math.max(1, Math.min(Number(exportParams.get('limit')) || 200, 200))
+      : 200;
+    const sinceMs = exportParams.has('sinceMs')
+      ? Math.max(0, Number(exportParams.get('sinceMs')) || 0)
+      : undefined;
+    const targetId = exportParams.get('targetId') || undefined;
+    const statusRaw = exportParams.get('status');
+    const status = statusRaw === 'success' || statusRaw === 'failure' ? statusRaw : undefined;
+
+    const result = exportDeliveryHistory(dataDir, { format, limit, sinceMs, targetId, status });
+
+    res.writeHead(200, {
+      'Content-Type': result.contentType,
+      'Content-Disposition': `attachment; filename="${result.filename}"`,
+      'Cache-Control': 'no-store',
+      'X-Export-Count': String(result.count),
+    });
+    res.end(result.content);
     return true;
   }
 

--- a/dashboard/server/webhook-delivery-history.ts
+++ b/dashboard/server/webhook-delivery-history.ts
@@ -527,3 +527,233 @@ export function queryRetryActivity(
     },
   };
 }
+
+// ─── Export Helpers (Phase 17: Delivery History Export) ───────────────────────
+
+/**
+ * Maximum number of events allowed in a single export.
+ * Prevents unbounded memory/CPU usage on export requests.
+ */
+export const EXPORT_MAX_EVENTS = 200;
+
+/** Supported export formats. */
+export type ExportFormat = 'csv' | 'json';
+
+/** Export query — same filters as DeliveryHistoryQuery, plus format. */
+export interface DeliveryExportQuery {
+  format?: ExportFormat;
+  limit?: number;
+  sinceMs?: number;
+  targetId?: string;
+  status?: 'success' | 'failure';
+  now?: number;
+}
+
+/** Export query for retries — same filters as RetryActivityQuery, plus format. */
+export interface RetryExportQuery {
+  format?: ExportFormat;
+  limit?: number;
+  sinceMs?: number;
+  targetId?: string;
+  now?: number;
+}
+
+/** Result of an export operation. */
+export interface ExportResult {
+  /** The serialized export content (CSV string or JSON string). */
+  content: string;
+  /** MIME type for the response Content-Type header. */
+  contentType: string;
+  /** Suggested filename for the Content-Disposition header. */
+  filename: string;
+  /** Number of events included in the export. */
+  count: number;
+}
+
+/**
+ * Escape a value for CSV output.
+ * Wraps in double quotes if the value contains commas, quotes, or newlines.
+ * Pure function.
+ */
+export function csvEscape(value: string | number | boolean | null | undefined): string {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  if (str.includes('"') || str.includes(',') || str.includes('\n') || str.includes('\r')) {
+    return '"' + str.replace(/"/g, '""') + '"';
+  }
+  return str;
+}
+
+/**
+ * Format a timestamp as ISO 8601 string for export.
+ * Returns empty string for null/undefined.
+ */
+function formatExportTs(ts: number | null | undefined): string {
+  if (ts == null) return '';
+  return new Date(ts).toISOString();
+}
+
+/**
+ * Sanitize an event for export: strips any fields that could leak secrets.
+ * Returns a plain object safe for serialization.
+ * The maskedUrl is already safe (set during recording), but we double-check
+ * that no `url` or `secret` field leaks through.
+ */
+function sanitizeEventForExport(event: WebhookDeliveryEvent): Record<string, unknown> {
+  return {
+    id: event.id,
+    timestamp: formatExportTs(event.ts),
+    targetId: event.targetId,
+    targetName: event.targetName,
+    success: event.success,
+    statusCode: event.statusCode,
+    attempts: event.attempts,
+    durationMs: event.durationMs,
+    error: event.error,
+    maskedUrl: event.maskedUrl,
+    triggerSeverity: event.triggerSeverity,
+    previousSeverity: event.previousSeverity,
+    // Explicitly omit: url, secret, payload, headers
+  };
+}
+
+/** CSV column headers for delivery export. */
+const DELIVERY_CSV_HEADERS = [
+  'id', 'timestamp', 'targetId', 'targetName', 'success',
+  'statusCode', 'attempts', 'durationMs', 'error',
+  'maskedUrl', 'triggerSeverity', 'previousSeverity',
+];
+
+/**
+ * Convert delivery events to CSV format.
+ * Pure function — no I/O, bounded by input array length.
+ */
+export function deliveryEventsToCsv(events: WebhookDeliveryEvent[]): string {
+  const rows: string[] = [DELIVERY_CSV_HEADERS.join(',')];
+
+  for (const event of events) {
+    const safe = sanitizeEventForExport(event);
+    const row = DELIVERY_CSV_HEADERS.map((h) => csvEscape(safe[h] as string | number | boolean | null));
+    rows.push(row.join(','));
+  }
+
+  return rows.join('\n');
+}
+
+/**
+ * Convert delivery events to a safe JSON export format.
+ * Returns a JSON string with sanitized events (no secrets).
+ * Pure function.
+ */
+export function deliveryEventsToJson(events: WebhookDeliveryEvent[]): string {
+  const safeEvents = events.map(sanitizeEventForExport);
+  return JSON.stringify({
+    exportedAt: new Date().toISOString(),
+    format: 'ventureos-webhook-delivery-export-v1',
+    count: safeEvents.length,
+    events: safeEvents,
+  }, null, 2);
+}
+
+/**
+ * Export delivery history with the same filter capabilities as queryDeliveryHistory.
+ * Returns formatted content (CSV or JSON), content type, and suggested filename.
+ *
+ * Secret-safe: all events pass through sanitizeEventForExport() which strips
+ * any non-masked fields. URLs are pre-masked at recording time.
+ */
+export function exportDeliveryHistory(
+  dataDir: string,
+  opts: DeliveryExportQuery = {},
+): ExportResult {
+  const format: ExportFormat = opts.format === 'csv' ? 'csv' : 'json';
+  const limit = Math.max(1, Math.min(opts.limit ?? EXPORT_MAX_EVENTS, EXPORT_MAX_EVENTS));
+
+  // Reuse the same query logic for filter parity
+  const queryResult = queryDeliveryHistory(dataDir, {
+    limit,
+    sinceMs: opts.sinceMs,
+    targetId: opts.targetId,
+    status: opts.status,
+    now: opts.now,
+  });
+
+  const events = queryResult.events;
+  const dateSuffix = new Date().toISOString().slice(0, 10);
+
+  if (format === 'csv') {
+    return {
+      content: deliveryEventsToCsv(events),
+      contentType: 'text/csv; charset=utf-8',
+      filename: `webhook-deliveries-${dateSuffix}.csv`,
+      count: events.length,
+    };
+  }
+
+  return {
+    content: deliveryEventsToJson(events),
+    contentType: 'application/json; charset=utf-8',
+    filename: `webhook-deliveries-${dateSuffix}.json`,
+    count: events.length,
+  };
+}
+
+/** CSV column headers for retry export (includes attempt count emphasis). */
+const RETRY_CSV_HEADERS = [
+  'id', 'timestamp', 'targetId', 'targetName', 'success',
+  'statusCode', 'attempts', 'durationMs', 'error',
+  'maskedUrl', 'triggerSeverity', 'previousSeverity',
+];
+
+/**
+ * Export retry activity with the same filter capabilities as queryRetryActivity.
+ * Returns formatted content (CSV or JSON), content type, and suggested filename.
+ *
+ * Secret-safe: same sanitization pipeline as delivery export.
+ */
+export function exportRetryActivity(
+  dataDir: string,
+  opts: RetryExportQuery = {},
+): ExportResult {
+  const format: ExportFormat = opts.format === 'csv' ? 'csv' : 'json';
+  const limit = Math.max(1, Math.min(opts.limit ?? EXPORT_MAX_EVENTS, EXPORT_MAX_EVENTS));
+
+  const queryResult = queryRetryActivity(dataDir, {
+    limit,
+    sinceMs: opts.sinceMs,
+    targetId: opts.targetId,
+    now: opts.now,
+  });
+
+  const events = queryResult.events;
+  const dateSuffix = new Date().toISOString().slice(0, 10);
+
+  if (format === 'csv') {
+    const rows: string[] = [RETRY_CSV_HEADERS.join(',')];
+    for (const event of events) {
+      const safe = sanitizeEventForExport(event);
+      const row = RETRY_CSV_HEADERS.map((h) => csvEscape(safe[h] as string | number | boolean | null));
+      rows.push(row.join(','));
+    }
+    return {
+      content: rows.join('\n'),
+      contentType: 'text/csv; charset=utf-8',
+      filename: `webhook-retries-${dateSuffix}.csv`,
+      count: events.length,
+    };
+  }
+
+  const safeEvents = events.map(sanitizeEventForExport);
+  return {
+    content: JSON.stringify({
+      exportedAt: new Date().toISOString(),
+      format: 'ventureos-webhook-retry-export-v1',
+      count: safeEvents.length,
+      summary: queryResult.summary,
+      events: safeEvents,
+    }, null, 2),
+    contentType: 'application/json; charset=utf-8',
+    filename: `webhook-retries-${dateSuffix}.json`,
+    count: events.length,
+  };
+}

--- a/dashboard/tests/unit/routes/task-board-webhook-delivery-export.test.ts
+++ b/dashboard/tests/unit/routes/task-board-webhook-delivery-export.test.ts
@@ -1,0 +1,732 @@
+/**
+ * Webhook Delivery History Export tests — Issue #219, Phase 17.
+ *
+ * Tests for:
+ * - csvEscape() — CSV value escaping edge cases
+ * - deliveryEventsToCsv() — CSV format correctness, headers, data rows
+ * - deliveryEventsToJson() — JSON export structure and safety
+ * - exportDeliveryHistory() — full export pipeline with filters
+ * - exportRetryActivity() — retry-specific export pipeline
+ * - GET /api/task-board/webhooks/deliveries/export — API endpoint
+ * - GET /api/task-board/webhooks/retries/export — API endpoint
+ * - Filter parity — export respects same filters as query endpoints
+ * - Secret safety — export never contains raw URLs or secrets
+ * - Bounded output — max 200 events enforced
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { mockRequest, mockResponse, parseJsonBody } from '../../helpers.js';
+import {
+  handleTaskBoard,
+} from '../../../server/routes/task-board.js';
+import {
+  appendDeliveryEvents,
+  queryDeliveryHistory,
+  csvEscape,
+  deliveryEventsToCsv,
+  deliveryEventsToJson,
+  exportDeliveryHistory,
+  exportRetryActivity,
+  EXPORT_MAX_EVENTS,
+} from '../../../server/webhook-delivery-history.js';
+import type {
+  WebhookDeliveryEvent,
+  WebhookDeliveryHistoryFile,
+  ExportResult,
+} from '../../../server/webhook-delivery-history.js';
+import type { TaskBoardDeps } from '../../../server/types.js';
+
+const testDataDir = path.join('/tmp', 'test-delivery-export-' + process.pid);
+
+function createDeps(overrides: Partial<TaskBoardDeps> = {}): TaskBoardDeps {
+  return {
+    dataDir: testDataDir,
+    sendJson: (res, data, status = 200) => {
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+    },
+    readRequestBody: async () => '{}',
+    ...overrides,
+  };
+}
+
+function sampleResult(overrides: Partial<{
+  targetId: string;
+  targetName: string;
+  success: boolean;
+  statusCode: number | null;
+  attempts: number;
+  error: string | null;
+  durationMs: number;
+}> = {}) {
+  return {
+    targetId: 'test-target',
+    targetName: 'Test Target',
+    success: true,
+    statusCode: 200,
+    attempts: 1,
+    error: null,
+    durationMs: 150,
+    ...overrides,
+  };
+}
+
+function sampleContext(overrides: Partial<{
+  url: string;
+  triggerSeverity: string;
+  previousSeverity: string | null;
+  ts: number;
+}> = {}) {
+  return {
+    url: 'https://hooks.example.com/webhook/secret-path',
+    triggerSeverity: 'warning',
+    previousSeverity: 'ok' as string | null,
+    ts: Date.now(),
+    ...overrides,
+  };
+}
+
+function seedEvents(events: Partial<WebhookDeliveryEvent>[]): void {
+  const history: WebhookDeliveryHistoryFile = {
+    version: 1,
+    events: events.map((e, i) => ({
+      id: i + 1,
+      ts: Date.now() - (events.length - i) * 60000,
+      targetId: 'target-a',
+      targetName: 'Target A',
+      success: true,
+      statusCode: 200,
+      attempts: 1,
+      durationMs: 100,
+      error: null,
+      maskedUrl: 'https://example.com/***',
+      triggerSeverity: 'warning',
+      previousSeverity: 'ok',
+      ...e,
+    })),
+    nextId: events.length + 1,
+  };
+  fs.writeFileSync(
+    path.join(testDataDir, 'task-board-webhook-delivery-history.json'),
+    JSON.stringify(history),
+  );
+}
+
+beforeEach(() => {
+  fs.mkdirSync(testDataDir, { recursive: true });
+});
+
+afterEach(() => {
+  try {
+    fs.rmSync(testDataDir, { recursive: true, force: true });
+  } catch {
+    // Ignore cleanup errors
+  }
+  vi.restoreAllMocks();
+});
+
+// ─── csvEscape ───────────────────────────────────────────────────────────────
+
+describe('csvEscape', () => {
+  it('returns empty string for null', () => {
+    expect(csvEscape(null)).toBe('');
+  });
+
+  it('returns empty string for undefined', () => {
+    expect(csvEscape(undefined)).toBe('');
+  });
+
+  it('passes through simple strings unchanged', () => {
+    expect(csvEscape('hello')).toBe('hello');
+  });
+
+  it('handles numbers', () => {
+    expect(csvEscape(200)).toBe('200');
+  });
+
+  it('handles booleans', () => {
+    expect(csvEscape(true)).toBe('true');
+    expect(csvEscape(false)).toBe('false');
+  });
+
+  it('wraps strings with commas in double quotes', () => {
+    expect(csvEscape('hello, world')).toBe('"hello, world"');
+  });
+
+  it('wraps strings with double quotes and escapes inner quotes', () => {
+    expect(csvEscape('she said "hi"')).toBe('"she said ""hi"""');
+  });
+
+  it('wraps strings with newlines in double quotes', () => {
+    expect(csvEscape('line1\nline2')).toBe('"line1\nline2"');
+  });
+
+  it('wraps strings with carriage returns in double quotes', () => {
+    expect(csvEscape('line1\rline2')).toBe('"line1\rline2"');
+  });
+
+  it('handles strings with all special characters', () => {
+    const result = csvEscape('a,"b"\nc');
+    expect(result).toBe('"a,""b""\nc"');
+  });
+});
+
+// ─── deliveryEventsToCsv ─────────────────────────────────────────────────────
+
+describe('deliveryEventsToCsv', () => {
+  it('returns header row for empty array', () => {
+    const csv = deliveryEventsToCsv([]);
+    const lines = csv.split('\n');
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toContain('id');
+    expect(lines[0]).toContain('timestamp');
+    expect(lines[0]).toContain('targetId');
+    expect(lines[0]).toContain('success');
+  });
+
+  it('produces correct number of rows', () => {
+    const events: WebhookDeliveryEvent[] = [
+      {
+        id: 1, ts: 1700000000000, targetId: 'slack', targetName: 'Slack',
+        success: true, statusCode: 200, attempts: 1, durationMs: 100,
+        error: null, maskedUrl: 'https://hooks.slack.com/***',
+        triggerSeverity: 'warning', previousSeverity: 'ok',
+      },
+      {
+        id: 2, ts: 1700000060000, targetId: 'discord', targetName: 'Discord',
+        success: false, statusCode: 503, attempts: 3, durationMs: 5000,
+        error: 'Service Unavailable', maskedUrl: 'https://discord.com/***',
+        triggerSeverity: 'critical', previousSeverity: 'warning',
+      },
+    ];
+
+    const csv = deliveryEventsToCsv(events);
+    const lines = csv.split('\n');
+    expect(lines).toHaveLength(3); // header + 2 data rows
+  });
+
+  it('includes all expected columns in header', () => {
+    const csv = deliveryEventsToCsv([]);
+    const headers = csv.split('\n')[0].split(',');
+    const expected = ['id', 'timestamp', 'targetId', 'targetName', 'success',
+      'statusCode', 'attempts', 'durationMs', 'error',
+      'maskedUrl', 'triggerSeverity', 'previousSeverity'];
+    expect(headers).toEqual(expected);
+  });
+
+  it('formats timestamps as ISO 8601', () => {
+    const events: WebhookDeliveryEvent[] = [{
+      id: 1, ts: 1700000000000, targetId: 't', targetName: 'T',
+      success: true, statusCode: 200, attempts: 1, durationMs: 100,
+      error: null, maskedUrl: 'https://x.com/***',
+      triggerSeverity: 'ok', previousSeverity: null,
+    }];
+
+    const csv = deliveryEventsToCsv(events);
+    const dataRow = csv.split('\n')[1];
+    expect(dataRow).toContain('2023-11-14T'); // ISO timestamp from epoch 1700000000000
+  });
+
+  it('properly escapes CSV special characters in error messages', () => {
+    const events: WebhookDeliveryEvent[] = [{
+      id: 1, ts: 1700000000000, targetId: 't', targetName: 'T',
+      success: false, statusCode: 500, attempts: 1, durationMs: 100,
+      error: 'error with "quotes" and, commas', maskedUrl: 'https://x.com/***',
+      triggerSeverity: 'warning', previousSeverity: 'ok',
+    }];
+
+    const csv = deliveryEventsToCsv(events);
+    const dataRow = csv.split('\n')[1];
+    // Should be properly quoted/escaped
+    expect(dataRow).toContain('"error with ""quotes"" and, commas"');
+  });
+
+  it('never contains the word "secret" or raw URLs', () => {
+    const events: WebhookDeliveryEvent[] = [{
+      id: 1, ts: 1700000000000, targetId: 't', targetName: 'T',
+      success: true, statusCode: 200, attempts: 1, durationMs: 100,
+      error: null, maskedUrl: 'https://hooks.slack.com/***',
+      triggerSeverity: 'warning', previousSeverity: 'ok',
+    }];
+
+    const csv = deliveryEventsToCsv(events);
+    expect(csv).not.toContain('/services/');
+    expect(csv).not.toContain('secret-path');
+    expect(csv).toContain('https://hooks.slack.com/***');
+  });
+});
+
+// ─── deliveryEventsToJson ────────────────────────────────────────────────────
+
+describe('deliveryEventsToJson', () => {
+  it('returns valid JSON with metadata', () => {
+    const json = deliveryEventsToJson([]);
+    const parsed = JSON.parse(json);
+    expect(parsed.format).toBe('ventureos-webhook-delivery-export-v1');
+    expect(parsed.exportedAt).toBeDefined();
+    expect(parsed.count).toBe(0);
+    expect(parsed.events).toEqual([]);
+  });
+
+  it('includes all events with sanitized fields', () => {
+    const events: WebhookDeliveryEvent[] = [{
+      id: 1, ts: 1700000000000, targetId: 'slack', targetName: 'Slack',
+      success: true, statusCode: 200, attempts: 1, durationMs: 100,
+      error: null, maskedUrl: 'https://hooks.slack.com/***',
+      triggerSeverity: 'warning', previousSeverity: 'ok',
+    }];
+
+    const json = deliveryEventsToJson(events);
+    const parsed = JSON.parse(json);
+    expect(parsed.count).toBe(1);
+    expect(parsed.events[0].id).toBe(1);
+    expect(parsed.events[0].timestamp).toBeDefined();
+    expect(parsed.events[0].maskedUrl).toBe('https://hooks.slack.com/***');
+  });
+
+  it('strips attempt details from export (flat format)', () => {
+    const events: WebhookDeliveryEvent[] = [{
+      id: 1, ts: 1700000000000, targetId: 't', targetName: 'T',
+      success: true, statusCode: 200, attempts: 2, durationMs: 200,
+      error: null, maskedUrl: 'https://x.com/***',
+      triggerSeverity: 'warning', previousSeverity: 'ok',
+      attemptDetails: [
+        { attempt: 1, ts: 1700000000000, statusCode: 503, error: 'fail', durationMs: 100, nextRetryDelayMs: 1000 },
+        { attempt: 2, ts: 1700000001000, statusCode: 200, error: null, durationMs: 100, nextRetryDelayMs: null },
+      ],
+    }];
+
+    const json = deliveryEventsToJson(events);
+    const parsed = JSON.parse(json);
+    // Sanitized export should NOT include attemptDetails (implementation detail)
+    expect(parsed.events[0]).not.toHaveProperty('attemptDetails');
+  });
+
+  it('never contains raw URL or secret fields', () => {
+    const events: WebhookDeliveryEvent[] = [{
+      id: 1, ts: 1700000000000, targetId: 't', targetName: 'T',
+      success: true, statusCode: 200, attempts: 1, durationMs: 100,
+      error: null, maskedUrl: 'https://hooks.slack.com/***',
+      triggerSeverity: 'warning', previousSeverity: 'ok',
+    }];
+
+    const json = deliveryEventsToJson(events);
+    const parsed = JSON.parse(json);
+    for (const event of parsed.events) {
+      expect(event).not.toHaveProperty('url');
+      expect(event).not.toHaveProperty('secret');
+      expect(event).toHaveProperty('maskedUrl');
+    }
+  });
+});
+
+// ─── exportDeliveryHistory ───────────────────────────────────────────────────
+
+describe('exportDeliveryHistory', () => {
+  it('returns JSON export by default', () => {
+    seedEvents([
+      { success: true },
+      { success: false, error: 'timeout' },
+    ]);
+
+    const result = exportDeliveryHistory(testDataDir);
+    expect(result.contentType).toContain('application/json');
+    expect(result.filename).toMatch(/^webhook-deliveries-\d{4}-\d{2}-\d{2}\.json$/);
+    expect(result.count).toBe(2);
+
+    const parsed = JSON.parse(result.content);
+    expect(parsed.events).toHaveLength(2);
+    expect(parsed.format).toBe('ventureos-webhook-delivery-export-v1');
+  });
+
+  it('returns CSV export when format=csv', () => {
+    seedEvents([
+      { success: true },
+      { success: false, error: 'fail' },
+    ]);
+
+    const result = exportDeliveryHistory(testDataDir, { format: 'csv' });
+    expect(result.contentType).toContain('text/csv');
+    expect(result.filename).toMatch(/^webhook-deliveries-\d{4}-\d{2}-\d{2}\.csv$/);
+    expect(result.count).toBe(2);
+
+    const lines = result.content.split('\n');
+    expect(lines).toHaveLength(3); // header + 2 rows
+  });
+
+  it('respects status filter', () => {
+    seedEvents([
+      { success: true },
+      { success: false, error: 'fail' },
+      { success: true },
+    ]);
+
+    const result = exportDeliveryHistory(testDataDir, { format: 'json', status: 'failure' });
+    const parsed = JSON.parse(result.content);
+    expect(parsed.events).toHaveLength(1);
+    expect(parsed.events[0].success).toBe(false);
+  });
+
+  it('respects targetId filter', () => {
+    seedEvents([
+      { targetId: 'slack' },
+      { targetId: 'discord' },
+      { targetId: 'slack' },
+    ]);
+
+    const result = exportDeliveryHistory(testDataDir, { format: 'json', targetId: 'slack' });
+    const parsed = JSON.parse(result.content);
+    expect(parsed.events).toHaveLength(2);
+    expect(parsed.events.every((e: Record<string, unknown>) => e.targetId === 'slack')).toBe(true);
+  });
+
+  it('respects sinceMs time window', () => {
+    const now = Date.now();
+    seedEvents([
+      { ts: now - 7200000, targetId: 'old' },  // 2h ago
+      { ts: now - 1800000, targetId: 'recent' }, // 30min ago
+      { ts: now - 600000, targetId: 'newest' },  // 10min ago
+    ]);
+
+    const result = exportDeliveryHistory(testDataDir, {
+      format: 'json', sinceMs: 3600000, now, // last 1h
+    });
+    const parsed = JSON.parse(result.content);
+    expect(parsed.events).toHaveLength(2);
+  });
+
+  it('enforces EXPORT_MAX_EVENTS limit', () => {
+    // Seed 200 events (max retention)
+    const events = Array.from({ length: 200 }, (_, i) => ({
+      targetId: 't' + i,
+      success: true,
+    }));
+    seedEvents(events);
+
+    const result = exportDeliveryHistory(testDataDir, { format: 'json', limit: 999 });
+    const parsed = JSON.parse(result.content);
+    expect(parsed.events.length).toBeLessThanOrEqual(EXPORT_MAX_EVENTS);
+  });
+
+  it('returns empty export when no events', () => {
+    const result = exportDeliveryHistory(testDataDir, { format: 'csv' });
+    expect(result.count).toBe(0);
+
+    const lines = result.content.split('\n');
+    expect(lines).toHaveLength(1); // header only
+  });
+});
+
+// ─── exportRetryActivity ─────────────────────────────────────────────────────
+
+describe('exportRetryActivity', () => {
+  it('returns JSON export with retry summary', () => {
+    seedEvents([
+      { attempts: 1, success: true },
+      { attempts: 3, success: true },
+      { attempts: 2, success: false, error: 'timeout' },
+    ]);
+
+    const result = exportRetryActivity(testDataDir);
+    expect(result.contentType).toContain('application/json');
+    expect(result.filename).toMatch(/^webhook-retries-\d{4}-\d{2}-\d{2}\.json$/);
+    expect(result.count).toBe(2); // only events with attempts > 1
+
+    const parsed = JSON.parse(result.content);
+    expect(parsed.format).toBe('ventureos-webhook-retry-export-v1');
+    expect(parsed.summary).toBeDefined();
+    expect(parsed.summary.retriedDeliveries).toBe(2);
+  });
+
+  it('returns CSV export for retries', () => {
+    seedEvents([
+      { attempts: 1, success: true },
+      { attempts: 3, success: true },
+      { attempts: 2, success: false, error: 'err' },
+    ]);
+
+    const result = exportRetryActivity(testDataDir, { format: 'csv' });
+    expect(result.contentType).toContain('text/csv');
+    expect(result.count).toBe(2);
+
+    const lines = result.content.split('\n');
+    expect(lines).toHaveLength(3); // header + 2 data rows
+  });
+
+  it('respects targetId filter', () => {
+    seedEvents([
+      { targetId: 'a', attempts: 3 },
+      { targetId: 'b', attempts: 2 },
+      { targetId: 'a', attempts: 2 },
+    ]);
+
+    const result = exportRetryActivity(testDataDir, { format: 'json', targetId: 'a' });
+    const parsed = JSON.parse(result.content);
+    expect(parsed.events.every((e: Record<string, unknown>) => e.targetId === 'a')).toBe(true);
+  });
+
+  it('returns empty when no retries needed', () => {
+    seedEvents([
+      { attempts: 1, success: true },
+      { attempts: 1, success: true },
+    ]);
+
+    const result = exportRetryActivity(testDataDir, { format: 'json' });
+    expect(result.count).toBe(0);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.events).toHaveLength(0);
+  });
+});
+
+// ─── API Routes ──────────────────────────────────────────────────────────────
+
+describe('GET /api/task-board/webhooks/deliveries/export', () => {
+  it('returns CSV download with correct headers', async () => {
+    seedEvents([
+      { success: true },
+      { success: false, error: 'timeout' },
+    ]);
+
+    const req = mockRequest({ url: '/api/task-board/webhooks/deliveries/export?format=csv' });
+    const res = mockResponse();
+    const deps = createDeps();
+
+    const handled = await handleTaskBoard(req, res, deps);
+    expect(handled).toBe(true);
+    expect(res._statusCode).toBe(200);
+    expect(res._headers['content-type']).toContain('text/csv');
+    expect(res._headers['content-disposition']).toContain('attachment');
+    expect(res._headers['content-disposition']).toContain('.csv');
+    expect(res._headers['cache-control']).toBe('no-store');
+    expect(res._headers['x-export-count']).toBeDefined();
+
+    // Body should be valid CSV
+    const lines = res._body.split('\n');
+    expect(lines.length).toBeGreaterThanOrEqual(2); // header + at least 1 row
+    expect(lines[0]).toContain('id');
+  });
+
+  it('returns JSON download by default', async () => {
+    seedEvents([{ success: true }]);
+
+    const req = mockRequest({ url: '/api/task-board/webhooks/deliveries/export' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    expect(res._statusCode).toBe(200);
+    expect(res._headers['content-type']).toContain('application/json');
+    expect(res._headers['content-disposition']).toContain('.json');
+
+    const parsed = JSON.parse(res._body);
+    expect(parsed.format).toBe('ventureos-webhook-delivery-export-v1');
+    expect(parsed.events).toHaveLength(1);
+  });
+
+  it('respects query filters', async () => {
+    seedEvents([
+      { success: true, targetId: 'slack' },
+      { success: false, targetId: 'discord', error: 'fail' },
+      { success: true, targetId: 'slack' },
+    ]);
+
+    const req = mockRequest({
+      url: '/api/task-board/webhooks/deliveries/export?format=json&status=success&targetId=slack',
+    });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    const parsed = JSON.parse(res._body);
+    expect(parsed.events).toHaveLength(2);
+    expect(parsed.events.every((e: Record<string, unknown>) => e.targetId === 'slack')).toBe(true);
+    expect(parsed.events.every((e: Record<string, unknown>) => e.success === true)).toBe(true);
+  });
+
+  it('returns empty export for no matching events', async () => {
+    const req = mockRequest({ url: '/api/task-board/webhooks/deliveries/export?format=csv' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    expect(res._statusCode).toBe(200);
+    // Should still have header row
+    const lines = res._body.split('\n');
+    expect(lines).toHaveLength(1);
+  });
+});
+
+describe('GET /api/task-board/webhooks/retries/export', () => {
+  it('returns CSV download for retries', async () => {
+    seedEvents([
+      { attempts: 1, success: true },
+      { attempts: 3, success: true },
+      { attempts: 2, success: false, error: 'fail' },
+    ]);
+
+    const req = mockRequest({ url: '/api/task-board/webhooks/retries/export?format=csv' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    expect(res._statusCode).toBe(200);
+    expect(res._headers['content-type']).toContain('text/csv');
+    expect(res._headers['content-disposition']).toContain('retries');
+
+    const lines = res._body.split('\n');
+    expect(lines).toHaveLength(3); // header + 2 retried events
+  });
+
+  it('returns JSON download with summary', async () => {
+    seedEvents([
+      { attempts: 1, success: true },
+      { attempts: 3, success: true },
+    ]);
+
+    const req = mockRequest({ url: '/api/task-board/webhooks/retries/export?format=json' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    expect(res._statusCode).toBe(200);
+    const parsed = JSON.parse(res._body);
+    expect(parsed.format).toBe('ventureos-webhook-retry-export-v1');
+    expect(parsed.summary).toBeDefined();
+    expect(parsed.events).toHaveLength(1);
+  });
+
+  it('respects targetId filter', async () => {
+    seedEvents([
+      { targetId: 'a', attempts: 3 },
+      { targetId: 'b', attempts: 2 },
+    ]);
+
+    const req = mockRequest({
+      url: '/api/task-board/webhooks/retries/export?format=json&targetId=a',
+    });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    const parsed = JSON.parse(res._body);
+    expect(parsed.events).toHaveLength(1);
+    expect(parsed.events[0].targetId).toBe('a');
+  });
+});
+
+// ─── Filter parity ───────────────────────────────────────────────────────────
+
+describe('filter parity between query and export', () => {
+  it('export returns same events as query with identical filters', () => {
+    const now = Date.now();
+    seedEvents([
+      { ts: now - 7200000, targetId: 'a', success: true },
+      { ts: now - 1800000, targetId: 'b', success: false, error: 'err' },
+      { ts: now - 600000, targetId: 'a', success: true },
+    ]);
+
+    // Use same filters for both
+    const filters = {
+      sinceMs: 3600000,
+      targetId: 'a',
+      status: 'success' as const,
+      now,
+    };
+
+    // Query result (the reference)
+    const queryResult = queryDeliveryHistory(testDataDir, { ...filters, limit: 200 });
+
+    // Export result
+    const exportResult = exportDeliveryHistory(testDataDir, { ...filters, format: 'json' });
+    const exportParsed = JSON.parse(exportResult.content);
+
+    expect(exportParsed.events.length).toBe(queryResult.events.length);
+    expect(exportParsed.count).toBe(queryResult.count);
+    // Verify same event IDs
+    const queryIds = queryResult.events.map((e: WebhookDeliveryEvent) => e.id);
+    const exportIds = exportParsed.events.map((e: Record<string, unknown>) => e.id);
+    expect(exportIds).toEqual(queryIds);
+  });
+});
+
+// ─── Secret safety (export-specific) ─────────────────────────────────────────
+
+describe('export secret safety', () => {
+  it('CSV export never contains raw webhook URLs', () => {
+    const secretUrl = 'https://hooks.slack.com/services/T00/B00/xoxb-secret-token-value';
+    appendDeliveryEvents(
+      testDataDir,
+      [sampleResult()],
+      [sampleContext({ url: secretUrl })],
+    );
+
+    const result = exportDeliveryHistory(testDataDir, { format: 'csv' });
+
+    expect(result.content).not.toContain('xoxb-secret-token-value');
+    expect(result.content).not.toContain('/services/T00');
+    expect(result.content).not.toContain('/B00/');
+    expect(result.content).toContain('hooks.slack.com/***');
+  });
+
+  it('JSON export never contains raw webhook URLs', () => {
+    const secretUrl = 'https://hooks.slack.com/services/T00/B00/xoxb-secret-token-value';
+    appendDeliveryEvents(
+      testDataDir,
+      [sampleResult()],
+      [sampleContext({ url: secretUrl })],
+    );
+
+    const result = exportDeliveryHistory(testDataDir, { format: 'json' });
+
+    expect(result.content).not.toContain('xoxb-secret-token-value');
+    expect(result.content).not.toContain('/services/T00');
+    expect(result.content).not.toContain('/B00/');
+    expect(result.content).toContain('hooks.slack.com/***');
+  });
+
+  it('export does not include url or secret fields', () => {
+    appendDeliveryEvents(
+      testDataDir,
+      [sampleResult()],
+      [sampleContext()],
+    );
+
+    const result = exportDeliveryHistory(testDataDir, { format: 'json' });
+    const parsed = JSON.parse(result.content);
+
+    for (const event of parsed.events) {
+      expect(event).not.toHaveProperty('url');
+      expect(event).not.toHaveProperty('secret');
+      expect(event).toHaveProperty('maskedUrl');
+    }
+  });
+
+  it('retry export also applies secret safety', () => {
+    appendDeliveryEvents(
+      testDataDir,
+      [sampleResult({ attempts: 3 })],
+      [sampleContext({ url: 'https://secret-webhook.com/path/to/token' })],
+    );
+
+    const result = exportRetryActivity(testDataDir, { format: 'json' });
+    expect(result.content).not.toContain('/path/to/token');
+    expect(result.content).toContain('secret-webhook.com/***');
+  });
+});
+
+// ─── Bounded output ──────────────────────────────────────────────────────────
+
+describe('bounded output', () => {
+  it('EXPORT_MAX_EVENTS is 200', () => {
+    expect(EXPORT_MAX_EVENTS).toBe(200);
+  });
+
+  it('export caps at EXPORT_MAX_EVENTS regardless of limit param', () => {
+    // Seed max events
+    const events = Array.from({ length: 200 }, (_, i) => ({
+      targetId: 'target-' + (i % 3),
+      success: i % 2 === 0,
+    }));
+    seedEvents(events);
+
+    const result = exportDeliveryHistory(testDataDir, { format: 'json', limit: 999 });
+    const parsed = JSON.parse(result.content);
+    expect(parsed.events.length).toBeLessThanOrEqual(EXPORT_MAX_EVENTS);
+  });
+});


### PR DESCRIPTION
## Summary
Adds export capability for webhook delivery history and retry activity as CSV or JSON file downloads.

**Refs #219**

## What's New

### API Endpoints
- `GET /api/task-board/webhooks/deliveries/export?format=csv|json` — Export delivery history
- `GET /api/task-board/webhooks/retries/export?format=csv|json` — Export retry activity
- Same filter params as existing query endpoints (sinceMs, targetId, status, limit)
- Returns file download with `Content-Disposition: attachment` headers
- Bounded: max 200 events per export

### Core Functions
- `exportDeliveryHistory()` / `exportRetryActivity()` — full export pipeline
- `deliveryEventsToCsv()` / `deliveryEventsToJson()` — format converters
- `csvEscape()` — RFC 4180 compliant CSV value escaping
- `sanitizeEventForExport()` — strips internal details, enforces secret safety

### Dashboard UI
- Export buttons (📥 CSV / 📥 JSON) in delivery history modal footer
- Context-aware: reads current tab (History/Retries) and active filters
- Blob-based download (no page navigation)
- Toast feedback with event count

### Security Guarantees
- All events pass through `sanitizeEventForExport()` redaction layer
- URLs pre-masked at recording time (`maskedUrl` only — never raw)
- No `url`, `secret`, `payload`, or `headers` fields in export output
- `Cache-Control: no-store` on all export responses
- Verified in tests: raw file content checked for absence of secrets

## Tests
**45 new tests, all passing:**
- `csvEscape`: null/undefined, special chars, RFC 4180 compliance
- `deliveryEventsToCsv`: headers, row counts, ISO timestamps, escaping
- `deliveryEventsToJson`: structure, sanitization, no attemptDetails
- `exportDeliveryHistory`: format selection, all filters, bounded output
- `exportRetryActivity`: format + filters
- API routes: both endpoints, response headers, filters, empty exports
- Filter parity: export matches query results with identical filters
- Secret safety: CSV + JSON never contain raw URLs/tokens
- Bounded output: `EXPORT_MAX_EVENTS = 200` enforced

## Risk Assessment
- **Low risk**: Purely additive — no schema changes, no existing behavior modified
- **Reversible**: Remove the 2 route handlers + UI buttons to fully revert
- **No new dependencies**: Uses existing query functions + standard Node.js APIs
- **Bounded output**: Hard cap at 200 events prevents memory/CPU abuse
- **Auth posture**: Inherits existing dashboard auth middleware (no new access paths)

## Pre-existing Test Failures
38 failures in `memory-state.test.ts` and `shared-context.test.ts` are pre-existing `better-sqlite3` native module loading errors — unrelated to this PR.