### PR TITLE
feat(#219): Webhook alert escalation policy — time-based tier escalation (Phase 19)

### DIFF
--- a/dashboard/server/alert-webhook.ts
+++ b/dashboard/server/alert-webhook.ts
@@ -25,6 +25,7 @@ import { appendDeliveryEvents } from './webhook-delivery-history.js';
 import type { WebhookDeliveryAttemptDetail } from './webhook-delivery-history.js';
 import { formatPayload, isValidProvider, ALLOWED_PROVIDERS } from './webhook-formatters.js';
 import type { WebhookProvider, FormattedPayload } from './webhook-formatters.js';
+import type { EscalationPolicyConfig } from './escalation-policy.js';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -74,6 +75,14 @@ export interface WebhookConfig {
    * Maximum retry attempts on failure. Default: 3.
    */
   maxRetries?: number;
+  /**
+   * Optional escalation policy configuration.
+   * When enabled, persistent alert states trigger escalation tiers
+   * with designated targets and cooldowns.
+   * Disabled by default — backward-compatible.
+   * Issue #219 — Phase 19.
+   */
+  escalation?: EscalationPolicyConfig;
 }
 
 /** Payload sent to webhook targets. */
@@ -297,7 +306,16 @@ export function sanitizeConfig(raw: unknown): WebhookConfig {
     }
   }
 
-  return { enabled, targets, cooldownMs, timeoutMs, maxRetries };
+  // Escalation policy (Phase 19): pass through if present, omit if absent.
+  // Sanitization of the escalation sub-object is handled by sanitizeEscalationPolicy()
+  // in escalation-policy.ts (called separately to avoid circular runtime deps).
+  const result: WebhookConfig = { enabled, targets, cooldownMs, timeoutMs, maxRetries };
+  if (obj.escalation !== undefined && obj.escalation !== null && typeof obj.escalation === 'object') {
+    // Preserve raw escalation config — the escalation module owns sanitization.
+    // readWebhookConfig() returns this as-is; escalation-policy.ts sanitizes on read.
+    result.escalation = obj.escalation as EscalationPolicyConfig;
+  }
+  return result;
 }
 
 // ─── Validation ──────────────────────────────────────────────────────────────
@@ -409,6 +427,91 @@ export function validateWebhookConfig(input: unknown): WebhookConfigValidationEr
               field: `${prefix}.provider`,
               message: `provider must be one of: ${ALLOWED_PROVIDERS.join(', ')}`,
             });
+          }
+        }
+      }
+    }
+  }
+
+  // Escalation policy validation (Phase 19) — inline to avoid circular imports.
+  // Validates the escalation sub-object if present in the input.
+  if (obj.escalation !== undefined) {
+    if (obj.escalation === null) {
+      // Explicitly null — allowed (removes escalation config)
+    } else if (typeof obj.escalation !== 'object' || Array.isArray(obj.escalation)) {
+      errors.push({ field: 'escalation', message: 'escalation must be an object or null' });
+    } else {
+      const esc = obj.escalation as Record<string, unknown>;
+      if (esc.enabled !== undefined && typeof esc.enabled !== 'boolean') {
+        errors.push({ field: 'escalation.enabled', message: 'enabled must be a boolean' });
+      }
+      if (esc.triggerSeverity !== undefined) {
+        if (typeof esc.triggerSeverity !== 'string' || !['ok', 'warning', 'critical'].includes(esc.triggerSeverity)) {
+          errors.push({ field: 'escalation.triggerSeverity', message: 'triggerSeverity must be ok, warning, or critical' });
+        }
+      }
+      if (esc.cooldownMs !== undefined) {
+        if (typeof esc.cooldownMs !== 'number' || !isFinite(esc.cooldownMs) || esc.cooldownMs < 0) {
+          errors.push({ field: 'escalation.cooldownMs', message: 'cooldownMs must be a non-negative finite number' });
+        }
+      }
+      if (esc.tiers !== undefined) {
+        if (!Array.isArray(esc.tiers)) {
+          errors.push({ field: 'escalation.tiers', message: 'tiers must be an array' });
+        } else {
+          if (esc.tiers.length > 3) {
+            errors.push({ field: 'escalation.tiers', message: 'maximum 3 escalation tiers allowed' });
+          }
+          // Collect available target IDs for cross-reference validation
+          const availableTargetIds = new Set<string>();
+          if (Array.isArray(obj.targets)) {
+            for (const t of obj.targets) {
+              if (t && typeof t === 'object' && typeof (t as Record<string, unknown>).id === 'string') {
+                availableTargetIds.add((t as Record<string, unknown>).id as string);
+              }
+            }
+          }
+          let prevAfterMs = 0;
+          for (let i = 0; i < esc.tiers.length; i++) {
+            const tier = esc.tiers[i];
+            const prefix = `escalation.tiers[${i}]`;
+            if (!tier || typeof tier !== 'object' || Array.isArray(tier)) {
+              errors.push({ field: prefix, message: 'tier must be an object' });
+              continue;
+            }
+            const tierObj = tier as Record<string, unknown>;
+            if (typeof tierObj.afterMs !== 'number' || !isFinite(tierObj.afterMs)) {
+              errors.push({ field: `${prefix}.afterMs`, message: 'afterMs is required and must be a finite number' });
+            } else {
+              if (tierObj.afterMs < 60000) {
+                errors.push({ field: `${prefix}.afterMs`, message: 'afterMs must be >= 60000ms (1 minute)' });
+              }
+              if (tierObj.afterMs > 86400000) {
+                errors.push({ field: `${prefix}.afterMs`, message: 'afterMs must be <= 86400000ms (24 hours)' });
+              }
+              if (tierObj.afterMs <= prevAfterMs) {
+                errors.push({ field: `${prefix}.afterMs`, message: `afterMs must be strictly greater than previous tier (${prevAfterMs}ms)` });
+              }
+              prevAfterMs = tierObj.afterMs;
+            }
+            if (!Array.isArray(tierObj.targetIds)) {
+              errors.push({ field: `${prefix}.targetIds`, message: 'targetIds must be an array' });
+            } else {
+              if (tierObj.targetIds.length > 5) {
+                errors.push({ field: `${prefix}.targetIds`, message: 'maximum 5 targets per tier' });
+              }
+              for (let j = 0; j < tierObj.targetIds.length; j++) {
+                const tid = tierObj.targetIds[j];
+                if (typeof tid !== 'string' || tid.trim().length === 0) {
+                  errors.push({ field: `${prefix}.targetIds[${j}]`, message: 'target ID must be a non-empty string' });
+                } else if (availableTargetIds.size > 0 && !availableTargetIds.has(tid)) {
+                  errors.push({ field: `${prefix}.targetIds[${j}]`, message: `target ID "${tid}" does not match any configured webhook target` });
+                }
+              }
+            }
+            if (tierObj.label !== undefined && typeof tierObj.label !== 'string') {
+              errors.push({ field: `${prefix}.label`, message: 'label must be a string' });
+            }
           }
         }
       }

--- a/dashboard/server/escalation-policy.ts
+++ b/dashboard/server/escalation-policy.ts
@@ -1,0 +1,618 @@
+/**
+ * Escalation Policy — time-based severity escalation for webhook alerts.
+ * Issue #219 — Phase 19: Webhook Alert Escalation Policy Baseline.
+ *
+ * Provides deterministic, bounded escalation behavior on top of the
+ * existing alert/webhook system. When a critical (or warning) state
+ * persists beyond configured time windows, the escalation policy can:
+ *
+ *   1. Upgrade the effective severity for webhook targeting (e.g., a
+ *      warning that persists for 15 minutes escalates to critical targets)
+ *   2. Override cooldown to re-notify designated escalation targets
+ *   3. Track escalation tiers with bounded progression (max 3 tiers)
+ *
+ * Design principles:
+ *   - **Additive**: escalation is layered on top of existing webhook
+ *     dispatch — it never modifies alert evaluation or history.
+ *   - **Deterministic**: decisions are pure functions of current state +
+ *     config + timestamps. No background timers or daemons.
+ *   - **Piggybacked**: evaluated inline during metrics reads (same path
+ *     as maybeDeliverWebhooks). Zero new scheduling.
+ *   - **Backward-compatible**: disabled by default. Existing configs
+ *     without escalation fields work identically to before.
+ *   - **Bounded**: max 3 escalation tiers, max 5 escalation targets,
+ *     cooldown enforced between escalation notifications.
+ *   - **Reversible**: escalation state resets immediately when severity
+ *     returns to 'ok'. No hysteresis traps.
+ *
+ * Escalation state is in-memory (non-persistent), matching the existing
+ * delivery state pattern. Resets on server restart — safe and bounded.
+ */
+
+import type { AlertSeverity, AlertEvaluation } from './alert-rules.js';
+import type { WebhookTarget, WebhookConfig, WebhookDeliveryResult } from './alert-webhook.js';
+import { deliverWebhook, buildWebhookPayload } from './alert-webhook.js';
+import { appendDeliveryEvents } from './webhook-delivery-history.js';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/**
+ * A single escalation tier — defines when and how to escalate.
+ * Tiers are evaluated in order; each tier requires the prior to have
+ * been reached (i.e., tier 2 requires tier 1 to have fired first).
+ */
+export interface EscalationTier {
+  /** Time (ms) the qualifying severity must persist before this tier fires. */
+  afterMs: number;
+  /**
+   * Target IDs to notify when this tier triggers.
+   * These reference WebhookTarget.id values from the main config.
+   * If empty, re-notifies all eligible targets from the base config.
+   */
+  targetIds: string[];
+  /**
+   * Optional label for dashboard display (e.g., "Page on-call", "Notify manager").
+   */
+  label?: string;
+}
+
+/**
+ * Escalation policy configuration — embedded in WebhookConfig.
+ * Disabled by default. When enabled, adds escalation tiers on top
+ * of the existing webhook dispatch.
+ */
+export interface EscalationPolicyConfig {
+  /** Whether escalation is enabled. Default: false. */
+  enabled: boolean;
+  /**
+   * Minimum severity that qualifies for escalation tracking.
+   * Only states at or above this severity start the escalation clock.
+   * Default: 'critical'.
+   */
+  triggerSeverity?: AlertSeverity;
+  /**
+   * Escalation tiers, evaluated in order. Max 3 tiers.
+   * Each tier's afterMs must be strictly greater than the previous.
+   */
+  tiers: EscalationTier[];
+  /**
+   * Cooldown between escalation notifications per tier (ms).
+   * Prevents flood if the qualifying state persists well beyond the tier threshold.
+   * Default: 300000 (5 minutes).
+   */
+  cooldownMs?: number;
+}
+
+/** In-memory escalation tracking state. */
+export interface EscalationState {
+  /**
+   * Timestamp when the qualifying severity was first observed (ms since epoch).
+   * Null when not in an escalating state.
+   */
+  qualifyingSince: number | null;
+  /**
+   * The severity that started the escalation clock.
+   * Null when not in an escalating state.
+   */
+  qualifyingSeverity: AlertSeverity | null;
+  /**
+   * Highest tier index that has been triggered (0-indexed).
+   * -1 means no tier has been triggered yet.
+   */
+  lastTriggeredTier: number;
+  /**
+   * Timestamp of last escalation notification per tier index.
+   * Used for per-tier cooldown enforcement.
+   */
+  lastNotifiedAt: Record<number, number>;
+}
+
+/** Result of an escalation evaluation — what action (if any) to take. */
+export interface EscalationDecision {
+  /** Whether any escalation notification should be sent. */
+  shouldEscalate: boolean;
+  /** Which tier index is triggering (null if no escalation). */
+  tierIndex: number | null;
+  /** The tier config (null if no escalation). */
+  tier: EscalationTier | null;
+  /** Target IDs to notify (empty if no escalation). */
+  targetIds: string[];
+  /** Duration the qualifying state has persisted (ms). */
+  qualifyingDurationMs: number;
+  /** Human-readable reason for the decision. */
+  reason: string;
+}
+
+/** Result of escalation dispatch (extends base delivery results). */
+export interface EscalationDeliveryResult {
+  /** The tier that triggered. */
+  tierIndex: number;
+  tierLabel: string | null;
+  /** Delivery results for each target. */
+  deliveryResults: WebhookDeliveryResult[];
+  /** Duration the qualifying state had persisted when triggered. */
+  qualifyingDurationMs: number;
+}
+
+/** Validation error for escalation policy config. */
+export interface EscalationConfigValidationError {
+  field: string;
+  message: string;
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const DEFAULT_ESCALATION_COOLDOWN_MS = 300_000; // 5 minutes
+const DEFAULT_TRIGGER_SEVERITY: AlertSeverity = 'critical';
+const MAX_TIERS = 3;
+const MAX_ESCALATION_TARGETS_PER_TIER = 5;
+const MIN_TIER_AFTER_MS = 60_000; // 1 minute minimum
+const MAX_TIER_AFTER_MS = 86_400_000; // 24 hours maximum
+
+/** Severity priority for comparison. */
+const SEVERITY_PRIORITY: Record<AlertSeverity, number> = {
+  ok: 0,
+  warning: 1,
+  critical: 2,
+};
+
+// ─── In-memory escalation state (non-persistent, resets on restart) ──────────
+
+let escalationState: EscalationState = {
+  qualifyingSince: null,
+  qualifyingSeverity: null,
+  lastTriggeredTier: -1,
+  lastNotifiedAt: {},
+};
+
+/** Reset escalation state (for testing). */
+export function resetEscalationState(): void {
+  escalationState = {
+    qualifyingSince: null,
+    qualifyingSeverity: null,
+    lastTriggeredTier: -1,
+    lastNotifiedAt: {},
+  };
+}
+
+/** Get current escalation state (for testing/inspection). */
+export function getEscalationState(): Readonly<EscalationState> {
+  return escalationState;
+}
+
+// ─── Default config ──────────────────────────────────────────────────────────
+
+export const DEFAULT_ESCALATION_POLICY: EscalationPolicyConfig = {
+  enabled: false,
+  triggerSeverity: DEFAULT_TRIGGER_SEVERITY,
+  tiers: [],
+  cooldownMs: DEFAULT_ESCALATION_COOLDOWN_MS,
+};
+
+// ─── Validation ──────────────────────────────────────────────────────────────
+
+/**
+ * Validate an escalation policy config.
+ * Returns array of errors (empty = valid).
+ * Pure function.
+ */
+export function validateEscalationPolicy(
+  input: unknown,
+  availableTargetIds?: string[],
+): EscalationConfigValidationError[] {
+  const errors: EscalationConfigValidationError[] = [];
+
+  if (!input || typeof input !== 'object' || Array.isArray(input)) {
+    errors.push({ field: 'escalation', message: 'escalation must be a non-null object' });
+    return errors;
+  }
+
+  const obj = input as Record<string, unknown>;
+
+  if (obj.enabled !== undefined && typeof obj.enabled !== 'boolean') {
+    errors.push({ field: 'escalation.enabled', message: 'enabled must be a boolean' });
+  }
+
+  if (obj.triggerSeverity !== undefined) {
+    if (typeof obj.triggerSeverity !== 'string' || !['ok', 'warning', 'critical'].includes(obj.triggerSeverity)) {
+      errors.push({ field: 'escalation.triggerSeverity', message: 'triggerSeverity must be ok, warning, or critical' });
+    }
+  }
+
+  if (obj.cooldownMs !== undefined) {
+    if (typeof obj.cooldownMs !== 'number' || !isFinite(obj.cooldownMs) || obj.cooldownMs < 0) {
+      errors.push({ field: 'escalation.cooldownMs', message: 'cooldownMs must be a non-negative finite number' });
+    }
+  }
+
+  if (obj.tiers !== undefined) {
+    if (!Array.isArray(obj.tiers)) {
+      errors.push({ field: 'escalation.tiers', message: 'tiers must be an array' });
+    } else {
+      if (obj.tiers.length > MAX_TIERS) {
+        errors.push({ field: 'escalation.tiers', message: `maximum ${MAX_TIERS} escalation tiers allowed` });
+      }
+
+      let prevAfterMs = 0;
+      for (let i = 0; i < obj.tiers.length; i++) {
+        const t = obj.tiers[i];
+        const prefix = `escalation.tiers[${i}]`;
+
+        if (!t || typeof t !== 'object' || Array.isArray(t)) {
+          errors.push({ field: prefix, message: 'tier must be an object' });
+          continue;
+        }
+
+        const tObj = t as Record<string, unknown>;
+
+        // afterMs validation
+        if (typeof tObj.afterMs !== 'number' || !isFinite(tObj.afterMs)) {
+          errors.push({ field: `${prefix}.afterMs`, message: 'afterMs is required and must be a finite number' });
+        } else {
+          if (tObj.afterMs < MIN_TIER_AFTER_MS) {
+            errors.push({ field: `${prefix}.afterMs`, message: `afterMs must be >= ${MIN_TIER_AFTER_MS}ms (1 minute)` });
+          }
+          if (tObj.afterMs > MAX_TIER_AFTER_MS) {
+            errors.push({ field: `${prefix}.afterMs`, message: `afterMs must be <= ${MAX_TIER_AFTER_MS}ms (24 hours)` });
+          }
+          if (tObj.afterMs <= prevAfterMs) {
+            errors.push({ field: `${prefix}.afterMs`, message: `afterMs must be strictly greater than previous tier (${prevAfterMs}ms)` });
+          }
+          prevAfterMs = tObj.afterMs;
+        }
+
+        // targetIds validation
+        if (!Array.isArray(tObj.targetIds)) {
+          errors.push({ field: `${prefix}.targetIds`, message: 'targetIds must be an array' });
+        } else {
+          if (tObj.targetIds.length > MAX_ESCALATION_TARGETS_PER_TIER) {
+            errors.push({
+              field: `${prefix}.targetIds`,
+              message: `maximum ${MAX_ESCALATION_TARGETS_PER_TIER} targets per tier`,
+            });
+          }
+          for (let j = 0; j < tObj.targetIds.length; j++) {
+            const tid = tObj.targetIds[j];
+            if (typeof tid !== 'string' || tid.trim().length === 0) {
+              errors.push({ field: `${prefix}.targetIds[${j}]`, message: 'target ID must be a non-empty string' });
+            } else if (availableTargetIds && !availableTargetIds.includes(tid)) {
+              errors.push({
+                field: `${prefix}.targetIds[${j}]`,
+                message: `target ID "${tid}" does not match any configured webhook target`,
+              });
+            }
+          }
+        }
+
+        // label validation (optional)
+        if (tObj.label !== undefined && typeof tObj.label !== 'string') {
+          errors.push({ field: `${prefix}.label`, message: 'label must be a string' });
+        }
+      }
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Sanitize/normalize an escalation policy config.
+ * Fills missing fields with defaults, validates types.
+ * Pure function.
+ */
+export function sanitizeEscalationPolicy(raw: unknown): EscalationPolicyConfig {
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    return { ...DEFAULT_ESCALATION_POLICY, tiers: [] };
+  }
+
+  const obj = raw as Record<string, unknown>;
+
+  const enabled = typeof obj.enabled === 'boolean' ? obj.enabled : false;
+
+  const triggerSeverity: AlertSeverity = (
+    typeof obj.triggerSeverity === 'string' &&
+    ['ok', 'warning', 'critical'].includes(obj.triggerSeverity)
+  )
+    ? obj.triggerSeverity as AlertSeverity
+    : DEFAULT_TRIGGER_SEVERITY;
+
+  const cooldownMs = typeof obj.cooldownMs === 'number' && isFinite(obj.cooldownMs) && obj.cooldownMs >= 0
+    ? obj.cooldownMs
+    : DEFAULT_ESCALATION_COOLDOWN_MS;
+
+  const tiers: EscalationTier[] = [];
+  if (Array.isArray(obj.tiers)) {
+    for (const t of obj.tiers.slice(0, MAX_TIERS)) {
+      if (t && typeof t === 'object' && !Array.isArray(t)) {
+        const tObj = t as Record<string, unknown>;
+        if (typeof tObj.afterMs === 'number' && isFinite(tObj.afterMs) && tObj.afterMs >= MIN_TIER_AFTER_MS) {
+          const targetIds: string[] = [];
+          if (Array.isArray(tObj.targetIds)) {
+            for (const tid of tObj.targetIds.slice(0, MAX_ESCALATION_TARGETS_PER_TIER)) {
+              if (typeof tid === 'string' && tid.trim().length > 0) {
+                targetIds.push(tid.trim());
+              }
+            }
+          }
+          tiers.push({
+            afterMs: Math.min(tObj.afterMs, MAX_TIER_AFTER_MS),
+            targetIds,
+            label: typeof tObj.label === 'string' ? tObj.label.slice(0, 100) : undefined,
+          });
+        }
+      }
+    }
+  }
+
+  return { enabled, triggerSeverity, tiers, cooldownMs };
+}
+
+// ─── Escalation Decision Logic ───────────────────────────────────────────────
+
+/**
+ * Determine whether the current severity qualifies for escalation tracking.
+ * Pure function.
+ */
+export function isQualifyingSeverity(
+  currentSeverity: AlertSeverity,
+  triggerSeverity: AlertSeverity,
+): boolean {
+  return SEVERITY_PRIORITY[currentSeverity] >= SEVERITY_PRIORITY[triggerSeverity];
+}
+
+/**
+ * Evaluate the escalation policy against current alert state.
+ * Returns a decision describing what action (if any) to take.
+ *
+ * This is a **pure function** — it reads the escalation state but
+ * does not mutate it. State mutation happens in applyEscalationDecision().
+ */
+export function evaluateEscalation(
+  policy: EscalationPolicyConfig,
+  currentSeverity: AlertSeverity,
+  state: Readonly<EscalationState>,
+  now: number,
+): EscalationDecision {
+  const noAction: EscalationDecision = {
+    shouldEscalate: false,
+    tierIndex: null,
+    tier: null,
+    targetIds: [],
+    qualifyingDurationMs: 0,
+    reason: '',
+  };
+
+  // Policy disabled
+  if (!policy.enabled) {
+    return { ...noAction, reason: 'escalation policy disabled' };
+  }
+
+  // No tiers configured
+  if (policy.tiers.length === 0) {
+    return { ...noAction, reason: 'no escalation tiers configured' };
+  }
+
+  const triggerSeverity = policy.triggerSeverity ?? DEFAULT_TRIGGER_SEVERITY;
+
+  // Current severity doesn't qualify
+  if (!isQualifyingSeverity(currentSeverity, triggerSeverity)) {
+    return { ...noAction, reason: `current severity '${currentSeverity}' below trigger threshold '${triggerSeverity}'` };
+  }
+
+  // Not currently tracking (shouldn't happen if state is managed correctly, but be safe)
+  if (state.qualifyingSince === null) {
+    return { ...noAction, reason: 'qualifying state not yet tracked (will start tracking)' };
+  }
+
+  const durationMs = now - state.qualifyingSince;
+  const cooldownMs = policy.cooldownMs ?? DEFAULT_ESCALATION_COOLDOWN_MS;
+
+  // Find the highest tier whose afterMs has been exceeded
+  // that hasn't been recently notified (respecting cooldown)
+  for (let i = policy.tiers.length - 1; i >= 0; i--) {
+    const tier = policy.tiers[i];
+
+    // Duration hasn't reached this tier yet
+    if (durationMs < tier.afterMs) continue;
+
+    // This tier has already been triggered — check cooldown for re-notification
+    if (i <= state.lastTriggeredTier) {
+      const lastNotified = state.lastNotifiedAt[i] ?? 0;
+      if (now - lastNotified < cooldownMs) {
+        continue; // Still in cooldown
+      }
+      // Cooldown expired — allow re-notification at this tier
+      return {
+        shouldEscalate: true,
+        tierIndex: i,
+        tier,
+        targetIds: [...tier.targetIds],
+        qualifyingDurationMs: durationMs,
+        reason: `tier ${i + 1} re-notification (cooldown expired, ${Math.round(durationMs / 1000)}s persisted)`,
+      };
+    }
+
+    // This is a new tier — trigger it
+    return {
+      shouldEscalate: true,
+      tierIndex: i,
+      tier,
+      targetIds: [...tier.targetIds],
+      qualifyingDurationMs: durationMs,
+      reason: `tier ${i + 1} triggered (${Math.round(durationMs / 1000)}s persisted, threshold ${Math.round(tier.afterMs / 1000)}s)`,
+    };
+  }
+
+  return {
+    ...noAction,
+    qualifyingDurationMs: durationMs,
+    reason: `qualifying for ${Math.round(durationMs / 1000)}s, no tier threshold reached yet`,
+  };
+}
+
+/**
+ * Update the in-memory escalation state based on the current alert severity.
+ * Handles starting/stopping the escalation clock and recording tier triggers.
+ *
+ * Call this AFTER evaluateEscalation() and (optionally) after dispatching.
+ */
+export function updateEscalationState(
+  currentSeverity: AlertSeverity,
+  triggerSeverity: AlertSeverity,
+  decision: EscalationDecision,
+  now: number,
+): void {
+  const qualifies = isQualifyingSeverity(currentSeverity, triggerSeverity);
+
+  if (!qualifies) {
+    // Severity dropped below threshold — reset escalation tracking
+    escalationState = {
+      qualifyingSince: null,
+      qualifyingSeverity: null,
+      lastTriggeredTier: -1,
+      lastNotifiedAt: {},
+    };
+    return;
+  }
+
+  // Start tracking if not already
+  if (escalationState.qualifyingSince === null) {
+    escalationState.qualifyingSince = now;
+    escalationState.qualifyingSeverity = currentSeverity;
+    return;
+  }
+
+  // Update severity if it worsened (but keep the original start time)
+  if (SEVERITY_PRIORITY[currentSeverity] > SEVERITY_PRIORITY[escalationState.qualifyingSeverity ?? 'ok']) {
+    escalationState.qualifyingSeverity = currentSeverity;
+  }
+
+  // Record tier trigger if a decision was made
+  if (decision.shouldEscalate && decision.tierIndex !== null) {
+    if (decision.tierIndex > escalationState.lastTriggeredTier) {
+      escalationState.lastTriggeredTier = decision.tierIndex;
+    }
+    escalationState.lastNotifiedAt[decision.tierIndex] = now;
+  }
+}
+
+// ─── Escalation Dispatch ─────────────────────────────────────────────────────
+
+/**
+ * Resolve escalation target IDs to actual WebhookTarget objects.
+ * Falls back to all enabled targets if the tier specifies no target IDs.
+ * Pure function.
+ */
+export function resolveEscalationTargets(
+  decision: EscalationDecision,
+  allTargets: WebhookTarget[],
+): WebhookTarget[] {
+  if (decision.targetIds.length === 0) {
+    // No specific targets — re-notify all enabled targets
+    return allTargets.filter((t) => t.enabled);
+  }
+
+  const idSet = new Set(decision.targetIds);
+  return allTargets.filter((t) => idSet.has(t.id));
+}
+
+/**
+ * Build an escalation-annotated webhook payload.
+ * Extends the base payload with escalation metadata so receivers
+ * can distinguish escalation notifications from initial alerts.
+ */
+export function buildEscalationPayload(
+  evaluation: AlertEvaluation,
+  previousSeverity: AlertSeverity | null,
+  decision: EscalationDecision,
+): Record<string, unknown> {
+  const basePayload = buildWebhookPayload(evaluation, previousSeverity);
+  return {
+    ...basePayload,
+    escalation: {
+      isEscalation: true,
+      tierIndex: decision.tierIndex,
+      tierLabel: decision.tier?.label ?? null,
+      qualifyingDurationMs: decision.qualifyingDurationMs,
+      reason: decision.reason,
+    },
+  };
+}
+
+/**
+ * Main escalation entry point — evaluate and dispatch escalation notifications.
+ *
+ * Called inline during metrics evaluation, AFTER the base webhook dispatch.
+ * Piggybacked on the same path — no new daemons or timers.
+ *
+ * Returns escalation delivery results (empty array if no escalation triggered).
+ */
+export async function maybeEscalate(
+  dataDir: string,
+  config: WebhookConfig,
+  evaluation: AlertEvaluation,
+  previousSeverity: AlertSeverity | null,
+  opts: { now?: number } = {},
+): Promise<EscalationDeliveryResult[]> {
+  const now = opts.now ?? evaluation.evaluatedAt;
+  const policy = config.escalation;
+
+  // No escalation policy configured or disabled
+  if (!policy || !policy.enabled) return [];
+
+  // No tiers configured
+  if (!policy.tiers || policy.tiers.length === 0) return [];
+
+  const currentSeverity = evaluation.overallSeverity;
+  const triggerSeverity = policy.triggerSeverity ?? DEFAULT_TRIGGER_SEVERITY;
+
+  // Evaluate what to do
+  const decision = evaluateEscalation(policy, currentSeverity, escalationState, now);
+
+  // Update state (start/stop clock, record triggers)
+  updateEscalationState(currentSeverity, triggerSeverity, decision, now);
+
+  // No escalation needed
+  if (!decision.shouldEscalate) return [];
+
+  // Resolve targets
+  const targets = resolveEscalationTargets(decision, config.targets);
+  if (targets.length === 0) return [];
+
+  // Build escalation payload
+  const payload = buildEscalationPayload(evaluation, previousSeverity, decision);
+
+  // Deliver to each target
+  const deliveryOpts = {
+    timeoutMs: config.timeoutMs ?? 10_000,
+    maxRetries: config.maxRetries ?? 3,
+  };
+
+  // We cast the escalation payload as a WebhookPayload for the existing
+  // deliverWebhook function — the extra `escalation` field is serialized
+  // as part of the JSON body and harmlessly passed through.
+  const results = await Promise.all(
+    targets.map((target) => deliverWebhook(target, payload as any, deliveryOpts)),
+  );
+
+  // Record in delivery history
+  try {
+    const targetMap = new Map(targets.map((t) => [t.id, t]));
+    const contexts = results.map((r) => ({
+      url: targetMap.get(r.targetId)?.url ?? '',
+      triggerSeverity: `escalation-tier-${(decision.tierIndex ?? 0) + 1}`,
+      previousSeverity: previousSeverity,
+      ts: now,
+    }));
+    appendDeliveryEvents(dataDir, results, contexts);
+  } catch {
+    // Non-critical
+  }
+
+  return [{
+    tierIndex: decision.tierIndex!,
+    tierLabel: decision.tier?.label ?? null,
+    deliveryResults: results,
+    qualifyingDurationMs: decision.qualifyingDurationMs,
+  }];
+}

--- a/dashboard/server/routes/task-board.ts
+++ b/dashboard/server/routes/task-board.ts
@@ -82,6 +82,10 @@ import {
   computeWebhookHealth,
 } from '../webhook-health-stats.js';
 
+import {
+  maybeEscalate,
+} from '../escalation-policy.js';
+
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 const VALID_STATUSES: TaskStatus[] = ['backlog', 'queued', 'running', 'done', 'failed'];
@@ -1039,6 +1043,18 @@ export async function handleTaskBoard(
       try {
         // Intentionally not awaited — delivery runs in background
         void maybeDeliverWebhooks(dataDir, metrics.alerts);
+      } catch {
+        // Non-critical — don't break the metrics response
+      }
+    }
+
+    // Piggyback (Phase 19): evaluate escalation policy for persistent alert states.
+    // Runs after base webhook dispatch — escalation is additive.
+    // Fire-and-forget — escalation delivery is async and non-blocking.
+    if (metrics.alerts) {
+      try {
+        const webhookConfig = readWebhookConfig(dataDir);
+        void maybeEscalate(dataDir, webhookConfig, metrics.alerts, null);
       } catch {
         // Non-critical — don't break the metrics response
       }

--- a/dashboard/tests/unit/routes/task-board-escalation-policy.test.ts
+++ b/dashboard/tests/unit/routes/task-board-escalation-policy.test.ts
@@ -1,0 +1,802 @@
+/**
+ * Escalation Policy tests — Issue #219, Phase 19: Webhook Alert Escalation Policy Baseline.
+ *
+ * Tests for:
+ * - validateEscalationPolicy() — config validation
+ * - sanitizeEscalationPolicy() — config normalization / backward compatibility
+ * - isQualifyingSeverity() — severity threshold check
+ * - evaluateEscalation() — deterministic escalation decisions
+ * - updateEscalationState() — state machine transitions
+ * - resolveEscalationTargets() — target resolution from tier config
+ * - buildEscalationPayload() — payload construction with escalation metadata
+ * - Cooldown enforcement between escalation notifications
+ * - State reset on severity recovery (de-escalation)
+ * - No-op behavior when escalation is disabled / not configured
+ * - Backward compatibility — configs without escalation field work unchanged
+ * - Escalation config validation in validateWebhookConfig()
+ */
+
+import { describe, it, expect, beforeEach } from 'vitest';
+import {
+  validateEscalationPolicy,
+  sanitizeEscalationPolicy,
+  isQualifyingSeverity,
+  evaluateEscalation,
+  updateEscalationState,
+  resolveEscalationTargets,
+  buildEscalationPayload,
+  resetEscalationState,
+  getEscalationState,
+  DEFAULT_ESCALATION_POLICY,
+} from '../../../server/escalation-policy.js';
+import type {
+  EscalationPolicyConfig,
+  EscalationState,
+  EscalationDecision,
+  EscalationTier,
+} from '../../../server/escalation-policy.js';
+import {
+  validateWebhookConfig,
+  sanitizeConfig,
+} from '../../../server/alert-webhook.js';
+import type {
+  WebhookTarget,
+  WebhookConfig,
+} from '../../../server/alert-webhook.js';
+import type {
+  AlertSeverity,
+  AlertEvaluation,
+} from '../../../server/alert-rules.js';
+
+// ─── Helpers ─────────────────────────────────────────────────────────────────
+
+function makeEvaluation(overrides: Partial<AlertEvaluation> = {}): AlertEvaluation {
+  return {
+    evaluatedAt: Date.now(),
+    overallSeverity: 'critical',
+    severityCounts: { ok: 0, warning: 0, critical: 1 },
+    rules: [
+      {
+        rule: 'stuckCount',
+        label: 'Stuck Tasks',
+        enabled: true,
+        severity: 'critical',
+        currentValue: 10,
+        warningThreshold: 2,
+        criticalThreshold: 5,
+        message: 'Stuck Tasks: 10 exceeds critical threshold of 5',
+      },
+    ],
+    ...overrides,
+  };
+}
+
+function makePolicy(overrides: Partial<EscalationPolicyConfig> = {}): EscalationPolicyConfig {
+  return {
+    enabled: true,
+    triggerSeverity: 'critical',
+    tiers: [
+      { afterMs: 300_000, targetIds: ['escalation-target-1'], label: 'Page on-call' },
+      { afterMs: 900_000, targetIds: ['escalation-target-2'], label: 'Notify manager' },
+    ],
+    cooldownMs: 300_000,
+    ...overrides,
+  };
+}
+
+function makeState(overrides: Partial<EscalationState> = {}): EscalationState {
+  return {
+    qualifyingSince: null,
+    qualifyingSeverity: null,
+    lastTriggeredTier: -1,
+    lastNotifiedAt: {},
+    ...overrides,
+  };
+}
+
+function makeTarget(overrides: Partial<WebhookTarget> = {}): WebhookTarget {
+  return {
+    id: 'target-1',
+    name: 'Primary',
+    url: 'https://example.com/webhook',
+    enabled: true,
+    ...overrides,
+  };
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+describe('Escalation Policy — Phase 19', () => {
+  beforeEach(() => {
+    resetEscalationState();
+  });
+
+  // ── isQualifyingSeverity ─────────────────────────────────────────────────
+
+  describe('isQualifyingSeverity', () => {
+    it('critical qualifies when trigger is critical', () => {
+      expect(isQualifyingSeverity('critical', 'critical')).toBe(true);
+    });
+
+    it('warning does not qualify when trigger is critical', () => {
+      expect(isQualifyingSeverity('warning', 'critical')).toBe(false);
+    });
+
+    it('ok does not qualify when trigger is critical', () => {
+      expect(isQualifyingSeverity('ok', 'critical')).toBe(false);
+    });
+
+    it('warning qualifies when trigger is warning', () => {
+      expect(isQualifyingSeverity('warning', 'warning')).toBe(true);
+    });
+
+    it('critical qualifies when trigger is warning', () => {
+      expect(isQualifyingSeverity('critical', 'warning')).toBe(true);
+    });
+
+    it('ok does not qualify when trigger is warning', () => {
+      expect(isQualifyingSeverity('ok', 'warning')).toBe(false);
+    });
+
+    it('everything qualifies when trigger is ok', () => {
+      expect(isQualifyingSeverity('ok', 'ok')).toBe(true);
+      expect(isQualifyingSeverity('warning', 'ok')).toBe(true);
+      expect(isQualifyingSeverity('critical', 'ok')).toBe(true);
+    });
+  });
+
+  // ── evaluateEscalation ───────────────────────────────────────────────────
+
+  describe('evaluateEscalation', () => {
+    it('returns no-op when policy is disabled', () => {
+      const policy = makePolicy({ enabled: false });
+      const state = makeState({ qualifyingSince: 1000 });
+      const decision = evaluateEscalation(policy, 'critical', state, 500_000);
+      expect(decision.shouldEscalate).toBe(false);
+      expect(decision.reason).toContain('disabled');
+    });
+
+    it('returns no-op when no tiers configured', () => {
+      const policy = makePolicy({ tiers: [] });
+      const state = makeState({ qualifyingSince: 1000 });
+      const decision = evaluateEscalation(policy, 'critical', state, 500_000);
+      expect(decision.shouldEscalate).toBe(false);
+      expect(decision.reason).toContain('no escalation tiers');
+    });
+
+    it('returns no-op when severity below trigger threshold', () => {
+      const policy = makePolicy({ triggerSeverity: 'critical' });
+      const state = makeState({ qualifyingSince: 1000 });
+      const decision = evaluateEscalation(policy, 'warning', state, 500_000);
+      expect(decision.shouldEscalate).toBe(false);
+      expect(decision.reason).toContain('below trigger threshold');
+    });
+
+    it('returns no-op when qualifying state not yet tracked', () => {
+      const policy = makePolicy();
+      const state = makeState({ qualifyingSince: null });
+      const decision = evaluateEscalation(policy, 'critical', state, 500_000);
+      expect(decision.shouldEscalate).toBe(false);
+      expect(decision.reason).toContain('not yet tracked');
+    });
+
+    it('returns no-op when duration below first tier threshold', () => {
+      const policy = makePolicy({
+        tiers: [{ afterMs: 300_000, targetIds: ['t1'] }],
+      });
+      const state = makeState({ qualifyingSince: 100_000 });
+      // 200_000 - 100_000 = 100_000ms, but tier requires 300_000
+      const decision = evaluateEscalation(policy, 'critical', state, 200_000);
+      expect(decision.shouldEscalate).toBe(false);
+      expect(decision.reason).toContain('no tier threshold reached');
+    });
+
+    it('triggers tier 1 when duration exceeds first tier threshold', () => {
+      const policy = makePolicy({
+        tiers: [
+          { afterMs: 300_000, targetIds: ['t1'], label: 'Page on-call' },
+          { afterMs: 900_000, targetIds: ['t2'], label: 'Notify manager' },
+        ],
+      });
+      // qualifyingSince = 0, now = 400_000 → 400s persisted
+      const state = makeState({ qualifyingSince: 0 });
+      const decision = evaluateEscalation(policy, 'critical', state, 400_000);
+      expect(decision.shouldEscalate).toBe(true);
+      expect(decision.tierIndex).toBe(0);
+      expect(decision.targetIds).toEqual(['t1']);
+      expect(decision.qualifyingDurationMs).toBe(400_000);
+    });
+
+    it('triggers tier 2 when duration exceeds second tier threshold', () => {
+      const policy = makePolicy({
+        tiers: [
+          { afterMs: 300_000, targetIds: ['t1'] },
+          { afterMs: 900_000, targetIds: ['t2'] },
+        ],
+      });
+      const state = makeState({
+        qualifyingSince: 0,
+        lastTriggeredTier: 0,
+        lastNotifiedAt: { 0: 300_000 },
+      });
+      const decision = evaluateEscalation(policy, 'critical', state, 1_000_000);
+      expect(decision.shouldEscalate).toBe(true);
+      expect(decision.tierIndex).toBe(1);
+      expect(decision.targetIds).toEqual(['t2']);
+    });
+
+    it('re-notifies a triggered tier after cooldown expires', () => {
+      const policy = makePolicy({
+        tiers: [{ afterMs: 300_000, targetIds: ['t1'] }],
+        cooldownMs: 300_000,
+      });
+      const state = makeState({
+        qualifyingSince: 0,
+        lastTriggeredTier: 0,
+        lastNotifiedAt: { 0: 400_000 },
+      });
+      // now = 800_000, lastNotified = 400_000, cooldown = 300_000 → cooldown expired
+      const decision = evaluateEscalation(policy, 'critical', state, 800_000);
+      expect(decision.shouldEscalate).toBe(true);
+      expect(decision.tierIndex).toBe(0);
+      expect(decision.reason).toContain('re-notification');
+    });
+
+    it('does NOT re-notify during cooldown', () => {
+      const policy = makePolicy({
+        tiers: [{ afterMs: 300_000, targetIds: ['t1'] }],
+        cooldownMs: 300_000,
+      });
+      const state = makeState({
+        qualifyingSince: 0,
+        lastTriggeredTier: 0,
+        lastNotifiedAt: { 0: 500_000 },
+      });
+      // now = 600_000, lastNotified = 500_000, cooldown = 300_000 → still in cooldown
+      const decision = evaluateEscalation(policy, 'critical', state, 600_000);
+      expect(decision.shouldEscalate).toBe(false);
+    });
+
+    it('prefers the highest reachable tier', () => {
+      const policy = makePolicy({
+        tiers: [
+          { afterMs: 60_000, targetIds: ['t1'] },
+          { afterMs: 120_000, targetIds: ['t2'] },
+          { afterMs: 180_000, targetIds: ['t3'] },
+        ],
+      });
+      // All 3 tiers should be reachable at 200s, but tier 3 (index 2) should be picked
+      const state = makeState({ qualifyingSince: 0 });
+      const decision = evaluateEscalation(policy, 'critical', state, 200_000);
+      expect(decision.shouldEscalate).toBe(true);
+      expect(decision.tierIndex).toBe(2);
+      expect(decision.targetIds).toEqual(['t3']);
+    });
+  });
+
+  // ── updateEscalationState ────────────────────────────────────────────────
+
+  describe('updateEscalationState', () => {
+    it('starts tracking when severity qualifies and state is empty', () => {
+      const noActionDecision: EscalationDecision = {
+        shouldEscalate: false,
+        tierIndex: null,
+        tier: null,
+        targetIds: [],
+        qualifyingDurationMs: 0,
+        reason: 'test',
+      };
+
+      updateEscalationState('critical', 'critical', noActionDecision, 1000);
+      const state = getEscalationState();
+      expect(state.qualifyingSince).toBe(1000);
+      expect(state.qualifyingSeverity).toBe('critical');
+    });
+
+    it('resets state when severity drops below threshold', () => {
+      // First, set up a qualifying state
+      const noAction: EscalationDecision = {
+        shouldEscalate: false, tierIndex: null, tier: null,
+        targetIds: [], qualifyingDurationMs: 0, reason: '',
+      };
+      updateEscalationState('critical', 'critical', noAction, 1000);
+      expect(getEscalationState().qualifyingSince).toBe(1000);
+
+      // Now severity drops to ok
+      updateEscalationState('ok', 'critical', noAction, 5000);
+      const state = getEscalationState();
+      expect(state.qualifyingSince).toBeNull();
+      expect(state.qualifyingSeverity).toBeNull();
+      expect(state.lastTriggeredTier).toBe(-1);
+      expect(state.lastNotifiedAt).toEqual({});
+    });
+
+    it('records tier trigger in state', () => {
+      // Set up initial qualifying state
+      const noAction: EscalationDecision = {
+        shouldEscalate: false, tierIndex: null, tier: null,
+        targetIds: [], qualifyingDurationMs: 0, reason: '',
+      };
+      updateEscalationState('critical', 'critical', noAction, 1000);
+
+      // Now trigger tier 0
+      const tier: EscalationTier = { afterMs: 300_000, targetIds: ['t1'] };
+      const triggerDecision: EscalationDecision = {
+        shouldEscalate: true,
+        tierIndex: 0,
+        tier,
+        targetIds: ['t1'],
+        qualifyingDurationMs: 400_000,
+        reason: 'tier 1 triggered',
+      };
+      updateEscalationState('critical', 'critical', triggerDecision, 401_000);
+
+      const state = getEscalationState();
+      expect(state.lastTriggeredTier).toBe(0);
+      expect(state.lastNotifiedAt[0]).toBe(401_000);
+    });
+
+    it('updates severity to worse but keeps original start time', () => {
+      const noAction: EscalationDecision = {
+        shouldEscalate: false, tierIndex: null, tier: null,
+        targetIds: [], qualifyingDurationMs: 0, reason: '',
+      };
+      // Start with warning (trigger at warning level)
+      updateEscalationState('warning', 'warning', noAction, 1000);
+      expect(getEscalationState().qualifyingSince).toBe(1000);
+      expect(getEscalationState().qualifyingSeverity).toBe('warning');
+
+      // Escalate to critical — should keep the original start time
+      updateEscalationState('critical', 'warning', noAction, 5000);
+      expect(getEscalationState().qualifyingSince).toBe(1000); // unchanged
+      expect(getEscalationState().qualifyingSeverity).toBe('critical'); // updated
+    });
+  });
+
+  // ── resolveEscalationTargets ─────────────────────────────────────────────
+
+  describe('resolveEscalationTargets', () => {
+    const targets: WebhookTarget[] = [
+      makeTarget({ id: 't1', name: 'Primary', enabled: true }),
+      makeTarget({ id: 't2', name: 'Secondary', enabled: true }),
+      makeTarget({ id: 't3', name: 'Disabled', enabled: false }),
+    ];
+
+    it('resolves specific target IDs from decision', () => {
+      const decision: EscalationDecision = {
+        shouldEscalate: true,
+        tierIndex: 0,
+        tier: { afterMs: 300_000, targetIds: ['t2'] },
+        targetIds: ['t2'],
+        qualifyingDurationMs: 400_000,
+        reason: 'test',
+      };
+      const resolved = resolveEscalationTargets(decision, targets);
+      expect(resolved).toHaveLength(1);
+      expect(resolved[0].id).toBe('t2');
+    });
+
+    it('falls back to all enabled targets when tier has empty targetIds', () => {
+      const decision: EscalationDecision = {
+        shouldEscalate: true,
+        tierIndex: 0,
+        tier: { afterMs: 300_000, targetIds: [] },
+        targetIds: [],
+        qualifyingDurationMs: 400_000,
+        reason: 'test',
+      };
+      const resolved = resolveEscalationTargets(decision, targets);
+      expect(resolved).toHaveLength(2); // t1 and t2 (enabled)
+      expect(resolved.map((t) => t.id)).toEqual(['t1', 't2']);
+    });
+
+    it('returns empty when specified target IDs do not exist', () => {
+      const decision: EscalationDecision = {
+        shouldEscalate: true,
+        tierIndex: 0,
+        tier: { afterMs: 300_000, targetIds: ['nonexistent'] },
+        targetIds: ['nonexistent'],
+        qualifyingDurationMs: 400_000,
+        reason: 'test',
+      };
+      const resolved = resolveEscalationTargets(decision, targets);
+      expect(resolved).toHaveLength(0);
+    });
+  });
+
+  // ── buildEscalationPayload ───────────────────────────────────────────────
+
+  describe('buildEscalationPayload', () => {
+    it('includes escalation metadata in payload', () => {
+      const evaluation = makeEvaluation({ evaluatedAt: 1000 });
+      const decision: EscalationDecision = {
+        shouldEscalate: true,
+        tierIndex: 1,
+        tier: { afterMs: 900_000, targetIds: ['t2'], label: 'Notify manager' },
+        targetIds: ['t2'],
+        qualifyingDurationMs: 1_000_000,
+        reason: 'tier 2 triggered',
+      };
+      const payload = buildEscalationPayload(evaluation, 'warning', decision);
+
+      expect(payload.event).toBe('alert.transition');
+      expect(payload.escalation).toBeDefined();
+      const esc = payload.escalation as Record<string, unknown>;
+      expect(esc.isEscalation).toBe(true);
+      expect(esc.tierIndex).toBe(1);
+      expect(esc.tierLabel).toBe('Notify manager');
+      expect(esc.qualifyingDurationMs).toBe(1_000_000);
+      expect(esc.reason).toBe('tier 2 triggered');
+    });
+
+    it('preserves base payload fields', () => {
+      const evaluation = makeEvaluation({
+        evaluatedAt: 5000,
+        overallSeverity: 'critical',
+      });
+      const decision: EscalationDecision = {
+        shouldEscalate: true,
+        tierIndex: 0,
+        tier: { afterMs: 300_000, targetIds: ['t1'] },
+        targetIds: ['t1'],
+        qualifyingDurationMs: 400_000,
+        reason: 'test',
+      };
+      const payload = buildEscalationPayload(evaluation, 'ok', decision);
+
+      expect(payload.currentSeverity).toBe('critical');
+      expect(payload.previousSeverity).toBe('ok');
+      expect(payload.source).toBe('ventureos-dashboard');
+      expect(payload.schemaVersion).toBe(1);
+    });
+  });
+
+  // ── sanitizeEscalationPolicy ─────────────────────────────────────────────
+
+  describe('sanitizeEscalationPolicy', () => {
+    it('returns defaults for null/undefined input', () => {
+      expect(sanitizeEscalationPolicy(null)).toEqual(DEFAULT_ESCALATION_POLICY);
+      expect(sanitizeEscalationPolicy(undefined)).toEqual({
+        ...DEFAULT_ESCALATION_POLICY,
+        tiers: [],
+      });
+    });
+
+    it('returns defaults for non-object input', () => {
+      expect(sanitizeEscalationPolicy('string')).toEqual({
+        ...DEFAULT_ESCALATION_POLICY,
+        tiers: [],
+      });
+      expect(sanitizeEscalationPolicy(42)).toEqual({
+        ...DEFAULT_ESCALATION_POLICY,
+        tiers: [],
+      });
+    });
+
+    it('sanitizes valid config', () => {
+      const result = sanitizeEscalationPolicy({
+        enabled: true,
+        triggerSeverity: 'warning',
+        tiers: [
+          { afterMs: 300_000, targetIds: ['t1'], label: 'First' },
+        ],
+        cooldownMs: 120_000,
+      });
+      expect(result.enabled).toBe(true);
+      expect(result.triggerSeverity).toBe('warning');
+      expect(result.tiers).toHaveLength(1);
+      expect(result.tiers[0].afterMs).toBe(300_000);
+      expect(result.tiers[0].targetIds).toEqual(['t1']);
+      expect(result.tiers[0].label).toBe('First');
+      expect(result.cooldownMs).toBe(120_000);
+    });
+
+    it('caps tiers at max 3', () => {
+      const result = sanitizeEscalationPolicy({
+        enabled: true,
+        tiers: [
+          { afterMs: 60_000, targetIds: [] },
+          { afterMs: 120_000, targetIds: [] },
+          { afterMs: 180_000, targetIds: [] },
+          { afterMs: 240_000, targetIds: [] },
+        ],
+      });
+      expect(result.tiers).toHaveLength(3);
+    });
+
+    it('filters invalid tiers', () => {
+      const result = sanitizeEscalationPolicy({
+        enabled: true,
+        tiers: [
+          { afterMs: 1000, targetIds: [] }, // below min (60_000)
+          { afterMs: 300_000, targetIds: ['t1'] }, // valid
+          'not-an-object', // invalid
+        ],
+      });
+      expect(result.tiers).toHaveLength(1);
+      expect(result.tiers[0].afterMs).toBe(300_000);
+    });
+
+    it('defaults triggerSeverity to critical for invalid values', () => {
+      const result = sanitizeEscalationPolicy({
+        enabled: true,
+        triggerSeverity: 'invalid',
+        tiers: [],
+      });
+      expect(result.triggerSeverity).toBe('critical');
+    });
+  });
+
+  // ── validateEscalationPolicy ─────────────────────────────────────────────
+
+  describe('validateEscalationPolicy', () => {
+    it('returns no errors for valid config', () => {
+      const errors = validateEscalationPolicy({
+        enabled: true,
+        triggerSeverity: 'critical',
+        tiers: [
+          { afterMs: 300_000, targetIds: ['t1'], label: 'First' },
+          { afterMs: 900_000, targetIds: ['t2'], label: 'Second' },
+        ],
+        cooldownMs: 300_000,
+      });
+      expect(errors).toHaveLength(0);
+    });
+
+    it('rejects non-object input', () => {
+      const errors = validateEscalationPolicy('string');
+      expect(errors).toHaveLength(1);
+      expect(errors[0].field).toBe('escalation');
+    });
+
+    it('validates triggerSeverity values', () => {
+      const errors = validateEscalationPolicy({
+        enabled: true,
+        triggerSeverity: 'extreme',
+        tiers: [],
+      });
+      expect(errors.some((e) => e.field === 'escalation.triggerSeverity')).toBe(true);
+    });
+
+    it('rejects more than 3 tiers', () => {
+      const errors = validateEscalationPolicy({
+        enabled: true,
+        tiers: [
+          { afterMs: 60_000, targetIds: [] },
+          { afterMs: 120_000, targetIds: [] },
+          { afterMs: 180_000, targetIds: [] },
+          { afterMs: 240_000, targetIds: [] },
+        ],
+      });
+      expect(errors.some((e) => e.message.includes('maximum 3'))).toBe(true);
+    });
+
+    it('rejects tier afterMs below 1 minute', () => {
+      const errors = validateEscalationPolicy({
+        enabled: true,
+        tiers: [{ afterMs: 30_000, targetIds: [] }],
+      });
+      expect(errors.some((e) => e.field.includes('afterMs') && e.message.includes('60000'))).toBe(true);
+    });
+
+    it('rejects tier afterMs above 24 hours', () => {
+      const errors = validateEscalationPolicy({
+        enabled: true,
+        tiers: [{ afterMs: 100_000_000, targetIds: [] }],
+      });
+      expect(errors.some((e) => e.field.includes('afterMs') && e.message.includes('86400000'))).toBe(true);
+    });
+
+    it('rejects non-increasing tier afterMs', () => {
+      const errors = validateEscalationPolicy({
+        enabled: true,
+        tiers: [
+          { afterMs: 300_000, targetIds: [] },
+          { afterMs: 200_000, targetIds: [] },
+        ],
+      });
+      expect(errors.some((e) => e.message.includes('strictly greater'))).toBe(true);
+    });
+
+    it('validates target IDs against available targets', () => {
+      const errors = validateEscalationPolicy(
+        {
+          enabled: true,
+          tiers: [{ afterMs: 300_000, targetIds: ['nonexistent'] }],
+        },
+        ['t1', 't2'],
+      );
+      expect(errors.some((e) => e.message.includes('does not match'))).toBe(true);
+    });
+
+    it('rejects negative cooldownMs', () => {
+      const errors = validateEscalationPolicy({
+        enabled: true,
+        cooldownMs: -1,
+        tiers: [],
+      });
+      expect(errors.some((e) => e.field === 'escalation.cooldownMs')).toBe(true);
+    });
+  });
+
+  // ── Webhook config backward compatibility ────────────────────────────────
+
+  describe('backward compatibility', () => {
+    it('sanitizeConfig preserves escalation field when present', () => {
+      const config = sanitizeConfig({
+        enabled: true,
+        targets: [],
+        escalation: {
+          enabled: true,
+          triggerSeverity: 'critical',
+          tiers: [{ afterMs: 300_000, targetIds: ['t1'] }],
+          cooldownMs: 300_000,
+        },
+      });
+      expect(config.escalation).toBeDefined();
+      expect(config.escalation!.enabled).toBe(true);
+      expect(config.escalation!.tiers).toHaveLength(1);
+    });
+
+    it('sanitizeConfig omits escalation when not present', () => {
+      const config = sanitizeConfig({
+        enabled: true,
+        targets: [],
+      });
+      expect(config.escalation).toBeUndefined();
+    });
+
+    it('validateWebhookConfig passes when escalation is absent', () => {
+      const errors = validateWebhookConfig({
+        enabled: true,
+        targets: [],
+      });
+      expect(errors).toHaveLength(0);
+    });
+
+    it('validateWebhookConfig validates escalation when present', () => {
+      const errors = validateWebhookConfig({
+        enabled: true,
+        targets: [
+          { id: 't1', url: 'https://example.com/hook', name: 'T1', enabled: true },
+        ],
+        escalation: {
+          enabled: true,
+          triggerSeverity: 'critical',
+          tiers: [
+            { afterMs: 300_000, targetIds: ['t1'], label: 'Page' },
+          ],
+          cooldownMs: 300_000,
+        },
+      });
+      expect(errors).toHaveLength(0);
+    });
+
+    it('validateWebhookConfig rejects invalid escalation config', () => {
+      const errors = validateWebhookConfig({
+        enabled: true,
+        targets: [],
+        escalation: {
+          enabled: 'yes', // invalid — should be boolean
+          tiers: 'not-an-array', // invalid
+        },
+      });
+      expect(errors.length).toBeGreaterThan(0);
+      expect(errors.some((e) => e.field.startsWith('escalation'))).toBe(true);
+    });
+
+    it('validateWebhookConfig allows null escalation (removal)', () => {
+      const errors = validateWebhookConfig({
+        enabled: true,
+        targets: [],
+        escalation: null,
+      });
+      expect(errors).toHaveLength(0);
+    });
+
+    it('validateWebhookConfig cross-validates escalation target IDs against targets', () => {
+      const errors = validateWebhookConfig({
+        enabled: true,
+        targets: [
+          { id: 't1', url: 'https://example.com/hook', name: 'T1', enabled: true },
+        ],
+        escalation: {
+          enabled: true,
+          tiers: [
+            { afterMs: 300_000, targetIds: ['nonexistent'] },
+          ],
+        },
+      });
+      expect(errors.some((e) => e.message.includes('does not match'))).toBe(true);
+    });
+  });
+
+  // ── Full escalation lifecycle ────────────────────────────────────────────
+
+  describe('full lifecycle', () => {
+    it('tracks → triggers → re-notifies → resets on recovery', () => {
+      const policy = makePolicy({
+        enabled: true,
+        triggerSeverity: 'critical',
+        tiers: [{ afterMs: 300_000, targetIds: ['t1'], label: 'Alert' }],
+        cooldownMs: 300_000,
+      });
+
+      const noAction: EscalationDecision = {
+        shouldEscalate: false, tierIndex: null, tier: null,
+        targetIds: [], qualifyingDurationMs: 0, reason: '',
+      };
+
+      // Step 1: Start tracking (critical begins)
+      let decision = evaluateEscalation(policy, 'critical', getEscalationState(), 100_000);
+      expect(decision.shouldEscalate).toBe(false); // not yet tracked
+      updateEscalationState('critical', 'critical', decision, 100_000);
+      expect(getEscalationState().qualifyingSince).toBe(100_000);
+
+      // Step 2: Not yet reached threshold (200s into critical)
+      decision = evaluateEscalation(policy, 'critical', getEscalationState(), 300_000);
+      expect(decision.shouldEscalate).toBe(false);
+      updateEscalationState('critical', 'critical', decision, 300_000);
+
+      // Step 3: Threshold reached (>300s into critical)
+      decision = evaluateEscalation(policy, 'critical', getEscalationState(), 500_000);
+      expect(decision.shouldEscalate).toBe(true);
+      expect(decision.tierIndex).toBe(0);
+      updateEscalationState('critical', 'critical', decision, 500_000);
+      expect(getEscalationState().lastTriggeredTier).toBe(0);
+
+      // Step 4: In cooldown — should not re-notify
+      decision = evaluateEscalation(policy, 'critical', getEscalationState(), 600_000);
+      expect(decision.shouldEscalate).toBe(false);
+      updateEscalationState('critical', 'critical', decision, 600_000);
+
+      // Step 5: Cooldown expired — re-notify
+      decision = evaluateEscalation(policy, 'critical', getEscalationState(), 900_000);
+      expect(decision.shouldEscalate).toBe(true);
+      expect(decision.reason).toContain('re-notification');
+      updateEscalationState('critical', 'critical', decision, 900_000);
+
+      // Step 6: Recovery — severity drops to ok
+      decision = evaluateEscalation(policy, 'ok', getEscalationState(), 1_000_000);
+      expect(decision.shouldEscalate).toBe(false);
+      updateEscalationState('ok', 'critical', decision, 1_000_000);
+      expect(getEscalationState().qualifyingSince).toBeNull();
+      expect(getEscalationState().lastTriggeredTier).toBe(-1);
+    });
+
+    it('multi-tier progression works correctly', () => {
+      const policy = makePolicy({
+        enabled: true,
+        triggerSeverity: 'critical',
+        tiers: [
+          { afterMs: 60_000, targetIds: ['t1'] },
+          { afterMs: 300_000, targetIds: ['t2'] },
+          { afterMs: 900_000, targetIds: ['t3'] },
+        ],
+        cooldownMs: 120_000,
+      });
+
+      // Start tracking
+      let decision = evaluateEscalation(policy, 'critical', getEscalationState(), 0);
+      updateEscalationState('critical', 'critical', decision, 0);
+
+      // At 70s → tier 1 triggers
+      decision = evaluateEscalation(policy, 'critical', getEscalationState(), 70_000);
+      expect(decision.shouldEscalate).toBe(true);
+      expect(decision.tierIndex).toBe(0);
+      updateEscalationState('critical', 'critical', decision, 70_000);
+
+      // At 350s → tier 2 triggers
+      decision = evaluateEscalation(policy, 'critical', getEscalationState(), 350_000);
+      expect(decision.shouldEscalate).toBe(true);
+      expect(decision.tierIndex).toBe(1);
+      updateEscalationState('critical', 'critical', decision, 350_000);
+
+      // At 950s → tier 3 triggers
+      decision = evaluateEscalation(policy, 'critical', getEscalationState(), 950_000);
+      expect(decision.shouldEscalate).toBe(true);
+      expect(decision.tierIndex).toBe(2);
+      updateEscalationState('critical', 'critical', decision, 950_000);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds a deterministic, bounded escalation policy system on top of the existing webhook alert infrastructure. When alert severity persists beyond configured time windows, escalation tiers trigger notifications to designated targets (e.g., page on-call → notify manager).

**Refs #219**

## What Changed

### New: `dashboard/server/escalation-policy.ts`
Pure escalation engine with:
- **Tier-based escalation**: up to 3 configurable tiers with increasing time thresholds
- **Target routing**: each tier can designate specific webhook targets or fall back to all enabled targets
- **Cooldown enforcement**: prevents flood re-notification per tier
- **State machine**: tracks qualifying duration, tier progression, and resets on recovery
- **Deterministic decisions**: pure functions of (config + state + timestamp) — no randomness, no timers

### Modified: `dashboard/server/alert-webhook.ts`
- `WebhookConfig` extended with optional `escalation?: EscalationPolicyConfig` field
- `sanitizeConfig()` passes through escalation sub-object when present
- `validateWebhookConfig()` validates escalation config including cross-reference of target IDs

### Modified: `dashboard/server/routes/task-board.ts`
- Escalation evaluation wired into metrics API handler, piggybacked after base webhook dispatch
- Fire-and-forget pattern — non-blocking, same as existing webhook delivery

### New: `dashboard/tests/unit/routes/task-board-escalation-policy.test.ts`
50 tests covering:
- Qualifying severity checks (all severity × trigger combinations)
- Escalation decision logic (disabled, no tiers, below threshold, tier triggers, re-notification)
- Cooldown enforcement (in-cooldown no-op, post-cooldown re-trigger)
- Multi-tier progression
- State machine (start tracking, reset on recovery, severity worsening)
- Target resolution (specific IDs, fallback to all enabled, missing IDs)
- Payload construction (escalation metadata + base payload preservation)
- Config sanitization (defaults, caps, invalid filtering)
- Config validation (all constraint edges)
- Backward compatibility (absent escalation field, null removal, cross-validation)
- Full lifecycle integration test

## Design Principles

| Principle | Implementation |
|-----------|---------------|
| **Additive** | New optional field on existing config; no changes to alert evaluation or history |
| **Backward-compatible** | Disabled by default; configs without `escalation` work identically |
| **Deterministic** | Pure function decisions — same inputs always produce same outputs |
| **Bounded** | Max 3 tiers, max 5 targets/tier, min 1min/max 24hr thresholds, enforced cooldowns |
| **No new daemons** | Piggybacked on existing metrics evaluation path |
| **Reversible** | State resets immediately on severity recovery; in-memory only (resets on restart) |

## Test Evidence

```
✓ task-board-escalation-policy.test.ts (50 tests) — all pass
✓ task-board-webhook.test.ts (72 tests) — all pass (regression)
✓ All 9 webhook/alert test suites (345 tests) — all pass
✓ tsc --noEmit — clean
```

38 pre-existing failures in `shared-context.test.ts` and `memory-state.test.ts` are unrelated (better-sqlite3 native module build issue).

## Risk Assessment

| Risk | Mitigation |
|------|-----------|
| Escalation floods | Bounded tiers (max 3) + per-tier cooldown enforcement |
| Config migration | Fully optional field; omitted = no behavior change |
| Circular imports | Type-only import from escalation→alert-webhook; runtime one-directional |
| State leak on restart | In-memory only — server restart clears all escalation tracking |
| Blocking metrics path | Fire-and-forget (void promise) — identical to existing webhook dispatch |