### PR TITLE
feat(#219): Metrics history export — CSV/JSON download with secret-safe allowlist (Phase 25)

### DIFF
--- a/dashboard/client/index.html
+++ b/dashboard/client/index.html
@@ -5487,6 +5487,10 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
                   <option value="604800000">Last 7d</option>
                 </select>
                 <span id="tbHistoryPointCount" style="font-size:11px;color:var(--text-muted);font-family:'JetBrains Mono',monospace;margin-left:auto;"></span>
+                <div class="tb-export-controls" style="margin-left:8px;">
+                  <button class="tb-export-btn" onclick="tbExportMetricsHistory('csv')" title="Download metrics history as CSV">📥 CSV</button>
+                  <button class="tb-export-btn" onclick="tbExportMetricsHistory('json')" title="Download metrics history as JSON">📥 JSON</button>
+                </div>
               </div>
               <div id="tbHistoryChart" style="height:100px;position:relative;">
                 <div style="text-align:center;color:var(--text-muted);font-size:12px;padding:30px;">No history data yet — snapshots are recorded every 5 minutes</div>
@@ -10248,6 +10252,28 @@ function tbRenderHistoryChart() {
     <div style="position:absolute;top:0;right:8px;font-size:10px;color:var(--text-muted);font-family:'JetBrains Mono',monospace;">${yMax}</div>
     <div style="position:absolute;bottom:20px;right:8px;font-size:10px;color:var(--text-muted);font-family:'JetBrains Mono',monospace;">${yMin}</div>
   `;
+}
+
+// ── Metrics History Export (Issue #219, Phase 25) ────────────────────────────
+// Download metrics history time-series as CSV/JSON file.
+// Uses the same filter state from the metrics history panel.
+
+/**
+ * Export metrics history as CSV or JSON.
+ * Reads current filter state and triggers a file download via the export API.
+ */
+function tbExportMetricsHistory(format) {
+  var params = new URLSearchParams();
+  params.set('format', format);
+  params.set('limit', '500');
+
+  var windowEl = document.getElementById('tbHistoryWindow');
+  if (windowEl && windowEl.value) params.set('sinceMs', windowEl.value);
+
+  tbTriggerExportDownload(
+    '/api/task-board/metrics/history/export?' + params.toString(),
+    format
+  );
 }
 
 // ── Alert Rules (Issue #219, Phase 9) ────────────────────────────────────────

--- a/dashboard/server/metrics-history.ts
+++ b/dashboard/server/metrics-history.ts
@@ -241,3 +241,162 @@ export function queryHistory(
 
   return snapshots;
 }
+
+// ─── Export Helpers (Phase 25: Metrics History Export) ────────────────────────
+
+/**
+ * Maximum number of snapshots allowed in a single export.
+ * Prevents unbounded memory/CPU usage on export requests.
+ */
+export const METRICS_EXPORT_MAX_SNAPSHOTS = 500;
+
+/** Supported export formats. */
+export type MetricsExportFormat = 'csv' | 'json';
+
+/** Export query — same filters as queryHistory, plus format. */
+export interface MetricsExportQuery {
+  format?: MetricsExportFormat;
+  limit?: number;
+  sinceMs?: number;
+  now?: number;
+}
+
+/** Result of a metrics history export operation. */
+export interface MetricsExportResult {
+  /** The serialized export content (CSV string or JSON string). */
+  content: string;
+  /** MIME type for the response Content-Type header. */
+  contentType: string;
+  /** Suggested filename for the Content-Disposition header. */
+  filename: string;
+  /** Number of snapshots included in the export. */
+  count: number;
+}
+
+/**
+ * Escape a value for CSV output.
+ * Wraps in double quotes if the value contains commas, quotes, or newlines.
+ * Pure function.
+ */
+export function csvEscapeMetrics(value: string | number | boolean | null | undefined): string {
+  if (value === null || value === undefined) return '';
+  const str = String(value);
+  if (str.includes('"') || str.includes(',') || str.includes('\n') || str.includes('\r')) {
+    return '"' + str.replace(/"/g, '""') + '"';
+  }
+  return str;
+}
+
+/**
+ * Format a timestamp as ISO 8601 string for export.
+ * Returns empty string for null/undefined.
+ */
+function formatMetricsExportTs(ts: number | null | undefined): string {
+  if (ts == null) return '';
+  return new Date(ts).toISOString();
+}
+
+/**
+ * Conservative field allowlist for metrics history export.
+ * Explicitly enumerates safe fields — only observable metrics state.
+ * No internal config, file paths, or implementation details leak through.
+ */
+function sanitizeSnapshotForExport(snapshot: MetricsSnapshot): Record<string, unknown> {
+  return {
+    timestamp: formatMetricsExportTs(snapshot.ts),
+    total: snapshot.total,
+    backlog: snapshot.statusCounts.backlog ?? 0,
+    queued: snapshot.statusCounts.queued ?? 0,
+    running: snapshot.statusCounts.running ?? 0,
+    done: snapshot.statusCounts.done ?? 0,
+    failed: snapshot.statusCounts.failed ?? 0,
+    throughputLast24h: snapshot.throughput.last24h,
+    throughputLast7d: snapshot.throughput.last7d,
+    throughputLast30d: snapshot.throughput.last30d,
+    avgRuntimeMs: snapshot.avgRuntimeMs,
+    medianRuntimeMs: snapshot.medianRuntimeMs,
+    successRate: snapshot.successRate,
+    stuckCount: snapshot.stuckCount,
+  };
+}
+
+/** CSV column headers for metrics history export. */
+const METRICS_CSV_HEADERS = [
+  'timestamp', 'total', 'backlog', 'queued', 'running', 'done', 'failed',
+  'throughputLast24h', 'throughputLast7d', 'throughputLast30d',
+  'avgRuntimeMs', 'medianRuntimeMs', 'successRate', 'stuckCount',
+];
+
+/**
+ * Convert metrics history snapshots to CSV format.
+ * Pure function — no I/O, bounded by input array length.
+ */
+export function metricsSnapshotsToCsv(snapshots: MetricsSnapshot[]): string {
+  const rows: string[] = [METRICS_CSV_HEADERS.join(',')];
+
+  for (const snapshot of snapshots) {
+    const safe = sanitizeSnapshotForExport(snapshot);
+    const row = METRICS_CSV_HEADERS.map((h) =>
+      csvEscapeMetrics(safe[h] as string | number | boolean | null),
+    );
+    rows.push(row.join(','));
+  }
+
+  return rows.join('\n');
+}
+
+/**
+ * Convert metrics history snapshots to a safe JSON export format.
+ * Returns a JSON string with sanitized snapshots (conservative allowlist).
+ * Pure function.
+ */
+export function metricsSnapshotsToJson(snapshots: MetricsSnapshot[]): string {
+  const safeSnapshots = snapshots.map(sanitizeSnapshotForExport);
+  return JSON.stringify({
+    exportedAt: new Date().toISOString(),
+    format: 'ventureos-metrics-history-export-v1',
+    count: safeSnapshots.length,
+    snapshots: safeSnapshots,
+  }, null, 2);
+}
+
+/**
+ * Export metrics history with the same filter capabilities as queryHistory.
+ * Returns formatted content (CSV or JSON), content type, and suggested filename.
+ *
+ * Secret-safe: all snapshots pass through sanitizeSnapshotForExport() which
+ * applies a conservative field allowlist. Only observable task metrics
+ * (counts, rates, timestamps) are included — no paths, configs, or internals.
+ */
+export function exportMetricsHistory(
+  dataDir: string,
+  opts: MetricsExportQuery = {},
+): MetricsExportResult {
+  const format: MetricsExportFormat = opts.format === 'csv' ? 'csv' : 'json';
+  const limit = Math.max(1, Math.min(opts.limit ?? METRICS_EXPORT_MAX_SNAPSHOTS, METRICS_EXPORT_MAX_SNAPSHOTS));
+
+  // Reuse the same query logic for filter parity
+  const snapshots = queryHistory(dataDir, {
+    limit,
+    sinceMs: opts.sinceMs,
+    now: opts.now,
+  });
+
+  const dateSuffix = new Date().toISOString().slice(0, 10);
+
+  if (format === 'csv') {
+    return {
+      content: metricsSnapshotsToCsv(snapshots),
+      contentType: 'text/csv; charset=utf-8',
+      filename: `metrics-history-${dateSuffix}.csv`,
+      count: snapshots.length,
+    };
+  }
+
+  return {
+    content: metricsSnapshotsToJson(snapshots),
+    contentType: 'application/json; charset=utf-8',
+    filename: `metrics-history-${dateSuffix}.json`,
+    count: snapshots.length,
+  };
+}

--- a/dashboard/server/routes/task-board.ts
+++ b/dashboard/server/routes/task-board.ts
@@ -40,7 +40,9 @@ import {
 import {
   maybeAppendSnapshot,
   queryHistory,
+  exportMetricsHistory,
 } from '../metrics-history.js';
+import type { MetricsExportFormat } from '../metrics-history.js';
 
 import {
   readAlertConfig,
@@ -847,6 +849,36 @@ export async function handleTaskBoard(
     } catch {
       sendJson(res, { error: 'Failed to query escalation history' }, 500);
     }
+    return true;
+  }
+
+  // ── GET /api/task-board/metrics/history/export — Issue #219, Phase 25 ────────
+  // Export metrics history as CSV or JSON file download.
+  // Query params: same as /metrics/history + ?format=csv|json (default json)
+  // Bounded: max 500 snapshots per export. Secret-safe: conservative field allowlist.
+  if (url.startsWith('/api/task-board/metrics/history/export') && method === 'GET') {
+    const exportParams = new URL(url, 'http://localhost').searchParams;
+    const format = (exportParams.get('format') === 'csv' ? 'csv' : 'json') as MetricsExportFormat;
+    const limit = exportParams.has('limit')
+      ? Math.max(1, Math.min(Number(exportParams.get('limit')) || 500, 500))
+      : 500;
+    const sinceMs = exportParams.has('sinceMs')
+      ? Math.max(0, Number(exportParams.get('sinceMs')) || 0)
+      : undefined;
+
+    const result = exportMetricsHistory(dataDir, {
+      format,
+      limit,
+      sinceMs,
+    });
+
+    res.writeHead(200, {
+      'Content-Type': result.contentType,
+      'Content-Disposition': `attachment; filename="${result.filename}"`,
+      'Cache-Control': 'no-store',
+      'X-Export-Count': String(result.count),
+    });
+    res.end(result.content);
     return true;
   }
 

--- a/dashboard/tests/unit/routes/task-board-metrics-history-export.test.ts
+++ b/dashboard/tests/unit/routes/task-board-metrics-history-export.test.ts
@@ -1,0 +1,526 @@
+/**
+ * Metrics History Export tests — Issue #219, Phase 25.
+ *
+ * Tests for:
+ * - CSV/JSON format correctness (column headers, field values, structure)
+ * - Secret-safe allowlist (no internal fields leak)
+ * - Bounded export (max 500 snapshots)
+ * - Filter parity with queryHistory (sinceMs, limit)
+ * - API endpoint: GET /api/task-board/metrics/history/export
+ * - CSV escaping edge cases
+ */
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import {
+  csvEscapeMetrics,
+  metricsSnapshotsToCsv,
+  metricsSnapshotsToJson,
+  exportMetricsHistory,
+  METRICS_EXPORT_MAX_SNAPSHOTS,
+  queryHistory,
+} from '../../../server/metrics-history.js';
+import type {
+  MetricsSnapshot,
+  MetricsHistoryFile,
+  MetricsExportResult,
+} from '../../../server/metrics-history.js';
+
+import { mockRequest, mockResponse } from '../../helpers.js';
+import { handleTaskBoard } from '../../../server/routes/task-board.js';
+import type { TaskBoardDeps } from '../../../server/types.js';
+
+// ─── Test Setup ──────────────────────────────────────────────────────────────
+
+let tmpDir: string;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'metrics-history-export-test-'));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const NOW = 1_700_000_000_000;
+
+function createDeps(overrides: Partial<TaskBoardDeps> = {}): TaskBoardDeps {
+  return {
+    dataDir: tmpDir,
+    sendJson: (res, data, status = 200) => {
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+    },
+    readRequestBody: async () => '{}',
+    ...overrides,
+  };
+}
+
+function makeSnapshot(overrides: Partial<MetricsSnapshot> = {}): MetricsSnapshot {
+  return {
+    ts: NOW,
+    statusCounts: { backlog: 3, queued: 2, running: 1, done: 10, failed: 2 },
+    total: 18,
+    throughput: { last24h: 5, last7d: 20, last30d: 50 },
+    avgRuntimeMs: 45000,
+    medianRuntimeMs: 30000,
+    successRate: 0.8333,
+    stuckCount: 1,
+    ...overrides,
+  };
+}
+
+function seedHistory(snapshots: MetricsSnapshot[]): void {
+  fs.mkdirSync(tmpDir, { recursive: true });
+  const data: MetricsHistoryFile = { version: 1, snapshots };
+  fs.writeFileSync(
+    path.join(tmpDir, 'task-board-metrics-history.json'),
+    JSON.stringify(data),
+  );
+}
+
+function seedTasks(): void {
+  fs.mkdirSync(tmpDir, { recursive: true });
+  fs.writeFileSync(
+    path.join(tmpDir, 'task-board.json'),
+    JSON.stringify({ tasks: [], updatedAt: Date.now() }),
+  );
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// csvEscapeMetrics — Unit Tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('csvEscapeMetrics()', () => {
+  it('returns empty string for null/undefined', () => {
+    expect(csvEscapeMetrics(null)).toBe('');
+    expect(csvEscapeMetrics(undefined)).toBe('');
+  });
+
+  it('passes through plain strings', () => {
+    expect(csvEscapeMetrics('hello')).toBe('hello');
+  });
+
+  it('wraps strings with commas in double quotes', () => {
+    expect(csvEscapeMetrics('a,b')).toBe('"a,b"');
+  });
+
+  it('escapes double quotes by doubling', () => {
+    expect(csvEscapeMetrics('say "hi"')).toBe('"say ""hi"""');
+  });
+
+  it('wraps strings with newlines', () => {
+    expect(csvEscapeMetrics('a\nb')).toBe('"a\nb"');
+    expect(csvEscapeMetrics('a\rb')).toBe('"a\rb"');
+  });
+
+  it('converts numbers to strings', () => {
+    expect(csvEscapeMetrics(42)).toBe('42');
+    expect(csvEscapeMetrics(0)).toBe('0');
+    expect(csvEscapeMetrics(3.14)).toBe('3.14');
+  });
+
+  it('converts booleans to strings', () => {
+    expect(csvEscapeMetrics(true)).toBe('true');
+    expect(csvEscapeMetrics(false)).toBe('false');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// metricsSnapshotsToCsv — Unit Tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('metricsSnapshotsToCsv()', () => {
+  it('returns header row for empty array', () => {
+    const csv = metricsSnapshotsToCsv([]);
+    const lines = csv.split('\n');
+    expect(lines).toHaveLength(1);
+    expect(lines[0]).toBe(
+      'timestamp,total,backlog,queued,running,done,failed,' +
+      'throughputLast24h,throughputLast7d,throughputLast30d,' +
+      'avgRuntimeMs,medianRuntimeMs,successRate,stuckCount',
+    );
+  });
+
+  it('produces correct CSV rows from snapshots', () => {
+    const snap = makeSnapshot({
+      ts: 1700000000000,
+      total: 18,
+      statusCounts: { backlog: 3, queued: 2, running: 1, done: 10, failed: 2 },
+      throughput: { last24h: 5, last7d: 20, last30d: 50 },
+      avgRuntimeMs: 45000,
+      medianRuntimeMs: 30000,
+      successRate: 0.8333,
+      stuckCount: 1,
+    });
+    const csv = metricsSnapshotsToCsv([snap]);
+    const lines = csv.split('\n');
+    expect(lines).toHaveLength(2);
+
+    // Parse the data row
+    const values = lines[1].split(',');
+    expect(values[0]).toBe(new Date(1700000000000).toISOString()); // timestamp
+    expect(values[1]).toBe('18');   // total
+    expect(values[2]).toBe('3');    // backlog
+    expect(values[3]).toBe('2');    // queued
+    expect(values[4]).toBe('1');    // running
+    expect(values[5]).toBe('10');   // done
+    expect(values[6]).toBe('2');    // failed
+    expect(values[7]).toBe('5');    // throughputLast24h
+    expect(values[8]).toBe('20');   // throughputLast7d
+    expect(values[9]).toBe('50');   // throughputLast30d
+    expect(values[10]).toBe('45000'); // avgRuntimeMs
+    expect(values[11]).toBe('30000'); // medianRuntimeMs
+    expect(values[12]).toBe('0.8333'); // successRate
+    expect(values[13]).toBe('1');   // stuckCount
+  });
+
+  it('handles null numeric fields as empty strings', () => {
+    const snap = makeSnapshot({
+      avgRuntimeMs: null,
+      medianRuntimeMs: null,
+      successRate: null,
+    });
+    const csv = metricsSnapshotsToCsv([snap]);
+    const lines = csv.split('\n');
+    const values = lines[1].split(',');
+    expect(values[10]).toBe(''); // avgRuntimeMs
+    expect(values[11]).toBe(''); // medianRuntimeMs
+    expect(values[12]).toBe(''); // successRate
+  });
+
+  it('produces correct number of rows for multiple snapshots', () => {
+    const snapshots = Array.from({ length: 5 }, (_, i) =>
+      makeSnapshot({ ts: NOW - (5 - i) * 300000, total: i + 1 }),
+    );
+    const csv = metricsSnapshotsToCsv(snapshots);
+    const lines = csv.split('\n');
+    expect(lines).toHaveLength(6); // 1 header + 5 data rows
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// metricsSnapshotsToJson — Unit Tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('metricsSnapshotsToJson()', () => {
+  it('produces valid JSON with format envelope', () => {
+    const snapshots = [makeSnapshot()];
+    const jsonStr = metricsSnapshotsToJson(snapshots);
+    const parsed = JSON.parse(jsonStr);
+
+    expect(parsed).toHaveProperty('exportedAt');
+    expect(parsed).toHaveProperty('format', 'ventureos-metrics-history-export-v1');
+    expect(parsed).toHaveProperty('count', 1);
+    expect(parsed).toHaveProperty('snapshots');
+    expect(parsed.snapshots).toHaveLength(1);
+  });
+
+  it('sanitizes snapshots with correct field allowlist', () => {
+    const snap = makeSnapshot({
+      ts: 1700000000000,
+      total: 18,
+      statusCounts: { backlog: 3, queued: 2, running: 1, done: 10, failed: 2 },
+    });
+    const jsonStr = metricsSnapshotsToJson([snap]);
+    const parsed = JSON.parse(jsonStr);
+    const exported = parsed.snapshots[0];
+
+    // Should have all allowlisted fields
+    expect(exported).toHaveProperty('timestamp');
+    expect(exported).toHaveProperty('total', 18);
+    expect(exported).toHaveProperty('backlog', 3);
+    expect(exported).toHaveProperty('queued', 2);
+    expect(exported).toHaveProperty('running', 1);
+    expect(exported).toHaveProperty('done', 10);
+    expect(exported).toHaveProperty('failed', 2);
+    expect(exported).toHaveProperty('throughputLast24h');
+    expect(exported).toHaveProperty('throughputLast7d');
+    expect(exported).toHaveProperty('throughputLast30d');
+    expect(exported).toHaveProperty('avgRuntimeMs');
+    expect(exported).toHaveProperty('medianRuntimeMs');
+    expect(exported).toHaveProperty('successRate');
+    expect(exported).toHaveProperty('stuckCount');
+
+    // Should NOT have raw internal fields
+    expect(exported).not.toHaveProperty('ts');
+    expect(exported).not.toHaveProperty('statusCounts');
+    expect(exported).not.toHaveProperty('throughput');
+  });
+
+  it('handles null values correctly', () => {
+    const snap = makeSnapshot({
+      avgRuntimeMs: null,
+      medianRuntimeMs: null,
+      successRate: null,
+    });
+    const jsonStr = metricsSnapshotsToJson([snap]);
+    const parsed = JSON.parse(jsonStr);
+    const exported = parsed.snapshots[0];
+
+    expect(exported.avgRuntimeMs).toBeNull();
+    expect(exported.medianRuntimeMs).toBeNull();
+    expect(exported.successRate).toBeNull();
+  });
+
+  it('produces valid JSON for empty input', () => {
+    const jsonStr = metricsSnapshotsToJson([]);
+    const parsed = JSON.parse(jsonStr);
+    expect(parsed.count).toBe(0);
+    expect(parsed.snapshots).toHaveLength(0);
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// exportMetricsHistory — Integration Tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('exportMetricsHistory()', () => {
+  it('exports as JSON by default', () => {
+    seedHistory([makeSnapshot({ ts: NOW })]);
+    const result = exportMetricsHistory(tmpDir);
+    expect(result.contentType).toBe('application/json; charset=utf-8');
+    expect(result.filename).toMatch(/^metrics-history-\d{4}-\d{2}-\d{2}\.json$/);
+    expect(result.count).toBe(1);
+
+    const parsed = JSON.parse(result.content);
+    expect(parsed.format).toBe('ventureos-metrics-history-export-v1');
+    expect(parsed.snapshots).toHaveLength(1);
+  });
+
+  it('exports as CSV when format=csv', () => {
+    seedHistory([makeSnapshot({ ts: NOW })]);
+    const result = exportMetricsHistory(tmpDir, { format: 'csv' });
+    expect(result.contentType).toBe('text/csv; charset=utf-8');
+    expect(result.filename).toMatch(/^metrics-history-\d{4}-\d{2}-\d{2}\.csv$/);
+    expect(result.count).toBe(1);
+
+    const lines = result.content.split('\n');
+    expect(lines).toHaveLength(2); // header + 1 data row
+  });
+
+  it('respects limit parameter', () => {
+    const snapshots = Array.from({ length: 10 }, (_, i) =>
+      makeSnapshot({ ts: NOW - (10 - i) * 60000 }),
+    );
+    seedHistory(snapshots);
+    const result = exportMetricsHistory(tmpDir, { format: 'csv', limit: 3 });
+    expect(result.count).toBe(3);
+    const lines = result.content.split('\n');
+    expect(lines).toHaveLength(4); // header + 3 data rows
+  });
+
+  it('respects sinceMs filter', () => {
+    seedHistory([
+      makeSnapshot({ ts: NOW - 7200000 }), // 2h ago
+      makeSnapshot({ ts: NOW - 1800000 }), // 30min ago
+      makeSnapshot({ ts: NOW }),             // now
+    ]);
+    const result = exportMetricsHistory(tmpDir, {
+      format: 'json',
+      sinceMs: 3600000, // last 1h
+      now: NOW,
+    });
+    expect(result.count).toBe(2); // only the last 2
+  });
+
+  it('bounds limit to METRICS_EXPORT_MAX_SNAPSHOTS', () => {
+    expect(METRICS_EXPORT_MAX_SNAPSHOTS).toBe(500);
+    // Generate more than max
+    const snapshots = Array.from({ length: 10 }, (_, i) =>
+      makeSnapshot({ ts: NOW - (10 - i) * 60000 }),
+    );
+    seedHistory(snapshots);
+    const result = exportMetricsHistory(tmpDir, { limit: 9999 });
+    // Should be capped — all 10 returned since 10 < 500
+    expect(result.count).toBe(10);
+  });
+
+  it('returns empty export for empty history', () => {
+    const result = exportMetricsHistory(tmpDir, { format: 'csv' });
+    expect(result.count).toBe(0);
+    const lines = result.content.split('\n');
+    expect(lines).toHaveLength(1); // header only
+  });
+
+  it('returns empty JSON export for empty history', () => {
+    const result = exportMetricsHistory(tmpDir, { format: 'json' });
+    expect(result.count).toBe(0);
+    const parsed = JSON.parse(result.content);
+    expect(parsed.snapshots).toHaveLength(0);
+  });
+
+  // ── Filter parity with queryHistory ────────────────────────────────────────
+
+  it('produces the same snapshots as queryHistory with matching filters', () => {
+    seedHistory([
+      makeSnapshot({ ts: NOW - 7200000, total: 5 }),
+      makeSnapshot({ ts: NOW - 3600000, total: 8 }),
+      makeSnapshot({ ts: NOW - 1800000, total: 12 }),
+      makeSnapshot({ ts: NOW, total: 15 }),
+    ]);
+
+    const queryOpts = { sinceMs: 5400000, limit: 3, now: NOW }; // last 1.5h, max 3
+    const queryResult = queryHistory(tmpDir, queryOpts);
+    const exportResult = exportMetricsHistory(tmpDir, { format: 'json', ...queryOpts });
+
+    const parsed = JSON.parse(exportResult.content);
+    expect(parsed.count).toBe(queryResult.length);
+    expect(exportResult.count).toBe(queryResult.length);
+
+    // Verify the same snapshots (by timestamp) are present
+    const queryTimestamps = queryResult.map(s => new Date(s.ts).toISOString());
+    const exportTimestamps = parsed.snapshots.map((s: Record<string, unknown>) => s.timestamp);
+    expect(exportTimestamps).toEqual(queryTimestamps);
+  });
+
+  // ── Secret safety ──────────────────────────────────────────────────────────
+
+  it('does not expose raw internal fields in CSV export', () => {
+    seedHistory([makeSnapshot({ ts: NOW })]);
+    const result = exportMetricsHistory(tmpDir, { format: 'csv' });
+    const header = result.content.split('\n')[0];
+
+    // Should not contain raw internal field names
+    expect(header).not.toContain('statusCounts');
+    expect(header).not.toContain('throughput.last');
+    // Should contain flattened safe field names
+    expect(header).toContain('timestamp');
+    expect(header).toContain('total');
+    expect(header).toContain('backlog');
+    expect(header).toContain('throughputLast24h');
+  });
+
+  it('does not expose raw internal fields in JSON export', () => {
+    seedHistory([makeSnapshot({ ts: NOW })]);
+    const result = exportMetricsHistory(tmpDir, { format: 'json' });
+    const content = result.content;
+
+    // Raw internal shapes should not appear
+    expect(content).not.toContain('"ts":');
+    expect(content).not.toContain('"statusCounts":');
+    expect(content).not.toContain('"last24h":');
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// API Endpoint: GET /api/task-board/metrics/history/export
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe('GET /api/task-board/metrics/history/export', () => {
+  it('returns JSON export by default', async () => {
+    seedTasks();
+    seedHistory([makeSnapshot({ ts: NOW, total: 7 })]);
+    const req = mockRequest({ url: '/api/task-board/metrics/history/export', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    expect(res._statusCode).toBe(200);
+    expect(res._headers['content-type']).toBe('application/json; charset=utf-8');
+    expect(res._headers['content-disposition']).toMatch(/attachment; filename="metrics-history-.*\.json"/);
+    expect(res._headers['cache-control']).toBe('no-store');
+    expect(res._headers['x-export-count']).toBe('1');
+
+    const parsed = JSON.parse(res._body);
+    expect(parsed.format).toBe('ventureos-metrics-history-export-v1');
+    expect(parsed.count).toBe(1);
+    expect(parsed.snapshots[0].total).toBe(7);
+  });
+
+  it('returns CSV export when format=csv', async () => {
+    seedTasks();
+    seedHistory([
+      makeSnapshot({ ts: NOW - 60000, total: 5 }),
+      makeSnapshot({ ts: NOW, total: 10 }),
+    ]);
+    const req = mockRequest({ url: '/api/task-board/metrics/history/export?format=csv', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    expect(res._statusCode).toBe(200);
+    expect(res._headers['content-type']).toBe('text/csv; charset=utf-8');
+    expect(res._headers['content-disposition']).toMatch(/attachment; filename="metrics-history-.*\.csv"/);
+    expect(res._headers['x-export-count']).toBe('2');
+
+    const lines = res._body.split('\n');
+    expect(lines).toHaveLength(3); // header + 2 data rows
+    expect(lines[0]).toContain('timestamp');
+    expect(lines[0]).toContain('total');
+  });
+
+  it('respects limit query param', async () => {
+    seedTasks();
+    const snapshots = Array.from({ length: 20 }, (_, i) =>
+      makeSnapshot({ ts: NOW - (20 - i) * 60000 }),
+    );
+    seedHistory(snapshots);
+    const req = mockRequest({ url: '/api/task-board/metrics/history/export?format=csv&limit=5', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    expect(res._headers['x-export-count']).toBe('5');
+    const lines = res._body.split('\n');
+    expect(lines).toHaveLength(6); // header + 5 data rows
+  });
+
+  it('respects sinceMs query param', async () => {
+    seedTasks();
+    const realNow = Date.now();
+    seedHistory([
+      makeSnapshot({ ts: realNow - 7200000 }), // 2h ago
+      makeSnapshot({ ts: realNow - 1800000 }), // 30min ago
+      makeSnapshot({ ts: realNow }),
+    ]);
+    const req = mockRequest({ url: '/api/task-board/metrics/history/export?format=json&sinceMs=3600000', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    expect(res._headers['x-export-count']).toBe('2');
+    const parsed = JSON.parse(res._body);
+    expect(parsed.count).toBe(2);
+  });
+
+  it('clamps limit to 500 max', async () => {
+    seedTasks();
+    seedHistory([makeSnapshot({ ts: NOW })]);
+    const req = mockRequest({ url: '/api/task-board/metrics/history/export?limit=9999', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+    // Should not error — clamped to 500
+    expect(res._statusCode).toBe(200);
+    expect(res._headers['x-export-count']).toBe('1');
+  });
+
+  it('returns empty export for empty history', async () => {
+    seedTasks();
+    const req = mockRequest({ url: '/api/task-board/metrics/history/export?format=csv', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    expect(res._statusCode).toBe(200);
+    expect(res._headers['x-export-count']).toBe('0');
+    const lines = res._body.split('\n');
+    expect(lines).toHaveLength(1); // header only
+  });
+
+  it('does not interfere with existing /metrics/history endpoint', async () => {
+    seedTasks();
+    seedHistory([makeSnapshot({ ts: NOW, total: 7 })]);
+
+    // Existing endpoint should still return JSON API response
+    const req = mockRequest({ url: '/api/task-board/metrics/history', method: 'GET' });
+    const res = mockResponse();
+    await handleTaskBoard(req, res, createDeps());
+
+    expect(res._statusCode).toBe(200);
+    const body = JSON.parse(res._body);
+    // The API endpoint returns { snapshots, count } — not the export envelope
+    expect(body).toHaveProperty('snapshots');
+    expect(body).toHaveProperty('count');
+    expect(body).not.toHaveProperty('format');
+    expect(body).not.toHaveProperty('exportedAt');
+  });
+});


### PR DESCRIPTION
## Summary

Adds read-only export endpoint for task-board metrics history time-series data with CSV and JSON format support. This is Phase 25 of Issue #219 — the metrics history export slice.

## What's New

### Backend
- **`GET /api/task-board/metrics/history/export?format=csv|json`**
  - Same filter params as `/metrics/history` (`sinceMs`, `limit`)
  - Bounded: max 500 snapshots per export
  - Secret-safe: conservative field allowlist via `sanitizeSnapshotForExport()`
  - Flattens `statusCounts`/`throughput` into flat CSV-friendly columns
  - Content-Disposition attachment header with date-stamped filename
  - `X-Export-Count` header for client feedback
  - `Cache-Control: no-store`

### Export Functions (`metrics-history.ts`)
| Function | Purpose |
|---|---|
| `exportMetricsHistory()` | Main entry point — reuses `queryHistory()` for filter parity |
| `metricsSnapshotsToCsv()` | Pure CSV formatter with 14-column allowlist |
| `metricsSnapshotsToJson()` | JSON envelope with versioned format tag |
| `csvEscapeMetrics()` | Standard CSV escaping |
| `sanitizeSnapshotForExport()` | Allowlist: timestamp, total, per-status counts, throughput windows, runtime stats, success rate, stuck count |

### Dashboard UI
- 📥 CSV / 📥 JSON export buttons added to metrics history panel controls
- `tbExportMetricsHistory()` reads current window filter state
- Reuses existing `tbTriggerExportDownload()` infrastructure

### CSV Columns (14-field allowlist)
```
timestamp, total, backlog, queued, running, done, failed,
throughputLast24h, throughputLast7d, throughputLast30d,
avgRuntimeMs, medianRuntimeMs, successRate, stuckCount
```

## Tests (32 tests, all passing)
- `csvEscapeMetrics`: null, undefined, plain strings, commas, quotes, newlines, numbers, booleans
- `metricsSnapshotsToCsv`: header-only for empty, correct values, null handling, multi-row output
- `metricsSnapshotsToJson`: format envelope, field allowlist, null values, empty input
- `exportMetricsHistory`: JSON default, CSV format, limit, sinceMs, bounds capping, empty history, **filter parity with queryHistory**, secret safety
- API endpoint: JSON/CSV responses, headers, limit/sinceMs params, bounds clamping, empty history, non-interference with existing `/metrics/history`

## Regression
- All 976 task-board tests pass (25 test files)
- TypeScript typecheck clean (`tsc --noEmit`)

## Risk Assessment
- **Low risk** — purely additive, read-only endpoint
- No schema migrations
- No auth/security changes  
- No new dependencies
- Reversible: remove route + export functions to revert

## Constraints Verified
- ✅ Additive/reversible only
- ✅ No schema migrations
- ✅ No auth/security changes
- ✅ No new dependencies
- ✅ Secret-safe allowlist (no raw internal fields in export)

Closes: contributes to #219