### PR TITLE
feat(#219): Escalation policy config UI — dashboard view/edit for escalation tiers (Phase 21)

### DIFF
--- a/dashboard/client/index.html
+++ b/dashboard/client/index.html
@@ -2602,6 +2602,203 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
 .tb-webhook-test-result-item .dot.ok { background: var(--green); }
 .tb-webhook-test-result-item .dot.fail { background: var(--red); }
 
+/* ─── Escalation Policy Config (Issue #219, Phase 21) ─────────────── */
+
+.tb-escalation-config-section {
+  margin-top: 18px;
+  border-top: 1px solid var(--border);
+  padding-top: 14px;
+}
+
+.tb-escalation-config-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 10px;
+}
+
+.tb-escalation-config-header .title {
+  font-size: 13px;
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.tb-escalation-config-toggle {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  margin-bottom: 12px;
+  padding: 10px 14px;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+}
+
+.tb-escalation-config-toggle label {
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.tb-escalation-config-toggle .desc {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-left: auto;
+}
+
+.tb-escalation-config-settings {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.tb-escalation-config-settings > div {
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 12px;
+}
+
+.tb-escalation-config-settings .tb-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 4px;
+  display: block;
+}
+
+.tb-escalation-config-settings .tb-input {
+  width: 100%;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-primary);
+  padding: 6px 8px;
+  font-size: 12px;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.tb-escalation-config-settings select.tb-input {
+  font-family: 'Inter', sans-serif;
+}
+
+.tb-escalation-tiers-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.tb-escalation-tiers-header .title {
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.tb-escalation-tiers-header .add-btn {
+  font-size: 11px;
+  padding: 3px 8px;
+  background: var(--purple);
+  color: #fff;
+  border: none;
+  border-radius: 6px;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+.tb-escalation-tiers-header .add-btn:hover:not(:disabled) {
+  opacity: 0.85;
+}
+
+.tb-escalation-tiers-header .add-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
+}
+
+.tb-escalation-config-tier {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 12px;
+  margin-bottom: 8px;
+  background: var(--bg-card);
+}
+
+.tb-escalation-config-tier-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.tb-escalation-config-tier-header .tier-label {
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--purple);
+}
+
+.tb-escalation-config-tier-remove {
+  font-size: 11px;
+  color: var(--red);
+  cursor: pointer;
+  background: none;
+  border: none;
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+.tb-escalation-config-tier-remove:hover {
+  opacity: 0.8;
+}
+
+.tb-escalation-config-tier-fields {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 8px;
+}
+
+.tb-escalation-config-tier-fields .full-width {
+  grid-column: 1 / -1;
+}
+
+.tb-escalation-config-tier-fields .tb-label {
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 3px;
+  display: block;
+}
+
+.tb-escalation-config-tier-fields .tb-input {
+  width: 100%;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--text-primary);
+  padding: 6px 8px;
+  font-size: 12px;
+  font-family: 'JetBrains Mono', monospace;
+}
+
+.tb-escalation-no-tiers {
+  text-align: center;
+  color: var(--text-muted);
+  font-size: 11px;
+  padding: 16px 12px;
+  border: 1px dashed var(--border);
+  border-radius: 10px;
+  margin-bottom: 8px;
+}
+
+.tb-escalation-config-disabled {
+  opacity: 0.5;
+  pointer-events: none;
+}
+
+/* ─── End Escalation Policy Config ─────────────────────────────────── */
+
 /* ─── End Webhook Config ────────────────────────────────────────────── */
 
 /* ─── Webhook Delivery History (Issue #219, Phase 13) ────────────────── */
@@ -10409,7 +10606,150 @@ function tbRenderWebhookConfigForm(config) {
     html += '</div>';
   }
 
+  // ── Escalation Policy Config (Issue #219, Phase 21) ──────────────────
+  html += tbRenderEscalationConfigSection(config);
+
   body.innerHTML = html;
+}
+
+/** Render the escalation policy configuration section within the webhook config form. */
+function tbRenderEscalationConfigSection(config) {
+  const esc = config.escalation || {};
+  const enabled = esc.enabled === true;
+  const triggerSeverity = esc.triggerSeverity || 'critical';
+  const cooldownSec = Math.round((esc.cooldownMs || 300000) / 1000);
+  const tiers = Array.isArray(esc.tiers) ? esc.tiers : [];
+
+  let html = '<div class="tb-escalation-config-section">';
+
+  // Section header
+  html += '<div class="tb-escalation-config-header">';
+  html += '  <span class="title">⚡ Escalation Policy</span>';
+  html += '</div>';
+
+  // Enable toggle
+  html += '<div class="tb-escalation-config-toggle">';
+  html += '  <label><input type="checkbox" id="tbEscEnabled" ' + (enabled ? 'checked' : '') + ' style="cursor:pointer;" onchange="tbToggleEscalationFields()"> Escalation Enabled</label>';
+  html += '  <span class="desc">' + (enabled ? 'Active — persistent alert states will trigger escalation tiers' : 'Disabled — no escalation behavior') + '</span>';
+  html += '</div>';
+
+  // Settings + tiers (dimmed when disabled)
+  html += '<div id="tbEscFieldsContainer"' + (enabled ? '' : ' class="tb-escalation-config-disabled"') + '>';
+
+  // Trigger severity + cooldown
+  html += '<div class="tb-escalation-config-settings">';
+  html += '  <div>';
+  html += '    <label class="tb-label">Trigger Severity</label>';
+  html += '    <select class="tb-input" id="tbEscTriggerSeverity">';
+  html += '      <option value="warning"' + (triggerSeverity === 'warning' ? ' selected' : '') + '>Warning+</option>';
+  html += '      <option value="critical"' + (triggerSeverity === 'critical' ? ' selected' : '') + '>Critical only</option>';
+  html += '    </select>';
+  html += '  </div>';
+  html += '  <div>';
+  html += '    <label class="tb-label">Cooldown (sec)</label>';
+  html += '    <input type="number" class="tb-input" id="tbEscCooldown" value="' + cooldownSec + '" min="0" step="1">';
+  html += '  </div>';
+  html += '</div>';
+
+  // Tiers header
+  const canAddTier = tiers.length < 3;
+  html += '<div class="tb-escalation-tiers-header">';
+  html += '  <span class="title">Tiers (' + tiers.length + '/3)</span>';
+  html += '  <button class="add-btn" onclick="tbAddEscalationTier()" ' + (canAddTier ? '' : 'disabled') + '>+ Add Tier</button>';
+  html += '</div>';
+
+  // Tiers list
+  if (tiers.length === 0) {
+    html += '<div class="tb-escalation-no-tiers">No escalation tiers configured. Click "Add Tier" to create one.</div>';
+  } else {
+    html += '<div id="tbEscTiersList">';
+    for (let i = 0; i < tiers.length; i++) {
+      html += tbRenderEscalationTierConfig(tiers[i], i, config.targets || []);
+    }
+    html += '</div>';
+  }
+
+  html += '</div>'; // tbEscFieldsContainer
+  html += '</div>'; // tb-escalation-config-section
+  return html;
+}
+
+/** Render a single escalation tier config row. */
+function tbRenderEscalationTierConfig(tier, index, targets) {
+  const afterMin = Math.round((tier.afterMs || 60000) / 60000);
+  const label = tier.label || '';
+  const targetIds = Array.isArray(tier.targetIds) ? tier.targetIds : [];
+
+  let html = '<div class="tb-escalation-config-tier" data-tier-index="' + index + '">';
+  html += '  <div class="tb-escalation-config-tier-header">';
+  html += '    <span class="tier-label">Tier ' + (index + 1) + '</span>';
+  html += '    <button class="tb-escalation-config-tier-remove" onclick="tbRemoveEscalationTier(' + index + ')">Remove</button>';
+  html += '  </div>';
+  html += '  <div class="tb-escalation-config-tier-fields">';
+
+  // After (minutes)
+  html += '    <div>';
+  html += '      <label class="tb-label">After (minutes)</label>';
+  html += '      <input type="number" class="tb-input tbEscTierAfter" data-tier-idx="' + index + '" value="' + afterMin + '" min="1" max="1440" step="1">';
+  html += '    </div>';
+
+  // Label
+  html += '    <div>';
+  html += '      <label class="tb-label">Label</label>';
+  html += '      <input type="text" class="tb-input tbEscTierLabel" data-tier-idx="' + index + '" value="' + tbEsc(label) + '" maxlength="100" placeholder="e.g. Page on-call">';
+  html += '    </div>';
+
+  // Target IDs (full width, comma-separated with helper text)
+  html += '    <div class="full-width">';
+  html += '      <label class="tb-label">Target IDs (comma-separated)</label>';
+  html += '      <input type="text" class="tb-input tbEscTierTargets" data-tier-idx="' + index + '" value="' + tbEsc(targetIds.join(', ')) + '" placeholder="target-id-1, target-id-2">';
+  if (targets.length > 0) {
+    html += '      <div style="font-size:10px;color:var(--text-muted);margin-top:2px;">Available: ' + targets.map(function(t) { return tbEsc(t.id); }).join(', ') + '</div>';
+  }
+  html += '    </div>';
+
+  html += '  </div>';
+  html += '</div>';
+  return html;
+}
+
+/** Toggle escalation fields enabled/disabled state. */
+function tbToggleEscalationFields() {
+  const enabled = document.getElementById('tbEscEnabled')?.checked ?? false;
+  const container = document.getElementById('tbEscFieldsContainer');
+  if (container) {
+    if (enabled) {
+      container.classList.remove('tb-escalation-config-disabled');
+    } else {
+      container.classList.add('tb-escalation-config-disabled');
+    }
+  }
+}
+
+/** Add a new empty escalation tier to the config form. */
+function tbAddEscalationTier() {
+  const current = tbCollectWebhookFormState();
+  if (!current) return;
+  if (!current.escalation) {
+    current.escalation = { enabled: false, triggerSeverity: 'critical', cooldownMs: 300000, tiers: [] };
+  }
+  if (current.escalation.tiers.length >= 3) {
+    tbShowToast('Maximum 3 escalation tiers allowed', 'error');
+    return;
+  }
+  // Default: afterMs based on tier count (5min, 15min, 30min)
+  const defaults = [300000, 900000, 1800000];
+  const afterMs = defaults[current.escalation.tiers.length] || 300000;
+  current.escalation.tiers.push({ afterMs: afterMs, targetIds: [], label: '' });
+  tbRenderWebhookConfigForm(current);
+}
+
+/** Remove an escalation tier from the config form by index. */
+function tbRemoveEscalationTier(index) {
+  const current = tbCollectWebhookFormState();
+  if (!current || !current.escalation) return;
+  current.escalation.tiers.splice(index, 1);
+  tbRenderWebhookConfigForm(current);
 }
 
 /** Render a single webhook target row. */
@@ -10513,12 +10853,37 @@ function tbCollectWebhookFormState() {
     });
   });
 
+  // Escalation policy state
+  const escEnabled = document.getElementById('tbEscEnabled')?.checked ?? false;
+  const escTriggerSeverity = document.getElementById('tbEscTriggerSeverity')?.value || 'critical';
+  const escCooldownSec = parseFloat(document.getElementById('tbEscCooldown')?.value ?? '300');
+  const tierEls = document.querySelectorAll('.tb-escalation-config-tier');
+  const escTiers = [];
+  tierEls.forEach(function(el, i) {
+    const afterInput = el.querySelector('.tbEscTierAfter');
+    const labelInput = el.querySelector('.tbEscTierLabel');
+    const targetsInput = el.querySelector('.tbEscTierTargets');
+    const afterMin = parseFloat(afterInput?.value ?? '1');
+    const targetIdsRaw = (targetsInput?.value || '').split(',').map(function(s) { return s.trim(); }).filter(function(s) { return s.length > 0; });
+    escTiers.push({
+      afterMs: Math.round(afterMin * 60000),
+      label: (labelInput?.value || '').trim(),
+      targetIds: targetIdsRaw,
+    });
+  });
+
   return {
     enabled: enabled,
     cooldownMs: Math.max(0, Math.round(cooldownSec * 1000)),
     timeoutMs: Math.max(1000, Math.min(30000, Math.round(timeoutSec * 1000))),
     maxRetries: Math.max(0, Math.min(5, maxRetries)),
     targets: targets,
+    escalation: {
+      enabled: escEnabled,
+      triggerSeverity: escTriggerSeverity,
+      cooldownMs: Math.max(0, Math.round(escCooldownSec * 1000)),
+      tiers: escTiers,
+    },
   };
 }
 
@@ -10564,12 +10929,48 @@ function tbValidateWebhookForm(state) {
     }
   }
 
+  // Escalation policy validation
+  if (state.escalation && state.escalation.enabled) {
+    const esc = state.escalation;
+    if (esc.cooldownMs < 0 || !isFinite(esc.cooldownMs)) {
+      errors.push('Escalation: Cooldown must be a non-negative number');
+    }
+    if (!['warning', 'critical'].includes(esc.triggerSeverity)) {
+      errors.push('Escalation: Trigger severity must be warning or critical');
+    }
+    if (esc.tiers.length > 3) {
+      errors.push('Escalation: Maximum 3 tiers allowed');
+    }
+    const targetIdSet = new Set(state.targets.map(function(t) { return t.id; }));
+    let prevAfterMs = 0;
+    for (let ti = 0; ti < esc.tiers.length; ti++) {
+      const tier = esc.tiers[ti];
+      const tp = 'Escalation Tier ' + (ti + 1);
+      if (!isFinite(tier.afterMs) || tier.afterMs < 60000) {
+        errors.push(tp + ': After must be >= 1 minute');
+      } else if (tier.afterMs > 86400000) {
+        errors.push(tp + ': After must be <= 24 hours');
+      } else if (tier.afterMs <= prevAfterMs) {
+        errors.push(tp + ': After must be greater than previous tier');
+      }
+      prevAfterMs = tier.afterMs || 0;
+      if (tier.targetIds.length > 5) {
+        errors.push(tp + ': Maximum 5 targets per tier');
+      }
+      for (let tj = 0; tj < tier.targetIds.length; tj++) {
+        if (targetIdSet.size > 0 && !targetIdSet.has(tier.targetIds[tj])) {
+          errors.push(tp + ': Target ID "' + tier.targetIds[tj] + '" not found in webhook targets');
+        }
+      }
+    }
+  }
+
   return errors;
 }
 
 /** Build the API payload from form state. Handles secret pass-through. */
 function tbBuildWebhookPayload(state) {
-  return {
+  const payload = {
     enabled: state.enabled,
     cooldownMs: state.cooldownMs,
     timeoutMs: state.timeoutMs,
@@ -10595,6 +10996,24 @@ function tbBuildWebhookPayload(state) {
       return target;
     }),
   };
+
+  // Include escalation policy config if present
+  if (state.escalation) {
+    payload.escalation = {
+      enabled: state.escalation.enabled,
+      triggerSeverity: state.escalation.triggerSeverity,
+      cooldownMs: state.escalation.cooldownMs,
+      tiers: state.escalation.tiers.map(function(t) {
+        return {
+          afterMs: t.afterMs,
+          targetIds: t.targetIds,
+          label: t.label || undefined,
+        };
+      }),
+    };
+  }
+
+  return payload;
 }
 
 /** Save webhook config to the server. */
@@ -10641,6 +11060,12 @@ function tbResetWebhookConfig() {
     timeoutMs: 10000,
     maxRetries: 3,
     targets: [],
+    escalation: {
+      enabled: false,
+      triggerSeverity: 'critical',
+      cooldownMs: 300000,
+      tiers: [],
+    },
   };
   tbRenderWebhookConfigForm(defaults);
   tbShowToast('Form reset to defaults (click Save to apply)', 'info');

--- a/dashboard/tests/unit/routes/task-board-escalation-config-ui.test.ts
+++ b/dashboard/tests/unit/routes/task-board-escalation-config-ui.test.ts
@@ -1,0 +1,991 @@
+/**
+ * Escalation Policy Config UI tests — Issue #219, Phase 21.
+ *
+ * Tests for the dashboard escalation policy configuration UI that lives
+ * inside the webhook config modal. Covers:
+ *
+ * - Config round-trip: read → edit → save → re-read
+ * - Validation errors: tier ordering, bounds, target cross-refs
+ * - Backward compatibility: configs without escalation field work unchanged
+ * - Escalation config persists alongside webhook config
+ * - Disabled-by-default behavior
+ * - Edge cases: max tiers, empty tiers, boundary values
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+import { mockRequest, mockResponse, parseJsonBody } from '../../helpers.js';
+import { handleTaskBoard } from '../../../server/routes/task-board.js';
+import {
+  readWebhookConfig,
+  writeWebhookConfig,
+  DEFAULT_WEBHOOK_CONFIG,
+} from '../../../server/alert-webhook.js';
+import type { WebhookConfig, WebhookTarget } from '../../../server/alert-webhook.js';
+import type { EscalationPolicyConfig } from '../../../server/escalation-policy.js';
+import type { TaskBoardDeps } from '../../../server/types.js';
+
+const testDataDir = path.join('/tmp', 'test-escalation-config-ui-' + process.pid);
+
+function createDeps(overrides: Partial<TaskBoardDeps> = {}): TaskBoardDeps {
+  return {
+    dataDir: testDataDir,
+    sendJson: (res, data, status = 200) => {
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+    },
+    readRequestBody: async () => '{}',
+    ...overrides,
+  };
+}
+
+function seedWebhookConfig(config: WebhookConfig): void {
+  fs.mkdirSync(testDataDir, { recursive: true });
+  writeWebhookConfig(testDataDir, config);
+}
+
+function seedTasks(): void {
+  fs.mkdirSync(testDataDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(testDataDir, 'task-board.json'),
+    JSON.stringify({ tasks: [], updatedAt: Date.now() }),
+  );
+}
+
+function makeTarget(overrides: Partial<WebhookTarget> = {}): WebhookTarget {
+  return {
+    id: 'target-' + Math.random().toString(36).slice(2, 6),
+    name: 'Test Target',
+    url: 'https://example.com/webhook',
+    enabled: true,
+    minSeverity: 'warning',
+    ...overrides,
+  };
+}
+
+function makeEscalation(overrides: Partial<EscalationPolicyConfig> = {}): EscalationPolicyConfig {
+  return {
+    enabled: false,
+    triggerSeverity: 'critical',
+    cooldownMs: 300000,
+    tiers: [],
+    ...overrides,
+  };
+}
+
+describe('Escalation Policy Config UI (Phase 21)', () => {
+  beforeEach(() => {
+    fs.mkdirSync(testDataDir, { recursive: true });
+    seedTasks();
+  });
+
+  afterEach(() => {
+    try {
+      fs.rmSync(testDataDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  // ── GET: Read escalation config via webhook config endpoint ───────────
+
+  describe('GET /api/task-board/webhooks/config — escalation section', () => {
+    it('returns default config without escalation when none configured', async () => {
+      const req = mockRequest({ url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps());
+      const body = parseJsonBody(res);
+
+      expect(body.config).toBeDefined();
+      expect(body.config.enabled).toBe(false);
+      // Escalation should be absent or have defaults
+      // The system is backward-compatible — no escalation field is fine
+    });
+
+    it('returns escalation config when present', async () => {
+      seedWebhookConfig({
+        enabled: true,
+        targets: [makeTarget({ id: 'slack' })],
+        cooldownMs: 60000,
+        timeoutMs: 10000,
+        maxRetries: 3,
+        escalation: {
+          enabled: true,
+          triggerSeverity: 'critical',
+          cooldownMs: 300000,
+          tiers: [
+            { afterMs: 300000, targetIds: ['slack'], label: 'Page on-call' },
+            { afterMs: 900000, targetIds: ['slack'], label: 'Notify manager' },
+          ],
+        },
+      });
+
+      const req = mockRequest({ url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps());
+      const body = parseJsonBody(res);
+
+      expect(body.config.escalation).toBeDefined();
+      expect(body.config.escalation.enabled).toBe(true);
+      expect(body.config.escalation.triggerSeverity).toBe('critical');
+      expect(body.config.escalation.cooldownMs).toBe(300000);
+      expect(body.config.escalation.tiers).toHaveLength(2);
+      expect(body.config.escalation.tiers[0].label).toBe('Page on-call');
+      expect(body.config.escalation.tiers[0].afterMs).toBe(300000);
+      expect(body.config.escalation.tiers[0].targetIds).toEqual(['slack']);
+    });
+
+    it('returns disabled escalation config', async () => {
+      seedWebhookConfig({
+        enabled: true,
+        targets: [],
+        cooldownMs: 60000,
+        timeoutMs: 10000,
+        maxRetries: 3,
+        escalation: {
+          enabled: false,
+          triggerSeverity: 'warning',
+          cooldownMs: 600000,
+          tiers: [
+            { afterMs: 120000, targetIds: [], label: 'First response' },
+          ],
+        },
+      });
+
+      const req = mockRequest({ url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps());
+      const body = parseJsonBody(res);
+
+      expect(body.config.escalation.enabled).toBe(false);
+      expect(body.config.escalation.triggerSeverity).toBe('warning');
+      expect(body.config.escalation.tiers).toHaveLength(1);
+    });
+  });
+
+  // ── PUT: Save escalation config ─────────────────────────────────────
+
+  describe('PUT /api/task-board/webhooks/config — escalation save', () => {
+    it('saves a valid escalation config', async () => {
+      const payload = {
+        enabled: true,
+        cooldownMs: 60000,
+        timeoutMs: 10000,
+        maxRetries: 3,
+        targets: [
+          { id: 'slack', name: 'Slack', url: 'https://hooks.slack.com/abc', enabled: true },
+          { id: 'pager', name: 'PagerDuty', url: 'https://events.pagerduty.com/hook', enabled: true },
+        ],
+        escalation: {
+          enabled: true,
+          triggerSeverity: 'critical',
+          cooldownMs: 300000,
+          tiers: [
+            { afterMs: 300000, targetIds: ['slack'], label: 'Page on-call' },
+            { afterMs: 900000, targetIds: ['pager'], label: 'Notify manager' },
+          ],
+        },
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      const deps = createDeps({ readRequestBody: async () => JSON.stringify(payload) });
+
+      await handleTaskBoard(req, res, deps);
+      const body = parseJsonBody(res);
+
+      expect(res._statusCode).toBe(200);
+      expect(body.config.escalation).toBeDefined();
+      expect(body.config.escalation.enabled).toBe(true);
+      expect(body.config.escalation.tiers).toHaveLength(2);
+
+      // Verify persisted
+      const persisted = readWebhookConfig(testDataDir);
+      expect(persisted.escalation).toBeDefined();
+      expect(persisted.escalation!.enabled).toBe(true);
+      expect(persisted.escalation!.tiers).toHaveLength(2);
+      expect(persisted.escalation!.tiers[0].label).toBe('Page on-call');
+      expect(persisted.escalation!.tiers[1].label).toBe('Notify manager');
+    });
+
+    it('saves disabled escalation config', async () => {
+      const payload = {
+        enabled: false,
+        targets: [],
+        escalation: {
+          enabled: false,
+          triggerSeverity: 'critical',
+          cooldownMs: 300000,
+          tiers: [],
+        },
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      const deps = createDeps({ readRequestBody: async () => JSON.stringify(payload) });
+
+      await handleTaskBoard(req, res, deps);
+      expect(res._statusCode).toBe(200);
+
+      const persisted = readWebhookConfig(testDataDir);
+      expect(persisted.escalation).toBeDefined();
+      expect(persisted.escalation!.enabled).toBe(false);
+    });
+
+    it('preserves escalation when not included in PUT (backward compat)', async () => {
+      // Seed with escalation
+      seedWebhookConfig({
+        enabled: true,
+        targets: [makeTarget({ id: 'wh-1' })],
+        cooldownMs: 60000,
+        timeoutMs: 10000,
+        maxRetries: 3,
+        escalation: {
+          enabled: true,
+          triggerSeverity: 'critical',
+          cooldownMs: 300000,
+          tiers: [
+            { afterMs: 300000, targetIds: ['wh-1'], label: 'Tier 1' },
+          ],
+        },
+      });
+
+      // PUT without escalation field — should not break
+      const payload = {
+        enabled: true,
+        targets: [
+          { id: 'wh-1', name: 'Updated', url: 'https://example.com/hook', enabled: true },
+        ],
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      const deps = createDeps({ readRequestBody: async () => JSON.stringify(payload) });
+
+      await handleTaskBoard(req, res, deps);
+      expect(res._statusCode).toBe(200);
+
+      // Config should save without error
+      const body = parseJsonBody(res);
+      expect(body.config.targets[0].id).toBe('wh-1');
+    });
+  });
+
+  // ── Round-trip: read → save → re-read ─────────────────────────────────
+
+  describe('round-trip: read → save → re-read', () => {
+    it('escalation config survives full round-trip', async () => {
+      const originalEscalation: EscalationPolicyConfig = {
+        enabled: true,
+        triggerSeverity: 'warning',
+        cooldownMs: 180000,
+        tiers: [
+          { afterMs: 120000, targetIds: ['t1'], label: 'Alert team lead' },
+          { afterMs: 600000, targetIds: ['t1', 't2'], label: 'Escalate to VP' },
+          { afterMs: 1800000, targetIds: ['t2'], label: 'Executive alert' },
+        ],
+      };
+
+      // Save
+      const payload = {
+        enabled: true,
+        cooldownMs: 60000,
+        timeoutMs: 10000,
+        maxRetries: 3,
+        targets: [
+          { id: 't1', name: 'Target 1', url: 'https://t1.example.com/hook', enabled: true },
+          { id: 't2', name: 'Target 2', url: 'https://t2.example.com/hook', enabled: true },
+        ],
+        escalation: originalEscalation,
+      };
+
+      const putReq = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const putRes = mockResponse();
+      await handleTaskBoard(putReq, putRes, createDeps({
+        readRequestBody: async () => JSON.stringify(payload),
+      }));
+      expect(putRes._statusCode).toBe(200);
+
+      // Re-read
+      const getReq = mockRequest({ url: '/api/task-board/webhooks/config' });
+      const getRes = mockResponse();
+      await handleTaskBoard(getReq, getRes, createDeps());
+      const body = parseJsonBody(getRes);
+
+      expect(body.config.escalation.enabled).toBe(true);
+      expect(body.config.escalation.triggerSeverity).toBe('warning');
+      expect(body.config.escalation.cooldownMs).toBe(180000);
+      expect(body.config.escalation.tiers).toHaveLength(3);
+      expect(body.config.escalation.tiers[0]).toMatchObject({
+        afterMs: 120000,
+        targetIds: ['t1'],
+        label: 'Alert team lead',
+      });
+      expect(body.config.escalation.tiers[1]).toMatchObject({
+        afterMs: 600000,
+        targetIds: ['t1', 't2'],
+        label: 'Escalate to VP',
+      });
+      expect(body.config.escalation.tiers[2]).toMatchObject({
+        afterMs: 1800000,
+        targetIds: ['t2'],
+        label: 'Executive alert',
+      });
+    });
+
+    it('escalation toggle off → save → re-read preserves disabled state', async () => {
+      const payload = {
+        enabled: true,
+        targets: [
+          { id: 'wh-1', name: 'T', url: 'https://example.com/hook', enabled: true },
+        ],
+        escalation: {
+          enabled: false,
+          triggerSeverity: 'critical',
+          cooldownMs: 300000,
+          tiers: [
+            { afterMs: 300000, targetIds: ['wh-1'], label: 'Tier 1' },
+          ],
+        },
+      };
+
+      const putReq = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const putRes = mockResponse();
+      await handleTaskBoard(putReq, putRes, createDeps({
+        readRequestBody: async () => JSON.stringify(payload),
+      }));
+      expect(putRes._statusCode).toBe(200);
+
+      const getReq = mockRequest({ url: '/api/task-board/webhooks/config' });
+      const getRes = mockResponse();
+      await handleTaskBoard(getReq, getRes, createDeps());
+      const body = parseJsonBody(getRes);
+
+      expect(body.config.escalation.enabled).toBe(false);
+      // Tiers should still be preserved even when disabled
+      expect(body.config.escalation.tiers).toHaveLength(1);
+    });
+  });
+
+  // ── Validation errors ──────────────────────────────────────────────────
+
+  describe('validation errors', () => {
+    it('rejects more than 3 escalation tiers', async () => {
+      const payload = {
+        enabled: true,
+        targets: [
+          { id: 'wh-1', url: 'https://example.com/hook', enabled: true },
+        ],
+        escalation: {
+          enabled: true,
+          tiers: [
+            { afterMs: 60000, targetIds: ['wh-1'] },
+            { afterMs: 120000, targetIds: ['wh-1'] },
+            { afterMs: 180000, targetIds: ['wh-1'] },
+            { afterMs: 240000, targetIds: ['wh-1'] },
+          ],
+        },
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps({
+        readRequestBody: async () => JSON.stringify(payload),
+      }));
+      const body = parseJsonBody(res);
+
+      expect(res._statusCode).toBe(400);
+      expect(body.error).toBe('validation failed');
+      expect(body.errors.some((e: any) => e.message.includes('3'))).toBe(true);
+    });
+
+    it('rejects afterMs below 1 minute', async () => {
+      const payload = {
+        enabled: true,
+        targets: [
+          { id: 'wh-1', url: 'https://example.com/hook', enabled: true },
+        ],
+        escalation: {
+          enabled: true,
+          tiers: [
+            { afterMs: 30000, targetIds: ['wh-1'] },
+          ],
+        },
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps({
+        readRequestBody: async () => JSON.stringify(payload),
+      }));
+      const body = parseJsonBody(res);
+
+      expect(res._statusCode).toBe(400);
+      expect(body.errors.some((e: any) => e.field.includes('afterMs') && e.message.includes('60000'))).toBe(true);
+    });
+
+    it('rejects afterMs above 24 hours', async () => {
+      const payload = {
+        enabled: true,
+        targets: [
+          { id: 'wh-1', url: 'https://example.com/hook', enabled: true },
+        ],
+        escalation: {
+          enabled: true,
+          tiers: [
+            { afterMs: 100000000, targetIds: ['wh-1'] },
+          ],
+        },
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps({
+        readRequestBody: async () => JSON.stringify(payload),
+      }));
+      const body = parseJsonBody(res);
+
+      expect(res._statusCode).toBe(400);
+      expect(body.errors.some((e: any) => e.field.includes('afterMs') && e.message.includes('86400000'))).toBe(true);
+    });
+
+    it('rejects non-ascending tier afterMs values', async () => {
+      const payload = {
+        enabled: true,
+        targets: [
+          { id: 'wh-1', url: 'https://example.com/hook', enabled: true },
+        ],
+        escalation: {
+          enabled: true,
+          tiers: [
+            { afterMs: 300000, targetIds: ['wh-1'] },
+            { afterMs: 120000, targetIds: ['wh-1'] }, // less than previous
+          ],
+        },
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps({
+        readRequestBody: async () => JSON.stringify(payload),
+      }));
+      const body = parseJsonBody(res);
+
+      expect(res._statusCode).toBe(400);
+      expect(body.errors.some((e: any) => e.message.includes('strictly greater'))).toBe(true);
+    });
+
+    it('rejects invalid target IDs that do not match webhook targets', async () => {
+      const payload = {
+        enabled: true,
+        targets: [
+          { id: 'wh-1', url: 'https://example.com/hook', enabled: true },
+        ],
+        escalation: {
+          enabled: true,
+          tiers: [
+            { afterMs: 300000, targetIds: ['nonexistent-target'] },
+          ],
+        },
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps({
+        readRequestBody: async () => JSON.stringify(payload),
+      }));
+      const body = parseJsonBody(res);
+
+      expect(res._statusCode).toBe(400);
+      expect(body.errors.some((e: any) => e.message.includes('nonexistent-target'))).toBe(true);
+    });
+
+    it('rejects more than 5 target IDs per tier', async () => {
+      const payload = {
+        enabled: true,
+        targets: [
+          { id: 'a', url: 'https://a.example.com/hook', enabled: true },
+          { id: 'b', url: 'https://b.example.com/hook', enabled: true },
+          { id: 'c', url: 'https://c.example.com/hook', enabled: true },
+          { id: 'd', url: 'https://d.example.com/hook', enabled: true },
+          { id: 'e', url: 'https://e.example.com/hook', enabled: true },
+        ],
+        escalation: {
+          enabled: true,
+          tiers: [
+            { afterMs: 300000, targetIds: ['a', 'b', 'c', 'd', 'e', 'a'] },
+          ],
+        },
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps({
+        readRequestBody: async () => JSON.stringify(payload),
+      }));
+      const body = parseJsonBody(res);
+
+      expect(res._statusCode).toBe(400);
+      expect(body.errors.some((e: any) => e.message.includes('5'))).toBe(true);
+    });
+
+    it('rejects invalid triggerSeverity', async () => {
+      const payload = {
+        enabled: true,
+        targets: [],
+        escalation: {
+          enabled: true,
+          triggerSeverity: 'banana',
+          tiers: [],
+        },
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps({
+        readRequestBody: async () => JSON.stringify(payload),
+      }));
+      const body = parseJsonBody(res);
+
+      expect(res._statusCode).toBe(400);
+      expect(body.errors.some((e: any) =>
+        e.field.includes('triggerSeverity'),
+      )).toBe(true);
+    });
+
+    it('rejects non-boolean escalation.enabled', async () => {
+      const payload = {
+        enabled: true,
+        targets: [],
+        escalation: {
+          enabled: 'yes',
+          tiers: [],
+        },
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps({
+        readRequestBody: async () => JSON.stringify(payload),
+      }));
+      const body = parseJsonBody(res);
+
+      expect(res._statusCode).toBe(400);
+      expect(body.errors.some((e: any) =>
+        e.field === 'escalation.enabled',
+      )).toBe(true);
+    });
+
+    it('rejects non-array tiers', async () => {
+      const payload = {
+        enabled: true,
+        targets: [],
+        escalation: {
+          enabled: true,
+          tiers: 'not-an-array',
+        },
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps({
+        readRequestBody: async () => JSON.stringify(payload),
+      }));
+      const body = parseJsonBody(res);
+
+      expect(res._statusCode).toBe(400);
+      expect(body.errors.some((e: any) =>
+        e.field === 'escalation.tiers' && e.message.includes('array'),
+      )).toBe(true);
+    });
+
+    it('rejects negative escalation cooldownMs', async () => {
+      const payload = {
+        enabled: true,
+        targets: [],
+        escalation: {
+          enabled: true,
+          cooldownMs: -100,
+          tiers: [],
+        },
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps({
+        readRequestBody: async () => JSON.stringify(payload),
+      }));
+      const body = parseJsonBody(res);
+
+      expect(res._statusCode).toBe(400);
+      expect(body.errors.some((e: any) =>
+        e.field === 'escalation.cooldownMs',
+      )).toBe(true);
+    });
+
+    it('rejects tier with non-array targetIds', async () => {
+      const payload = {
+        enabled: true,
+        targets: [
+          { id: 'wh-1', url: 'https://example.com/hook', enabled: true },
+        ],
+        escalation: {
+          enabled: true,
+          tiers: [
+            { afterMs: 300000, targetIds: 'not-an-array' },
+          ],
+        },
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps({
+        readRequestBody: async () => JSON.stringify(payload),
+      }));
+      const body = parseJsonBody(res);
+
+      expect(res._statusCode).toBe(400);
+      expect(body.errors.some((e: any) =>
+        e.message.includes('targetIds') && e.message.includes('array'),
+      )).toBe(true);
+    });
+
+    it('rejects non-string label', async () => {
+      const payload = {
+        enabled: true,
+        targets: [
+          { id: 'wh-1', url: 'https://example.com/hook', enabled: true },
+        ],
+        escalation: {
+          enabled: true,
+          tiers: [
+            { afterMs: 300000, targetIds: ['wh-1'], label: 42 },
+          ],
+        },
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps({
+        readRequestBody: async () => JSON.stringify(payload),
+      }));
+      const body = parseJsonBody(res);
+
+      expect(res._statusCode).toBe(400);
+      expect(body.errors.some((e: any) => e.message.includes('label'))).toBe(true);
+    });
+  });
+
+  // ── Backward compatibility ────────────────────────────────────────────
+
+  describe('backward compatibility', () => {
+    it('configs without escalation field are handled gracefully', async () => {
+      // Save a config that has no escalation field
+      const payload = {
+        enabled: true,
+        cooldownMs: 60000,
+        timeoutMs: 10000,
+        maxRetries: 3,
+        targets: [
+          { id: 'wh-1', name: 'Test', url: 'https://example.com/hook', enabled: true },
+        ],
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps({
+        readRequestBody: async () => JSON.stringify(payload),
+      }));
+      expect(res._statusCode).toBe(200);
+
+      // Verify it persists and reads back without errors
+      const persisted = readWebhookConfig(testDataDir);
+      expect(persisted.enabled).toBe(true);
+      expect(persisted.targets).toHaveLength(1);
+      // escalation may or may not be present — that's fine
+    });
+
+    it('explicit null escalation is accepted', async () => {
+      const payload = {
+        enabled: true,
+        targets: [],
+        escalation: null,
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps({
+        readRequestBody: async () => JSON.stringify(payload),
+      }));
+      expect(res._statusCode).toBe(200);
+    });
+  });
+
+  // ── Disabled-by-default behavior ──────────────────────────────────────
+
+  describe('disabled-by-default', () => {
+    it('new config has escalation disabled by default', async () => {
+      const payload = {
+        enabled: true,
+        targets: [],
+        escalation: {
+          enabled: false,
+          tiers: [],
+        },
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps({
+        readRequestBody: async () => JSON.stringify(payload),
+      }));
+      const body = parseJsonBody(res);
+
+      expect(res._statusCode).toBe(200);
+      expect(body.config.escalation.enabled).toBe(false);
+    });
+
+    it('DEFAULT_WEBHOOK_CONFIG has no escalation', () => {
+      expect(DEFAULT_WEBHOOK_CONFIG.escalation).toBeUndefined();
+    });
+  });
+
+  // ── Edge cases ────────────────────────────────────────────────────────
+
+  describe('edge cases', () => {
+    it('saves escalation with empty tiers array', async () => {
+      const payload = {
+        enabled: true,
+        targets: [],
+        escalation: {
+          enabled: true,
+          triggerSeverity: 'critical',
+          cooldownMs: 300000,
+          tiers: [],
+        },
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps({
+        readRequestBody: async () => JSON.stringify(payload),
+      }));
+      expect(res._statusCode).toBe(200);
+
+      const persisted = readWebhookConfig(testDataDir);
+      expect(persisted.escalation!.tiers).toEqual([]);
+    });
+
+    it('saves escalation tier with empty targetIds', async () => {
+      const payload = {
+        enabled: true,
+        targets: [],
+        escalation: {
+          enabled: true,
+          tiers: [
+            { afterMs: 300000, targetIds: [], label: 'Tier with no targets' },
+          ],
+        },
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps({
+        readRequestBody: async () => JSON.stringify(payload),
+      }));
+      expect(res._statusCode).toBe(200);
+
+      const persisted = readWebhookConfig(testDataDir);
+      expect(persisted.escalation!.tiers[0].targetIds).toEqual([]);
+    });
+
+    it('saves maximum 3 tiers at boundary', async () => {
+      const payload = {
+        enabled: true,
+        targets: [
+          { id: 'a', url: 'https://a.example.com/hook', enabled: true },
+        ],
+        escalation: {
+          enabled: true,
+          tiers: [
+            { afterMs: 60000, targetIds: ['a'], label: 'Tier 1' },
+            { afterMs: 300000, targetIds: ['a'], label: 'Tier 2' },
+            { afterMs: 900000, targetIds: ['a'], label: 'Tier 3' },
+          ],
+        },
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps({
+        readRequestBody: async () => JSON.stringify(payload),
+      }));
+      expect(res._statusCode).toBe(200);
+
+      const persisted = readWebhookConfig(testDataDir);
+      expect(persisted.escalation!.tiers).toHaveLength(3);
+    });
+
+    it('saves tier afterMs at exact 1-minute boundary', async () => {
+      const payload = {
+        enabled: true,
+        targets: [],
+        escalation: {
+          enabled: true,
+          tiers: [
+            { afterMs: 60000, targetIds: [] },
+          ],
+        },
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps({
+        readRequestBody: async () => JSON.stringify(payload),
+      }));
+      expect(res._statusCode).toBe(200);
+    });
+
+    it('saves tier afterMs at exact 24-hour boundary', async () => {
+      const payload = {
+        enabled: true,
+        targets: [],
+        escalation: {
+          enabled: true,
+          tiers: [
+            { afterMs: 86400000, targetIds: [] },
+          ],
+        },
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps({
+        readRequestBody: async () => JSON.stringify(payload),
+      }));
+      expect(res._statusCode).toBe(200);
+    });
+
+    it('saves escalation with triggerSeverity warning', async () => {
+      const payload = {
+        enabled: true,
+        targets: [],
+        escalation: {
+          enabled: true,
+          triggerSeverity: 'warning',
+          cooldownMs: 60000,
+          tiers: [],
+        },
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps({
+        readRequestBody: async () => JSON.stringify(payload),
+      }));
+      expect(res._statusCode).toBe(200);
+
+      const persisted = readWebhookConfig(testDataDir);
+      expect(persisted.escalation!.triggerSeverity).toBe('warning');
+    });
+
+    it('saving webhook config with escalation does not break existing webhook targets', async () => {
+      // Seed existing webhook config
+      seedWebhookConfig({
+        enabled: true,
+        targets: [makeTarget({ id: 'original', secret: 'my-secret' })],
+        cooldownMs: 60000,
+        timeoutMs: 10000,
+        maxRetries: 3,
+      });
+
+      // PUT with escalation added, preserving target (secret omitted → should be preserved)
+      const payload = {
+        enabled: true,
+        cooldownMs: 60000,
+        timeoutMs: 10000,
+        maxRetries: 3,
+        targets: [
+          { id: 'original', name: 'Test Target', url: 'https://example.com/webhook', enabled: true },
+        ],
+        escalation: {
+          enabled: true,
+          triggerSeverity: 'critical',
+          cooldownMs: 300000,
+          tiers: [
+            { afterMs: 300000, targetIds: ['original'], label: 'Escalate' },
+          ],
+        },
+      };
+
+      const req = mockRequest({ method: 'PUT', url: '/api/task-board/webhooks/config' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps({
+        readRequestBody: async () => JSON.stringify(payload),
+      }));
+      expect(res._statusCode).toBe(200);
+
+      // Verify secret preserved and escalation saved
+      const persisted = readWebhookConfig(testDataDir);
+      expect(persisted.targets[0].secret).toBe('my-secret');
+      expect(persisted.escalation!.enabled).toBe(true);
+      expect(persisted.escalation!.tiers).toHaveLength(1);
+    });
+  });
+
+  // ── Escalation status endpoint still works with config ────────────────
+
+  describe('GET /api/task-board/escalation/status with config', () => {
+    it('returns status when escalation config exists but is disabled', async () => {
+      seedWebhookConfig({
+        enabled: true,
+        targets: [],
+        cooldownMs: 60000,
+        timeoutMs: 10000,
+        maxRetries: 3,
+        escalation: {
+          enabled: false,
+          triggerSeverity: 'critical',
+          cooldownMs: 300000,
+          tiers: [],
+        },
+      });
+
+      const req = mockRequest({ url: '/api/task-board/escalation/status' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps());
+      const body = parseJsonBody(res);
+
+      expect(res._statusCode).toBe(200);
+      expect(body.status).toBeDefined();
+      expect(body.status.policyEnabled).toBe(false);
+    });
+
+    it('returns status when escalation config is enabled', async () => {
+      seedWebhookConfig({
+        enabled: true,
+        targets: [makeTarget({ id: 'wh-1' })],
+        cooldownMs: 60000,
+        timeoutMs: 10000,
+        maxRetries: 3,
+        escalation: {
+          enabled: true,
+          triggerSeverity: 'critical',
+          cooldownMs: 300000,
+          tiers: [
+            { afterMs: 300000, targetIds: ['wh-1'], label: 'Tier 1' },
+          ],
+        },
+      });
+
+      const req = mockRequest({ url: '/api/task-board/escalation/status' });
+      const res = mockResponse();
+      await handleTaskBoard(req, res, createDeps());
+      const body = parseJsonBody(res);
+
+      expect(res._statusCode).toBe(200);
+      expect(body.status).toBeDefined();
+      expect(body.status.policyEnabled).toBe(true);
+      expect(body.status.tiers).toHaveLength(1);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds an additive escalation policy configuration section to the webhook config modal in the task-board dashboard. Refs #219.

## What's included

### Client-side UI (dashboard/client/index.html)
- **Escalation Policy section** inside the Webhook Notifications modal
- Enable/disable toggle with visual disabled state
- Trigger severity selector (warning/critical)
- Escalation cooldown (seconds) input
- Up to 3 tiers, each with:
  - After (minutes) — time threshold before tier fires
  - Label — human-readable description
  - Target IDs — comma-separated, cross-validated against webhook targets
- Add/remove tier buttons with bounded limits
- Client-side validation matching server-side rules:
  - Tier afterMs ordering (strictly ascending)
  - Bounds: min 1 minute, max 24 hours
  - Max 5 targets per tier
  - Target ID cross-reference validation
  - Max 3 tiers

### Server-side
No server changes needed — the existing `PUT /api/task-board/webhooks/config` endpoint already validates and persists escalation config (Phase 19).

### Tests (33 new)
- Config round-trip: read → save → re-read
- All validation error paths (tier ordering, bounds, target refs, types)
- Backward compatibility (configs without escalation field)
- Disabled-by-default behavior
- Edge cases (boundary values, empty tiers, max tiers, secret preservation)
- Escalation status endpoint integration

## Test Results
- **33 new tests**: All passing
- **799 total task-board tests**: All passing (21 test files)
- **TypeScript typecheck**: Clean (zero errors)

## Risk Assessment
- **Low risk**: Purely additive UI code + test file
- **No server changes**: Leverages existing Phase 19 backend validation
- **No new dependencies**: HTML/CSS/JS only
- **Backward compatible**: Disabled by default, existing configs unaffected
- **Reversible**: Can be removed by reverting this single commit

## Remaining #219 scope after this slice
- Escalation policy runtime integration tests (E2E: UI → config → trigger → dispatch)
- Escalation history/audit trail (persisted escalation events)
- Escalation notification templates (customizable escalation message format)
- Multi-policy support (per-rule escalation configs)
- Escalation schedule awareness (business hours, on-call rotation)