### PR TITLE
Bridge parity: implement stubbed data endpoints + proxy wiring

### DIFF
--- a/dashboard/server/bridge.ts
+++ b/dashboard/server/bridge.ts
@@ -10,6 +10,7 @@ import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
 import crypto from 'node:crypto';
+import { execSync } from 'node:child_process';
 
 import { handleKpis } from './routes/kpis.js';
 import { handleObservations } from './routes/observations.js';
@@ -33,6 +34,8 @@ const {
   KPI_DIR,
   OBSERVATIONS_DIR,
   LOG_DIR,
+  ACTIVE_WORK_PATH,
+  PRIORITIES_PATH,
   agentSessionsDir,
   agentWorkspaceDir,
 } = paths as typeof import('../../lib/paths.js');
@@ -56,7 +59,16 @@ const WORKSPACE_DIR: string =
 const sessDir: string = agentSessionsDir(AGENT_ID);
 const cronFile: string = path.join(OPENCLAW_DIR, 'cron', 'jobs.json');
 const DATA_DIR: string = path.join(WORKSPACE_DIR, 'data');
+const memoryDir: string = path.join(WORKSPACE_DIR, 'memory');
+const memoryMdPath: string = path.join(WORKSPACE_DIR, 'MEMORY.md');
+const heartbeatPath: string = path.join(WORKSPACE_DIR, 'HEARTBEAT.md');
 const healthHistoryFile: string = path.join(DATA_DIR, 'health-history.json');
+const VENTUREOS_AGENTS: string[] = (
+  process.env.VENTUREOS_AGENTS ?? 'oracle,atlas,sentinel,verifier,archivist,synth'
+)
+  .split(',')
+  .map((s) => s.trim())
+  .filter(Boolean);
 
 // ─── Utilities ─────────────────────────────────────────────────────────────
 
@@ -410,6 +422,684 @@ function getSessionMessages(sessionId: string): Array<{ role: string; content: s
   return messages;
 }
 
+// ─── Dashboard Parity Data Helpers ─────────────────────────────────────────
+
+interface BridgeAgentSessionEntry {
+  sessionId: string;
+  label: string;
+  updatedAt: number;
+  createdAt: number;
+  aborted: boolean;
+  lastMessage: string;
+}
+
+interface BridgeObservationEntry {
+  date: string;
+  time: string;
+  tsMs: number | null;
+  title: string;
+  context: string;
+  action: string;
+  outcome: string;
+  tags: string[];
+  raw: string;
+}
+
+function parseNumber(value: unknown, fallback = 0): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string') {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return fallback;
+}
+
+function getLastMessageFromDir(agentSessDir: string, sessionId: string): string {
+  try {
+    const filePath = path.join(agentSessDir, `${sessionId}.jsonl`);
+    if (!fs.existsSync(filePath)) return '';
+    const lines = fs.readFileSync(filePath, 'utf8').split('\n').filter((line) => line.trim());
+    for (let i = lines.length - 1; i >= Math.max(0, lines.length - 30); i--) {
+      try {
+        const row = JSON.parse(lines[i]) as {
+          type?: string;
+          message?: { role?: string; content?: unknown };
+        };
+        if (row.type !== 'message') continue;
+        const msg = row.message;
+        if (!msg || msg.role !== 'assistant') continue;
+        if (typeof msg.content === 'string') return msg.content.slice(0, 150);
+        if (Array.isArray(msg.content)) {
+          for (const block of msg.content) {
+            if (
+              block &&
+              typeof block === 'object' &&
+              (block as { type?: string }).type === 'text'
+            ) {
+              const text = (block as { text?: string }).text ?? '';
+              if (text) return text.slice(0, 150);
+            }
+          }
+        }
+      } catch {
+        // ignore line parse errors
+      }
+    }
+  } catch {
+    // ignore read errors
+  }
+  return '';
+}
+
+function getAgentSessionsIndex(agentId: string): BridgeAgentSessionEntry[] {
+  try {
+    const safeAgentId = agentId.toLowerCase().replace(/[^a-z0-9\-_]/g, '');
+    if (!safeAgentId) return [];
+    const agentSessDir = path.join(OPENCLAW_DIR, 'agents', safeAgentId, 'sessions');
+    const indexPath = path.join(agentSessDir, 'sessions.json');
+    if (!fs.existsSync(indexPath)) return [];
+    const data = safeReadJson(indexPath, {}) as Record<string, Record<string, unknown>>;
+    const items = Object.entries(data).map(([key, entry]) => {
+      const sessionId = String(entry.sessionId ?? key);
+      const updatedAt = parseNumber(entry.updatedAt, 0);
+      const createdAt = parseNumber(entry.createdAt, updatedAt);
+      return {
+        sessionId,
+        label: String(entry.label ?? sessionId),
+        updatedAt,
+        createdAt,
+        aborted: entry.abortedLastRun === true,
+        lastMessage: getLastMessageFromDir(agentSessDir, sessionId),
+      } satisfies BridgeAgentSessionEntry;
+    });
+    items.sort((a, b) => b.updatedAt - a.updatedAt);
+    return items;
+  } catch {
+    return [];
+  }
+}
+
+function getVentureosAgents(): {
+  updatedAt: number;
+  agentIds: string[];
+  agents: Record<string, {
+    agentId: string;
+    status: string;
+    lastActivityMs: number;
+    sessionCount: number;
+    successRate: number | null;
+    avgLatencyMs: number | null;
+    recentSessions: Array<{
+      label: string;
+      sessionId: string;
+      updatedAt: number;
+      aborted: boolean;
+      lastMessage: string;
+    }>;
+    recentSessions24h: number;
+    successRate24h: number | null;
+    avgLatencySeconds24h: number | null;
+    recentCompletions: Array<{
+      label: string;
+      sessionId: string;
+      updatedAt: number;
+      summary: string;
+    }>;
+  }>;
+} {
+  const now = Date.now();
+  const agents: Record<string, {
+    agentId: string;
+    status: string;
+    lastActivityMs: number;
+    sessionCount: number;
+    successRate: number | null;
+    avgLatencyMs: number | null;
+    recentSessions: Array<{
+      label: string;
+      sessionId: string;
+      updatedAt: number;
+      aborted: boolean;
+      lastMessage: string;
+    }>;
+    recentSessions24h: number;
+    successRate24h: number | null;
+    avgLatencySeconds24h: number | null;
+    recentCompletions: Array<{
+      label: string;
+      sessionId: string;
+      updatedAt: number;
+      summary: string;
+    }>;
+  }> = {};
+
+  for (const agentId of VENTUREOS_AGENTS) {
+    const sessions = getAgentSessionsIndex(agentId);
+    const last24h = sessions.filter((s) => now - s.updatedAt < 24 * 60 * 60 * 1000);
+    const success24h = last24h.filter((s) => !s.aborted).length;
+    const total24h = last24h.length;
+    const allSuccess = sessions.filter((s) => !s.aborted).length;
+    const allTotal = sessions.length;
+    const maxUpdatedAt = sessions.reduce((max, s) => Math.max(max, s.updatedAt), 0);
+
+    agents[agentId] = {
+      agentId,
+      status: maxUpdatedAt > 0 && now - maxUpdatedAt < 120_000 ? 'working' : 'idle',
+      lastActivityMs: maxUpdatedAt,
+      sessionCount: sessions.length,
+      successRate: allTotal > 0 ? allSuccess / allTotal : null,
+      avgLatencyMs: null,
+      recentSessions: sessions.slice(0, 10).map((s) => ({
+        label: s.label,
+        sessionId: s.sessionId,
+        updatedAt: s.updatedAt,
+        aborted: s.aborted,
+        lastMessage: s.lastMessage,
+      })),
+      recentSessions24h: last24h.length,
+      successRate24h: total24h > 0 ? success24h / total24h : null,
+      avgLatencySeconds24h: null,
+      recentCompletions: last24h
+        .filter((s) => !s.aborted && now - s.updatedAt > 5 * 60_000)
+        .slice(0, 6)
+        .map((s) => ({
+          label: s.label,
+          sessionId: s.sessionId,
+          updatedAt: s.updatedAt,
+          summary: s.lastMessage,
+        })),
+    };
+  }
+
+  return {
+    updatedAt: now,
+    agentIds: VENTUREOS_AGENTS,
+    agents,
+  };
+}
+
+function listWorkflowLogFiles(): string[] {
+  const out: string[] = [];
+  const root = '/tmp';
+
+  function walk(dir: string, depth: number): void {
+    if (depth < 0 || out.length >= 800) return;
+    let entries: fs.Dirent[] = [];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const entry of entries) {
+      if (out.length >= 800) return;
+      const full = path.join(dir, entry.name);
+      if (entry.isFile() && entry.name.endsWith('.jsonl')) {
+        out.push(full);
+      } else if (entry.isDirectory() && depth > 0 && !entry.name.startsWith('.')) {
+        walk(full, depth - 1);
+      }
+    }
+  }
+
+  try {
+    const dirs = fs.readdirSync(root).filter((name) => name.startsWith('agent-'));
+    for (const name of dirs) {
+      const dir = path.join(root, name);
+      try {
+        if (fs.statSync(dir).isDirectory()) walk(dir, 2);
+      } catch {
+        // ignore invalid entries
+      }
+    }
+  } catch {
+    // ignore read errors
+  }
+
+  return out;
+}
+
+function getWorkflowPatterns(): {
+  updatedAt: number;
+  totals: {
+    totalWorkflowRuns: number;
+    successful: number;
+    failed: number;
+    successRate: number | null;
+    avgVerifyCycles: number;
+    maxVerifyCycles: number;
+    avgRetries: number;
+    maxRetries: number;
+  };
+  perDay: Array<{
+    day: string;
+    runs: number;
+    success: number;
+    failure: number;
+    avgVerifyCycles: number;
+    maxVerifyCycles: number;
+    avgRetries: number;
+  }>;
+} {
+  const runs: Record<string, {
+    startTs: number | null;
+    ok: boolean | null;
+    verifyCycles: number;
+    verifyRetries: number;
+    spawnRetries: number;
+  }> = {};
+
+  for (const filePath of listWorkflowLogFiles()) {
+    const lines = safeReadText(filePath, '').split('\n').filter((line) => line.trim());
+    for (const line of lines) {
+      let eventRow: Record<string, unknown>;
+      try {
+        eventRow = JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        continue;
+      }
+      const event = String(eventRow.event ?? '');
+      const runId = String(eventRow.runId ?? eventRow.runID ?? eventRow.run ?? '');
+      if (!event || !runId) continue;
+      if (!runs[runId]) {
+        runs[runId] = {
+          startTs: null,
+          ok: null,
+          verifyCycles: 0,
+          verifyRetries: 0,
+          spawnRetries: 0,
+        };
+      }
+
+      const tsRaw = String(eventRow.ts ?? eventRow.timestamp ?? '');
+      const ts = tsRaw ? new Date(tsRaw).getTime() : 0;
+      if (event === 'workflow_start' && Number.isFinite(ts) && ts > 0) runs[runId].startTs = ts;
+      if (event === 'workflow_success') runs[runId].ok = true;
+      if (event === 'workflow_fail' || event === 'workflow_failure') runs[runId].ok = false;
+      if (event === 'verify_status') {
+        runs[runId].verifyCycles = Math.max(
+          runs[runId].verifyCycles,
+          parseInt(String(eventRow.cycle ?? '0'), 10) || 0,
+        );
+      }
+      if (event === 'verify_retry') runs[runId].verifyRetries += 1;
+      if (event === 'spawn_attempt') {
+        const attempt = parseInt(String(eventRow.attempt ?? '1'), 10) || 1;
+        if (attempt > 1) runs[runId].spawnRetries += 1;
+      }
+    }
+  }
+
+  const runList = Object.values(runs).filter((run) => run.startTs && run.startTs > 0);
+  const totalWorkflowRuns = runList.length;
+  const successful = runList.filter((run) => run.ok === true).length;
+  const failed = runList.filter((run) => run.ok === false).length;
+  const successRate = totalWorkflowRuns > 0 ? successful / totalWorkflowRuns : null;
+  const verifyCycles = runList.map((run) => run.verifyCycles).filter((n) => n > 0);
+  const retryCounts = runList.map((run) => run.verifyRetries + run.spawnRetries);
+
+  const perDay: Record<string, {
+    runs: number;
+    success: number;
+    failure: number;
+    verifyCyclesSum: number;
+    verifyCyclesMax: number;
+    retriesSum: number;
+  }> = {};
+  for (const run of runList) {
+    const day = new Date(run.startTs ?? 0).toISOString().slice(0, 10);
+    if (!perDay[day]) {
+      perDay[day] = {
+        runs: 0,
+        success: 0,
+        failure: 0,
+        verifyCyclesSum: 0,
+        verifyCyclesMax: 0,
+        retriesSum: 0,
+      };
+    }
+    perDay[day].runs += 1;
+    if (run.ok === true) perDay[day].success += 1;
+    if (run.ok === false) perDay[day].failure += 1;
+    perDay[day].verifyCyclesSum += run.verifyCycles;
+    perDay[day].verifyCyclesMax = Math.max(perDay[day].verifyCyclesMax, run.verifyCycles);
+    perDay[day].retriesSum += run.verifyRetries + run.spawnRetries;
+  }
+
+  return {
+    updatedAt: Date.now(),
+    totals: {
+      totalWorkflowRuns,
+      successful,
+      failed,
+      successRate,
+      avgVerifyCycles: verifyCycles.length
+        ? Math.round((verifyCycles.reduce((a, b) => a + b, 0) / verifyCycles.length) * 100) / 100
+        : 0,
+      maxVerifyCycles: verifyCycles.length ? Math.max(...verifyCycles) : 0,
+      avgRetries: retryCounts.length
+        ? Math.round((retryCounts.reduce((a, b) => a + b, 0) / retryCounts.length) * 100) / 100
+        : 0,
+      maxRetries: retryCounts.length ? Math.max(...retryCounts) : 0,
+    },
+    perDay: Object.entries(perDay)
+      .sort((a, b) => a[0].localeCompare(b[0]))
+      .slice(-30)
+      .map(([day, row]) => ({
+        day,
+        runs: row.runs,
+        success: row.success,
+        failure: row.failure,
+        avgVerifyCycles: row.runs ? row.verifyCyclesSum / row.runs : 0,
+        maxVerifyCycles: row.verifyCyclesMax,
+        avgRetries: row.runs ? row.retriesSum / row.runs : 0,
+      })),
+  };
+}
+
+function getMissionControl(): {
+  updatedAt: number;
+  activeWorkMd: string;
+  prioritiesMd: string;
+  team: {
+    overall: string;
+    agents: Array<{
+      agentId: string;
+      status: string;
+      lastActivityMs: number;
+      successRate24h: number | null;
+      recentSessions24h: number;
+      avgLatencySeconds24h: number | null;
+    }>;
+  };
+  recentCompletions: Array<{
+    agentId: string;
+    label: string;
+    sessionId: string;
+    updatedAt: number;
+    summary: string;
+  }>;
+} {
+  const agentsData = getVentureosAgents();
+  const completions: Array<{
+    agentId: string;
+    label: string;
+    sessionId: string;
+    updatedAt: number;
+    summary: string;
+  }> = [];
+
+  for (const [agentId, summary] of Object.entries(agentsData.agents)) {
+    for (const completion of summary.recentCompletions) {
+      completions.push({ agentId, ...completion });
+    }
+  }
+
+  completions.sort((a, b) => b.updatedAt - a.updatedAt);
+
+  return {
+    updatedAt: Date.now(),
+    activeWorkMd: safeReadText(ACTIVE_WORK_PATH, ''),
+    prioritiesMd: safeReadText(PRIORITIES_PATH, ''),
+    team: {
+      overall: Object.values(agentsData.agents).some((agent) => agent.status === 'working')
+        ? 'busy'
+        : 'idle',
+      agents: Object.values(agentsData.agents).map((agent) => ({
+        agentId: agent.agentId,
+        status: agent.status,
+        lastActivityMs: agent.lastActivityMs,
+        successRate24h: agent.successRate24h,
+        recentSessions24h: agent.recentSessions24h,
+        avgLatencySeconds24h: agent.avgLatencySeconds24h,
+      })),
+    },
+    recentCompletions: completions.slice(0, 20),
+  };
+}
+
+interface CronJobRaw {
+  id: string;
+  name?: string;
+  schedule?: { expr?: string; tz?: string };
+  enabled?: boolean;
+  state?: {
+    lastStatus?: string;
+    lastRunAtMs?: number;
+    nextRunAtMs?: number;
+    lastDurationMs?: number;
+  };
+}
+
+function getCronJobs(): Array<{
+  id: string;
+  name: string;
+  schedule: string;
+  enabled: boolean;
+  lastStatus: string;
+  lastRunAt: number;
+  nextRunAt: number;
+  lastDuration: number;
+}> {
+  try {
+    if (!fs.existsSync(cronFile)) return [];
+    const data = JSON.parse(fs.readFileSync(cronFile, 'utf8')) as { jobs?: CronJobRaw[] };
+    return (data.jobs ?? []).map((job) => ({
+      id: job.id,
+      name: job.name ?? job.id.slice(0, 8),
+      schedule: job.schedule?.expr ?? '',
+      enabled: job.enabled !== false,
+      lastStatus: job.state?.lastStatus ?? 'unknown',
+      lastRunAt: job.state?.lastRunAtMs ?? 0,
+      nextRunAt: job.state?.nextRunAtMs ?? 0,
+      lastDuration: job.state?.lastDurationMs ?? 0,
+    }));
+  } catch {
+    return [];
+  }
+}
+
+function getGitRepos(): Array<{ path: string; name: string }> {
+  const repos: Array<{ path: string; name: string }> = [];
+  const projectsDir = path.join(WORKSPACE_DIR, 'projects');
+  try {
+    if (fs.existsSync(projectsDir)) {
+      for (const dir of fs.readdirSync(projectsDir)) {
+        const full = path.join(projectsDir, dir);
+        if (fs.existsSync(path.join(full, '.git'))) repos.push({ path: full, name: dir });
+      }
+    }
+  } catch {
+    // ignore
+  }
+  if (fs.existsSync(path.join(WORKSPACE_DIR, '.git'))) {
+    repos.push({ path: WORKSPACE_DIR, name: path.basename(WORKSPACE_DIR) });
+  }
+  return repos;
+}
+
+function getGitActivity(): Array<{ repo: string; hash: string; message: string; timestamp: number }> {
+  const commits: Array<{ repo: string; hash: string; message: string; timestamp: number }> = [];
+  for (const repo of getGitRepos()) {
+    try {
+      const raw = execSync(
+        `git -C ${repo.path} log --oneline --since='7 days ago' -10 --format='%H|%s|%at'`,
+        { encoding: 'utf8', timeout: 5000 },
+      ).trim();
+      if (!raw) continue;
+      for (const line of raw.split('\n')) {
+        const [hash, message, ts] = line.split('|');
+        commits.push({
+          repo: repo.name,
+          hash: (hash ?? '').slice(0, 7),
+          message: message ?? '',
+          timestamp: (parseInt(ts ?? '0', 10) || 0) * 1000,
+        });
+      }
+    } catch {
+      // ignore per-repo failures
+    }
+  }
+  commits.sort((a, b) => b.timestamp - a.timestamp);
+  return commits.slice(0, 15);
+}
+
+function getServicesStatus(): Array<{ name: string; active: boolean }> {
+  const services = ['openclaw', 'agent-dashboard', 'tailscaled'];
+  return services.map((name) => {
+    try {
+      const status = execSync(`systemctl is-active ${name} 2>/dev/null`, {
+        encoding: 'utf8',
+        timeout: 3000,
+      }).trim();
+      return { name, active: status === 'active' };
+    } catch {
+      return { name, active: false };
+    }
+  });
+}
+
+function getMemoryFiles(): Array<{ name: string; modified: number; size: number }> {
+  const files: Array<{ name: string; modified: number; size: number }> = [];
+
+  try {
+    if (fs.existsSync(memoryMdPath)) {
+      const stat = fs.statSync(memoryMdPath);
+      files.push({ name: 'MEMORY.md', modified: stat.mtimeMs, size: stat.size });
+    }
+  } catch {
+    // ignore
+  }
+
+  try {
+    if (fs.existsSync(heartbeatPath)) {
+      const stat = fs.statSync(heartbeatPath);
+      files.push({ name: 'HEARTBEAT.md', modified: stat.mtimeMs, size: stat.size });
+    }
+  } catch {
+    // ignore
+  }
+
+  try {
+    if (fs.existsSync(memoryDir)) {
+      const entries = fs.readdirSync(memoryDir).filter((name) => name.endsWith('.md')).sort().reverse();
+      for (const name of entries) {
+        try {
+          const stat = fs.statSync(path.join(memoryDir, name));
+          files.push({ name: `memory/${name}`, modified: stat.mtimeMs, size: stat.size });
+        } catch {
+          // ignore missing file races
+        }
+      }
+    }
+  } catch {
+    // ignore
+  }
+
+  return files;
+}
+
+function parseObservationFile(date: string, filePath: string): BridgeObservationEntry[] {
+  const content = safeReadText(filePath, '');
+  if (!content) return [];
+  const blocks = content
+    .split(/\n---\s*\n/)
+    .map((block) => block.trim())
+    .filter(Boolean);
+
+  const dayBase = new Date(`${date}T00:00:00`).getTime();
+  const entries: BridgeObservationEntry[] = [];
+
+  for (let idx = 0; idx < blocks.length; idx++) {
+    const block = blocks[idx];
+    const titleMatch = block.match(/^## \[([^\]]+)\] (.+)$/m);
+    if (!titleMatch) continue;
+    const when = (titleMatch[1] ?? '').trim();
+    const title = (titleMatch[2] ?? '').trim();
+    const context = (block.match(/\*\*Context\*\*:\s*([^\n]+)/) ?? [])[1] ?? '';
+    const action = (block.match(/\*\*Action\*\*:\s*([^\n]+)/) ?? [])[1] ?? '';
+    const outcome = (block.match(/\*\*Outcome\*\*:\s*([^\n]+)/) ?? [])[1] ?? '';
+    const tags = (((block.match(/\*\*Tags\*\*:\s*([^\n]+)/) ?? [])[1] ?? '') as string)
+      .split(/\s+/)
+      .filter((tag) => tag.startsWith('#'));
+
+    let tsMs: number | null = null;
+    const explicitTime = when.match(/^(\d{2}):(\d{2})$/);
+    if (explicitTime && Number.isFinite(dayBase)) {
+      tsMs = dayBase + parseInt(explicitTime[1] ?? '0', 10) * 3600000 + parseInt(explicitTime[2] ?? '0', 10) * 60000;
+    } else if (Number.isFinite(dayBase)) {
+      tsMs = dayBase + idx * 1000;
+    }
+
+    entries.push({
+      date,
+      time: when,
+      tsMs,
+      title,
+      context,
+      action,
+      outcome,
+      tags,
+      raw: block,
+    });
+  }
+
+  return entries;
+}
+
+function getAllObservations(): {
+  updatedAt: number;
+  entries: BridgeObservationEntry[];
+  tags: Array<{ tag: string; count: number }>;
+  index: Record<string, unknown> | null;
+} {
+  const now = Date.now();
+  if (observationsCache && now - observationsCache.updatedAt < 5000) return observationsCache;
+
+  const files: string[] = [];
+  try {
+    if (fs.existsSync(OBSERVATIONS_DIR)) {
+      for (const name of fs.readdirSync(OBSERVATIONS_DIR)) {
+        if (/^\d{4}-\d{2}-\d{2}\.md$/.test(name)) files.push(name);
+      }
+    }
+  } catch {
+    // ignore
+  }
+
+  const entries: BridgeObservationEntry[] = [];
+  const tagCounts: Record<string, number> = {};
+  for (const fileName of files.sort()) {
+    const date = fileName.replace('.md', '');
+    const fullPath = path.join(OBSERVATIONS_DIR, fileName);
+    for (const entry of parseObservationFile(date, fullPath)) {
+      entries.push(entry);
+      for (const tag of entry.tags) tagCounts[tag] = (tagCounts[tag] ?? 0) + 1;
+    }
+  }
+
+  entries.sort((a, b) => (b.tsMs ?? 0) - (a.tsMs ?? 0));
+  observationsCache = {
+    updatedAt: now,
+    entries,
+    tags: Object.entries(tagCounts)
+      .sort((a, b) => b[1] - a[1])
+      .slice(0, 60)
+      .map(([tag, count]) => ({ tag, count })),
+    index: safeReadJson(path.join(OBSERVATIONS_DIR, 'index.json'), null),
+  };
+  return observationsCache;
+}
+
+function getObservationFile(relPath: string): string | null {
+  const safe = String(relPath ?? '').trim();
+  if (!/^\d{4}-\d{2}-\d{2}\.md$/.test(safe)) return null;
+  const dir = path.resolve(OBSERVATIONS_DIR);
+  const full = path.resolve(path.join(dir, safe));
+  if (!full.startsWith(`${dir}${path.sep}`)) return null;
+  if (!fs.existsSync(full)) return null;
+  return full;
+}
+
 // ─── Metrics Cache ─────────────────────────────────────────────────────────
 
 let costCache: ReturnType<typeof buildCostData> | null = null;
@@ -418,6 +1108,12 @@ let usageCache: ReturnType<typeof buildUsageWindows> | null = null;
 let usageCacheTime: number = 0;
 let lifetimeStatsCache: ReturnType<typeof buildLifetimeStats> | null = null;
 let lifetimeStatsCacheTime: number = 0;
+let observationsCache: {
+  updatedAt: number;
+  entries: BridgeObservationEntry[];
+  tags: Array<{ tag: string; count: number }>;
+  index: Record<string, unknown> | null;
+} | null = null;
 
 // ─── Server ────────────────────────────────────────────────────────────────
 
@@ -513,7 +1209,7 @@ const server = http.createServer(async (req, res) => {
       return;
     }
     logAudit('session_messages', req, sessionId);
-    sendJson(res, { ok: true, id: sessionId, messages: getSessionMessages(sessionId) });
+    sendJson(res, getSessionMessages(sessionId));
     return;
   }
 
@@ -580,6 +1276,76 @@ const server = http.createServer(async (req, res) => {
     return;
   }
 
+  if (pathname === '/api/bridge/ventureos-agents') {
+    logAudit('ventureos_agents', req);
+    sendJson(res, getVentureosAgents());
+    return;
+  }
+
+  if (pathname === '/api/bridge/workflow-patterns') {
+    logAudit('workflow_patterns', req);
+    sendJson(res, getWorkflowPatterns());
+    return;
+  }
+
+  if (pathname === '/api/bridge/mission-control') {
+    logAudit('mission_control', req);
+    sendJson(res, getMissionControl());
+    return;
+  }
+
+  if (pathname === '/api/bridge/crons') {
+    logAudit('crons', req);
+    sendJson(res, getCronJobs());
+    return;
+  }
+
+  if (pathname === '/api/bridge/git') {
+    logAudit('git', req);
+    sendJson(res, getGitActivity());
+    return;
+  }
+
+  if (pathname === '/api/bridge/services') {
+    logAudit('services', req);
+    sendJson(res, getServicesStatus());
+    return;
+  }
+
+  if (pathname === '/api/bridge/memory') {
+    logAudit('memory', req);
+    sendJson(res, getMemoryFiles());
+    return;
+  }
+
+  if (pathname === '/api/bridge/observations-index') {
+    const observations = getAllObservations();
+    logAudit('observations_index', req);
+    sendJson(res, {
+      updatedAt: observations.updatedAt,
+      tags: observations.tags,
+      index: observations.index,
+      total: observations.entries.length,
+    });
+    return;
+  }
+
+  if (pathname === '/api/bridge/observation') {
+    const relPath = url.searchParams.get('path') ?? '';
+    const filePath = getObservationFile(relPath);
+    if (!filePath) {
+      sendJson(res, { ok: false, error: 'Not found' }, 404);
+      return;
+    }
+    logAudit('observation_file', req, relPath);
+    sendJson(res, {
+      ok: true,
+      path: relPath,
+      content: safeReadText(filePath, ''),
+    });
+    return;
+  }
+
   // SSE live feed (stub)
   if (pathname === '/api/bridge/live') {
     res.writeHead(200, {
@@ -592,25 +1358,6 @@ const server = http.createServer(async (req, res) => {
       res.write(`event: ping\ndata: ${Date.now()}\n\n`);
     }, 15000);
     req.on('close', () => clearInterval(interval));
-    return;
-  }
-
-  // Stub endpoints (to be implemented)
-  const stubbed = new Set([
-    '/api/bridge/ventureos-agents',
-    '/api/bridge/observations',
-    '/api/bridge/observations-index',
-    '/api/bridge/observation',
-    '/api/bridge/crons',
-    '/api/bridge/git',
-    '/api/bridge/services',
-    '/api/bridge/memory',
-    '/api/bridge/mission-control',
-    '/api/bridge/workflow-patterns',
-  ]);
-
-  if (stubbed.has(pathname)) {
-    sendJson(res, { ok: false, error: 'Not implemented', path: pathname }, 501);
     return;
   }
 

--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -2831,18 +2831,46 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
     return;
   }
   if (req.url === '/api/ventureos-agents') {
+    if (
+      await proxyBridgeJson(req, res, bridgeProxyDeps, {
+        targetPath: '/api/bridge/ventureos-agents',
+        forwardQuery: true,
+      })
+    )
+      return;
     sendJson(res, getVentureosAgents());
     return;
   }
   if (req.url === '/api/workflow-patterns') {
+    if (
+      await proxyBridgeJson(req, res, bridgeProxyDeps, {
+        targetPath: '/api/bridge/workflow-patterns',
+        forwardQuery: true,
+      })
+    )
+      return;
     sendJson(res, getWorkflowPatterns());
     return;
   }
   if (req.url === '/api/mission-control') {
+    if (
+      await proxyBridgeJson(req, res, bridgeProxyDeps, {
+        targetPath: '/api/bridge/mission-control',
+        forwardQuery: true,
+      })
+    )
+      return;
     sendJson(res, getMissionControl());
     return;
   }
   if (req.url === '/api/observations-index') {
+    if (
+      await proxyBridgeJson(req, res, bridgeProxyDeps, {
+        targetPath: '/api/bridge/observations-index',
+        forwardQuery: true,
+      })
+    )
+      return;
     const obs = getAllObservations();
     sendJson(res, {
       updatedAt: obs.updatedAt,
@@ -2853,6 +2881,13 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
     return;
   }
   if (req.url && req.url.startsWith('/api/observations?')) {
+    if (
+      await proxyBridgeJson(req, res, bridgeProxyDeps, {
+        targetPath: '/api/bridge/observations',
+        forwardQuery: true,
+      })
+    )
+      return;
     const params = new URL(req.url, 'http://localhost').searchParams;
     const q: string = params.get('q') ?? '';
     const tag: string = params.get('tag') ?? '';
@@ -2970,6 +3005,13 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
   }
 
   if (req.url === '/api/sessions') {
+    if (
+      await proxyBridgeJson(req, res, bridgeProxyDeps, {
+        targetPath: '/api/bridge/sessions',
+        forwardQuery: true,
+      })
+    )
+      return;
     sendJson(res, getSessionsJson());
     return;
   }
@@ -3021,10 +3063,24 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
 
   // VentureOS API aliases
   if (req.url === '/api/ventureos-mission-control') {
+    if (
+      await proxyBridgeJson(req, res, bridgeProxyDeps, {
+        targetPath: '/api/bridge/mission-control',
+        forwardQuery: true,
+      })
+    )
+      return;
     sendJson(res, getMissionControl());
     return;
   }
   if (req.url === '/api/ventureos-workflow-patterns') {
+    if (
+      await proxyBridgeJson(req, res, bridgeProxyDeps, {
+        targetPath: '/api/bridge/workflow-patterns',
+        forwardQuery: true,
+      })
+    )
+      return;
     sendJson(res, getWorkflowPatterns());
     return;
   }
@@ -3043,6 +3099,13 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
     return;
   }
   if (req.url && req.url.startsWith('/api/ventureos-observation?')) {
+    if (
+      await proxyBridgeJson(req, res, bridgeProxyDeps, {
+        targetPath: '/api/bridge/observation',
+        forwardQuery: true,
+      })
+    )
+      return;
     try {
       const params = new URL(req.url, 'http://localhost').searchParams;
       const rel: string = params.get('path') ?? '';
@@ -3060,6 +3123,13 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
   }
 
   if (req.url && req.url.startsWith('/api/session-messages?')) {
+    if (
+      await proxyBridgeJson(req, res, bridgeProxyDeps, {
+        targetPath: '/api/bridge/session-messages',
+        forwardQuery: true,
+      })
+    )
+      return;
     const params = new URL(req.url, 'http://localhost').searchParams;
     const rawId: string = params.get('id') ?? '';
     const sessionId: string = rawId.replace(/[^a-zA-Z0-9\-_:.]/g, '');
@@ -3120,18 +3190,46 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
     return;
   }
   if (req.url === '/api/crons') {
+    if (
+      await proxyBridgeJson(req, res, bridgeProxyDeps, {
+        targetPath: '/api/bridge/crons',
+        forwardQuery: true,
+      })
+    )
+      return;
     sendJson(res, getCronJobs());
     return;
   }
   if (req.url === '/api/git') {
+    if (
+      await proxyBridgeJson(req, res, bridgeProxyDeps, {
+        targetPath: '/api/bridge/git',
+        forwardQuery: true,
+      })
+    )
+      return;
     sendJson(res, getGitActivity());
     return;
   }
   if (req.url === '/api/services') {
+    if (
+      await proxyBridgeJson(req, res, bridgeProxyDeps, {
+        targetPath: '/api/bridge/services',
+        forwardQuery: true,
+      })
+    )
+      return;
     sendJson(res, getServicesStatus());
     return;
   }
   if (req.url === '/api/memory') {
+    if (
+      await proxyBridgeJson(req, res, bridgeProxyDeps, {
+        targetPath: '/api/bridge/memory',
+        forwardQuery: true,
+      })
+    )
+      return;
     sendJson(res, getMemoryFiles());
     return;
   }


### PR DESCRIPTION
## Summary
- implement bridge data endpoints that were previously 501 stubs
- add bridge responses for ventureos agents, mission control, workflow patterns, crons, git, services, memory, observations-index, and observation file
- wire dashboard endpoints to proxy these resources when DASHBOARD_DATA_MODE=bridge
- keep existing filesystem-mode local fallbacks unchanged

## Tracking
Closes #310

## Validation
- npm run build --workspace=dashboard
- npm run test:unit --workspace=dashboard *(fails locally in this environment: vitest command not found)*
