### PR TITLE
feat(#219): Provider-specific webhook payload formatters — Slack + Discord + generic fallback (Phase 18)

### DIFF
--- a/dashboard/server/alert-webhook.ts
+++ b/dashboard/server/alert-webhook.ts
@@ -23,6 +23,8 @@ import type { AlertSeverity, AlertEvaluation, AlertRuleResult } from './alert-ru
 import type { AlertHistoryEvent } from './alert-history.js';
 import { appendDeliveryEvents } from './webhook-delivery-history.js';
 import type { WebhookDeliveryAttemptDetail } from './webhook-delivery-history.js';
+import { formatPayload, isValidProvider, ALLOWED_PROVIDERS } from './webhook-formatters.js';
+import type { WebhookProvider, FormattedPayload } from './webhook-formatters.js';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -43,6 +45,14 @@ export interface WebhookTarget {
    * Default: 'warning' (notifies on warning and critical transitions).
    */
   minSeverity?: AlertSeverity;
+  /**
+   * Payload format provider for this target.
+   * Controls how the webhook payload is shaped for the receiving service.
+   * Default: 'generic' (raw VentureOS JSON — backward-compatible).
+   * Allowed values: 'generic', 'slack', 'discord'.
+   * Issue #219 — Phase 18.
+   */
+  provider?: WebhookProvider;
 }
 
 /** Full webhook configuration. */
@@ -280,6 +290,7 @@ export function sanitizeConfig(raw: unknown): WebhookConfig {
             minSeverity: typeof tObj.minSeverity === 'string' && ['ok', 'warning', 'critical'].includes(tObj.minSeverity)
               ? (tObj.minSeverity as AlertSeverity)
               : 'warning',
+            provider: isValidProvider(tObj.provider) ? tObj.provider : undefined,
           });
         }
       }
@@ -389,6 +400,15 @@ export function validateWebhookConfig(input: unknown): WebhookConfigValidationEr
         if (tObj.minSeverity !== undefined) {
           if (typeof tObj.minSeverity !== 'string' || !['ok', 'warning', 'critical'].includes(tObj.minSeverity)) {
             errors.push({ field: `${prefix}.minSeverity`, message: 'minSeverity must be ok, warning, or critical' });
+          }
+        }
+
+        if (tObj.provider !== undefined) {
+          if (!isValidProvider(tObj.provider)) {
+            errors.push({
+              field: `${prefix}.provider`,
+              message: `provider must be one of: ${ALLOWED_PROVIDERS.join(', ')}`,
+            });
           }
         }
       }
@@ -509,7 +529,11 @@ export async function deliverWebhook(
 ): Promise<WebhookDeliveryResult> {
   const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
   const maxRetries = opts.maxRetries ?? DEFAULT_MAX_RETRIES;
-  const body = JSON.stringify(payload);
+
+  // Format payload for the target's provider (Phase 18).
+  // Falls back to generic JSON if provider is unset or unknown.
+  const formatted = formatPayload(payload, target.provider);
+  const body = formatted.body;
   const startMs = Date.now();
 
   let lastError: string | null = null;
@@ -530,12 +554,15 @@ export async function deliverWebhook(
 
     try {
       const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
+        'Content-Type': formatted.contentType,
         'User-Agent': 'VentureOS-Dashboard/1.0',
         'X-VentureOS-Event': 'alert.transition',
+        ...formatted.extraHeaders,
       };
 
-      // Add HMAC signature if secret is configured
+      // Add HMAC signature if secret is configured.
+      // Signature is computed over the final formatted body so verification
+      // works regardless of which provider formatter was used.
       if (target.secret) {
         const signature = await computeSignature(body, target.secret);
         headers['X-VentureOS-Signature'] = `sha256=${signature}`;
@@ -814,7 +841,10 @@ export async function deliverTestWebhook(
 ): Promise<WebhookTestResult> {
   const timeoutMs = opts.timeoutMs ?? TEST_TIMEOUT_MS;
   const maxRetries = opts.maxRetries ?? TEST_MAX_RETRIES;
-  const body = JSON.stringify(payload);
+
+  // Format test payload for the target's provider (Phase 18).
+  const formatted = formatPayload(payload, target.provider);
+  const body = formatted.body;
   const startMs = Date.now();
 
   let lastError: string | null = null;
@@ -833,13 +863,15 @@ export async function deliverTestWebhook(
 
     try {
       const headers: Record<string, string> = {
-        'Content-Type': 'application/json',
+        'Content-Type': formatted.contentType,
         'User-Agent': 'VentureOS-Dashboard/1.0',
         'X-VentureOS-Event': 'webhook.test',
         'X-VentureOS-Test': 'true',
+        ...formatted.extraHeaders,
       };
 
-      // Add HMAC signature if secret is configured
+      // Add HMAC signature if secret is configured.
+      // Signature is computed over the final formatted body.
       if (target.secret) {
         const signature = await computeSignature(body, target.secret);
         headers['X-VentureOS-Signature'] = `sha256=${signature}`;

--- a/dashboard/server/webhook-formatters.ts
+++ b/dashboard/server/webhook-formatters.ts
@@ -1,0 +1,388 @@
+/**
+ * Webhook Payload Formatters — provider/channel-specific payload shaping.
+ * Issue #219 — Phase 18: Provider-Specific Webhook Payload Formatters.
+ *
+ * Transforms the generic VentureOS webhook payload into provider-native
+ * formats (Slack Block Kit, Discord Embeds, etc.) while preserving the
+ * existing generic JSON payload as the default.
+ *
+ * Design:
+ *   - Pure functions — no side effects, no external SDKs
+ *   - Each formatter produces { body, headers } ready for HTTP delivery
+ *   - The generic formatter is always the fallback
+ *   - Provider set is closed/validated — no arbitrary strings
+ *   - HMAC signatures are computed over the final serialized body
+ *     (downstream of formatting), so security posture is preserved
+ *
+ * Supported providers:
+ *   - 'generic'  — raw VentureOS JSON payload (default, backward-compatible)
+ *   - 'slack'    — Slack Incoming Webhook (Block Kit + text fallback)
+ *   - 'discord'  — Discord Webhook (Embeds)
+ */
+
+import type { WebhookPayload, WebhookTestPayload } from './alert-webhook.js';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/** Allowed webhook provider identifiers. */
+export type WebhookProvider = 'generic' | 'slack' | 'discord';
+
+/** The set of allowed provider strings for validation. */
+export const ALLOWED_PROVIDERS: readonly WebhookProvider[] = ['generic', 'slack', 'discord'] as const;
+
+/** Result of formatting a payload for delivery. */
+export interface FormattedPayload {
+  /** Serialized body string (JSON). */
+  body: string;
+  /** Content-Type header value. */
+  contentType: string;
+  /** Additional provider-specific headers to merge into the request. */
+  extraHeaders: Record<string, string>;
+}
+
+/** Union of payload types the formatters can handle. */
+export type AnyWebhookPayload = WebhookPayload | WebhookTestPayload;
+
+// ─── Severity Helpers ────────────────────────────────────────────────────────
+
+const SEVERITY_EMOJI: Record<string, string> = {
+  ok: '✅',
+  warning: '⚠️',
+  critical: '🔴',
+};
+
+const SEVERITY_COLOR_SLACK: Record<string, string> = {
+  ok: '#36a64f',       // green
+  warning: '#f2c744',  // amber
+  critical: '#e01e5a', // red
+};
+
+/** Discord embed colors are decimal integers. */
+const SEVERITY_COLOR_DISCORD: Record<string, number> = {
+  ok: 0x36a64f,       // green
+  warning: 0xf2c744,  // amber
+  critical: 0xe01e5a, // red
+};
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+/**
+ * Check whether a string is a valid webhook provider.
+ * Pure function.
+ */
+export function isValidProvider(value: unknown): value is WebhookProvider {
+  return typeof value === 'string' && (ALLOWED_PROVIDERS as readonly string[]).includes(value);
+}
+
+// ─── Generic Formatter (default — backward-compatible) ───────────────────────
+
+/**
+ * Format payload as raw VentureOS JSON.
+ * This is the existing behavior — no transformation applied.
+ */
+export function formatGeneric(payload: AnyWebhookPayload): FormattedPayload {
+  return {
+    body: JSON.stringify(payload),
+    contentType: 'application/json',
+    extraHeaders: {},
+  };
+}
+
+// ─── Slack Formatter ─────────────────────────────────────────────────────────
+
+/**
+ * Format an alert transition payload for Slack Incoming Webhooks.
+ *
+ * Uses Slack Block Kit for rich formatting with a plain-text fallback
+ * in the `text` field (required by Slack for notifications/accessibility).
+ *
+ * Reference: https://api.slack.com/messaging/webhooks
+ * Reference: https://api.slack.com/reference/block-kit
+ */
+function formatSlackAlert(payload: WebhookPayload): FormattedPayload {
+  const severity = payload.currentSeverity;
+  const emoji = SEVERITY_EMOJI[severity] ?? '❓';
+  const color = SEVERITY_COLOR_SLACK[severity] ?? '#808080';
+
+  // Plain-text fallback (shown in notifications)
+  const fallbackText = `${emoji} ${payload.transitionLabel}`;
+
+  // Rule summary lines
+  const ruleLines = payload.evaluation.rules
+    .filter((r) => r.enabled)
+    .map((r) => {
+      const ruleEmoji = SEVERITY_EMOJI[r.severity] ?? '•';
+      const val = r.currentValue !== null ? r.currentValue.toFixed(1) : 'N/A';
+      return `${ruleEmoji} *${r.label}*: ${val} — ${r.message}`;
+    });
+
+  const slackPayload = {
+    text: fallbackText,
+    blocks: [
+      {
+        type: 'header',
+        text: {
+          type: 'plain_text',
+          text: `${emoji} VentureOS Alert`,
+          emoji: true,
+        },
+      },
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*${payload.transitionLabel}*`,
+        },
+      },
+      {
+        type: 'section',
+        fields: [
+          {
+            type: 'mrkdwn',
+            text: `*Previous:*\n${payload.previousSeverity ?? 'none'}`,
+          },
+          {
+            type: 'mrkdwn',
+            text: `*Current:*\n${payload.currentSeverity}`,
+          },
+          {
+            type: 'mrkdwn',
+            text: `*Timestamp:*\n${payload.timestampISO}`,
+          },
+          {
+            type: 'mrkdwn',
+            text: `*Source:*\n${payload.source}`,
+          },
+        ],
+      },
+      ...(ruleLines.length > 0
+        ? [
+            { type: 'divider' },
+            {
+              type: 'section',
+              text: {
+                type: 'mrkdwn',
+                text: ruleLines.join('\n'),
+              },
+            },
+          ]
+        : []),
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: `VentureOS Dashboard • Schema v${payload.schemaVersion}`,
+          },
+        ],
+      },
+    ],
+    // Attachment with color bar (sidebar accent)
+    attachments: [
+      {
+        color,
+        blocks: [],
+      },
+    ],
+  };
+
+  return {
+    body: JSON.stringify(slackPayload),
+    contentType: 'application/json',
+    extraHeaders: {},
+  };
+}
+
+/**
+ * Format a test payload for Slack.
+ */
+function formatSlackTest(payload: WebhookTestPayload): FormattedPayload {
+  const slackPayload = {
+    text: '🔔 VentureOS Webhook Test Ping',
+    blocks: [
+      {
+        type: 'header',
+        text: {
+          type: 'plain_text',
+          text: '🔔 VentureOS Webhook Test',
+          emoji: true,
+        },
+      },
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: payload.message,
+        },
+      },
+      {
+        type: 'context',
+        elements: [
+          {
+            type: 'mrkdwn',
+            text: `_Test ping — ${payload.timestampISO}_ • ${payload.source}`,
+          },
+        ],
+      },
+    ],
+  };
+
+  return {
+    body: JSON.stringify(slackPayload),
+    contentType: 'application/json',
+    extraHeaders: {},
+  };
+}
+
+/**
+ * Format any webhook payload for Slack.
+ */
+export function formatSlack(payload: AnyWebhookPayload): FormattedPayload {
+  if (payload.event === 'webhook.test') {
+    return formatSlackTest(payload as WebhookTestPayload);
+  }
+  return formatSlackAlert(payload as WebhookPayload);
+}
+
+// ─── Discord Formatter ───────────────────────────────────────────────────────
+
+/**
+ * Format an alert transition payload for Discord Webhooks.
+ *
+ * Uses Discord's embed format for rich cards with color-coded severity.
+ *
+ * Reference: https://discord.com/developers/docs/resources/webhook
+ * Reference: https://discord.com/developers/docs/resources/message#embed-object
+ */
+function formatDiscordAlert(payload: WebhookPayload): FormattedPayload {
+  const severity = payload.currentSeverity;
+  const emoji = SEVERITY_EMOJI[severity] ?? '❓';
+  const color = SEVERITY_COLOR_DISCORD[severity] ?? 0x808080;
+
+  // Build rule fields for the embed
+  const ruleFields = payload.evaluation.rules
+    .filter((r) => r.enabled)
+    .slice(0, 25) // Discord embeds max 25 fields
+    .map((r) => {
+      const ruleEmoji = SEVERITY_EMOJI[r.severity] ?? '•';
+      const val = r.currentValue !== null ? r.currentValue.toFixed(1) : 'N/A';
+      return {
+        name: `${ruleEmoji} ${r.label}`,
+        value: `Value: ${val}\n${r.message}`,
+        inline: true,
+      };
+    });
+
+  const discordPayload = {
+    content: `${emoji} **${payload.transitionLabel}**`,
+    embeds: [
+      {
+        title: `${emoji} VentureOS Alert`,
+        description: payload.transitionLabel,
+        color,
+        fields: [
+          {
+            name: 'Previous Severity',
+            value: payload.previousSeverity ?? 'none',
+            inline: true,
+          },
+          {
+            name: 'Current Severity',
+            value: payload.currentSeverity,
+            inline: true,
+          },
+          {
+            name: 'Timestamp',
+            value: payload.timestampISO,
+            inline: true,
+          },
+          ...ruleFields,
+        ],
+        footer: {
+          text: `VentureOS Dashboard • Schema v${payload.schemaVersion}`,
+        },
+        timestamp: payload.timestampISO,
+      },
+    ],
+  };
+
+  return {
+    body: JSON.stringify(discordPayload),
+    contentType: 'application/json',
+    extraHeaders: {},
+  };
+}
+
+/**
+ * Format a test payload for Discord.
+ */
+function formatDiscordTest(payload: WebhookTestPayload): FormattedPayload {
+  const discordPayload = {
+    content: '🔔 **VentureOS Webhook Test Ping**',
+    embeds: [
+      {
+        title: '🔔 Webhook Test',
+        description: payload.message,
+        color: 0x3b82f6, // blue
+        footer: {
+          text: `${payload.source} • Test Ping`,
+        },
+        timestamp: payload.timestampISO,
+      },
+    ],
+  };
+
+  return {
+    body: JSON.stringify(discordPayload),
+    contentType: 'application/json',
+    extraHeaders: {},
+  };
+}
+
+/**
+ * Format any webhook payload for Discord.
+ */
+export function formatDiscord(payload: AnyWebhookPayload): FormattedPayload {
+  if (payload.event === 'webhook.test') {
+    return formatDiscordTest(payload as WebhookTestPayload);
+  }
+  return formatDiscordAlert(payload as WebhookPayload);
+}
+
+// ─── Formatter Registry ──────────────────────────────────────────────────────
+
+/** Formatter function signature. */
+export type PayloadFormatter = (payload: AnyWebhookPayload) => FormattedPayload;
+
+/** Registry of provider → formatter. */
+const FORMATTERS: Record<WebhookProvider, PayloadFormatter> = {
+  generic: formatGeneric,
+  slack: formatSlack,
+  discord: formatDiscord,
+};
+
+/**
+ * Get the appropriate formatter for a provider.
+ * Falls back to generic if the provider is unknown.
+ * Pure function.
+ */
+export function getFormatter(provider: WebhookProvider | undefined): PayloadFormatter {
+  if (!provider || !FORMATTERS[provider]) {
+    return FORMATTERS.generic;
+  }
+  return FORMATTERS[provider];
+}
+
+/**
+ * Format a webhook payload for a specific provider.
+ * Convenience wrapper around getFormatter().
+ * Falls back to generic for unknown providers.
+ * Pure function.
+ */
+export function formatPayload(
+  payload: AnyWebhookPayload,
+  provider?: WebhookProvider,
+): FormattedPayload {
+  const formatter = getFormatter(provider);
+  return formatter(payload);
+}

--- a/dashboard/tests/unit/routes/task-board-webhook-formatters.test.ts
+++ b/dashboard/tests/unit/routes/task-board-webhook-formatters.test.ts
@@ -1,0 +1,854 @@
+/**
+ * Webhook Provider Formatters tests — Issue #219, Phase 18.
+ *
+ * Tests for:
+ * - formatGeneric() — backward-compatible raw JSON output
+ * - formatSlack() — Slack Block Kit output for alerts + test pings
+ * - formatDiscord() — Discord Embed output for alerts + test pings
+ * - getFormatter() / formatPayload() — dispatcher + fallback behavior
+ * - isValidProvider() — provider string validation
+ * - ALLOWED_PROVIDERS — registry completeness
+ * - Provider field in WebhookTarget — sanitize, validate, redact round-trip
+ * - Delivery with provider — correct formatting applied during HTTP delivery
+ * - No regression in existing webhook delivery paths (generic default)
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import {
+  formatGeneric,
+  formatSlack,
+  formatDiscord,
+  formatPayload,
+  getFormatter,
+  isValidProvider,
+  ALLOWED_PROVIDERS,
+} from '../../../server/webhook-formatters.js';
+import type {
+  WebhookProvider,
+  FormattedPayload,
+} from '../../../server/webhook-formatters.js';
+
+import {
+  buildWebhookPayload,
+  buildTestPayload,
+  validateWebhookConfig,
+  sanitizeConfig,
+  redactConfig,
+  readWebhookConfig,
+  writeWebhookConfig,
+  deliverWebhook,
+  deliverTestWebhook,
+  resetDeliveryState,
+  computeSignature,
+} from '../../../server/alert-webhook.js';
+import type {
+  WebhookPayload,
+  WebhookTestPayload,
+  WebhookTarget,
+  WebhookConfig,
+} from '../../../server/alert-webhook.js';
+
+import {
+  evaluateAlerts,
+  DEFAULT_ALERT_CONFIG,
+} from '../../../server/alert-rules.js';
+import type {
+  AlertEvaluation,
+  AlertSeverity,
+} from '../../../server/alert-rules.js';
+
+// ─── Test Fixtures ───────────────────────────────────────────────────────────
+
+const testDataDir = path.join('/tmp', 'test-webhook-fmt-' + process.pid);
+
+function makeSampleEvaluation(overrides: Partial<AlertEvaluation> = {}): AlertEvaluation {
+  return {
+    evaluatedAt: 1700000000000,
+    overallSeverity: 'warning',
+    severityCounts: { ok: 1, warning: 1, critical: 0 },
+    rules: [
+      {
+        rule: 'stuckTaskCount',
+        label: 'Stuck Tasks',
+        enabled: true,
+        severity: 'warning',
+        currentValue: 3,
+        warningThreshold: 2,
+        criticalThreshold: 5,
+        message: '3 stuck tasks (threshold: 2)',
+      },
+      {
+        rule: 'failureRate',
+        label: 'Failure Rate',
+        enabled: true,
+        severity: 'ok',
+        currentValue: 0.05,
+        warningThreshold: 0.2,
+        criticalThreshold: 0.5,
+        message: '5.0% failure rate (threshold: 20%)',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makeSamplePayload(overrides: Partial<WebhookPayload> = {}): WebhookPayload {
+  return buildWebhookPayload(makeSampleEvaluation(), 'ok');
+}
+
+function makeSampleTarget(overrides: Partial<WebhookTarget> = {}): WebhookTarget {
+  return {
+    id: 'test-target',
+    name: 'Test Target',
+    url: 'https://hooks.example.com/webhook',
+    enabled: true,
+    ...overrides,
+  };
+}
+
+// ─── Lifecycle ───────────────────────────────────────────────────────────────
+
+beforeEach(() => {
+  resetDeliveryState();
+  fs.mkdirSync(testDataDir, { recursive: true });
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  try {
+    fs.rmSync(testDataDir, { recursive: true, force: true });
+  } catch { /* ignore */ }
+});
+
+// ─── isValidProvider ─────────────────────────────────────────────────────────
+
+describe('isValidProvider', () => {
+  it('accepts all allowed providers', () => {
+    expect(isValidProvider('generic')).toBe(true);
+    expect(isValidProvider('slack')).toBe(true);
+    expect(isValidProvider('discord')).toBe(true);
+  });
+
+  it('rejects unknown strings', () => {
+    expect(isValidProvider('teams')).toBe(false);
+    expect(isValidProvider('pagerduty')).toBe(false);
+    expect(isValidProvider('')).toBe(false);
+    expect(isValidProvider('SLACK')).toBe(false);
+  });
+
+  it('rejects non-string values', () => {
+    expect(isValidProvider(undefined)).toBe(false);
+    expect(isValidProvider(null)).toBe(false);
+    expect(isValidProvider(42)).toBe(false);
+    expect(isValidProvider(true)).toBe(false);
+    expect(isValidProvider({})).toBe(false);
+  });
+});
+
+describe('ALLOWED_PROVIDERS', () => {
+  it('contains generic, slack, and discord', () => {
+    expect(ALLOWED_PROVIDERS).toContain('generic');
+    expect(ALLOWED_PROVIDERS).toContain('slack');
+    expect(ALLOWED_PROVIDERS).toContain('discord');
+  });
+
+  it('is readonly (immutable at compile time)', () => {
+    // `as const` produces a readonly tuple — verified by TypeScript.
+    // Runtime check: the array has the expected length and values.
+    expect(ALLOWED_PROVIDERS.length).toBe(3);
+    expect([...ALLOWED_PROVIDERS]).toEqual(['generic', 'slack', 'discord']);
+  });
+});
+
+// ─── formatGeneric ───────────────────────────────────────────────────────────
+
+describe('formatGeneric', () => {
+  it('produces a JSON body identical to JSON.stringify(payload)', () => {
+    const payload = makeSamplePayload();
+    const result = formatGeneric(payload);
+    expect(result.body).toBe(JSON.stringify(payload));
+  });
+
+  it('sets Content-Type to application/json', () => {
+    const result = formatGeneric(makeSamplePayload());
+    expect(result.contentType).toBe('application/json');
+  });
+
+  it('has no extra headers', () => {
+    const result = formatGeneric(makeSamplePayload());
+    expect(result.extraHeaders).toEqual({});
+  });
+
+  it('works with test payloads', () => {
+    const testPayload = buildTestPayload(1700000000000);
+    const result = formatGeneric(testPayload);
+    const parsed = JSON.parse(result.body);
+    expect(parsed.event).toBe('webhook.test');
+    expect(parsed.test).toBe(true);
+  });
+
+  it('preserves all payload fields (schema fidelity)', () => {
+    const payload = makeSamplePayload();
+    const result = formatGeneric(payload);
+    const parsed = JSON.parse(result.body);
+    expect(parsed.event).toBe('alert.transition');
+    expect(parsed.schemaVersion).toBe(1);
+    expect(parsed.source).toBe('ventureos-dashboard');
+    expect(parsed.evaluation.rules).toHaveLength(2);
+  });
+});
+
+// ─── formatSlack ─────────────────────────────────────────────────────────────
+
+describe('formatSlack', () => {
+  describe('alert payloads', () => {
+    it('produces valid Slack Block Kit payload', () => {
+      const payload = makeSamplePayload();
+      const result = formatSlack(payload);
+      const parsed = JSON.parse(result.body);
+
+      // Slack requires `text` fallback
+      expect(typeof parsed.text).toBe('string');
+      expect(parsed.text.length).toBeGreaterThan(0);
+
+      // Must have blocks array
+      expect(Array.isArray(parsed.blocks)).toBe(true);
+      expect(parsed.blocks.length).toBeGreaterThan(0);
+    });
+
+    it('includes header block', () => {
+      const result = formatSlack(makeSamplePayload());
+      const parsed = JSON.parse(result.body);
+      const header = parsed.blocks.find((b: any) => b.type === 'header');
+      expect(header).toBeDefined();
+      expect(header.text.type).toBe('plain_text');
+      expect(header.text.text).toContain('VentureOS');
+    });
+
+    it('includes severity emoji in text fallback', () => {
+      // warning severity
+      const warningPayload = buildWebhookPayload(
+        makeSampleEvaluation({ overallSeverity: 'warning' }),
+        'ok',
+      );
+      const warningResult = formatSlack(warningPayload);
+      const warningParsed = JSON.parse(warningResult.body);
+      expect(warningParsed.text).toContain('⚠️');
+
+      // critical severity
+      const critPayload = buildWebhookPayload(
+        makeSampleEvaluation({ overallSeverity: 'critical' }),
+        'warning',
+      );
+      const critResult = formatSlack(critPayload);
+      const critParsed = JSON.parse(critResult.body);
+      expect(critParsed.text).toContain('🔴');
+    });
+
+    it('includes rule details in section blocks', () => {
+      const result = formatSlack(makeSamplePayload());
+      const parsed = JSON.parse(result.body);
+      const bodyText = JSON.stringify(parsed);
+      expect(bodyText).toContain('Stuck Tasks');
+    });
+
+    it('includes color attachment for severity bar', () => {
+      const result = formatSlack(makeSamplePayload());
+      const parsed = JSON.parse(result.body);
+      expect(Array.isArray(parsed.attachments)).toBe(true);
+      expect(parsed.attachments[0]).toHaveProperty('color');
+    });
+
+    it('includes section fields with previous/current severity', () => {
+      const payload = makeSamplePayload();
+      const result = formatSlack(payload);
+      const parsed = JSON.parse(result.body);
+      const sectionWithFields = parsed.blocks.find((b: any) => b.fields);
+      expect(sectionWithFields).toBeDefined();
+      const fieldTexts = sectionWithFields.fields.map((f: any) => f.text);
+      expect(fieldTexts.some((t: string) => t.includes('Previous'))).toBe(true);
+      expect(fieldTexts.some((t: string) => t.includes('Current'))).toBe(true);
+    });
+
+    it('sets Content-Type to application/json', () => {
+      const result = formatSlack(makeSamplePayload());
+      expect(result.contentType).toBe('application/json');
+    });
+  });
+
+  describe('test payloads', () => {
+    it('produces valid Slack Block Kit for test pings', () => {
+      const testPayload = buildTestPayload(1700000000000);
+      const result = formatSlack(testPayload);
+      const parsed = JSON.parse(result.body);
+
+      expect(typeof parsed.text).toBe('string');
+      expect(parsed.text).toContain('Test');
+      expect(Array.isArray(parsed.blocks)).toBe(true);
+    });
+
+    it('includes the test message text', () => {
+      const testPayload = buildTestPayload();
+      const result = formatSlack(testPayload);
+      const parsed = JSON.parse(result.body);
+      const bodyStr = JSON.stringify(parsed);
+      expect(bodyStr).toContain(testPayload.message);
+    });
+  });
+});
+
+// ─── formatDiscord ───────────────────────────────────────────────────────────
+
+describe('formatDiscord', () => {
+  describe('alert payloads', () => {
+    it('produces valid Discord embed payload', () => {
+      const payload = makeSamplePayload();
+      const result = formatDiscord(payload);
+      const parsed = JSON.parse(result.body);
+
+      // Discord requires content or embeds
+      expect(typeof parsed.content).toBe('string');
+      expect(Array.isArray(parsed.embeds)).toBe(true);
+      expect(parsed.embeds.length).toBeGreaterThan(0);
+    });
+
+    it('embed has title, description, color, and fields', () => {
+      const result = formatDiscord(makeSamplePayload());
+      const parsed = JSON.parse(result.body);
+      const embed = parsed.embeds[0];
+
+      expect(typeof embed.title).toBe('string');
+      expect(typeof embed.description).toBe('string');
+      expect(typeof embed.color).toBe('number');
+      expect(Array.isArray(embed.fields)).toBe(true);
+    });
+
+    it('uses correct color for severity', () => {
+      // warning → amber (0xf2c744)
+      const warningPayload = buildWebhookPayload(
+        makeSampleEvaluation({ overallSeverity: 'warning' }),
+        'ok',
+      );
+      const warningResult = formatDiscord(warningPayload);
+      const warningParsed = JSON.parse(warningResult.body);
+      expect(warningParsed.embeds[0].color).toBe(0xf2c744);
+
+      // critical → red (0xe01e5a)
+      const critPayload = buildWebhookPayload(
+        makeSampleEvaluation({ overallSeverity: 'critical' }),
+        'warning',
+      );
+      const critResult = formatDiscord(critPayload);
+      const critParsed = JSON.parse(critResult.body);
+      expect(critParsed.embeds[0].color).toBe(0xe01e5a);
+    });
+
+    it('includes previous/current severity fields', () => {
+      const result = formatDiscord(makeSamplePayload());
+      const parsed = JSON.parse(result.body);
+      const fieldNames = parsed.embeds[0].fields.map((f: any) => f.name);
+      expect(fieldNames).toContain('Previous Severity');
+      expect(fieldNames).toContain('Current Severity');
+      expect(fieldNames).toContain('Timestamp');
+    });
+
+    it('includes rule fields for enabled rules', () => {
+      const result = formatDiscord(makeSamplePayload());
+      const parsed = JSON.parse(result.body);
+      const fieldNames = parsed.embeds[0].fields.map((f: any) => f.name);
+      expect(fieldNames.some((n: string) => n.includes('Stuck Tasks'))).toBe(true);
+    });
+
+    it('includes footer and timestamp', () => {
+      const result = formatDiscord(makeSamplePayload());
+      const parsed = JSON.parse(result.body);
+      const embed = parsed.embeds[0];
+      expect(embed.footer).toBeDefined();
+      expect(embed.footer.text).toContain('VentureOS');
+      expect(typeof embed.timestamp).toBe('string');
+    });
+
+    it('caps rule fields at 25 (Discord limit)', () => {
+      // Create an evaluation with >25 rules
+      const manyRules = Array.from({ length: 30 }, (_, i) => ({
+        rule: `rule_${i}`,
+        label: `Rule ${i}`,
+        enabled: true,
+        severity: 'ok' as AlertSeverity,
+        currentValue: i,
+        warningThreshold: 50,
+        criticalThreshold: 100,
+        message: `Rule ${i} message`,
+      }));
+      const eval30 = makeSampleEvaluation({ rules: manyRules });
+      const payload = buildWebhookPayload(eval30, 'ok');
+      const result = formatDiscord(payload);
+      const parsed = JSON.parse(result.body);
+      // 3 fixed fields + max 25 rule fields = 28
+      expect(parsed.embeds[0].fields.length).toBeLessThanOrEqual(28);
+    });
+
+    it('sets Content-Type to application/json', () => {
+      const result = formatDiscord(makeSamplePayload());
+      expect(result.contentType).toBe('application/json');
+    });
+  });
+
+  describe('test payloads', () => {
+    it('produces valid Discord embed for test pings', () => {
+      const testPayload = buildTestPayload(1700000000000);
+      const result = formatDiscord(testPayload);
+      const parsed = JSON.parse(result.body);
+
+      expect(typeof parsed.content).toBe('string');
+      expect(parsed.content).toContain('Test');
+      expect(Array.isArray(parsed.embeds)).toBe(true);
+      expect(parsed.embeds[0].color).toBe(0x3b82f6); // blue for test
+    });
+
+    it('includes the test message in embed description', () => {
+      const testPayload = buildTestPayload();
+      const result = formatDiscord(testPayload);
+      const parsed = JSON.parse(result.body);
+      expect(parsed.embeds[0].description).toBe(testPayload.message);
+    });
+  });
+});
+
+// ─── getFormatter / formatPayload ────────────────────────────────────────────
+
+describe('getFormatter', () => {
+  it('returns generic formatter for undefined provider', () => {
+    const formatter = getFormatter(undefined);
+    const result = formatter(makeSamplePayload());
+    // Generic output is raw JSON.stringify
+    expect(result.body).toBe(JSON.stringify(makeSamplePayload()));
+  });
+
+  it('returns generic formatter for "generic" provider', () => {
+    const formatter = getFormatter('generic');
+    const result = formatter(makeSamplePayload());
+    expect(result.body).toBe(JSON.stringify(makeSamplePayload()));
+  });
+
+  it('returns slack formatter for "slack" provider', () => {
+    const formatter = getFormatter('slack');
+    const result = formatter(makeSamplePayload());
+    const parsed = JSON.parse(result.body);
+    expect(parsed).toHaveProperty('blocks');
+    expect(parsed).toHaveProperty('text');
+  });
+
+  it('returns discord formatter for "discord" provider', () => {
+    const formatter = getFormatter('discord');
+    const result = formatter(makeSamplePayload());
+    const parsed = JSON.parse(result.body);
+    expect(parsed).toHaveProperty('embeds');
+    expect(parsed).toHaveProperty('content');
+  });
+});
+
+describe('formatPayload', () => {
+  it('falls back to generic when provider is undefined', () => {
+    const payload = makeSamplePayload();
+    const result = formatPayload(payload);
+    expect(result.body).toBe(JSON.stringify(payload));
+  });
+
+  it('falls back to generic when provider is "generic"', () => {
+    const payload = makeSamplePayload();
+    const result = formatPayload(payload, 'generic');
+    expect(result.body).toBe(JSON.stringify(payload));
+  });
+
+  it('formats for slack when provider is "slack"', () => {
+    const result = formatPayload(makeSamplePayload(), 'slack');
+    const parsed = JSON.parse(result.body);
+    expect(parsed).toHaveProperty('blocks');
+  });
+
+  it('formats for discord when provider is "discord"', () => {
+    const result = formatPayload(makeSamplePayload(), 'discord');
+    const parsed = JSON.parse(result.body);
+    expect(parsed).toHaveProperty('embeds');
+  });
+});
+
+// ─── Provider in WebhookTarget validation ────────────────────────────────────
+
+describe('validateWebhookConfig — provider field', () => {
+  it('accepts valid providers', () => {
+    for (const provider of ALLOWED_PROVIDERS) {
+      const errors = validateWebhookConfig({
+        enabled: true,
+        targets: [
+          { id: 'a', url: 'https://example.com', name: 'A', enabled: true, provider },
+        ],
+      });
+      expect(errors.filter((e) => e.field.includes('provider'))).toHaveLength(0);
+    }
+  });
+
+  it('rejects invalid provider string', () => {
+    const errors = validateWebhookConfig({
+      enabled: true,
+      targets: [
+        { id: 'a', url: 'https://example.com', name: 'A', enabled: true, provider: 'teams' },
+      ],
+    });
+    const providerErrors = errors.filter((e) => e.field.includes('provider'));
+    expect(providerErrors.length).toBe(1);
+    expect(providerErrors[0].message).toContain('generic');
+    expect(providerErrors[0].message).toContain('slack');
+    expect(providerErrors[0].message).toContain('discord');
+  });
+
+  it('accepts missing provider (optional)', () => {
+    const errors = validateWebhookConfig({
+      enabled: true,
+      targets: [
+        { id: 'a', url: 'https://example.com', name: 'A', enabled: true },
+      ],
+    });
+    expect(errors.filter((e) => e.field.includes('provider'))).toHaveLength(0);
+  });
+
+  it('rejects non-string provider', () => {
+    const errors = validateWebhookConfig({
+      enabled: true,
+      targets: [
+        { id: 'a', url: 'https://example.com', name: 'A', enabled: true, provider: 42 },
+      ],
+    });
+    expect(errors.filter((e) => e.field.includes('provider')).length).toBe(1);
+  });
+});
+
+// ─── Provider in sanitizeConfig ──────────────────────────────────────────────
+
+describe('sanitizeConfig — provider field', () => {
+  it('preserves valid provider values', () => {
+    const config = sanitizeConfig({
+      enabled: true,
+      targets: [
+        { id: 'a', url: 'https://example.com', name: 'A', enabled: true, provider: 'slack' },
+        { id: 'b', url: 'https://example.com', name: 'B', enabled: true, provider: 'discord' },
+        { id: 'c', url: 'https://example.com', name: 'C', enabled: true, provider: 'generic' },
+      ],
+    });
+    expect(config.targets[0].provider).toBe('slack');
+    expect(config.targets[1].provider).toBe('discord');
+    expect(config.targets[2].provider).toBe('generic');
+  });
+
+  it('strips invalid provider values (falls back to undefined)', () => {
+    const config = sanitizeConfig({
+      enabled: true,
+      targets: [
+        { id: 'a', url: 'https://example.com', name: 'A', enabled: true, provider: 'teams' },
+      ],
+    });
+    expect(config.targets[0].provider).toBeUndefined();
+  });
+
+  it('handles missing provider gracefully', () => {
+    const config = sanitizeConfig({
+      enabled: true,
+      targets: [
+        { id: 'a', url: 'https://example.com', name: 'A', enabled: true },
+      ],
+    });
+    expect(config.targets[0].provider).toBeUndefined();
+  });
+});
+
+// ─── Provider in redactConfig ────────────────────────────────────────────────
+
+describe('redactConfig — provider field', () => {
+  it('includes provider in redacted output', () => {
+    const config: WebhookConfig = {
+      enabled: true,
+      targets: [
+        { id: 'a', name: 'Slack', url: 'https://hooks.slack.com/x', enabled: true, secret: 'secret123', provider: 'slack' },
+      ],
+    };
+    const redacted = redactConfig(config);
+    expect(redacted.targets[0]).toHaveProperty('hasSecret', true);
+    expect((redacted.targets[0] as any).provider).toBe('slack');
+    expect((redacted.targets[0] as any).secret).toBeUndefined();
+  });
+});
+
+// ─── Config I/O round-trip with provider ─────────────────────────────────────
+
+describe('readWebhookConfig / writeWebhookConfig — provider round-trip', () => {
+  it('persists and reads back provider field', () => {
+    const config: WebhookConfig = {
+      enabled: true,
+      targets: [
+        { id: 'slack1', name: 'Slack', url: 'https://hooks.slack.com/x', enabled: true, provider: 'slack' },
+        { id: 'disc1', name: 'Discord', url: 'https://discord.com/api/webhooks/x', enabled: true, provider: 'discord' },
+        { id: 'gen1', name: 'Generic', url: 'https://example.com/webhook', enabled: true },
+      ],
+    };
+    writeWebhookConfig(testDataDir, config);
+    const loaded = readWebhookConfig(testDataDir);
+    expect(loaded.targets[0].provider).toBe('slack');
+    expect(loaded.targets[1].provider).toBe('discord');
+    expect(loaded.targets[2].provider).toBeUndefined();
+  });
+});
+
+// ─── HMAC signature correctness with formatted payloads ──────────────────────
+
+describe('HMAC signature with formatted payloads', () => {
+  it('signature is computed over the formatted body, not raw payload', async () => {
+    const payload = makeSamplePayload();
+    const secret = 'test-secret-key';
+
+    // Generic: signature should match JSON.stringify(payload)
+    const genericBody = JSON.stringify(payload);
+    const genericSig = await computeSignature(genericBody, secret);
+
+    // Slack: body is different, so signature must differ
+    const slackFormatted = formatSlack(payload);
+    const slackSig = await computeSignature(slackFormatted.body, secret);
+
+    expect(slackSig).not.toBe(genericSig);
+
+    // Each signature should be a valid hex string
+    expect(genericSig).toMatch(/^[0-9a-f]{64}$/);
+    expect(slackSig).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+// ─── No regression: existing webhook delivery (generic default) ──────────────
+
+describe('delivery regression — generic default behavior', () => {
+  it('deliverWebhook uses generic format when target has no provider', async () => {
+    const target = makeSampleTarget(); // no provider
+    const payload = makeSamplePayload();
+
+    // Mock fetch to capture the request body
+    let capturedBody: string | undefined;
+    let capturedHeaders: Record<string, string> | undefined;
+
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init: any) => {
+      capturedBody = init?.body;
+      capturedHeaders = init?.headers;
+      return new Response('OK', { status: 200 });
+    }));
+
+    const result = await deliverWebhook(target, payload, { maxRetries: 1 });
+    expect(result.success).toBe(true);
+
+    // Body should be raw JSON.stringify of the payload (generic format)
+    expect(capturedBody).toBe(JSON.stringify(payload));
+    expect(capturedHeaders?.['Content-Type']).toBe('application/json');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('deliverWebhook uses Slack format when target has provider=slack', async () => {
+    const target = makeSampleTarget({ provider: 'slack' });
+    const payload = makeSamplePayload();
+
+    let capturedBody: string | undefined;
+
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init: any) => {
+      capturedBody = init?.body;
+      return new Response('OK', { status: 200 });
+    }));
+
+    const result = await deliverWebhook(target, payload, { maxRetries: 1 });
+    expect(result.success).toBe(true);
+
+    // Body should be Slack-formatted
+    const parsed = JSON.parse(capturedBody!);
+    expect(parsed).toHaveProperty('blocks');
+    expect(parsed).toHaveProperty('text');
+    // Should NOT be the raw payload
+    expect(parsed).not.toHaveProperty('event');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('deliverWebhook uses Discord format when target has provider=discord', async () => {
+    const target = makeSampleTarget({ provider: 'discord' });
+    const payload = makeSamplePayload();
+
+    let capturedBody: string | undefined;
+
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init: any) => {
+      capturedBody = init?.body;
+      return new Response('OK', { status: 200 });
+    }));
+
+    const result = await deliverWebhook(target, payload, { maxRetries: 1 });
+    expect(result.success).toBe(true);
+
+    const parsed = JSON.parse(capturedBody!);
+    expect(parsed).toHaveProperty('embeds');
+    expect(parsed).toHaveProperty('content');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('deliverTestWebhook uses provider formatter for test pings', async () => {
+    const target = makeSampleTarget({ provider: 'slack' });
+    const testPayload = buildTestPayload();
+
+    let capturedBody: string | undefined;
+
+    vi.stubGlobal('fetch', vi.fn(async (url: string, init: any) => {
+      capturedBody = init?.body;
+      return new Response('OK', { status: 200 });
+    }));
+
+    const result = await deliverTestWebhook(target, testPayload, { maxRetries: 1 });
+    expect(result.success).toBe(true);
+    expect(result.isTest).toBe(true);
+
+    const parsed = JSON.parse(capturedBody!);
+    expect(parsed).toHaveProperty('blocks');
+    expect(parsed.text).toContain('Test');
+
+    vi.unstubAllGlobals();
+  });
+
+  it('HMAC signature header is present when secret is set (all providers)', async () => {
+    const secret = 'my-webhook-secret';
+
+    for (const provider of [undefined, 'slack' as const, 'discord' as const]) {
+      const target = makeSampleTarget({ secret, provider });
+      const payload = makeSamplePayload();
+
+      let capturedHeaders: Record<string, string> | undefined;
+      let capturedBody: string | undefined;
+
+      vi.stubGlobal('fetch', vi.fn(async (url: string, init: any) => {
+        capturedHeaders = init?.headers;
+        capturedBody = init?.body;
+        return new Response('OK', { status: 200 });
+      }));
+
+      await deliverWebhook(target, payload, { maxRetries: 1 });
+
+      expect(capturedHeaders?.['X-VentureOS-Signature']).toBeDefined();
+      // Verify signature matches the actual body sent
+      const expectedSig = await computeSignature(capturedBody!, secret);
+      expect(capturedHeaders?.['X-VentureOS-Signature']).toBe(`sha256=${expectedSig}`);
+
+      vi.unstubAllGlobals();
+    }
+  });
+});
+
+// ─── Output schema validation ────────────────────────────────────────────────
+
+describe('formatter output schemas', () => {
+  const payload = makeSamplePayload();
+
+  it('all formatters produce valid FormattedPayload shape', () => {
+    for (const provider of ALLOWED_PROVIDERS) {
+      const result = formatPayload(payload, provider);
+      expect(typeof result.body).toBe('string');
+      expect(typeof result.contentType).toBe('string');
+      expect(typeof result.extraHeaders).toBe('object');
+      expect(result.body.length).toBeGreaterThan(0);
+
+      // Body must be valid JSON
+      expect(() => JSON.parse(result.body)).not.toThrow();
+    }
+  });
+
+  it('Slack output always has text and blocks', () => {
+    const result = formatPayload(payload, 'slack');
+    const parsed = JSON.parse(result.body);
+    expect(typeof parsed.text).toBe('string');
+    expect(Array.isArray(parsed.blocks)).toBe(true);
+  });
+
+  it('Discord output always has content and embeds', () => {
+    const result = formatPayload(payload, 'discord');
+    const parsed = JSON.parse(result.body);
+    expect(typeof parsed.content).toBe('string');
+    expect(Array.isArray(parsed.embeds)).toBe(true);
+    // Embeds have required fields
+    const embed = parsed.embeds[0];
+    expect(typeof embed.title).toBe('string');
+    expect(typeof embed.color).toBe('number');
+  });
+
+  it('generic output preserves full VentureOS schema', () => {
+    const result = formatPayload(payload, 'generic');
+    const parsed = JSON.parse(result.body);
+    expect(parsed.event).toBe('alert.transition');
+    expect(parsed.schemaVersion).toBe(1);
+    expect(parsed.source).toBe('ventureos-dashboard');
+    expect(typeof parsed.timestamp).toBe('number');
+    expect(typeof parsed.timestampISO).toBe('string');
+    expect(typeof parsed.currentSeverity).toBe('string');
+    expect(parsed.evaluation).toBeDefined();
+  });
+});
+
+// ─── Edge cases ──────────────────────────────────────────────────────────────
+
+describe('formatter edge cases', () => {
+  it('handles evaluation with no enabled rules gracefully', () => {
+    const emptyEval = makeSampleEvaluation({
+      rules: [
+        {
+          rule: 'disabled',
+          label: 'Disabled Rule',
+          enabled: false,
+          severity: 'ok',
+          currentValue: 0,
+          warningThreshold: 1,
+          criticalThreshold: 2,
+          message: 'disabled',
+        },
+      ],
+    });
+    const payload = buildWebhookPayload(emptyEval, 'ok');
+
+    // All formatters should handle this without throwing
+    for (const provider of ALLOWED_PROVIDERS) {
+      expect(() => formatPayload(payload, provider)).not.toThrow();
+    }
+  });
+
+  it('handles null previousSeverity', () => {
+    const payload = buildWebhookPayload(makeSampleEvaluation(), null);
+    for (const provider of ALLOWED_PROVIDERS) {
+      const result = formatPayload(payload, provider);
+      expect(() => JSON.parse(result.body)).not.toThrow();
+    }
+  });
+
+  it('handles null currentValue in rules', () => {
+    const evalWithNull = makeSampleEvaluation({
+      rules: [
+        {
+          rule: 'nullVal',
+          label: 'Null Value Rule',
+          enabled: true,
+          severity: 'warning',
+          currentValue: null,
+          warningThreshold: 1,
+          criticalThreshold: 2,
+          message: 'no data',
+        },
+      ],
+    });
+    const payload = buildWebhookPayload(evalWithNull, 'ok');
+    for (const provider of ALLOWED_PROVIDERS) {
+      const result = formatPayload(payload, provider);
+      expect(() => JSON.parse(result.body)).not.toThrow();
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Adds per-target **provider-specific payload formatting** for webhook delivery. Targets can now optionally specify a `provider` field (`slack`, `discord`, or `generic`) to shape the outgoing payload for the receiving service's native format.

**Refs #219** — Phase 18: Provider/Channel-Specific Webhook Payload Formatters (Baseline).

## What Changed

### New: `webhook-formatters.ts`
Pure formatter module with zero external SDK dependencies:
- **Slack**: Block Kit layout with header, severity fields, rule details, color-bar attachment, and `text` fallback for notifications
- **Discord**: Rich Embed with color-coded severity, previous/current fields, rule fields (capped at 25 per Discord limit), footer + timestamp
- **Generic**: Raw VentureOS JSON payload (default — fully backward-compatible)

### Modified: `alert-webhook.ts`
- `WebhookTarget` gains optional `provider?: 'generic' | 'slack' | 'discord'`
- `validateWebhookConfig()` rejects invalid provider strings with descriptive error
- `sanitizeConfig()` strips invalid providers (defaults to undefined → generic)
- `deliverWebhook()` + `deliverTestWebhook()` use `formatPayload()` for body/headers
- HMAC signatures computed over the **final formatted body** — security posture preserved
- `redactConfig()` naturally carries `provider` through (no secret leakage)

### New: `task-board-webhook-formatters.test.ts` (59 tests)
- Formatter output schema validation (Slack blocks, Discord embeds, generic fidelity)
- Fallback to generic when provider is undefined
- Per-target provider selection through the delivery pipeline
- Validation: valid providers accepted, invalid rejected, optional omission OK
- `sanitizeConfig` / `redactConfig` / config I/O round-trip with provider
- HMAC signature correctness across all provider formats
- No regression in existing delivery paths

## Test Results
| Suite | Result |
|-------|--------|
| New formatter tests | 59/59 ✅ |
| Existing webhook tests | 72/72 ✅ |
| Delivery history | 43/43 ✅ |
| Test ping | 33/33 ✅ |
| Config UI | 22/22 ✅ |
| Retry activity | 25/25 ✅ |
| Health stats | 27/27 ✅ |
| Delivery export | 45/45 ✅ |
| TypeScript | Clean ✅ |

38 pre-existing failures in `shared-context.test.ts` / `memory-state.test.ts` (native module issue) — unrelated to this PR.

## Risk Assessment
- **Low risk**: Additive-only change. No existing behavior altered.
- **Backward-compatible**: Default `provider` is `undefined` → generic JSON, identical to prior behavior.
- **Reversible**: Removing the `provider` field from any target config reverts to generic.
- **Security preserved**: HMAC signatures computed over formatted body; secrets never exposed.
- **No new dependencies**: Pure TypeScript formatters — no Slack SDK, no Discord SDK.