### PR TITLE
feat(#219): Alert history + webhook health stats export — CSV/JSON (Phase 24)

### DIFF
--- a/dashboard/client/index.html
+++ b/dashboard/client/index.html
@@ -5390,6 +5390,10 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
                 <option value="172800000">Last 48h</option>
               </select>
               <span class="subtitle" id="tbTimelineSubtitle"></span>
+              <div class="tb-export-controls">
+                <button class="tb-export-btn" onclick="tbExportAlertHistory('csv')" title="Download alert history as CSV">📥 CSV</button>
+                <button class="tb-export-btn" onclick="tbExportAlertHistory('json')" title="Download alert history as JSON">📥 JSON</button>
+              </div>
             </div>
             <div id="tbTimelineBar" class="tb-alert-timeline-bar"></div>
             <div id="tbTimelineStats" class="tb-alert-timeline-stats"></div>
@@ -10807,6 +10811,28 @@ function tbEscHistEventLabel(type) {
   }
 }
 
+// ── Alert History Export (Issue #219, Phase 24) ─────────────────────────────
+// Download alert history timeline as CSV/JSON file.
+// Uses the same filter state from the alert timeline panel.
+
+/**
+ * Export alert history as CSV or JSON.
+ * Reads current filter state and triggers a file download via the export API.
+ */
+function tbExportAlertHistory(format) {
+  var params = new URLSearchParams();
+  params.set('format', format);
+  params.set('limit', '200');
+
+  var windowEl = document.getElementById('tbTimelineWindow');
+  if (windowEl && windowEl.value) params.set('sinceMs', windowEl.value);
+
+  tbTriggerExportDownload(
+    '/api/task-board/alerts/timeline/export?' + params.toString(),
+    format
+  );
+}
+
 // ── Escalation History Export (Issue #219, Phase 23) ────────────────────────
 // Download escalation history as CSV/JSON file.
 // Uses the same filter state from the escalation history panel.
@@ -12145,7 +12171,15 @@ function tbExportCurrentTab(format) {
   params.set('format', format);
   params.set('limit', '200');
 
-  if (tab === 'retries') {
+  if (tab === 'health') {
+    // Read health filters (Phase 24: webhook health stats export)
+    var healthWindowSel = document.getElementById('tbHealthWindowSelect');
+    var healthTargetSel = document.getElementById('tbHealthTargetFilter');
+    if (healthWindowSel && healthWindowSel.value) params.set('windowMs', healthWindowSel.value);
+    if (healthTargetSel && healthTargetSel.value) params.set('targetId', healthTargetSel.value);
+
+    tbTriggerExportDownload('/api/task-board/webhooks/health/export?' + params.toString(), format);
+  } else if (tab === 'retries') {
     // Read retry filters
     var retryWindowSel = document.getElementById('tbRetryWindowSelect');
     var retryTargetSel = document.getElementById('tbRetryTargetFilter');

--- a/dashboard/server/alert-history.ts
+++ b/dashboard/server/alert-history.ts
@@ -368,3 +368,163 @@ export function queryAlertTimeline(
     events,
   };
 }
+
+// ─── Export Helpers (Phase 24: Alert History Export) ──────────────────────────
+
+/**
+ * Maximum number of events allowed in a single export.
+ * Prevents unbounded memory/CPU usage on export requests.
+ */
+export const ALERT_EXPORT_MAX_EVENTS = 200;
+
+/** Supported export formats. */
+export type AlertExportFormat = 'csv' | 'json';
+
+/** Export query — same filters as AlertHistoryQuery, plus format. */
+export interface AlertExportQuery {
+  format?: AlertExportFormat;
+  limit?: number;
+  sinceMs?: number;
+  minSeverity?: AlertSeverity;
+  now?: number;
+}
+
+/** Result of an alert history export operation. */
+export interface AlertExportResult {
+  /** The serialized export content (CSV string or JSON string). */
+  content: string;
+  /** MIME type for the response Content-Type header. */
+  contentType: string;
+  /** Suggested filename for the Content-Disposition header. */
+  filename: string;
+  /** Number of events included in the export. */
+  count: number;
+}
+
+/**
+ * Escape a value for CSV output.
+ * Wraps in double quotes if the value contains commas, quotes, or newlines.
+ * Pure function.
+ */
+export function csvEscapeAlert(value: string | number | boolean | null | undefined): string {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  if (str.includes('"') || str.includes(',') || str.includes('\n') || str.includes('\r')) {
+    return '"' + str.replace(/"/g, '""') + '"';
+  }
+  return str;
+}
+
+/**
+ * Format a timestamp as ISO 8601 string for export.
+ * Returns empty string for null/undefined.
+ */
+function formatAlertExportTs(ts: number | null | undefined): string {
+  if (ts == null) return '';
+  return new Date(ts).toISOString();
+}
+
+/**
+ * Conservative field allowlist for alert history export.
+ * Explicitly enumerates safe fields — no internal rule config, thresholds,
+ * or implementation details leak through. Only observable alert state.
+ */
+function sanitizeAlertEventForExport(event: AlertHistoryEvent): Record<string, unknown> {
+  return {
+    timestamp: formatAlertExportTs(event.ts),
+    overallSeverity: event.overallSeverity,
+    okCount: event.severityCounts.ok ?? 0,
+    warningCount: event.severityCounts.warning ?? 0,
+    criticalCount: event.severityCounts.critical ?? 0,
+    activeMessages: (event.activeMessages || []).join('; '),
+    // Expose per-rule severities as a flattened string for CSV friendliness.
+    // Rule names are observable (displayed in dashboard) and not secrets.
+    ruleSeverities: Object.entries(event.ruleSeverities || {})
+      .map(([rule, sev]) => `${rule}=${sev}`)
+      .join('; '),
+    // Explicitly omit: raw ruleSeverities object (flattened above),
+    // any internal fields that may be added in future.
+  };
+}
+
+/** CSV column headers for alert history export. */
+const ALERT_CSV_HEADERS = [
+  'timestamp', 'overallSeverity', 'okCount', 'warningCount', 'criticalCount',
+  'activeMessages', 'ruleSeverities',
+];
+
+/**
+ * Convert alert history events to CSV format.
+ * Pure function — no I/O, bounded by input array length.
+ */
+export function alertEventsToCsv(events: AlertHistoryEvent[]): string {
+  const rows: string[] = [ALERT_CSV_HEADERS.join(',')];
+
+  for (const event of events) {
+    const safe = sanitizeAlertEventForExport(event);
+    const row = ALERT_CSV_HEADERS.map((h) =>
+      csvEscapeAlert(safe[h] as string | number | boolean | null),
+    );
+    rows.push(row.join(','));
+  }
+
+  return rows.join('\n');
+}
+
+/**
+ * Convert alert history events to a safe JSON export format.
+ * Returns a JSON string with sanitized events (conservative allowlist).
+ * Pure function.
+ */
+export function alertEventsToJson(events: AlertHistoryEvent[]): string {
+  const safeEvents = events.map(sanitizeAlertEventForExport);
+  return JSON.stringify({
+    exportedAt: new Date().toISOString(),
+    format: 'ventureos-alert-history-export-v1',
+    count: safeEvents.length,
+    events: safeEvents,
+  }, null, 2);
+}
+
+/**
+ * Export alert history with the same filter capabilities as queryAlertTimeline.
+ * Returns formatted content (CSV or JSON), content type, and suggested filename.
+ *
+ * Secret-safe: all events pass through sanitizeAlertEventForExport() which
+ * applies a conservative field allowlist. Rule names and severity levels
+ * are observable data (displayed in dashboard), not secrets.
+ */
+export function exportAlertHistory(
+  dataDir: string,
+  opts: AlertExportQuery = {},
+): AlertExportResult {
+  const format: AlertExportFormat = opts.format === 'csv' ? 'csv' : 'json';
+  const limit = Math.max(1, Math.min(opts.limit ?? ALERT_EXPORT_MAX_EVENTS, ALERT_EXPORT_MAX_EVENTS));
+
+  // Reuse the same query logic for filter parity
+  const queryResult = queryAlertTimeline(dataDir, {
+    limit,
+    sinceMs: opts.sinceMs,
+    minSeverity: opts.minSeverity,
+    now: opts.now,
+  });
+
+  const events = queryResult.events;
+  const dateSuffix = new Date().toISOString().slice(0, 10);
+
+  if (format === 'csv') {
+    return {
+      content: alertEventsToCsv(events),
+      contentType: 'text/csv; charset=utf-8',
+      filename: `alert-history-${dateSuffix}.csv`,
+      count: events.length,
+    };
+  }
+
+  return {
+    content: alertEventsToJson(events),
+    contentType: 'application/json; charset=utf-8',
+    filename: `alert-history-${dateSuffix}.json`,
+    count: events.length,
+  };
+}

--- a/dashboard/server/routes/task-board.ts
+++ b/dashboard/server/routes/task-board.ts
@@ -94,6 +94,16 @@ import {
 } from '../escalation-history.js';
 import type { EscalationEventType, EscalationExportFormat } from '../escalation-history.js';
 
+import {
+  exportAlertHistory,
+} from '../alert-history.js';
+import type { AlertExportFormat } from '../alert-history.js';
+
+import {
+  exportWebhookHealth,
+} from '../webhook-health-stats.js';
+import type { HealthExportFormat } from '../webhook-health-stats.js';
+
 // ─── Constants ───────────────────────────────────────────────────────────────
 
 const VALID_STATUSES: TaskStatus[] = ['backlog', 'queued', 'running', 'done', 'failed'];
@@ -888,6 +898,42 @@ export async function handleTaskBoard(
     return true;
   }
 
+  // ── GET /api/task-board/alerts/timeline/export — Issue #219, Phase 24 ───────
+  // Export alert history as CSV or JSON file download.
+  // Query params: same as /alerts/timeline + ?format=csv|json (default json)
+  // Bounded: max 200 events per export. Secret-safe: conservative field allowlist.
+  if (url.startsWith('/api/task-board/alerts/timeline/export') && method === 'GET') {
+    const exportParams = new URL(url, 'http://localhost').searchParams;
+    const format = (exportParams.get('format') === 'csv' ? 'csv' : 'json') as AlertExportFormat;
+    const limit = exportParams.has('limit')
+      ? Math.max(1, Math.min(Number(exportParams.get('limit')) || 200, 200))
+      : 200;
+    const sinceMs = exportParams.has('sinceMs')
+      ? Math.max(0, Number(exportParams.get('sinceMs')) || 0)
+      : undefined;
+    const minSeverityRaw = exportParams.get('minSeverity');
+    const validSeverities = ['ok', 'warning', 'critical'];
+    const minSeverity = minSeverityRaw && validSeverities.includes(minSeverityRaw)
+      ? (minSeverityRaw as 'ok' | 'warning' | 'critical')
+      : undefined;
+
+    const result = exportAlertHistory(dataDir, {
+      format,
+      limit,
+      sinceMs,
+      minSeverity,
+    });
+
+    res.writeHead(200, {
+      'Content-Type': result.contentType,
+      'Content-Disposition': `attachment; filename="${result.filename}"`,
+      'Cache-Control': 'no-store',
+      'X-Export-Count': String(result.count),
+    });
+    res.end(result.content);
+    return true;
+  }
+
   // ── GET /api/task-board/alerts/timeline — Issue #219, Phase 10 ─────────────
   // Returns alert history timeline with summary statistics.
   // Query params:
@@ -1000,6 +1046,34 @@ export async function handleTaskBoard(
       sendJson(res, { error: `Test delivery failed: ${msg}`, results: [] }, 500);
     }
 
+    return true;
+  }
+
+  // ── GET /api/task-board/webhooks/health/export — Issue #219, Phase 24 ──────
+  // Export webhook health stats as CSV or JSON file download.
+  // Query params: same as /webhooks/health + ?format=csv|json (default json)
+  // Bounded: max 100 targets per export. Secret-safe: maskedUrl omitted.
+  if (url.startsWith('/api/task-board/webhooks/health/export') && method === 'GET') {
+    const exportParams = new URL(url, 'http://localhost').searchParams;
+    const format = (exportParams.get('format') === 'csv' ? 'csv' : 'json') as HealthExportFormat;
+    const windowMs = exportParams.has('windowMs')
+      ? Math.max(1000, Math.min(Number(exportParams.get('windowMs')) || 86400000, 172800000))
+      : undefined;
+    const targetId = exportParams.get('targetId') || undefined;
+
+    const result = exportWebhookHealth(dataDir, {
+      format,
+      windowMs,
+      targetId,
+    });
+
+    res.writeHead(200, {
+      'Content-Type': result.contentType,
+      'Content-Disposition': `attachment; filename="${result.filename}"`,
+      'Cache-Control': 'no-store',
+      'X-Export-Count': String(result.count),
+    });
+    res.end(result.content);
     return true;
   }
 

--- a/dashboard/server/webhook-health-stats.ts
+++ b/dashboard/server/webhook-health-stats.ts
@@ -310,3 +310,183 @@ export function computeWebhookHealth(
     computedAt: now,
   };
 }
+
+// ─── Export Helpers (Phase 24: Webhook Health Stats Export) ───────────────────
+
+/**
+ * Maximum number of target rows allowed in a single export.
+ * In practice, the number of targets is small (< 20 typically),
+ * but we bound for safety.
+ */
+export const HEALTH_EXPORT_MAX_TARGETS = 100;
+
+/** Supported export formats. */
+export type HealthExportFormat = 'csv' | 'json';
+
+/** Export query — same filters as WebhookHealthQuery, plus format. */
+export interface HealthExportQuery {
+  format?: HealthExportFormat;
+  windowMs?: number;
+  targetId?: string;
+  now?: number;
+}
+
+/** Result of a health stats export operation. */
+export interface HealthExportResult {
+  /** The serialized export content (CSV string or JSON string). */
+  content: string;
+  /** MIME type for the response Content-Type header. */
+  contentType: string;
+  /** Suggested filename for the Content-Disposition header. */
+  filename: string;
+  /** Number of target rows included in the export. */
+  count: number;
+}
+
+/**
+ * Escape a value for CSV output.
+ * Wraps in double quotes if the value contains commas, quotes, or newlines.
+ * Pure function.
+ */
+export function csvEscapeHealth(value: string | number | boolean | null | undefined): string {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  if (str.includes('"') || str.includes(',') || str.includes('\n') || str.includes('\r')) {
+    return '"' + str.replace(/"/g, '""') + '"';
+  }
+  return str;
+}
+
+/**
+ * Format a timestamp as ISO 8601 string for export.
+ * Returns empty string for null/undefined.
+ */
+function formatHealthExportTs(ts: number | null | undefined): string {
+  if (ts == null) return '';
+  return new Date(ts).toISOString();
+}
+
+/**
+ * Conservative field allowlist for webhook health stats export.
+ * Explicitly enumerates safe fields — no raw webhook URLs, secrets,
+ * or internal identifiers leak through. maskedUrl is already safe
+ * (protocol + host only).
+ */
+function sanitizeHealthTargetForExport(target: WebhookTargetHealthStats): Record<string, unknown> {
+  return {
+    targetId: target.targetId,
+    targetName: target.targetName,
+    healthStatus: target.healthStatus,
+    successCount: target.successCount,
+    failureCount: target.failureCount,
+    totalCount: target.totalCount,
+    successRate: target.successRate,
+    avgLatencyMs: target.avgLatencyMs,
+    lastSuccessAt: formatHealthExportTs(target.lastSuccessTs),
+    lastFailureAt: formatHealthExportTs(target.lastFailureTs),
+    lastStatusCode: target.lastStatusCode,
+    // Explicitly omit: maskedUrl (even masked URLs could leak infrastructure info in exports)
+    // Explicitly omit: any fields that may be added in future
+  };
+}
+
+/** CSV column headers for webhook health stats export. */
+const HEALTH_CSV_HEADERS = [
+  'targetId', 'targetName', 'healthStatus', 'successCount', 'failureCount',
+  'totalCount', 'successRate', 'avgLatencyMs', 'lastSuccessAt', 'lastFailureAt',
+  'lastStatusCode',
+];
+
+/**
+ * Convert webhook health target stats to CSV format.
+ * Pure function — no I/O, bounded by input array length.
+ */
+export function healthTargetsToCsv(targets: WebhookTargetHealthStats[]): string {
+  const rows: string[] = [HEALTH_CSV_HEADERS.join(',')];
+
+  for (const target of targets) {
+    const safe = sanitizeHealthTargetForExport(target);
+    const row = HEALTH_CSV_HEADERS.map((h) =>
+      csvEscapeHealth(safe[h] as string | number | boolean | null),
+    );
+    rows.push(row.join(','));
+  }
+
+  return rows.join('\n');
+}
+
+/**
+ * Convert webhook health stats to a safe JSON export format.
+ * Returns a JSON string with sanitized targets and summary (no secrets).
+ * Pure function.
+ */
+export function healthStatsToJson(
+  response: WebhookHealthResponse,
+): string {
+  const safeTargets = response.targets.map(sanitizeHealthTargetForExport);
+  return JSON.stringify({
+    exportedAt: new Date().toISOString(),
+    format: 'ventureos-webhook-health-export-v1',
+    windowMs: response.windowMs,
+    computedAt: new Date(response.computedAt).toISOString(),
+    count: safeTargets.length,
+    summary: {
+      totalDeliveries: response.summary.totalDeliveries,
+      totalSuccesses: response.summary.totalSuccesses,
+      totalFailures: response.summary.totalFailures,
+      overallSuccessRate: response.summary.overallSuccessRate,
+      overallAvgLatencyMs: response.summary.overallAvgLatencyMs,
+      targetCount: response.summary.targetCount,
+      healthyCount: response.summary.healthyCount,
+      degradedCount: response.summary.degradedCount,
+      unhealthyCount: response.summary.unhealthyCount,
+    },
+    targets: safeTargets,
+  }, null, 2);
+}
+
+/**
+ * Export webhook health stats with the same filter capabilities as computeWebhookHealth.
+ * Returns formatted content (CSV or JSON), content type, and suggested filename.
+ *
+ * Secret-safe: all targets pass through sanitizeHealthTargetForExport() which
+ * applies a conservative field allowlist. maskedUrl is intentionally omitted
+ * from exports as even partial URL info could leak infrastructure details.
+ */
+export function exportWebhookHealth(
+  dataDir: string,
+  opts: HealthExportQuery = {},
+): HealthExportResult {
+  const format: HealthExportFormat = opts.format === 'csv' ? 'csv' : 'json';
+
+  // Reuse the same computation logic for filter parity
+  const healthResult = computeWebhookHealth(dataDir, {
+    windowMs: opts.windowMs,
+    targetId: opts.targetId,
+    now: opts.now,
+  });
+
+  // Bound target count (defensive — unlikely to exceed in practice)
+  let targets = healthResult.targets;
+  if (targets.length > HEALTH_EXPORT_MAX_TARGETS) {
+    targets = targets.slice(0, HEALTH_EXPORT_MAX_TARGETS);
+  }
+
+  const dateSuffix = new Date().toISOString().slice(0, 10);
+
+  if (format === 'csv') {
+    return {
+      content: healthTargetsToCsv(targets),
+      contentType: 'text/csv; charset=utf-8',
+      filename: `webhook-health-${dateSuffix}.csv`,
+      count: targets.length,
+    };
+  }
+
+  return {
+    content: healthStatsToJson(healthResult),
+    contentType: 'application/json; charset=utf-8',
+    filename: `webhook-health-${dateSuffix}.json`,
+    count: targets.length,
+  };
+}

--- a/dashboard/tests/unit/routes/task-board-alert-history-export.test.ts
+++ b/dashboard/tests/unit/routes/task-board-alert-history-export.test.ts
@@ -1,0 +1,580 @@
+/**
+ * Alert History Export + Webhook Health Stats Export tests — Issue #219, Phase 24.
+ *
+ * Tests for:
+ * - Alert history export: CSV/JSON format correctness, filter parity, bounds, secret safety
+ * - Webhook health stats export: CSV/JSON format correctness, filter parity, bounds, secret safety
+ * - API endpoints: GET /api/task-board/alerts/timeline/export
+ *                  GET /api/task-board/webhooks/health/export
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  csvEscapeAlert,
+  alertEventsToCsv,
+  alertEventsToJson,
+  exportAlertHistory,
+  ALERT_EXPORT_MAX_EVENTS,
+  maybeAppendAlertEvent,
+} from '../../../server/alert-history.js';
+import type {
+  AlertHistoryEvent,
+  AlertExportResult,
+} from '../../../server/alert-history.js';
+
+import {
+  csvEscapeHealth,
+  healthTargetsToCsv,
+  healthStatsToJson,
+  exportWebhookHealth,
+  HEALTH_EXPORT_MAX_TARGETS,
+} from '../../../server/webhook-health-stats.js';
+import type {
+  WebhookTargetHealthStats,
+  WebhookHealthResponse,
+  HealthExportResult,
+} from '../../../server/webhook-health-stats.js';
+
+import { appendDeliveryEvents } from '../../../server/webhook-delivery-history.js';
+
+import { mockRequest, mockResponse } from '../../helpers.js';
+import { handleTaskBoard } from '../../../server/routes/task-board.js';
+import type { TaskBoardDeps } from '../../../server/types.js';
+
+// ─── Test Setup ──────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'alert-health-export-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const NOW = 1_700_000_000_000;
+
+function createDeps(overrides: Partial<TaskBoardDeps> = {}): TaskBoardDeps {
+  return {
+    dataDir: tmpDir,
+    sendJson: (res, data, status = 200) => {
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+    },
+    readRequestBody: async () => '{}',
+    ...overrides,
+  };
+}
+
+function makeAlertEvent(overrides: Partial<AlertHistoryEvent> = {}): AlertHistoryEvent {
+  return {
+    ts: NOW,
+    overallSeverity: 'warning',
+    severityCounts: { ok: 1, warning: 2, critical: 0 },
+    ruleSeverities: { stuckTasks: 'warning', failureRate: 'warning' },
+    activeMessages: ['2 stuck tasks', 'Failure rate 45%'],
+    ...overrides,
+  };
+}
+
+function seedAlertEvents(count = 3) {
+  // Write alert events with incrementing timestamps and forced cooldown bypass
+  for (let i = 0; i < count; i++) {
+    const severity = i % 3 === 0 ? 'ok' : i % 3 === 1 ? 'warning' : 'critical';
+    const eval_ = {
+      evaluatedAt: NOW - (count - i) * 120_000, // 2min apart
+      overallSeverity: severity as 'ok' | 'warning' | 'critical',
+      severityCounts: { ok: severity === 'ok' ? 3 : 1, warning: severity === 'warning' ? 2 : 0, critical: severity === 'critical' ? 1 : 0 },
+      rules: [
+        { rule: 'stuckTasks', enabled: true, severity: severity as 'ok' | 'warning' | 'critical', message: severity === 'ok' ? 'OK' : 'stuck', value: i, threshold: 1, comparator: '>=' as const },
+      ],
+    };
+    maybeAppendAlertEvent(tmpDir, eval_, { minIntervalMs: 0 });
+  }
+}
+
+function makeHealthTarget(overrides: Partial<WebhookTargetHealthStats> = {}): WebhookTargetHealthStats {
+  return {
+    targetId: 'slack',
+    targetName: 'Slack Alerts',
+    successCount: 15,
+    failureCount: 2,
+    totalCount: 17,
+    successRate: 0.8824,
+    avgLatencyMs: 250,
+    lastSuccessTs: NOW - 60_000,
+    lastFailureTs: NOW - 300_000,
+    lastStatusCode: 200,
+    maskedUrl: 'https://hooks.slack.com/***',
+    healthStatus: 'degraded',
+    ...overrides,
+  };
+}
+
+function seedDeliveryEvents() {
+  const results = [
+    { targetId: 'slack', targetName: 'Slack', success: true, statusCode: 200, attempts: 1, error: null, durationMs: 150 },
+    { targetId: 'slack', targetName: 'Slack', success: false, statusCode: 500, attempts: 3, error: 'Server Error', durationMs: 3000 },
+    { targetId: 'discord', targetName: 'Discord', success: true, statusCode: 200, attempts: 1, error: null, durationMs: 200 },
+  ];
+  const contexts = results.map(() => ({
+    url: 'https://hooks.slack.com/services/T00/B00/xxx',
+    triggerSeverity: 'critical',
+    previousSeverity: 'warning',
+    ts: NOW - 60_000,
+  }));
+  appendDeliveryEvents(tmpDir, results, contexts);
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Alert History Export — Unit Tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('Alert History Export', () => {
+  describe('csvEscapeAlert()', () => {
+    it('returns empty string for null/undefined', () => {
+      expect(csvEscapeAlert(null)).toBe('');
+      expect(csvEscapeAlert(undefined)).toBe('');
+    });
+
+    it('passes through plain strings', () => {
+      expect(csvEscapeAlert('hello')).toBe('hello');
+    });
+
+    it('wraps strings with commas in double quotes', () => {
+      expect(csvEscapeAlert('a,b')).toBe('"a,b"');
+    });
+
+    it('escapes double quotes by doubling them', () => {
+      expect(csvEscapeAlert('say "hi"')).toBe('"say ""hi"""');
+    });
+
+    it('wraps strings with newlines', () => {
+      expect(csvEscapeAlert('line1\nline2')).toBe('"line1\nline2"');
+    });
+
+    it('converts numbers and booleans to strings', () => {
+      expect(csvEscapeAlert(42)).toBe('42');
+      expect(csvEscapeAlert(true)).toBe('true');
+    });
+  });
+
+  describe('alertEventsToCsv()', () => {
+    it('returns header row for empty input', () => {
+      const csv = alertEventsToCsv([]);
+      const lines = csv.split('\n');
+      expect(lines.length).toBe(1);
+      expect(lines[0]).toContain('timestamp');
+      expect(lines[0]).toContain('overallSeverity');
+      expect(lines[0]).toContain('activeMessages');
+    });
+
+    it('includes data rows with correct column count', () => {
+      const events = [makeAlertEvent()];
+      const csv = alertEventsToCsv(events);
+      const lines = csv.split('\n');
+      expect(lines.length).toBe(2);
+      const headerCols = lines[0].split(',').length;
+      // Data row may have quoted commas, but the unquoted structure should work
+      expect(headerCols).toBe(7); // timestamp,overallSeverity,okCount,warningCount,criticalCount,activeMessages,ruleSeverities
+    });
+
+    it('formats timestamps as ISO 8601', () => {
+      const events = [makeAlertEvent({ ts: NOW })];
+      const csv = alertEventsToCsv(events);
+      expect(csv).toContain(new Date(NOW).toISOString());
+    });
+
+    it('never contains raw internal field names', () => {
+      const events = [makeAlertEvent()];
+      const csv = alertEventsToCsv(events);
+      // Should not leak raw object references
+      expect(csv).not.toContain('[object');
+    });
+  });
+
+  describe('alertEventsToJson()', () => {
+    it('returns valid JSON with export metadata', () => {
+      const events = [makeAlertEvent()];
+      const json = alertEventsToJson(events);
+      const parsed = JSON.parse(json);
+      expect(parsed.format).toBe('ventureos-alert-history-export-v1');
+      expect(parsed.count).toBe(1);
+      expect(parsed.exportedAt).toBeDefined();
+      expect(Array.isArray(parsed.events)).toBe(true);
+    });
+
+    it('sanitizes events — only allowlisted fields present', () => {
+      const events = [makeAlertEvent()];
+      const json = alertEventsToJson(events);
+      const parsed = JSON.parse(json);
+      const ev = parsed.events[0];
+      // Allowlisted fields
+      expect(ev.timestamp).toBeDefined();
+      expect(ev.overallSeverity).toBe('warning');
+      expect(ev.okCount).toBeDefined();
+      expect(ev.warningCount).toBeDefined();
+      expect(ev.criticalCount).toBeDefined();
+      expect(ev.activeMessages).toBeDefined();
+      expect(ev.ruleSeverities).toBeDefined();
+      // No raw ts field (transformed to timestamp)
+      expect(ev.ts).toBeUndefined();
+      // No internal fields
+      expect(ev.severityCounts).toBeUndefined();
+    });
+  });
+
+  describe('exportAlertHistory()', () => {
+    it('returns CSV with correct content type and filename', () => {
+      seedAlertEvents(3);
+      const result = exportAlertHistory(tmpDir, { format: 'csv', now: NOW });
+      expect(result.contentType).toBe('text/csv; charset=utf-8');
+      expect(result.filename).toMatch(/^alert-history-\d{4}-\d{2}-\d{2}\.csv$/);
+      expect(result.count).toBe(3);
+    });
+
+    it('returns JSON with correct content type and filename', () => {
+      seedAlertEvents(3);
+      const result = exportAlertHistory(tmpDir, { format: 'json', now: NOW });
+      expect(result.contentType).toBe('application/json; charset=utf-8');
+      expect(result.filename).toMatch(/^alert-history-\d{4}-\d{2}-\d{2}\.json$/);
+      expect(result.count).toBe(3);
+    });
+
+    it('defaults to JSON format', () => {
+      seedAlertEvents(1);
+      const result = exportAlertHistory(tmpDir, { now: NOW });
+      expect(result.contentType).toBe('application/json; charset=utf-8');
+    });
+
+    it('respects limit parameter (bounded to ALERT_EXPORT_MAX_EVENTS)', () => {
+      seedAlertEvents(5);
+      const result = exportAlertHistory(tmpDir, { format: 'json', limit: 2, now: NOW });
+      expect(result.count).toBeLessThanOrEqual(2);
+    });
+
+    it('caps limit at ALERT_EXPORT_MAX_EVENTS', () => {
+      expect(ALERT_EXPORT_MAX_EVENTS).toBe(200);
+      const result = exportAlertHistory(tmpDir, { format: 'json', limit: 9999, now: NOW });
+      expect(result.count).toBeLessThanOrEqual(200);
+    });
+
+    it('filter parity: sinceMs filters match query endpoint', () => {
+      seedAlertEvents(5);
+      // Export with tight window should return fewer events
+      const tight = exportAlertHistory(tmpDir, { format: 'json', sinceMs: 180_000, now: NOW });
+      const wide = exportAlertHistory(tmpDir, { format: 'json', sinceMs: 900_000, now: NOW });
+      expect(tight.count).toBeLessThanOrEqual(wide.count);
+    });
+
+    it('filter parity: minSeverity filter works', () => {
+      seedAlertEvents(6); // Mix of ok/warning/critical
+      const all = exportAlertHistory(tmpDir, { format: 'json', now: NOW });
+      const warningPlus = exportAlertHistory(tmpDir, { format: 'json', minSeverity: 'warning', now: NOW });
+      const criticalOnly = exportAlertHistory(tmpDir, { format: 'json', minSeverity: 'critical', now: NOW });
+      expect(warningPlus.count).toBeLessThanOrEqual(all.count);
+      expect(criticalOnly.count).toBeLessThanOrEqual(warningPlus.count);
+    });
+
+    it('returns empty export for empty history', () => {
+      const result = exportAlertHistory(tmpDir, { format: 'csv', now: NOW });
+      expect(result.count).toBe(0);
+      // CSV should still have header row
+      expect(result.content.split('\n').length).toBe(1);
+    });
+
+    it('secret safety: CSV export never contains internal field names', () => {
+      seedAlertEvents(3);
+      const result = exportAlertHistory(tmpDir, { format: 'csv', now: NOW });
+      expect(result.content).not.toContain('severityCounts');
+      expect(result.content).not.toContain('[object');
+      expect(result.content).not.toContain('undefined');
+    });
+
+    it('secret safety: JSON export uses sanitized allowlist', () => {
+      seedAlertEvents(3);
+      const result = exportAlertHistory(tmpDir, { format: 'json', now: NOW });
+      const parsed = JSON.parse(result.content);
+      for (const ev of parsed.events) {
+        // Must have allowlisted fields
+        expect(ev.timestamp).toBeDefined();
+        expect(ev.overallSeverity).toBeDefined();
+        // Must NOT have raw internal fields
+        expect(ev.ts).toBeUndefined();
+        expect(ev.severityCounts).toBeUndefined();
+      }
+    });
+  });
+
+  describe('GET /api/task-board/alerts/timeline/export', () => {
+    it('returns CSV download with correct headers', async () => {
+      seedAlertEvents(3);
+      const req = mockRequest({ url: '/api/task-board/alerts/timeline/export?format=csv', method: 'GET' });
+      const res = mockResponse();
+      const handled = await handleTaskBoard(req, res, createDeps());
+      expect(handled).toBe(true);
+      expect(res._statusCode).toBe(200);
+      expect(res._headers['content-type']).toBe('text/csv; charset=utf-8');
+      expect(res._headers['content-disposition']).toMatch(/attachment; filename="alert-history-.*\.csv"/);
+      expect(res._headers['cache-control']).toBe('no-store');
+      expect(res._headers['x-export-count']).toBeDefined();
+    });
+
+    it('returns JSON download by default', async () => {
+      seedAlertEvents(2);
+      const req = mockRequest({ url: '/api/task-board/alerts/timeline/export', method: 'GET' });
+      const res = mockResponse();
+      const handled = await handleTaskBoard(req, res, createDeps());
+      expect(handled).toBe(true);
+      expect(res._statusCode).toBe(200);
+      expect(res._headers['content-type']).toBe('application/json; charset=utf-8');
+      const parsed = JSON.parse(res._body);
+      expect(parsed.format).toBe('ventureos-alert-history-export-v1');
+    });
+
+    it('passes sinceMs and minSeverity filters to export', async () => {
+      seedAlertEvents(5);
+      const req = mockRequest({
+        url: '/api/task-board/alerts/timeline/export?format=json&sinceMs=180000&minSeverity=warning',
+        method: 'GET',
+      });
+      const res = mockResponse();
+      const handled = await handleTaskBoard(req, res, createDeps());
+      expect(handled).toBe(true);
+      expect(res._statusCode).toBe(200);
+      const parsed = JSON.parse(res._body);
+      // All exported events should be warning or critical
+      for (const ev of parsed.events) {
+        expect(['warning', 'critical']).toContain(ev.overallSeverity);
+      }
+    });
+
+    it('does not match the non-export timeline endpoint', async () => {
+      seedAlertEvents(2);
+      const req = mockRequest({ url: '/api/task-board/alerts/timeline?sinceMs=3600000', method: 'GET' });
+      const res = mockResponse();
+      const handled = await handleTaskBoard(req, res, createDeps());
+      expect(handled).toBe(true);
+      // The non-export endpoint returns JSON API response, not file download
+      expect(res._headers['content-disposition']).toBeUndefined();
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// Webhook Health Stats Export — Unit Tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('Webhook Health Stats Export', () => {
+  describe('csvEscapeHealth()', () => {
+    it('returns empty string for null/undefined', () => {
+      expect(csvEscapeHealth(null)).toBe('');
+      expect(csvEscapeHealth(undefined)).toBe('');
+    });
+
+    it('wraps strings with commas', () => {
+      expect(csvEscapeHealth('a,b')).toBe('"a,b"');
+    });
+
+    it('escapes double quotes', () => {
+      expect(csvEscapeHealth('say "hi"')).toBe('"say ""hi"""');
+    });
+  });
+
+  describe('healthTargetsToCsv()', () => {
+    it('returns header row for empty input', () => {
+      const csv = healthTargetsToCsv([]);
+      const lines = csv.split('\n');
+      expect(lines.length).toBe(1);
+      expect(lines[0]).toContain('targetId');
+      expect(lines[0]).toContain('healthStatus');
+      expect(lines[0]).toContain('successRate');
+    });
+
+    it('includes data rows with correct column count', () => {
+      const targets = [makeHealthTarget()];
+      const csv = healthTargetsToCsv(targets);
+      const lines = csv.split('\n');
+      expect(lines.length).toBe(2);
+      const headerCols = lines[0].split(',').length;
+      expect(headerCols).toBe(11);
+    });
+
+    it('secret safety: never contains maskedUrl', () => {
+      const targets = [makeHealthTarget({ maskedUrl: 'https://secret.com/***' })];
+      const csv = healthTargetsToCsv(targets);
+      expect(csv).not.toContain('secret.com');
+      expect(csv).not.toContain('maskedUrl');
+    });
+
+    it('formats timestamps as ISO 8601', () => {
+      const targets = [makeHealthTarget({ lastSuccessTs: NOW })];
+      const csv = healthTargetsToCsv(targets);
+      expect(csv).toContain(new Date(NOW).toISOString());
+    });
+  });
+
+  describe('healthStatsToJson()', () => {
+    it('returns valid JSON with export metadata', () => {
+      const response: WebhookHealthResponse = {
+        targets: [makeHealthTarget()],
+        summary: {
+          totalDeliveries: 17, totalSuccesses: 15, totalFailures: 2,
+          overallSuccessRate: 0.8824, overallAvgLatencyMs: 250,
+          targetCount: 1, healthyCount: 0, degradedCount: 1, unhealthyCount: 0,
+        },
+        windowMs: 86400000,
+        computedAt: NOW,
+      };
+      const json = healthStatsToJson(response);
+      const parsed = JSON.parse(json);
+      expect(parsed.format).toBe('ventureos-webhook-health-export-v1');
+      expect(parsed.count).toBe(1);
+      expect(parsed.summary).toBeDefined();
+      expect(parsed.summary.totalDeliveries).toBe(17);
+      expect(Array.isArray(parsed.targets)).toBe(true);
+    });
+
+    it('secret safety: targets do not contain maskedUrl', () => {
+      const response: WebhookHealthResponse = {
+        targets: [makeHealthTarget({ maskedUrl: 'https://hooks.slack.com/***' })],
+        summary: {
+          totalDeliveries: 1, totalSuccesses: 1, totalFailures: 0,
+          overallSuccessRate: 1, overallAvgLatencyMs: 100,
+          targetCount: 1, healthyCount: 1, degradedCount: 0, unhealthyCount: 0,
+        },
+        windowMs: 86400000,
+        computedAt: NOW,
+      };
+      const json = healthStatsToJson(response);
+      expect(json).not.toContain('hooks.slack.com');
+      expect(json).not.toContain('maskedUrl');
+    });
+  });
+
+  describe('exportWebhookHealth()', () => {
+    it('returns CSV with correct content type and filename', () => {
+      seedDeliveryEvents();
+      const result = exportWebhookHealth(tmpDir, { format: 'csv', now: NOW });
+      expect(result.contentType).toBe('text/csv; charset=utf-8');
+      expect(result.filename).toMatch(/^webhook-health-\d{4}-\d{2}-\d{2}\.csv$/);
+    });
+
+    it('returns JSON with correct content type and filename', () => {
+      seedDeliveryEvents();
+      const result = exportWebhookHealth(tmpDir, { format: 'json', now: NOW });
+      expect(result.contentType).toBe('application/json; charset=utf-8');
+      expect(result.filename).toMatch(/^webhook-health-\d{4}-\d{2}-\d{2}\.json$/);
+    });
+
+    it('defaults to JSON format', () => {
+      const result = exportWebhookHealth(tmpDir, { now: NOW });
+      expect(result.contentType).toBe('application/json; charset=utf-8');
+    });
+
+    it('returns empty export for empty delivery history', () => {
+      const result = exportWebhookHealth(tmpDir, { format: 'csv', now: NOW });
+      expect(result.count).toBe(0);
+      expect(result.content.split('\n').length).toBe(1); // header only
+    });
+
+    it('filter parity: targetId filter works', () => {
+      seedDeliveryEvents();
+      const all = exportWebhookHealth(tmpDir, { format: 'json', now: NOW });
+      const slackOnly = exportWebhookHealth(tmpDir, { format: 'json', targetId: 'slack', now: NOW });
+      expect(slackOnly.count).toBeLessThanOrEqual(all.count);
+      if (slackOnly.count > 0) {
+        const parsed = JSON.parse(slackOnly.content);
+        for (const t of parsed.targets) {
+          expect(t.targetId).toBe('slack');
+        }
+      }
+    });
+
+    it('filter parity: windowMs filter works', () => {
+      seedDeliveryEvents();
+      const result = exportWebhookHealth(tmpDir, { format: 'json', windowMs: 86400000, now: NOW });
+      expect(result.count).toBeGreaterThanOrEqual(0);
+    });
+
+    it('secret safety: JSON export does not contain maskedUrl', () => {
+      seedDeliveryEvents();
+      const result = exportWebhookHealth(tmpDir, { format: 'json', now: NOW });
+      expect(result.content).not.toContain('maskedUrl');
+    });
+
+    it('secret safety: CSV export does not contain maskedUrl', () => {
+      seedDeliveryEvents();
+      const result = exportWebhookHealth(tmpDir, { format: 'csv', now: NOW });
+      expect(result.content).not.toContain('maskedUrl');
+    });
+  });
+
+  describe('GET /api/task-board/webhooks/health/export', () => {
+    it('returns CSV download with correct headers', async () => {
+      seedDeliveryEvents();
+      const req = mockRequest({ url: '/api/task-board/webhooks/health/export?format=csv', method: 'GET' });
+      const res = mockResponse();
+      const handled = await handleTaskBoard(req, res, createDeps());
+      expect(handled).toBe(true);
+      expect(res._statusCode).toBe(200);
+      expect(res._headers['content-type']).toBe('text/csv; charset=utf-8');
+      expect(res._headers['content-disposition']).toMatch(/attachment; filename="webhook-health-.*\.csv"/);
+      expect(res._headers['cache-control']).toBe('no-store');
+      expect(res._headers['x-export-count']).toBeDefined();
+    });
+
+    it('returns JSON download by default', async () => {
+      seedDeliveryEvents();
+      const req = mockRequest({ url: '/api/task-board/webhooks/health/export', method: 'GET' });
+      const res = mockResponse();
+      const handled = await handleTaskBoard(req, res, createDeps());
+      expect(handled).toBe(true);
+      expect(res._statusCode).toBe(200);
+      expect(res._headers['content-type']).toBe('application/json; charset=utf-8');
+      const parsed = JSON.parse(res._body);
+      expect(parsed.format).toBe('ventureos-webhook-health-export-v1');
+    });
+
+    it('passes windowMs and targetId filters to export', async () => {
+      seedDeliveryEvents();
+      const req = mockRequest({
+        url: '/api/task-board/webhooks/health/export?format=json&windowMs=86400000&targetId=slack',
+        method: 'GET',
+      });
+      const res = mockResponse();
+      const handled = await handleTaskBoard(req, res, createDeps());
+      expect(handled).toBe(true);
+      expect(res._statusCode).toBe(200);
+      const parsed = JSON.parse(res._body);
+      for (const t of parsed.targets) {
+        expect(t.targetId).toBe('slack');
+      }
+    });
+
+    it('does not match the non-export health endpoint', async () => {
+      seedDeliveryEvents();
+      const req = mockRequest({ url: '/api/task-board/webhooks/health?windowMs=86400000', method: 'GET' });
+      const res = mockResponse();
+      const handled = await handleTaskBoard(req, res, createDeps());
+      expect(handled).toBe(true);
+      // Non-export endpoint returns JSON via sendJson, not file download
+      expect(res._headers['content-disposition']).toBeUndefined();
+    });
+  });
+
+  describe('bounds enforcement', () => {
+    it('ALERT_EXPORT_MAX_EVENTS is 200', () => {
+      expect(ALERT_EXPORT_MAX_EVENTS).toBe(200);
+    });
+
+    it('HEALTH_EXPORT_MAX_TARGETS is 100', () => {
+      expect(HEALTH_EXPORT_MAX_TARGETS).toBe(100);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds two read-only export endpoints under `/api/task-board/` with secret-safe allowlists, bounded limits, and filter parity to their respective query endpoints.

### Delivered Scope

**1. Alert History Export** (priority 1)
- `GET /api/task-board/alerts/timeline/export?format=csv|json`
- Filter parity with `/alerts/timeline`: `sinceMs`, `minSeverity`, `limit`
- Conservative field allowlist: timestamp, severities, messages, rule names only
- Bounded: max 200 events per export
- Dashboard: CSV/JSON buttons added to Alert Timeline panel header

**2. Webhook Health Stats Export** (priority 2)
- `GET /api/task-board/webhooks/health/export?format=csv|json`
- Filter parity with `/webhooks/health`: `windowMs`, `targetId`
- Conservative field allowlist: target stats, health status, latency
- `maskedUrl` intentionally omitted (defense in depth — even partial URLs excluded from exports)
- Bounded: max 100 targets per export
- Dashboard: health tab now exports via existing webhook modal export controls

### Tests
- **49 new tests** covering: format correctness, filter parity, bounds enforcement, secret safety (field allowlist), and API endpoint behavior
- **944/944 task-board tests pass** (zero regressions)
- TypeScript clean (`tsc --noEmit` passes)

### Risk Notes
- **Additive/reversible only** — no schema migrations, no existing behavior changes
- **Auth posture preserved** — endpoints follow existing auth middleware chain
- **Secret-safe** — both exports use conservative field allowlists; raw thresholds, config internals, and URLs excluded
- Pre-existing `better-sqlite3` dlopen failures in `shared-context.test.ts` are unrelated (native module issue)

### Files Changed (5 files, +1029/-1)
| File | Change |
|------|--------|
| `dashboard/server/alert-history.ts` | +160 — export functions, CSV/JSON serialization, field allowlist |
| `dashboard/server/webhook-health-stats.ts` | +180 — export functions, CSV/JSON serialization, field allowlist |
| `dashboard/server/routes/task-board.ts` | +74 — two new route handlers + imports |
| `dashboard/client/index.html` | +36/-1 — export buttons (alert timeline + health tab routing) |
| `dashboard/tests/unit/routes/task-board-alert-history-export.test.ts` | +580 — 49 tests |

Closes no issues (partial progress on #219).
Refs #219