### PR TITLE
feat(#219): Escalation history audit trail — persisted escalation events with API + dashboard UI (Phase 22)

### DIFF
--- a/dashboard/client/index.html
+++ b/dashboard/client/index.html
@@ -2269,6 +2269,142 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
 
 /* ─── End Escalation Status ───────────────────────────────────────── */
 
+/* ─── Escalation History (Issue #219, Phase 22) ────────────────────── */
+
+.tb-escalation-history-panel {
+  display: none;
+  background: var(--bg-card);
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 14px 16px;
+  margin-bottom: 16px;
+}
+.tb-escalation-history-panel.active {
+  display: block;
+}
+.tb-escalation-history-header {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: 10px;
+  font-size: 13px;
+  font-weight: 600;
+}
+.tb-escalation-history-header .icon {
+  font-size: 15px;
+}
+.tb-escalation-history-header .title {
+  flex: 1;
+}
+.tb-escalation-history-header .subtitle {
+  font-size: 11px;
+  font-weight: 400;
+  color: var(--text-muted);
+}
+.tb-escalation-history-controls {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+.tb-escalation-history-controls select {
+  padding: 2px 6px;
+  background: var(--bg-tertiary);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-primary);
+  font-size: 11px;
+  font-family: inherit;
+}
+.tb-escalation-history-stats {
+  display: flex;
+  gap: 12px;
+  font-size: 11px;
+  color: var(--text-muted);
+  margin-bottom: 10px;
+  flex-wrap: wrap;
+}
+.tb-escalation-history-stats .stat-value {
+  font-weight: 600;
+  color: var(--text-primary);
+}
+.tb-escalation-history-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 11px;
+}
+.tb-escalation-history-table th {
+  text-align: left;
+  padding: 6px 8px;
+  font-weight: 600;
+  color: var(--text-muted);
+  border-bottom: 1px solid var(--border);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+.tb-escalation-history-table td {
+  padding: 6px 8px;
+  border-bottom: 1px solid rgba(255,255,255,0.04);
+  vertical-align: top;
+}
+.tb-escalation-history-table tr:hover td {
+  background: rgba(255,255,255,0.02);
+}
+.tb-escalation-event-badge {
+  display: inline-block;
+  font-size: 9px;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: 4px;
+  text-transform: uppercase;
+  letter-spacing: 0.3px;
+}
+.tb-escalation-event-badge.tier_triggered {
+  background: rgba(245, 158, 11, 0.2);
+  color: var(--yellow);
+}
+.tb-escalation-event-badge.tier_renotified {
+  background: rgba(168, 85, 247, 0.2);
+  color: var(--purple);
+}
+.tb-escalation-event-badge.notification_sent {
+  background: rgba(59, 130, 246, 0.2);
+  color: var(--blue);
+}
+.tb-escalation-event-badge.escalation_reset {
+  background: rgba(16, 185, 129, 0.2);
+  color: var(--green);
+}
+.tb-escalation-delivery-outcomes {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+.tb-escalation-delivery-pill {
+  font-size: 9px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  white-space: nowrap;
+}
+.tb-escalation-delivery-pill.success {
+  background: rgba(16, 185, 129, 0.15);
+  color: var(--green);
+}
+.tb-escalation-delivery-pill.failure {
+  background: rgba(239, 68, 68, 0.15);
+  color: var(--red);
+}
+.tb-escalation-history-empty {
+  text-align: center;
+  color: var(--text-muted);
+  padding: 24px 0;
+  font-size: 12px;
+}
+
+/* ─── End Escalation History ──────────────────────────────────────── */
+
 /* ─── Webhook Config (Issue #219, Phase 12) ─────────────────────────── */
 
 .tb-webhook-config-link {
@@ -5205,6 +5341,38 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
             </div>
             <div id="tbEscalationSummary" class="tb-escalation-summary"></div>
             <div id="tbEscalationTiers" class="tb-escalation-tiers"></div>
+          </div>
+
+          <!-- Escalation History Panel (Phase 22) — audit trail of escalation events -->
+          <div id="tbEscalationHistoryPanel" class="tb-escalation-history-panel">
+            <div class="tb-escalation-history-header">
+              <span class="icon">📋</span>
+              <span class="title">Escalation History</span>
+              <span class="subtitle" id="tbEscHistSubtitle"></span>
+            </div>
+            <div class="tb-escalation-history-controls">
+              <select id="tbEscHistWindow" onchange="tbFetchEscalationHistory()">
+                <option value="3600000">Last 1h</option>
+                <option value="21600000" selected>Last 6h</option>
+                <option value="86400000">Last 24h</option>
+                <option value="172800000">Last 48h</option>
+              </select>
+              <select id="tbEscHistEventType" onchange="tbFetchEscalationHistory()">
+                <option value="">All events</option>
+                <option value="tier_triggered">Tier triggered</option>
+                <option value="tier_renotified">Re-notified</option>
+                <option value="escalation_reset">Reset</option>
+              </select>
+              <select id="tbEscHistDeliveryStatus" onchange="tbFetchEscalationHistory()">
+                <option value="">Any delivery</option>
+                <option value="success">Success</option>
+                <option value="failure">Failure</option>
+              </select>
+            </div>
+            <div id="tbEscHistStats" class="tb-escalation-history-stats"></div>
+            <div id="tbEscHistBody">
+              <div class="tb-escalation-history-empty">No escalation events recorded yet</div>
+            </div>
           </div>
 
           <!-- Alert History Timeline (Phase 10) — compact recent alert transitions -->
@@ -9032,6 +9200,7 @@ async function tbRefresh() {
       tbFetchHistory();
       tbFetchAlertTimeline();
       tbFetchEscalationStatus();
+      tbFetchEscalationHistory();
     }
   } catch (e) {
     console.error('[task-board] refresh error', e);
@@ -9813,6 +9982,7 @@ function tbToggleMetrics() {
     tbFetchHistory();
     tbFetchAlertTimeline();
     tbFetchEscalationStatus();
+    tbFetchEscalationHistory();
   }
 }
 
@@ -10519,6 +10689,117 @@ function tbStopEscalationTimer() {
   if (tbEscalationTimer) {
     clearInterval(tbEscalationTimer);
     tbEscalationTimer = null;
+  }
+}
+
+// ── Escalation History (Issue #219, Phase 22) ────────────────────────────────
+// Fetches and renders the escalation history audit trail panel.
+// Integrates with GET /api/task-board/escalation/history endpoint.
+
+async function tbFetchEscalationHistory() {
+  try {
+    const windowMs = document.getElementById('tbEscHistWindow')?.value || '21600000';
+    const eventType = document.getElementById('tbEscHistEventType')?.value || '';
+    const deliveryStatus = document.getElementById('tbEscHistDeliveryStatus')?.value || '';
+
+    let qs = `?sinceMs=${windowMs}&limit=50`;
+    if (eventType) qs += `&eventType=${eventType}`;
+    if (deliveryStatus) qs += `&deliveryStatus=${deliveryStatus}`;
+
+    const res = await fetch('/api/task-board/escalation/history' + qs);
+    if (!res.ok) return;
+    const data = await res.json();
+    tbRenderEscalationHistory(data);
+  } catch (e) {
+    console.warn('[task-board] escalation history fetch error', e);
+  }
+}
+
+function tbRenderEscalationHistory(data) {
+  const panel = document.getElementById('tbEscalationHistoryPanel');
+  const subtitle = document.getElementById('tbEscHistSubtitle');
+  const statsEl = document.getElementById('tbEscHistStats');
+  const body = document.getElementById('tbEscHistBody');
+  if (!panel || !body) return;
+
+  const events = data.events || [];
+  const summary = data.summary || {};
+
+  // Always show panel when escalation policy exists
+  panel.classList.add('active');
+
+  // Subtitle
+  if (subtitle) {
+    subtitle.textContent = events.length > 0
+      ? `${summary.totalEvents || events.length} event${(summary.totalEvents || events.length) !== 1 ? 's' : ''}`
+      : '';
+  }
+
+  // Stats row
+  if (statsEl) {
+    const counts = summary.eventTypeCounts || {};
+    const parts = [];
+    if (counts.tier_triggered) parts.push(`<span class="stat-value">${counts.tier_triggered}</span> triggered`);
+    if (counts.tier_renotified) parts.push(`<span class="stat-value">${counts.tier_renotified}</span> re-notified`);
+    if (counts.escalation_reset) parts.push(`<span class="stat-value">${counts.escalation_reset}</span> resets`);
+    if (summary.totalNotificationsSent) {
+      parts.push(`<span class="stat-value">${summary.totalNotificationSuccesses || 0}/${summary.totalNotificationsSent}</span> delivered`);
+    }
+    statsEl.innerHTML = parts.join(' · ');
+  }
+
+  // No events
+  if (events.length === 0) {
+    body.innerHTML = '<div class="tb-escalation-history-empty">No escalation events in this time window</div>';
+    return;
+  }
+
+  // Render table
+  let html = '<table class="tb-escalation-history-table">';
+  html += '<thead><tr><th>Time</th><th>Event</th><th>Tier</th><th>Duration</th><th>Deliveries</th><th>Reason</th></tr></thead>';
+  html += '<tbody>';
+
+  for (const ev of events) {
+    const timeStr = tbTimelineTimeAgo(ev.ts);
+    const eventBadge = `<span class="tb-escalation-event-badge ${ev.eventType}">${tbEscHistEventLabel(ev.eventType)}</span>`;
+    const tierStr = ev.tierIndex != null ? `${ev.tierLabel || ('Tier ' + (ev.tierIndex + 1))}` : '—';
+    const durStr = tbEscDuration(ev.qualifyingDurationMs);
+
+    // Delivery outcomes
+    let deliveryHtml = '—';
+    if (ev.deliveries && ev.deliveries.length > 0) {
+      deliveryHtml = '<div class="tb-escalation-delivery-outcomes">';
+      for (const d of ev.deliveries) {
+        const cls = d.success ? 'success' : 'failure';
+        const icon = d.success ? '✓' : '✗';
+        deliveryHtml += `<span class="tb-escalation-delivery-pill ${cls}" title="${tbEsc(d.targetName)}${d.error ? ': ' + tbEsc(d.error) : ''}">${icon} ${tbEsc(d.targetName)}</span>`;
+      }
+      deliveryHtml += '</div>';
+    }
+
+    const reasonStr = ev.reason ? tbEsc(ev.reason).slice(0, 80) : '—';
+
+    html += `<tr>
+      <td style="white-space:nowrap;color:var(--text-muted);">${timeStr}</td>
+      <td>${eventBadge}</td>
+      <td>${tbEsc(tierStr)}</td>
+      <td style="font-family:'JetBrains Mono',monospace;">${durStr}</td>
+      <td>${deliveryHtml}</td>
+      <td style="color:var(--text-secondary);max-width:200px;overflow:hidden;text-overflow:ellipsis;" title="${tbEsc(ev.reason || '')}">${reasonStr}</td>
+    </tr>`;
+  }
+
+  html += '</tbody></table>';
+  body.innerHTML = html;
+}
+
+function tbEscHistEventLabel(type) {
+  switch (type) {
+    case 'tier_triggered': return 'Triggered';
+    case 'tier_renotified': return 'Re-notified';
+    case 'notification_sent': return 'Notification';
+    case 'escalation_reset': return 'Reset';
+    default: return type || 'Unknown';
   }
 }
 

--- a/dashboard/server/escalation-history.ts
+++ b/dashboard/server/escalation-history.ts
@@ -1,0 +1,404 @@
+/**
+ * Escalation History — persistent audit trail for escalation events.
+ * Issue #219 — Phase 22: Escalation History / Audit Trail.
+ *
+ * Records each escalation event (tier transitions + notifications sent)
+ * as an append-only log with bounded retention. Designed for dashboard
+ * display and operational debugging — provides a persistent record of
+ * escalation activity that survives server restarts (unlike the in-memory
+ * escalation state).
+ *
+ * Key design decisions:
+ *   - Append-only JSON file (same pattern as alert-history.ts, webhook-delivery-history.ts)
+ *   - Bounded retention: max 200 events, max 48h age (configurable)
+ *   - No secrets stored — webhook URLs are masked, payloads omitted
+ *   - Inline recording: appended during escalation dispatch (no background jobs)
+ *   - Error summaries are truncated (max 200 chars)
+ *   - Safe redaction: target URLs are pre-masked, no raw secrets exposed
+ *
+ * File format: { version: 1, events: EscalationHistoryEvent[], nextId: number }
+ * File location: <dataDir>/task-board-escalation-history.json
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+
+/**
+ * Event type — distinguishes between different escalation event categories.
+ * - 'tier_triggered': A new escalation tier was reached for the first time.
+ * - 'tier_renotified': A previously-triggered tier re-fired after cooldown.
+ * - 'notification_sent': A webhook notification was dispatched for an escalation.
+ * - 'escalation_reset': The escalation state was reset (severity dropped to OK).
+ */
+export type EscalationEventType =
+  | 'tier_triggered'
+  | 'tier_renotified'
+  | 'notification_sent'
+  | 'escalation_reset';
+
+/**
+ * Delivery outcome for a single target within an escalation notification.
+ * Secret-safe: URL is pre-masked, no payload/headers stored.
+ */
+export interface EscalationDeliveryOutcome {
+  /** Webhook target ID. */
+  targetId: string;
+  /** Webhook target display name. */
+  targetName: string;
+  /** Whether delivery succeeded. */
+  success: boolean;
+  /** HTTP status code (null if network error). */
+  statusCode: number | null;
+  /** Number of delivery attempts. */
+  attempts: number;
+  /** Delivery duration in ms. */
+  durationMs: number;
+  /** Error summary, truncated (null on success). */
+  error: string | null;
+}
+
+/**
+ * A single escalation history event — records a tier transition,
+ * notification dispatch, or state reset.
+ */
+export interface EscalationHistoryEvent {
+  /** Unique event ID (monotonic counter within file). */
+  id: number;
+  /** Timestamp of the event (ms since epoch). */
+  ts: number;
+  /** Event type classification. */
+  eventType: EscalationEventType;
+  /** Tier index that triggered (0-based), null for resets. */
+  tierIndex: number | null;
+  /** Tier label (from config), null if no label or reset event. */
+  tierLabel: string | null;
+  /** The severity that qualified for escalation. */
+  qualifyingSeverity: string;
+  /** How long the qualifying state had persisted (ms) when this event occurred. */
+  qualifyingDurationMs: number;
+  /** Human-readable reason from the escalation decision engine. */
+  reason: string;
+  /** Per-target delivery outcomes (for notification events), empty for resets. */
+  deliveries: EscalationDeliveryOutcome[];
+  /** Number of successful deliveries. */
+  deliverySuccessCount: number;
+  /** Number of failed deliveries. */
+  deliveryFailureCount: number;
+}
+
+/** On-disk file format. */
+export interface EscalationHistoryFile {
+  version: 1;
+  events: EscalationHistoryEvent[];
+  /** Monotonic counter for unique event IDs. */
+  nextId: number;
+}
+
+/** Configuration for escalation history retention. */
+export interface EscalationHistoryConfig {
+  /** Maximum number of events to retain. Default: 200. */
+  maxEvents?: number;
+  /** Maximum age of events in ms. Default: 48 hours. */
+  maxAgeMs?: number;
+}
+
+/** Query options for reading escalation history. */
+export interface EscalationHistoryQuery {
+  /** Maximum number of events to return (default 50, max 200). */
+  limit?: number;
+  /** Only events within this time window from now (ms). */
+  sinceMs?: number;
+  /** Filter by event type. */
+  eventType?: EscalationEventType;
+  /** Filter by tier index. */
+  tierIndex?: number;
+  /** Filter by delivery status: 'success' = at least one successful, 'failure' = any failures. */
+  deliveryStatus?: 'success' | 'failure';
+  /** Current time override (for testing). */
+  now?: number;
+}
+
+/** Summary statistics for an escalation history query. */
+export interface EscalationHistorySummary {
+  /** Total events matching filters (before limit). */
+  totalEvents: number;
+  /** Events returned (after limit). */
+  returnedEvents: number;
+  /** Count by event type. */
+  eventTypeCounts: Record<EscalationEventType, number>;
+  /** Total notifications sent (across all events). */
+  totalNotificationsSent: number;
+  /** Total notification successes. */
+  totalNotificationSuccesses: number;
+  /** Total notification failures. */
+  totalNotificationFailures: number;
+  /** Distinct tier indices that appear in the results. */
+  tierIndices: number[];
+  /** Timestamp of the most recent event (null if no events). */
+  latestEventTs: number | null;
+  /** Timestamp of the oldest event in the results (null if no events). */
+  oldestEventTs: number | null;
+}
+
+/** Query result shape for the API endpoint. */
+export interface EscalationHistoryResponse {
+  events: EscalationHistoryEvent[];
+  count: number;
+  summary: EscalationHistorySummary;
+}
+
+// ─── Constants ───────────────────────────────────────────────────────────────
+
+const DEFAULT_MAX_EVENTS = 200;
+const DEFAULT_MAX_AGE_MS = 48 * 60 * 60 * 1000; // 48 hours
+const MAX_ERROR_LENGTH = 200;
+const HISTORY_FILENAME = 'task-board-escalation-history.json';
+
+// ─── File I/O ────────────────────────────────────────────────────────────────
+
+function historyFilePath(dataDir: string): string {
+  return path.join(dataDir, HISTORY_FILENAME);
+}
+
+/**
+ * Read escalation history from disk.
+ * Returns empty history if file doesn't exist or is corrupt.
+ */
+export function readEscalationHistory(dataDir: string): EscalationHistoryFile {
+  try {
+    const fp = historyFilePath(dataDir);
+    if (!fs.existsSync(fp)) return { version: 1, events: [], nextId: 1 };
+    const raw = fs.readFileSync(fp, 'utf8');
+    const parsed = JSON.parse(raw);
+    if (parsed && parsed.version === 1 && Array.isArray(parsed.events)) {
+      return {
+        version: 1,
+        events: parsed.events,
+        nextId: typeof parsed.nextId === 'number' ? parsed.nextId : parsed.events.length + 1,
+      };
+    }
+    return { version: 1, events: [], nextId: 1 };
+  } catch {
+    return { version: 1, events: [], nextId: 1 };
+  }
+}
+
+/**
+ * Write escalation history to disk atomically (write-rename pattern).
+ */
+function writeEscalationHistory(dataDir: string, history: EscalationHistoryFile): void {
+  const fp = historyFilePath(dataDir);
+  const dir = path.dirname(fp);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  const tmpFp = fp + '.tmp';
+  fs.writeFileSync(tmpFp, JSON.stringify(history, null, 2));
+  fs.renameSync(tmpFp, fp);
+}
+
+// ─── Core Operations ─────────────────────────────────────────────────────────
+
+/**
+ * Truncate an error string to bounded length.
+ * Pure function.
+ */
+export function truncateError(error: string | null): string | null {
+  if (!error) return null;
+  if (error.length <= MAX_ERROR_LENGTH) return error;
+  return error.slice(0, MAX_ERROR_LENGTH - 3) + '...';
+}
+
+/**
+ * Prune events that exceed retention bounds.
+ * Returns a new array (does not mutate input).
+ * Pure function.
+ */
+export function pruneEscalationHistory(
+  events: EscalationHistoryEvent[],
+  opts: {
+    maxEvents?: number;
+    maxAgeMs?: number;
+    now?: number;
+  } = {},
+): EscalationHistoryEvent[] {
+  const maxEvents = opts.maxEvents ?? DEFAULT_MAX_EVENTS;
+  const maxAgeMs = opts.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+  const now = opts.now ?? Date.now();
+
+  // Filter by age first
+  let result = events.filter((e) => now - e.ts <= maxAgeMs);
+
+  // Then cap by count (keep most recent)
+  if (result.length > maxEvents) {
+    result = result.slice(result.length - maxEvents);
+  }
+
+  return result;
+}
+
+/**
+ * Append a tier-triggered or tier-renotified escalation event to history.
+ * Called from maybeEscalate() after successful dispatch.
+ *
+ * @param dataDir - Data directory for persistence.
+ * @param event - Partial event data (id and ts will be filled in).
+ * @param config - Retention configuration.
+ * @returns The recorded event ID, or null if write failed.
+ */
+export function appendEscalationEvent(
+  dataDir: string,
+  event: Omit<EscalationHistoryEvent, 'id' | 'ts'> & { ts?: number },
+  config: EscalationHistoryConfig = {},
+): number | null {
+  try {
+    const maxEvents = config.maxEvents ?? DEFAULT_MAX_EVENTS;
+    const maxAgeMs = config.maxAgeMs ?? DEFAULT_MAX_AGE_MS;
+    const now = event.ts ?? Date.now();
+
+    const history = readEscalationHistory(dataDir);
+    const id = history.nextId;
+
+    const fullEvent: EscalationHistoryEvent = {
+      id,
+      ts: now,
+      eventType: event.eventType,
+      tierIndex: event.tierIndex,
+      tierLabel: event.tierLabel,
+      qualifyingSeverity: event.qualifyingSeverity,
+      qualifyingDurationMs: event.qualifyingDurationMs,
+      reason: event.reason,
+      deliveries: event.deliveries.map((d) => ({
+        ...d,
+        error: truncateError(d.error),
+      })),
+      deliverySuccessCount: event.deliverySuccessCount,
+      deliveryFailureCount: event.deliveryFailureCount,
+    };
+
+    history.events.push(fullEvent);
+    history.events = pruneEscalationHistory(history.events, { maxEvents, maxAgeMs, now });
+    history.nextId = id + 1;
+
+    writeEscalationHistory(dataDir, history);
+    return id;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Record an escalation reset event (severity dropped below threshold).
+ * Lightweight event with no delivery data.
+ */
+export function appendEscalationReset(
+  dataDir: string,
+  opts: {
+    qualifyingSeverity: string;
+    qualifyingDurationMs: number;
+    ts?: number;
+  },
+  config: EscalationHistoryConfig = {},
+): number | null {
+  return appendEscalationEvent(dataDir, {
+    ts: opts.ts,
+    eventType: 'escalation_reset',
+    tierIndex: null,
+    tierLabel: null,
+    qualifyingSeverity: opts.qualifyingSeverity,
+    qualifyingDurationMs: opts.qualifyingDurationMs,
+    reason: 'severity dropped below threshold — escalation reset',
+    deliveries: [],
+    deliverySuccessCount: 0,
+    deliveryFailureCount: 0,
+  }, config);
+}
+
+// ─── Query Helpers ───────────────────────────────────────────────────────────
+
+/**
+ * Query escalation history with optional filters.
+ * Returns events sorted most-recent-first (reverse chronological)
+ * with summary statistics for dashboard display.
+ */
+export function queryEscalationHistory(
+  dataDir: string,
+  opts: EscalationHistoryQuery = {},
+): EscalationHistoryResponse {
+  const history = readEscalationHistory(dataDir);
+  const now = opts.now ?? Date.now();
+  let events = history.events;
+
+  // Filter by time window
+  if (opts.sinceMs != null && opts.sinceMs > 0) {
+    const cutoff = now - opts.sinceMs;
+    events = events.filter((e) => e.ts >= cutoff);
+  }
+
+  // Filter by event type
+  if (opts.eventType) {
+    events = events.filter((e) => e.eventType === opts.eventType);
+  }
+
+  // Filter by tier index
+  if (opts.tierIndex != null) {
+    events = events.filter((e) => e.tierIndex === opts.tierIndex);
+  }
+
+  // Filter by delivery status
+  if (opts.deliveryStatus === 'success') {
+    events = events.filter((e) => e.deliverySuccessCount > 0);
+  } else if (opts.deliveryStatus === 'failure') {
+    events = events.filter((e) => e.deliveryFailureCount > 0);
+  }
+
+  const totalEvents = events.length;
+
+  // Compute summary before applying limit
+  const eventTypeCounts: Record<EscalationEventType, number> = {
+    tier_triggered: 0,
+    tier_renotified: 0,
+    notification_sent: 0,
+    escalation_reset: 0,
+  };
+  let totalNotificationsSent = 0;
+  let totalNotificationSuccesses = 0;
+  let totalNotificationFailures = 0;
+  const tierIndexSet = new Set<number>();
+
+  for (const e of events) {
+    eventTypeCounts[e.eventType] = (eventTypeCounts[e.eventType] ?? 0) + 1;
+    totalNotificationsSent += e.deliveries.length;
+    totalNotificationSuccesses += e.deliverySuccessCount;
+    totalNotificationFailures += e.deliveryFailureCount;
+    if (e.tierIndex != null) tierIndexSet.add(e.tierIndex);
+  }
+
+  // Apply limit (most recent N) — events are stored chronologically
+  const limit = Math.max(1, Math.min(opts.limit ?? 50, 200));
+  if (events.length > limit) {
+    events = events.slice(events.length - limit);
+  }
+
+  // Reverse to most-recent-first for display
+  events = [...events].reverse();
+
+  const latestEventTs = events.length > 0 ? events[0].ts : null;
+  const oldestEventTs = events.length > 0 ? events[events.length - 1].ts : null;
+
+  return {
+    events,
+    count: events.length,
+    summary: {
+      totalEvents,
+      returnedEvents: events.length,
+      eventTypeCounts,
+      totalNotificationsSent,
+      totalNotificationSuccesses,
+      totalNotificationFailures,
+      tierIndices: [...tierIndexSet].sort((a, b) => a - b),
+      latestEventTs,
+      oldestEventTs,
+    },
+  };
+}

--- a/dashboard/server/escalation-policy.ts
+++ b/dashboard/server/escalation-policy.ts
@@ -33,6 +33,8 @@ import type { AlertSeverity, AlertEvaluation } from './alert-rules.js';
 import type { WebhookTarget, WebhookConfig, WebhookDeliveryResult } from './alert-webhook.js';
 import { deliverWebhook, buildWebhookPayload } from './alert-webhook.js';
 import { appendDeliveryEvents } from './webhook-delivery-history.js';
+import { appendEscalationEvent, appendEscalationReset } from './escalation-history.js';
+import type { EscalationDeliveryOutcome } from './escalation-history.js';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -771,11 +773,29 @@ export async function maybeEscalate(
   const currentSeverity = evaluation.overallSeverity;
   const triggerSeverity = policy.triggerSeverity ?? DEFAULT_TRIGGER_SEVERITY;
 
+  // Capture pre-update state for reset detection (Phase 22)
+  const wasTracking = escalationState.qualifyingSince !== null;
+  const priorQualifyingSeverity = escalationState.qualifyingSeverity;
+  const priorQualifyingSince = escalationState.qualifyingSince;
+
   // Evaluate what to do
   const decision = evaluateEscalation(policy, currentSeverity, escalationState, now);
 
   // Update state (start/stop clock, record triggers)
   updateEscalationState(currentSeverity, triggerSeverity, decision, now);
+
+  // Phase 22: Record escalation reset event if we were tracking and just stopped
+  if (wasTracking && escalationState.qualifyingSince === null && priorQualifyingSince !== null) {
+    try {
+      appendEscalationReset(dataDir, {
+        qualifyingSeverity: priorQualifyingSeverity ?? 'unknown',
+        qualifyingDurationMs: now - priorQualifyingSince,
+        ts: now,
+      });
+    } catch {
+      // Non-critical — don't break the metrics response
+    }
+  }
 
   // No escalation needed
   if (!decision.shouldEscalate) return [];
@@ -801,8 +821,8 @@ export async function maybeEscalate(
   );
 
   // Record in delivery history
+  const targetMap = new Map(targets.map((t) => [t.id, t]));
   try {
-    const targetMap = new Map(targets.map((t) => [t.id, t]));
     const contexts = results.map((r) => ({
       url: targetMap.get(r.targetId)?.url ?? '',
       triggerSeverity: `escalation-tier-${(decision.tierIndex ?? 0) + 1}`,
@@ -812,6 +832,40 @@ export async function maybeEscalate(
     appendDeliveryEvents(dataDir, results, contexts);
   } catch {
     // Non-critical
+  }
+
+  // Phase 22: Record escalation event in escalation history (audit trail)
+  try {
+    const isNewTier = decision.tierIndex != null && decision.reason.includes('triggered');
+    const eventType = isNewTier ? 'tier_triggered' : 'tier_renotified';
+
+    const deliveries: EscalationDeliveryOutcome[] = results.map((r) => ({
+      targetId: r.targetId,
+      targetName: r.targetName,
+      success: r.success,
+      statusCode: r.statusCode,
+      attempts: r.attempts,
+      durationMs: r.durationMs,
+      error: r.error,
+    }));
+
+    const successCount = deliveries.filter((d) => d.success).length;
+    const failureCount = deliveries.length - successCount;
+
+    appendEscalationEvent(dataDir, {
+      ts: now,
+      eventType,
+      tierIndex: decision.tierIndex,
+      tierLabel: decision.tier?.label ?? null,
+      qualifyingSeverity: currentSeverity,
+      qualifyingDurationMs: decision.qualifyingDurationMs,
+      reason: decision.reason,
+      deliveries,
+      deliverySuccessCount: successCount,
+      deliveryFailureCount: failureCount,
+    });
+  } catch {
+    // Non-critical — don't break the metrics response
   }
 
   return [{

--- a/dashboard/server/routes/task-board.ts
+++ b/dashboard/server/routes/task-board.ts
@@ -88,6 +88,11 @@ import {
   computeEscalationStatus,
 } from '../escalation-policy.js';
 
+import {
+  queryEscalationHistory,
+} from '../escalation-history.js';
+import type { EscalationEventType } from '../escalation-history.js';
+
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 const VALID_STATUSES: TaskStatus[] = ['backlog', 'queued', 'running', 'done', 'failed'];
@@ -731,6 +736,54 @@ export async function handleTaskBoard(
       sendJson(res, { status });
     } catch {
       sendJson(res, { error: 'Failed to compute escalation status' }, 500);
+    }
+    return true;
+  }
+
+  // ── GET /api/task-board/escalation/history — Issue #219, Phase 22 ──────────
+  // Read-only endpoint returning persisted escalation event history (audit trail).
+  // Query params:
+  //   ?limit=50            — max events to return (default 50, max 200)
+  //   ?sinceMs=86400000    — only events within this time window from now
+  //   ?eventType=tier_triggered — filter by event type
+  //   ?tierIndex=0         — filter by tier index
+  //   ?deliveryStatus=success — filter: 'success' or 'failure'
+  if (url.startsWith('/api/task-board/escalation/history') && method === 'GET') {
+    try {
+      const histParams = new URL(url, 'http://localhost').searchParams;
+      const limit = Math.max(1, Math.min(Number(histParams.get('limit')) || 50, 200));
+      const sinceMs = histParams.has('sinceMs')
+        ? Math.max(0, Number(histParams.get('sinceMs')) || 0)
+        : undefined;
+
+      const eventTypeRaw = histParams.get('eventType');
+      const validEventTypes: EscalationEventType[] = [
+        'tier_triggered', 'tier_renotified', 'notification_sent', 'escalation_reset',
+      ];
+      const eventType = eventTypeRaw && validEventTypes.includes(eventTypeRaw as EscalationEventType)
+        ? (eventTypeRaw as EscalationEventType)
+        : undefined;
+
+      const tierIndexRaw = histParams.get('tierIndex');
+      const tierIndex = tierIndexRaw !== null && !isNaN(Number(tierIndexRaw))
+        ? Number(tierIndexRaw)
+        : undefined;
+
+      const deliveryStatusRaw = histParams.get('deliveryStatus');
+      const deliveryStatus = deliveryStatusRaw === 'success' || deliveryStatusRaw === 'failure'
+        ? deliveryStatusRaw
+        : undefined;
+
+      const result = queryEscalationHistory(dataDir, {
+        limit,
+        sinceMs,
+        eventType,
+        tierIndex,
+        deliveryStatus,
+      });
+      sendJson(res, result);
+    } catch {
+      sendJson(res, { error: 'Failed to query escalation history' }, 500);
     }
     return true;
   }

--- a/dashboard/tests/unit/routes/task-board-escalation-history.test.ts
+++ b/dashboard/tests/unit/routes/task-board-escalation-history.test.ts
@@ -1,0 +1,736 @@
+/**
+ * Escalation History tests — Issue #219, Phase 22.
+ *
+ * Tests for:
+ * - Event recording correctness (appendEscalationEvent, appendEscalationReset)
+ * - Retention/limit behavior (pruneEscalationHistory, bounded max events/age)
+ * - API filtering correctness (queryEscalationHistory with all filter combos)
+ * - Secret-safe output (no raw URLs, secrets, or payloads in persisted events)
+ * - Regression safety (existing escalation policy + status are unaffected)
+ * - GET /api/task-board/escalation/history — API endpoint
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  readEscalationHistory,
+  appendEscalationEvent,
+  appendEscalationReset,
+  pruneEscalationHistory,
+  queryEscalationHistory,
+  truncateError,
+} from '../../../server/escalation-history.js';
+import type {
+  EscalationHistoryEvent,
+  EscalationHistoryFile,
+  EscalationHistoryResponse,
+  EscalationEventType,
+  EscalationDeliveryOutcome,
+} from '../../../server/escalation-history.js';
+
+// ─── Test Setup ──────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'esc-hist-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const NOW = 1_700_000_000_000;
+
+function makeDelivery(overrides: Partial<EscalationDeliveryOutcome> = {}): EscalationDeliveryOutcome {
+  return {
+    targetId: 'slack',
+    targetName: 'Slack',
+    success: true,
+    statusCode: 200,
+    attempts: 1,
+    durationMs: 150,
+    error: null,
+    ...overrides,
+  };
+}
+
+function makeEvent(
+  overrides: Partial<Omit<EscalationHistoryEvent, 'id'>> = {},
+): Omit<EscalationHistoryEvent, 'id' | 'ts'> & { ts?: number } {
+  return {
+    ts: NOW,
+    eventType: 'tier_triggered',
+    tierIndex: 0,
+    tierLabel: 'Page on-call',
+    qualifyingSeverity: 'critical',
+    qualifyingDurationMs: 300_000,
+    reason: 'tier 1 triggered (300s persisted, threshold 300s)',
+    deliveries: [makeDelivery()],
+    deliverySuccessCount: 1,
+    deliveryFailureCount: 0,
+    ...overrides,
+  };
+}
+
+// ─── readEscalationHistory() ─────────────────────────────────────────────────
+
+describe('readEscalationHistory()', () => {
+  it('returns empty history when file does not exist', () => {
+    const result = readEscalationHistory(tmpDir);
+    expect(result.version).toBe(1);
+    expect(result.events).toEqual([]);
+    expect(result.nextId).toBe(1);
+  });
+
+  it('returns empty history for corrupt file', () => {
+    fs.writeFileSync(path.join(tmpDir, 'task-board-escalation-history.json'), 'NOT JSON');
+    const result = readEscalationHistory(tmpDir);
+    expect(result.events).toEqual([]);
+    expect(result.nextId).toBe(1);
+  });
+
+  it('returns empty history for wrong version', () => {
+    fs.writeFileSync(
+      path.join(tmpDir, 'task-board-escalation-history.json'),
+      JSON.stringify({ version: 99, events: [] }),
+    );
+    const result = readEscalationHistory(tmpDir);
+    expect(result.events).toEqual([]);
+  });
+
+  it('reads valid history file', () => {
+    const data: EscalationHistoryFile = {
+      version: 1,
+      events: [{
+        id: 1, ts: NOW, eventType: 'tier_triggered', tierIndex: 0,
+        tierLabel: 'T1', qualifyingSeverity: 'critical', qualifyingDurationMs: 300_000,
+        reason: 'test', deliveries: [], deliverySuccessCount: 0, deliveryFailureCount: 0,
+      }],
+      nextId: 2,
+    };
+    fs.writeFileSync(
+      path.join(tmpDir, 'task-board-escalation-history.json'),
+      JSON.stringify(data),
+    );
+    const result = readEscalationHistory(tmpDir);
+    expect(result.events).toHaveLength(1);
+    expect(result.events[0].id).toBe(1);
+    expect(result.nextId).toBe(2);
+  });
+});
+
+// ─── truncateError() ─────────────────────────────────────────────────────────
+
+describe('truncateError()', () => {
+  it('returns null for null input', () => {
+    expect(truncateError(null)).toBeNull();
+  });
+
+  it('returns short strings unchanged', () => {
+    expect(truncateError('short error')).toBe('short error');
+  });
+
+  it('truncates strings over 200 chars', () => {
+    const long = 'x'.repeat(300);
+    const result = truncateError(long);
+    expect(result!.length).toBe(200);
+    expect(result!.endsWith('...')).toBe(true);
+  });
+
+  it('returns empty string for empty input', () => {
+    expect(truncateError('')).toBeNull();
+  });
+});
+
+// ─── appendEscalationEvent() — Event Recording Correctness ──────────────────
+
+describe('appendEscalationEvent()', () => {
+  it('records a tier_triggered event with correct fields', () => {
+    const id = appendEscalationEvent(tmpDir, makeEvent());
+    expect(id).toBe(1);
+
+    const history = readEscalationHistory(tmpDir);
+    expect(history.events).toHaveLength(1);
+    const ev = history.events[0];
+    expect(ev.id).toBe(1);
+    expect(ev.ts).toBe(NOW);
+    expect(ev.eventType).toBe('tier_triggered');
+    expect(ev.tierIndex).toBe(0);
+    expect(ev.tierLabel).toBe('Page on-call');
+    expect(ev.qualifyingSeverity).toBe('critical');
+    expect(ev.qualifyingDurationMs).toBe(300_000);
+    expect(ev.deliveries).toHaveLength(1);
+    expect(ev.deliveries[0].targetId).toBe('slack');
+    expect(ev.deliveries[0].success).toBe(true);
+    expect(ev.deliverySuccessCount).toBe(1);
+    expect(ev.deliveryFailureCount).toBe(0);
+  });
+
+  it('records a tier_renotified event', () => {
+    const id = appendEscalationEvent(tmpDir, makeEvent({
+      eventType: 'tier_renotified',
+      reason: 'tier 1 re-notification (cooldown expired)',
+    }));
+    expect(id).toBe(1);
+    const ev = readEscalationHistory(tmpDir).events[0];
+    expect(ev.eventType).toBe('tier_renotified');
+  });
+
+  it('assigns monotonically increasing IDs', () => {
+    appendEscalationEvent(tmpDir, makeEvent({ ts: NOW }));
+    appendEscalationEvent(tmpDir, makeEvent({ ts: NOW + 1000 }));
+    appendEscalationEvent(tmpDir, makeEvent({ ts: NOW + 2000 }));
+
+    const history = readEscalationHistory(tmpDir);
+    expect(history.events.map(e => e.id)).toEqual([1, 2, 3]);
+    expect(history.nextId).toBe(4);
+  });
+
+  it('truncates long error strings in delivery outcomes', () => {
+    const longError = 'E'.repeat(500);
+    const id = appendEscalationEvent(tmpDir, makeEvent({
+      deliveries: [makeDelivery({ error: longError, success: false })],
+      deliverySuccessCount: 0,
+      deliveryFailureCount: 1,
+    }));
+    expect(id).toBe(1);
+
+    const ev = readEscalationHistory(tmpDir).events[0];
+    expect(ev.deliveries[0].error!.length).toBe(200);
+    expect(ev.deliveries[0].error!.endsWith('...')).toBe(true);
+  });
+
+  it('records multiple deliveries per event', () => {
+    const id = appendEscalationEvent(tmpDir, makeEvent({
+      deliveries: [
+        makeDelivery({ targetId: 'slack', success: true }),
+        makeDelivery({ targetId: 'discord', targetName: 'Discord', success: false, statusCode: 500, error: 'Server Error' }),
+      ],
+      deliverySuccessCount: 1,
+      deliveryFailureCount: 1,
+    }));
+    expect(id).toBe(1);
+    const ev = readEscalationHistory(tmpDir).events[0];
+    expect(ev.deliveries).toHaveLength(2);
+    expect(ev.deliveries[0].targetId).toBe('slack');
+    expect(ev.deliveries[1].targetId).toBe('discord');
+    expect(ev.deliveries[1].error).toBe('Server Error');
+  });
+
+  it('returns null on write failure (non-existent deep path)', () => {
+    // Create a file where the dir should be, so mkdir fails
+    const badDir = path.join(tmpDir, 'blocked');
+    fs.writeFileSync(badDir, 'block');
+    const id = appendEscalationEvent(path.join(badDir, 'deep'), makeEvent());
+    expect(id).toBeNull();
+  });
+});
+
+// ─── appendEscalationReset() ─────────────────────────────────────────────────
+
+describe('appendEscalationReset()', () => {
+  it('records a reset event with correct fields', () => {
+    const id = appendEscalationReset(tmpDir, {
+      qualifyingSeverity: 'critical',
+      qualifyingDurationMs: 600_000,
+      ts: NOW,
+    });
+    expect(id).toBe(1);
+
+    const ev = readEscalationHistory(tmpDir).events[0];
+    expect(ev.eventType).toBe('escalation_reset');
+    expect(ev.tierIndex).toBeNull();
+    expect(ev.tierLabel).toBeNull();
+    expect(ev.qualifyingSeverity).toBe('critical');
+    expect(ev.qualifyingDurationMs).toBe(600_000);
+    expect(ev.deliveries).toEqual([]);
+    expect(ev.deliverySuccessCount).toBe(0);
+    expect(ev.deliveryFailureCount).toBe(0);
+    expect(ev.reason).toContain('reset');
+  });
+
+  it('works alongside regular events', () => {
+    appendEscalationEvent(tmpDir, makeEvent({ ts: NOW }));
+    appendEscalationReset(tmpDir, {
+      qualifyingSeverity: 'critical',
+      qualifyingDurationMs: 600_000,
+      ts: NOW + 5000,
+    });
+    const history = readEscalationHistory(tmpDir);
+    expect(history.events).toHaveLength(2);
+    expect(history.events[0].eventType).toBe('tier_triggered');
+    expect(history.events[1].eventType).toBe('escalation_reset');
+    expect(history.events[0].id).toBe(1);
+    expect(history.events[1].id).toBe(2);
+  });
+});
+
+// ─── pruneEscalationHistory() — Retention/Limit Behavior ────────────────────
+
+describe('pruneEscalationHistory()', () => {
+  function makeMinimalEvent(ts: number, id: number): EscalationHistoryEvent {
+    return {
+      id, ts, eventType: 'tier_triggered', tierIndex: 0, tierLabel: 'T1',
+      qualifyingSeverity: 'critical', qualifyingDurationMs: 300_000,
+      reason: 'test', deliveries: [], deliverySuccessCount: 0, deliveryFailureCount: 0,
+    };
+  }
+
+  it('removes events older than maxAgeMs', () => {
+    const ms48h = 48 * 60 * 60 * 1000;
+    const events = [
+      makeMinimalEvent(NOW - ms48h - 10_000, 1), // just past 48h — should be pruned
+      makeMinimalEvent(NOW - ms48h + 10_000, 2), // just within 48h — should remain
+      makeMinimalEvent(NOW - 1000, 3),            // recent — should remain
+    ];
+    const result = pruneEscalationHistory(events, { maxAgeMs: ms48h, now: NOW });
+    expect(result).toHaveLength(2);
+    expect(result[0].id).toBe(2);
+    expect(result[1].id).toBe(3);
+  });
+
+  it('caps at maxEvents keeping most recent', () => {
+    const events = Array.from({ length: 250 }, (_, i) =>
+      makeMinimalEvent(NOW - (250 - i) * 1000, i + 1),
+    );
+    const result = pruneEscalationHistory(events, { maxEvents: 200, now: NOW });
+    expect(result).toHaveLength(200);
+    expect(result[0].id).toBe(51);  // oldest kept
+    expect(result[199].id).toBe(250); // most recent
+  });
+
+  it('applies both age and count limits', () => {
+    const events = Array.from({ length: 300 }, (_, i) =>
+      makeMinimalEvent(NOW - (300 - i) * 1000, i + 1),
+    );
+    const result = pruneEscalationHistory(events, {
+      maxEvents: 100,
+      maxAgeMs: 200_000, // only events within 200s
+      now: NOW,
+    });
+    // 200 events within age window, then capped to 100
+    expect(result.length).toBeLessThanOrEqual(100);
+    // All events should be within age window
+    for (const e of result) {
+      expect(NOW - e.ts).toBeLessThanOrEqual(200_000);
+    }
+  });
+
+  it('returns empty array when all events are expired', () => {
+    const events = [
+      makeMinimalEvent(NOW - 1_000_000_000, 1),
+      makeMinimalEvent(NOW - 500_000_000, 2),
+    ];
+    const result = pruneEscalationHistory(events, { maxAgeMs: 1000, now: NOW });
+    expect(result).toEqual([]);
+  });
+
+  it('does not mutate input array', () => {
+    const events = [makeMinimalEvent(NOW - 1000, 1)];
+    const original = [...events];
+    pruneEscalationHistory(events, { maxEvents: 0, now: NOW });
+    expect(events).toEqual(original);
+  });
+});
+
+describe('appendEscalationEvent retention behavior', () => {
+  it('prunes on append when exceeding maxEvents', () => {
+    // Seed 200 events
+    for (let i = 0; i < 200; i++) {
+      appendEscalationEvent(tmpDir, makeEvent({ ts: NOW + i * 1000 }), { maxEvents: 200 });
+    }
+    let history = readEscalationHistory(tmpDir);
+    expect(history.events).toHaveLength(200);
+
+    // Add one more — should still be 200
+    appendEscalationEvent(tmpDir, makeEvent({ ts: NOW + 300_000 }), { maxEvents: 200 });
+    history = readEscalationHistory(tmpDir);
+    expect(history.events).toHaveLength(200);
+    // Oldest should have been pruned
+    expect(history.events[0].id).toBe(2);
+  });
+
+  it('prunes by age on append', () => {
+    // Add an old event
+    appendEscalationEvent(tmpDir, makeEvent({ ts: NOW - 200_000_000 }), {
+      maxAgeMs: 48 * 60 * 60 * 1000,
+    });
+    // Add a recent event — old one should be pruned
+    appendEscalationEvent(tmpDir, makeEvent({ ts: NOW }), {
+      maxAgeMs: 48 * 60 * 60 * 1000,
+    });
+    const history = readEscalationHistory(tmpDir);
+    expect(history.events).toHaveLength(1);
+    expect(history.events[0].ts).toBe(NOW);
+  });
+});
+
+// ─── queryEscalationHistory() — API Filtering Correctness ────────────────────
+
+describe('queryEscalationHistory()', () => {
+  function seedEvents() {
+    // Seed a variety of events
+    appendEscalationEvent(tmpDir, makeEvent({
+      ts: NOW - 3000, eventType: 'tier_triggered', tierIndex: 0, tierLabel: 'Tier 1',
+      deliveries: [makeDelivery({ success: true })], deliverySuccessCount: 1, deliveryFailureCount: 0,
+    }));
+    appendEscalationEvent(tmpDir, makeEvent({
+      ts: NOW - 2000, eventType: 'tier_triggered', tierIndex: 1, tierLabel: 'Tier 2',
+      deliveries: [makeDelivery({ success: false, error: 'Timeout', statusCode: null })],
+      deliverySuccessCount: 0, deliveryFailureCount: 1,
+    }));
+    appendEscalationEvent(tmpDir, makeEvent({
+      ts: NOW - 1000, eventType: 'tier_renotified', tierIndex: 0, tierLabel: 'Tier 1',
+      deliveries: [makeDelivery({ success: true })], deliverySuccessCount: 1, deliveryFailureCount: 0,
+    }));
+    appendEscalationReset(tmpDir, {
+      qualifyingSeverity: 'critical', qualifyingDurationMs: 600_000, ts: NOW,
+    });
+  }
+
+  it('returns all events with no filters', () => {
+    seedEvents();
+    const result = queryEscalationHistory(tmpDir, { now: NOW + 1 });
+    expect(result.count).toBe(4);
+    // Most-recent-first ordering
+    expect(result.events[0].eventType).toBe('escalation_reset');
+    expect(result.events[3].eventType).toBe('tier_triggered');
+  });
+
+  it('filters by eventType', () => {
+    seedEvents();
+    const triggered = queryEscalationHistory(tmpDir, { eventType: 'tier_triggered', now: NOW + 1 });
+    expect(triggered.count).toBe(2);
+    expect(triggered.events.every(e => e.eventType === 'tier_triggered')).toBe(true);
+
+    const resets = queryEscalationHistory(tmpDir, { eventType: 'escalation_reset', now: NOW + 1 });
+    expect(resets.count).toBe(1);
+    expect(resets.events[0].eventType).toBe('escalation_reset');
+  });
+
+  it('filters by tierIndex', () => {
+    seedEvents();
+    const tier0 = queryEscalationHistory(tmpDir, { tierIndex: 0, now: NOW + 1 });
+    expect(tier0.count).toBe(2); // triggered + renotified
+    expect(tier0.events.every(e => e.tierIndex === 0)).toBe(true);
+
+    const tier1 = queryEscalationHistory(tmpDir, { tierIndex: 1, now: NOW + 1 });
+    expect(tier1.count).toBe(1);
+    expect(tier1.events[0].tierIndex).toBe(1);
+  });
+
+  it('filters by deliveryStatus=success', () => {
+    seedEvents();
+    const result = queryEscalationHistory(tmpDir, { deliveryStatus: 'success', now: NOW + 1 });
+    expect(result.count).toBe(2); // tier_triggered[0] + tier_renotified[0]
+    expect(result.events.every(e => e.deliverySuccessCount > 0)).toBe(true);
+  });
+
+  it('filters by deliveryStatus=failure', () => {
+    seedEvents();
+    const result = queryEscalationHistory(tmpDir, { deliveryStatus: 'failure', now: NOW + 1 });
+    expect(result.count).toBe(1); // tier_triggered[1] failed
+    expect(result.events[0].deliveryFailureCount).toBeGreaterThan(0);
+  });
+
+  it('filters by sinceMs time window', () => {
+    seedEvents();
+    const result = queryEscalationHistory(tmpDir, { sinceMs: 1500, now: NOW + 1 });
+    // Events at NOW-1000 and NOW are within 1500ms of NOW+1
+    expect(result.count).toBe(2);
+  });
+
+  it('applies limit correctly', () => {
+    seedEvents();
+    const result = queryEscalationHistory(tmpDir, { limit: 2, now: NOW + 1 });
+    expect(result.count).toBe(2);
+    expect(result.events).toHaveLength(2);
+    // Most recent 2
+    expect(result.events[0].eventType).toBe('escalation_reset');
+    expect(result.events[1].eventType).toBe('tier_renotified');
+  });
+
+  it('clamps limit to [1, 200]', () => {
+    seedEvents();
+    const r1 = queryEscalationHistory(tmpDir, { limit: 0, now: NOW + 1 });
+    expect(r1.count).toBe(1); // clamped to 1
+
+    const r2 = queryEscalationHistory(tmpDir, { limit: 999, now: NOW + 1 });
+    expect(r2.count).toBe(4); // clamped to 200, but only 4 events
+  });
+
+  it('combines multiple filters', () => {
+    seedEvents();
+    const result = queryEscalationHistory(tmpDir, {
+      eventType: 'tier_triggered',
+      tierIndex: 0,
+      deliveryStatus: 'success',
+      now: NOW + 1,
+    });
+    expect(result.count).toBe(1);
+    expect(result.events[0].tierIndex).toBe(0);
+    expect(result.events[0].eventType).toBe('tier_triggered');
+  });
+
+  it('returns correct summary statistics', () => {
+    seedEvents();
+    const result = queryEscalationHistory(tmpDir, { now: NOW + 1 });
+    expect(result.summary.totalEvents).toBe(4);
+    expect(result.summary.returnedEvents).toBe(4);
+    expect(result.summary.eventTypeCounts.tier_triggered).toBe(2);
+    expect(result.summary.eventTypeCounts.tier_renotified).toBe(1);
+    expect(result.summary.eventTypeCounts.escalation_reset).toBe(1);
+    expect(result.summary.totalNotificationsSent).toBe(3);
+    expect(result.summary.totalNotificationSuccesses).toBe(2);
+    expect(result.summary.totalNotificationFailures).toBe(1);
+    expect(result.summary.tierIndices).toEqual([0, 1]);
+    expect(result.summary.latestEventTs).toBe(NOW); // most recent event
+    expect(result.summary.oldestEventTs).toBe(NOW - 3000);
+  });
+
+  it('returns empty response for empty directory', () => {
+    const result = queryEscalationHistory(tmpDir, { now: NOW });
+    expect(result.count).toBe(0);
+    expect(result.events).toEqual([]);
+    expect(result.summary.totalEvents).toBe(0);
+    expect(result.summary.latestEventTs).toBeNull();
+    expect(result.summary.oldestEventTs).toBeNull();
+  });
+
+  it('events are ordered most-recent-first', () => {
+    seedEvents();
+    const result = queryEscalationHistory(tmpDir, { now: NOW + 1 });
+    for (let i = 1; i < result.events.length; i++) {
+      expect(result.events[i - 1].ts).toBeGreaterThanOrEqual(result.events[i].ts);
+    }
+  });
+});
+
+// ─── Secret-Safe Output ─────────────────────────────────────────────────────
+
+describe('secret-safe output', () => {
+  it('does not store raw webhook URLs in events', () => {
+    appendEscalationEvent(tmpDir, makeEvent({
+      deliveries: [makeDelivery({ targetId: 'slack', targetName: 'Slack' })],
+    }));
+    const raw = fs.readFileSync(
+      path.join(tmpDir, 'task-board-escalation-history.json'),
+      'utf8',
+    );
+    // No URL fields should appear
+    expect(raw).not.toContain('https://hooks.slack.com');
+    expect(raw).not.toContain('url');
+    expect(raw).not.toContain('secret');
+    expect(raw).not.toContain('payload');
+    expect(raw).not.toContain('headers');
+  });
+
+  it('does not include webhook secrets in delivery outcomes', () => {
+    const delivery = makeDelivery();
+    // Ensure the type does not have url/secret fields
+    const keys = Object.keys(delivery);
+    expect(keys).not.toContain('url');
+    expect(keys).not.toContain('secret');
+    expect(keys).not.toContain('payload');
+    expect(keys).not.toContain('headers');
+  });
+
+  it('truncates error messages to prevent data leaks', () => {
+    const longError = 'Secret-token-12345 ' + 'x'.repeat(500);
+    appendEscalationEvent(tmpDir, makeEvent({
+      deliveries: [makeDelivery({ error: longError, success: false })],
+      deliverySuccessCount: 0,
+      deliveryFailureCount: 1,
+    }));
+    const ev = readEscalationHistory(tmpDir).events[0];
+    expect(ev.deliveries[0].error!.length).toBe(200);
+  });
+});
+
+// ─── GET /api/task-board/escalation/history — API Endpoint Tests ─────────────
+
+describe('GET /api/task-board/escalation/history', () => {
+  async function callEndpoint(
+    dataDir: string,
+    queryString = '',
+  ): Promise<{ data: any; status: number }> {
+    const { handleTaskBoard } = await import('../../../server/routes/task-board.js');
+    const req = {
+      url: '/api/task-board/escalation/history' + queryString,
+      method: 'GET',
+      headers: {},
+      on: () => {},
+    };
+    let capturedData: any = null;
+    let capturedStatus = 200;
+
+    const deps = {
+      dataDir,
+      sendJson: (_r: any, data: any, status = 200) => {
+        capturedData = data;
+        capturedStatus = status;
+      },
+      readRequestBody: async () => '{}',
+    };
+
+    await handleTaskBoard(req as any, {} as any, deps as any);
+    return { data: capturedData, status: capturedStatus };
+  }
+
+  it('returns empty history for clean directory', async () => {
+    const { data, status } = await callEndpoint(tmpDir);
+    expect(status).toBe(200);
+    expect(data).toBeDefined();
+    expect(data.events).toEqual([]);
+    expect(data.count).toBe(0);
+    expect(data.summary).toBeDefined();
+    expect(data.summary.totalEvents).toBe(0);
+  });
+
+  it('returns recorded events', async () => {
+    appendEscalationEvent(tmpDir, makeEvent({ ts: Date.now() }));
+    const { data, status } = await callEndpoint(tmpDir);
+    expect(status).toBe(200);
+    expect(data.count).toBe(1);
+    expect(data.events[0].eventType).toBe('tier_triggered');
+  });
+
+  it('accepts limit query param', async () => {
+    for (let i = 0; i < 5; i++) {
+      appendEscalationEvent(tmpDir, makeEvent({ ts: Date.now() + i }));
+    }
+    const { data } = await callEndpoint(tmpDir, '?limit=2');
+    expect(data.count).toBe(2);
+  });
+
+  it('accepts sinceMs query param', async () => {
+    // Old event
+    appendEscalationEvent(tmpDir, makeEvent({ ts: Date.now() - 100_000 }));
+    // Recent event
+    appendEscalationEvent(tmpDir, makeEvent({ ts: Date.now() }));
+    const { data } = await callEndpoint(tmpDir, '?sinceMs=5000');
+    expect(data.count).toBe(1);
+  });
+
+  it('accepts eventType filter', async () => {
+    appendEscalationEvent(tmpDir, makeEvent({ ts: Date.now(), eventType: 'tier_triggered' }));
+    appendEscalationReset(tmpDir, { qualifyingSeverity: 'critical', qualifyingDurationMs: 1000, ts: Date.now() });
+
+    const { data: trigData } = await callEndpoint(tmpDir, '?eventType=tier_triggered');
+    expect(trigData.count).toBe(1);
+    expect(trigData.events[0].eventType).toBe('tier_triggered');
+
+    const { data: resetData } = await callEndpoint(tmpDir, '?eventType=escalation_reset');
+    expect(resetData.count).toBe(1);
+    expect(resetData.events[0].eventType).toBe('escalation_reset');
+  });
+
+  it('accepts tierIndex filter', async () => {
+    appendEscalationEvent(tmpDir, makeEvent({ ts: Date.now(), tierIndex: 0 }));
+    appendEscalationEvent(tmpDir, makeEvent({ ts: Date.now() + 1, tierIndex: 1, tierLabel: 'Tier 2' }));
+
+    const { data } = await callEndpoint(tmpDir, '?tierIndex=1');
+    expect(data.count).toBe(1);
+    expect(data.events[0].tierIndex).toBe(1);
+  });
+
+  it('accepts deliveryStatus filter', async () => {
+    appendEscalationEvent(tmpDir, makeEvent({
+      ts: Date.now(),
+      deliveries: [makeDelivery({ success: true })],
+      deliverySuccessCount: 1, deliveryFailureCount: 0,
+    }));
+    appendEscalationEvent(tmpDir, makeEvent({
+      ts: Date.now() + 1,
+      deliveries: [makeDelivery({ success: false, error: 'fail' })],
+      deliverySuccessCount: 0, deliveryFailureCount: 1,
+    }));
+
+    const { data: successData } = await callEndpoint(tmpDir, '?deliveryStatus=success');
+    expect(successData.count).toBe(1);
+    expect(successData.events[0].deliverySuccessCount).toBeGreaterThan(0);
+
+    const { data: failData } = await callEndpoint(tmpDir, '?deliveryStatus=failure');
+    expect(failData.count).toBe(1);
+    expect(failData.events[0].deliveryFailureCount).toBeGreaterThan(0);
+  });
+
+  it('ignores invalid eventType values', async () => {
+    appendEscalationEvent(tmpDir, makeEvent({ ts: Date.now() }));
+    const { data } = await callEndpoint(tmpDir, '?eventType=invalid_type');
+    expect(data.count).toBe(1); // No filter applied
+  });
+
+  it('ignores invalid deliveryStatus values', async () => {
+    appendEscalationEvent(tmpDir, makeEvent({ ts: Date.now() }));
+    const { data } = await callEndpoint(tmpDir, '?deliveryStatus=invalid');
+    expect(data.count).toBe(1); // No filter applied
+  });
+});
+
+// ─── Regression Safety ──────────────────────────────────────────────────────
+
+describe('regression safety', () => {
+  it('escalation status endpoint still works after history module addition', async () => {
+    const { resetEscalationState } = await import('../../../server/escalation-policy.js');
+    resetEscalationState();
+
+    const { handleTaskBoard } = await import('../../../server/routes/task-board.js');
+    const req = {
+      url: '/api/task-board/escalation/status',
+      method: 'GET',
+      headers: {},
+      on: () => {},
+    };
+    let capturedData: any = null;
+
+    const deps = {
+      dataDir: tmpDir,
+      sendJson: (_r: any, data: any) => { capturedData = data; },
+      readRequestBody: async () => '{}',
+    };
+
+    await handleTaskBoard(req as any, {} as any, deps as any);
+    expect(capturedData).toBeDefined();
+    expect(capturedData.status).toBeDefined();
+    expect(capturedData.status.policyEnabled).toBe(false);
+  });
+
+  it('escalation history module imports do not affect escalation policy exports', async () => {
+    const policy = await import('../../../server/escalation-policy.js');
+    // Verify all critical exports are still available
+    expect(typeof policy.evaluateEscalation).toBe('function');
+    expect(typeof policy.updateEscalationState).toBe('function');
+    expect(typeof policy.computeEscalationStatus).toBe('function');
+    expect(typeof policy.resetEscalationState).toBe('function');
+    expect(typeof policy.getEscalationState).toBe('function');
+    expect(typeof policy.maybeEscalate).toBe('function');
+    expect(typeof policy.validateEscalationPolicy).toBe('function');
+    expect(typeof policy.sanitizeEscalationPolicy).toBe('function');
+  });
+
+  it('task-board route still handles non-escalation routes', async () => {
+    const { handleTaskBoard } = await import('../../../server/routes/task-board.js');
+    const req = {
+      url: '/api/task-board/summary',
+      method: 'GET',
+      headers: {},
+      on: () => {},
+    };
+    let capturedData: any = null;
+
+    const deps = {
+      dataDir: tmpDir,
+      sendJson: (_r: any, data: any) => { capturedData = data; },
+      readRequestBody: async () => '{}',
+    };
+
+    await handleTaskBoard(req as any, {} as any, deps as any);
+    expect(capturedData).toBeDefined();
+    expect(capturedData.total).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary
Refs #219

Adds persistent escalation event recording (tier transitions + notifications sent), a read-only API endpoint with filtering, and a minimal dashboard panel for inspecting escalation history.

## Changes

### New: `dashboard/server/escalation-history.ts`
- Append-only JSON persistence for escalation events
- Event types: `tier_triggered`, `tier_renotified`, `escalation_reset`
- Bounded retention: max 200 events, max 48h age
- Secret-safe: no raw URLs/secrets/payloads stored; errors truncated to 200 chars
- Per-delivery outcome tracking (targetId, success, statusCode, attempts)

### New: `GET /api/task-board/escalation/history`
- Read-only endpoint with query filters: `sinceMs`, `eventType`, `tierIndex`, `deliveryStatus`, `limit`
- Returns events (most-recent-first) + summary statistics

### Modified: `dashboard/server/escalation-policy.ts`
- `maybeEscalate()` now records events after successful dispatch
- Detects and records escalation resets (severity drop while tracking)
- All recording is try/catch guarded — never breaks metrics response

### Modified: `dashboard/client/index.html`
- New Escalation History panel with filter controls + summary stats + table view
- Delivery outcome pills with hover tooltips
- Auto-refreshes with metrics panel

### New: `dashboard/tests/unit/routes/task-board-escalation-history.test.ts`
- 50 tests covering: recording correctness, retention/limit behavior, API filtering, secret-safe output, regression safety

## Test Results
- **50 new tests** — all pass
- **849 total task-board tests** — all pass, zero regressions
- **TypeScript** — clean typecheck (`tsc --noEmit`)

## Risk Assessment
- **LOW**: Additive only, no schema changes, no new dependencies
- Bounded file growth (200 events max, 48h max age)
- Non-blocking recording (try/catch guarded)
- Reversible: removing the module restores prior behavior