### PR TITLE
feat(task-board): mission-linked assignee-aware tasks board

### DIFF
--- a/dashboard/client/index.html
+++ b/dashboard/client/index.html
@@ -5255,12 +5255,21 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
               <option value="backlog">📋 Backlog</option>
               <option value="queued">⏳ Queued</option>
               <option value="running">⚡ Running</option>
+              <option value="blocked">⛔ Blocked</option>
+              <option value="review">🧪 Review</option>
               <option value="done">✅ Done</option>
               <option value="failed">❌ Failed</option>
             </select>
             <select id="tbFilterAgent" class="tb-input" style="width:auto;min-width:110px;padding:6px 8px;font-size:12px;" onchange="tbApplyFilters()" title="Filter by agent">
               <option value="">All agents</option>
             </select>
+            <select id="tbFilterAssigneeType" class="tb-input" style="width:auto;min-width:110px;padding:6px 8px;font-size:12px;" onchange="tbApplyFilters()" title="Filter by owner type">
+              <option value="">All owners</option>
+              <option value="human">🧑 Human</option>
+              <option value="nexus">🧠 Nexus</option>
+              <option value="agent">🤖 Agent</option>
+            </select>
+            <input id="tbFilterMission" class="tb-input" style="width:auto;min-width:120px;padding:6px 8px;font-size:12px;" placeholder="Mission ID" onchange="tbApplyFilters()" title="Filter by mission id">
             <select id="tbFilterPriority" class="tb-input" style="width:auto;min-width:100px;padding:6px 8px;font-size:12px;" onchange="tbApplyFilters()" title="Filter by priority">
               <option value="">All priorities</option>
               <option value="critical">🔴 Critical</option>
@@ -5281,7 +5290,7 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
       </div>
 
       <!-- Summary cards -->
-      <div class="grid mb-24" style="grid-template-columns: repeat(5, 1fr);">
+      <div class="grid mb-24" style="grid-template-columns: repeat(7, 1fr);">
         <div class="card" style="padding:16px;">
           <div class="metric" style="gap:6px;">
             <div class="metric-value" style="font-size:28px;color:var(--text-muted);" id="tbCountBacklog">0</div>
@@ -5298,6 +5307,18 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
           <div class="metric" style="gap:6px;">
             <div class="metric-value" style="font-size:28px;color:var(--yellow);" id="tbCountRunning">0</div>
             <div class="metric-label">Running</div>
+          </div>
+        </div>
+        <div class="card" style="padding:16px;">
+          <div class="metric" style="gap:6px;">
+            <div class="metric-value" style="font-size:28px;color:var(--yellow);" id="tbCountBlocked">0</div>
+            <div class="metric-label">Blocked</div>
+          </div>
+        </div>
+        <div class="card" style="padding:16px;">
+          <div class="metric" style="gap:6px;">
+            <div class="metric-value" style="font-size:28px;color:var(--purple);" id="tbCountReview">0</div>
+            <div class="metric-label">Review</div>
           </div>
         </div>
         <div class="card" style="padding:16px;">
@@ -5534,6 +5555,49 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
             <label class="tb-label">Agent ID (optional)</label>
             <input type="text" id="tbNewAgent" class="tb-input" placeholder="e.g. synth, nexus…">
           </div>
+          <div>
+            <label class="tb-label">Mission ID</label>
+            <input type="text" id="tbNewMissionId" class="tb-input" placeholder="e.g. mc-2026-021" maxlength="120">
+          </div>
+          <div>
+            <label class="tb-label">Mission Origin</label>
+            <input type="text" id="tbNewMissionBrief" class="tb-input" placeholder="Mission brief title/path…" maxlength="300">
+          </div>
+          <div>
+            <label class="tb-label">Owner Type</label>
+            <select id="tbNewAssigneeType" class="tb-input">
+              <option value="agent" selected>Agent</option>
+              <option value="nexus">Nexus</option>
+              <option value="human">Human</option>
+            </select>
+          </div>
+          <div>
+            <label class="tb-label">Owner ID</label>
+            <input type="text" id="tbNewAssigneeId" class="tb-input" placeholder="agent id / nexus / your name" maxlength="120">
+          </div>
+          <div>
+            <label class="tb-label">Initial Status</label>
+            <select id="tbNewStatus" class="tb-input">
+              <option value="queued" selected>Queued</option>
+              <option value="running">Running</option>
+              <option value="blocked">Blocked</option>
+              <option value="review">Review</option>
+              <option value="done">Done</option>
+              <option value="backlog">Backlog</option>
+            </select>
+          </div>
+          <div>
+            <label class="tb-label">Replay Session ID</label>
+            <input type="text" id="tbNewReplayId" class="tb-input" placeholder="optional replay session id" maxlength="120">
+          </div>
+          <div style="grid-column:1/-1;">
+            <label class="tb-label">Dependencies (comma-separated task IDs)</label>
+            <input type="text" id="tbNewDependencies" class="tb-input" placeholder="task-a, task-b">
+          </div>
+          <div style="grid-column:1/-1;">
+            <label class="tb-label">Artifacts / Links (one per line)</label>
+            <textarea id="tbNewArtifacts" class="tb-input" placeholder="https://...&#10;docs/...&#10;replay:..." rows="2" maxlength="2000" style="resize:vertical;"></textarea>
+          </div>
           <div style="grid-column:1/-1;display:flex;gap:8px;justify-content:flex-end;margin-top:4px;">
             <button onclick="tbHideCreateForm()" class="tb-btn tb-btn-secondary">Cancel</button>
             <button onclick="tbCreateTask()" class="tb-btn tb-btn-primary">Create</button>
@@ -5546,6 +5610,9 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
         <span class="tb-bulk-count" id="tbBulkCount">0 selected</span>
         <div class="tb-bulk-actions">
           <button class="tb-bulk-btn" onclick="tbBulkTransition('queued')" id="tbBulkToQueued" title="Move selected to Queued">⏳ → Queued</button>
+          <button class="tb-bulk-btn" onclick="tbBulkTransition('running')" id="tbBulkToRunning" title="Move selected to Running">⚡ → Running</button>
+          <button class="tb-bulk-btn" onclick="tbBulkTransition('blocked')" id="tbBulkToBlocked" title="Move selected to Blocked">⛔ → Blocked</button>
+          <button class="tb-bulk-btn" onclick="tbBulkTransition('review')" id="tbBulkToReview" title="Move selected to Review">🧪 → Review</button>
           <button class="tb-bulk-btn" onclick="tbBulkTransition('backlog')" id="tbBulkToBacklog" title="Move selected to Backlog">📋 → Backlog</button>
           <button class="tb-bulk-btn" onclick="tbBulkTransition('done')" id="tbBulkToDone" title="Mark selected as Done">✅ → Done</button>
           <div class="tb-bulk-divider"></div>
@@ -5582,6 +5649,22 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
             <span class="tb-column-count" id="tbColRunning">0</span>
           </div>
           <div class="tb-column-cards" id="tbCardsRunning"></div>
+        </div>
+        <div class="tb-column" data-status="blocked">
+          <div class="tb-column-header">
+            <span class="tb-column-dot" style="background:var(--red);"></span>
+            <span>Blocked</span>
+            <span class="tb-column-count" id="tbColBlocked">0</span>
+          </div>
+          <div class="tb-column-cards" id="tbCardsBlocked"></div>
+        </div>
+        <div class="tb-column" data-status="review">
+          <div class="tb-column-header">
+            <span class="tb-column-dot" style="background:var(--purple);"></span>
+            <span>Review</span>
+            <span class="tb-column-count" id="tbColReview">0</span>
+          </div>
+          <div class="tb-column-cards" id="tbCardsReview"></div>
         </div>
         <div class="tb-column" data-status="done">
           <div class="tb-column-header">
@@ -5677,6 +5760,22 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
           <span id="tbDetailAgent" class="tb-detail-meta-value"></span>
         </div>
         <div class="tb-detail-meta-item">
+          <span class="tb-detail-meta-label">Mission</span>
+          <span id="tbDetailMissionId" class="tb-detail-meta-value mono"></span>
+        </div>
+        <div class="tb-detail-meta-item">
+          <span class="tb-detail-meta-label">Origin</span>
+          <span id="tbDetailMissionBrief" class="tb-detail-meta-value"></span>
+        </div>
+        <div class="tb-detail-meta-item">
+          <span class="tb-detail-meta-label">Owner</span>
+          <span id="tbDetailOwner" class="tb-detail-meta-value"></span>
+        </div>
+        <div class="tb-detail-meta-item">
+          <span class="tb-detail-meta-label">Replay</span>
+          <span id="tbDetailReplay" class="tb-detail-meta-value mono"></span>
+        </div>
+        <div class="tb-detail-meta-item">
           <span class="tb-detail-meta-label">Created</span>
           <span id="tbDetailCreated" class="tb-detail-meta-value mono"></span>
         </div>
@@ -5731,6 +5830,30 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
           <span class="tb-detail-expand-icon">▸</span>
         </summary>
         <div id="tbDetailLog" class="tb-detail-expand-body tb-detail-log-body"></div>
+      </details>
+
+      <details id="tbDetailDepsSection" class="tb-detail-expandable">
+        <summary class="tb-detail-expand-header">
+          <span>🧩 Dependencies</span>
+          <span class="tb-detail-expand-icon">▸</span>
+        </summary>
+        <div id="tbDetailDeps" class="tb-detail-expand-body"></div>
+      </details>
+
+      <details id="tbDetailArtifactsSection" class="tb-detail-expandable">
+        <summary class="tb-detail-expand-header">
+          <span>📦 Artifacts & Links</span>
+          <span class="tb-detail-expand-icon">▸</span>
+        </summary>
+        <div id="tbDetailArtifacts" class="tb-detail-expand-body"></div>
+      </details>
+
+      <details id="tbDetailHistorySection" class="tb-detail-expandable">
+        <summary class="tb-detail-expand-header">
+          <span>🕓 Status History</span>
+          <span class="tb-detail-expand-icon">▸</span>
+        </summary>
+        <div id="tbDetailHistory" class="tb-detail-expand-body"></div>
       </details>
     </div>
 
@@ -9187,15 +9310,23 @@ function escHtml(s) { if (!s) return ''; const d = document.createElement('div')
 // ═══════════════════════════════════════════════════════════════════════════
 
 const TB_TRANSITIONS = {
-  backlog: ['queued', 'done'],
-  queued: ['running', 'backlog', 'done'],
-  running: ['done', 'failed'],
+  backlog: ['queued', 'blocked', 'review', 'done'],
+  queued: ['running', 'blocked', 'backlog', 'done'],
+  running: ['review', 'blocked', 'done', 'failed'],
+  blocked: ['queued', 'running', 'review', 'done'],
+  review: ['running', 'done', 'blocked'],
   done: ['backlog'],
-  failed: ['backlog', 'queued'],
+  failed: ['backlog', 'queued', 'blocked'],
 };
 
 const TB_STATUS_EMOJI = {
-  backlog: '📋', queued: '⏳', running: '⚡', done: '✅', failed: '❌',
+  backlog: '📋',
+  queued: '⏳',
+  running: '⚡',
+  blocked: '⛔',
+  review: '🧪',
+  done: '✅',
+  failed: '❌',
 };
 
 const TB_PRIORITY_ORDER = { critical: 0, high: 1, medium: 2, low: 3 };
@@ -9204,7 +9335,7 @@ let tbTasks = [];
 let tbAutoRefreshTimer = null;
 
 // ── Filter state (Issue #219 — SSE subscription filtering) ──────────────────
-let tbActiveFilters = { status: '', agentId: '', priority: '' };
+let tbActiveFilters = { status: '', agentId: '', priority: '', missionId: '', assigneeType: '' };
 let tbKnownAgents = new Set(); // populated from task data
 
 /** Build URL query string from active filters (empty fields omitted). */
@@ -9213,6 +9344,8 @@ function tbFilterQueryString() {
   if (tbActiveFilters.status) parts.push('status=' + encodeURIComponent(tbActiveFilters.status));
   if (tbActiveFilters.agentId) parts.push('agentId=' + encodeURIComponent(tbActiveFilters.agentId));
   if (tbActiveFilters.priority) parts.push('priority=' + encodeURIComponent(tbActiveFilters.priority));
+  if (tbActiveFilters.missionId) parts.push('missionId=' + encodeURIComponent(tbActiveFilters.missionId));
+  if (tbActiveFilters.assigneeType) parts.push('assigneeType=' + encodeURIComponent(tbActiveFilters.assigneeType));
   return parts.length ? '?' + parts.join('&') : '';
 }
 
@@ -9221,6 +9354,8 @@ function tbReadFilterUi() {
   tbActiveFilters.status = (document.getElementById('tbFilterStatus') || {}).value || '';
   tbActiveFilters.agentId = (document.getElementById('tbFilterAgent') || {}).value || '';
   tbActiveFilters.priority = (document.getElementById('tbFilterPriority') || {}).value || '';
+  tbActiveFilters.missionId = (document.getElementById('tbFilterMission') || {}).value || '';
+  tbActiveFilters.assigneeType = (document.getElementById('tbFilterAssigneeType') || {}).value || '';
 }
 
 /** Called when any filter dropdown changes — reconnect SSE with new filter params. */
@@ -9238,9 +9373,13 @@ function tbClearFilters() {
   const statusEl = document.getElementById('tbFilterStatus');
   const agentEl = document.getElementById('tbFilterAgent');
   const priorityEl = document.getElementById('tbFilterPriority');
+  const missionEl = document.getElementById('tbFilterMission');
+  const assigneeEl = document.getElementById('tbFilterAssigneeType');
   if (statusEl) statusEl.value = '';
   if (agentEl) agentEl.value = '';
   if (priorityEl) priorityEl.value = '';
+  if (missionEl) missionEl.value = '';
+  if (assigneeEl) assigneeEl.value = '';
   tbApplyFilters();
 }
 
@@ -9281,6 +9420,8 @@ async function tbRefresh() {
     document.getElementById('tbCountBacklog').textContent = cols.backlog ?? 0;
     document.getElementById('tbCountQueued').textContent = cols.queued ?? 0;
     document.getElementById('tbCountRunning').textContent = cols.running ?? 0;
+    document.getElementById('tbCountBlocked').textContent = cols.blocked ?? 0;
+    document.getElementById('tbCountReview').textContent = cols.review ?? 0;
     document.getElementById('tbCountDone').textContent = cols.done ?? 0;
     document.getElementById('tbCountFailed').textContent = cols.failed ?? 0;
 
@@ -9303,7 +9444,15 @@ async function tbRefresh() {
 }
 
 function tbRenderBoard() {
-  const groups = { backlog: [], queued: [], running: [], done: [], failed: [] };
+  const groups = {
+    backlog: [],
+    queued: [],
+    running: [],
+    blocked: [],
+    review: [],
+    done: [],
+    failed: [],
+  };
   for (const t of tbTasks) {
     if (groups[t.status]) groups[t.status].push(t);
   }
@@ -9349,6 +9498,18 @@ function tbRenderCard(card) {
   const ago = tbTimeAgo(card.createdAt);
   const desc = card.description ? `<div class="tb-card-desc">${tbEsc(card.description)}</div>` : '';
   const agent = card.agentId ? `<span class="tb-badge tb-badge-agent">🤖 ${tbEsc(card.agentId)}</span>` : '';
+  const mission = card.missionId ? `<span class="tb-badge" style="background:rgba(99,102,241,0.15);color:var(--accent);">🎯 ${tbEsc(card.missionId)}</span>` : '';
+  const ownerType = card.assigneeType ? card.assigneeType : (card.agentId ? 'agent' : '');
+  const ownerLabel = card.assigneeId || ownerType;
+  const owner = ownerLabel
+    ? `<span class="tb-badge" style="background:rgba(168,85,247,0.15);color:var(--purple);">👤 ${tbEsc(ownerLabel)}</span>`
+    : '';
+  const deps = Array.isArray(card.dependencies) && card.dependencies.length > 0
+    ? `<span class="tb-badge" style="background:rgba(245,158,11,0.15);color:var(--yellow);">🧩 ${card.dependencies.length}</span>`
+    : '';
+  const artifacts = Array.isArray(card.artifactLinks) && card.artifactLinks.length > 0
+    ? `<span class="tb-badge" style="background:rgba(16,185,129,0.15);color:var(--green);">📦 ${card.artifactLinks.length}</span>`
+    : '';
   const result = card.resultSummary ? `<div style="margin-top:6px;font-size:11px;color:var(--green);"><b>Result:</b> ${tbEsc(card.resultSummary)}</div>` : '';
   const errorMsg = card.error ? `<div style="margin-top:6px;font-size:11px;color:var(--red);"><b>Error:</b> ${tbEsc(card.error)}</div>` : '';
   const tokens = card.tokensUsed ? `<span class="tb-badge" style="background:rgba(168,85,247,0.12);color:var(--purple);">🪙 ${card.tokensUsed.toLocaleString()}</span>` : '';
@@ -9383,6 +9544,10 @@ function tbRenderCard(card) {
     <div class="tb-card-meta">
       <span class="tb-badge ${priClass}">${card.priority}</span>
       ${agent}
+      ${owner}
+      ${mission}
+      ${deps}
+      ${artifacts}
       ${stuckBadge}
       ${tokens}
       ${elapsed}
@@ -9428,16 +9593,40 @@ function tbHideCreateForm() {
   document.getElementById('tbNewDesc').value = '';
   document.getElementById('tbNewPriority').value = 'medium';
   document.getElementById('tbNewAgent').value = '';
+  document.getElementById('tbNewMissionId').value = '';
+  document.getElementById('tbNewMissionBrief').value = '';
+  document.getElementById('tbNewAssigneeType').value = 'agent';
+  document.getElementById('tbNewAssigneeId').value = '';
+  document.getElementById('tbNewDependencies').value = '';
+  document.getElementById('tbNewArtifacts').value = '';
+  document.getElementById('tbNewReplayId').value = '';
+  document.getElementById('tbNewStatus').value = 'queued';
 }
 
 async function tbCreateTask() {
   const title = document.getElementById('tbNewTitle').value.trim();
   if (!title) { document.getElementById('tbNewTitle').focus(); return; }
+  const dependencies = (document.getElementById('tbNewDependencies').value || '')
+    .split(',')
+    .map(s => s.trim())
+    .filter(Boolean);
+  const artifactLinks = (document.getElementById('tbNewArtifacts').value || '')
+    .split('\n')
+    .map(s => s.trim())
+    .filter(Boolean);
   const body = {
     title,
     description: document.getElementById('tbNewDesc').value.trim(),
     priority: document.getElementById('tbNewPriority').value,
     agentId: document.getElementById('tbNewAgent').value.trim() || null,
+    missionId: document.getElementById('tbNewMissionId').value.trim() || null,
+    missionBrief: document.getElementById('tbNewMissionBrief').value.trim() || null,
+    assigneeType: document.getElementById('tbNewAssigneeType').value || 'agent',
+    assigneeId: document.getElementById('tbNewAssigneeId').value.trim() || null,
+    dependencies,
+    artifactLinks,
+    replaySessionId: document.getElementById('tbNewReplayId').value.trim() || null,
+    status: document.getElementById('tbNewStatus').value || 'queued',
   };
   try {
     const res = await fetch('/api/task-board', {
@@ -9677,6 +9866,8 @@ function tbOpenDetail(cardId, event) {
     backlog: 'background:rgba(113,113,122,0.15);color:var(--text-muted);',
     queued: 'background:rgba(59,130,246,0.15);color:var(--blue);',
     running: 'background:rgba(245,158,11,0.15);color:var(--yellow);',
+    blocked: 'background:rgba(239,68,68,0.15);color:var(--red);',
+    review: 'background:rgba(168,85,247,0.15);color:var(--purple);',
     done: 'background:rgba(16,185,129,0.15);color:var(--green);',
     failed: 'background:rgba(239,68,68,0.15);color:var(--red);',
   };
@@ -9700,6 +9891,14 @@ function tbOpenDetail(cardId, event) {
   // Agent
   document.getElementById('tbDetailAgent').textContent = card.agentId || '—';
   document.getElementById('tbDetailAgent').style.color = card.agentId ? 'var(--cyan)' : 'var(--text-muted)';
+  document.getElementById('tbDetailMissionId').textContent = card.missionId || '—';
+  document.getElementById('tbDetailMissionBrief').textContent = card.missionBrief || '—';
+  const ownerType = card.assigneeType || (card.agentId ? 'agent' : null);
+  const ownerId = card.assigneeId || card.agentId || null;
+  document.getElementById('tbDetailOwner').textContent = ownerType
+    ? `${ownerType}${ownerId ? `: ${ownerId}` : ''}`
+    : '—';
+  document.getElementById('tbDetailReplay').textContent = card.replaySessionId || '—';
 
   // Timestamps
   document.getElementById('tbDetailCreated').textContent = card.createdAt ? tbFormatTimestamp(card.createdAt) : '—';
@@ -9764,6 +9963,59 @@ function tbOpenDetail(cardId, event) {
     logSection.style.display = 'none';
   }
 
+  // Dependencies
+  const depsSection = document.getElementById('tbDetailDepsSection');
+  const depsEl = document.getElementById('tbDetailDeps');
+  if (Array.isArray(card.dependencies) && card.dependencies.length > 0) {
+    depsSection.style.display = '';
+    depsEl.innerHTML = card.dependencies
+      .map(dep => `<div class="mono" style="font-size:12px;margin-bottom:4px;">• ${tbEsc(dep)}</div>`)
+      .join('');
+  } else {
+    depsSection.style.display = 'none';
+    depsSection.open = false;
+  }
+
+  // Artifacts / Links
+  const artifactsSection = document.getElementById('tbDetailArtifactsSection');
+  const artifactsEl = document.getElementById('tbDetailArtifacts');
+  if (Array.isArray(card.artifactLinks) && card.artifactLinks.length > 0) {
+    artifactsSection.style.display = '';
+    artifactsEl.innerHTML = card.artifactLinks
+      .map(link => {
+        const safe = tbEsc(link);
+        const isUrl = /^https?:\/\//i.test(link);
+        return isUrl
+          ? `<div style="margin-bottom:4px;"><a href="${safe}" target="_blank" rel="noopener noreferrer" style="color:var(--accent);text-decoration:none;">${safe}</a></div>`
+          : `<div class="mono" style="font-size:12px;margin-bottom:4px;">${safe}</div>`;
+      })
+      .join('');
+  } else {
+    artifactsSection.style.display = 'none';
+    artifactsSection.open = false;
+  }
+
+  // Status history
+  const historySection = document.getElementById('tbDetailHistorySection');
+  const historyEl = document.getElementById('tbDetailHistory');
+  if (Array.isArray(card.statusHistory) && card.statusHistory.length > 0) {
+    historySection.style.display = '';
+    const sortedHistory = [...card.statusHistory]
+      .sort((a, b) => (a.at || 0) - (b.at || 0));
+    historyEl.innerHTML = sortedHistory
+      .map((h) => {
+        const ts = h.at ? tbFormatTimestamp(h.at) : '—';
+        const note = h.note ? ` · ${tbEsc(h.note)}` : '';
+        return `<div class="mono" style="font-size:12px;margin-bottom:4px;">
+          <span style="color:var(--text-muted);">${tbEsc(ts)}</span> · ${tbEsc(h.status)} · ${tbEsc(h.by || 'system')}${note}
+        </div>`;
+      })
+      .join('');
+  } else {
+    historySection.style.display = 'none';
+    historySection.open = false;
+  }
+
   // Transition buttons in footer
   const transContainer = document.getElementById('tbDetailTransitions');
   const transitions = TB_TRANSITIONS[card.status] || [];
@@ -9787,6 +10039,9 @@ function tbCloseDetail() {
   document.getElementById('tbDetailResultSection').open = false;
   document.getElementById('tbDetailErrorSection').open = false;
   document.getElementById('tbDetailLogSection').open = false;
+  document.getElementById('tbDetailDepsSection').open = false;
+  document.getElementById('tbDetailArtifactsSection').open = false;
+  document.getElementById('tbDetailHistorySection').open = false;
 }
 
 /** Transition from within the detail modal. */
@@ -9814,11 +10069,37 @@ function tbFormatTimestamp(ts) {
 /** Build execution log entries from card timestamps. */
 function tbBuildExecutionLog(card) {
   const entries = [];
-  if (card.createdAt) entries.push({ ts: tbFormatTimestamp(card.createdAt), msg: 'Task created' + (card.agentId ? ' — assigned to ' + card.agentId : '') });
+  if (card.createdAt) {
+    entries.push({
+      ts: tbFormatTimestamp(card.createdAt),
+      msg: 'Task created' + (card.agentId ? ' — assigned to ' + card.agentId : ''),
+    });
+  }
+  if (card.missionId) entries.push({ ts: '', msg: `🎯 Mission linked: ${card.missionId}` });
+  if (card.missionBrief) entries.push({ ts: '', msg: `🧭 Origin: ${card.missionBrief}` });
+  if (card.assigneeType || card.assigneeId) {
+    const owner = [card.assigneeType || 'agent', card.assigneeId || card.agentId || ''].filter(Boolean).join(': ');
+    entries.push({ ts: '', msg: `👤 Owner: ${owner}` });
+  }
   if (card.queuedAt) entries.push({ ts: tbFormatTimestamp(card.queuedAt), msg: 'Moved to queue' });
   if (card.startedAt) entries.push({ ts: tbFormatTimestamp(card.startedAt), msg: 'Execution started' });
   if (card.completedAt && card.status === 'done') entries.push({ ts: tbFormatTimestamp(card.completedAt), msg: 'Completed successfully' });
   if (card.completedAt && card.status === 'failed') entries.push({ ts: tbFormatTimestamp(card.completedAt), msg: 'Execution failed' });
+  if (Array.isArray(card.dependencies) && card.dependencies.length > 0) {
+    entries.push({ ts: '', msg: `🧩 Dependencies: ${card.dependencies.join(', ')}` });
+  }
+  if (Array.isArray(card.artifactLinks) && card.artifactLinks.length > 0) {
+    entries.push({ ts: '', msg: `📦 Artifacts: ${card.artifactLinks.length} linked` });
+  }
+  if (card.replaySessionId) entries.push({ ts: '', msg: `🎞 Replay: ${card.replaySessionId}` });
+  if (Array.isArray(card.statusHistory) && card.statusHistory.length > 0) {
+    for (const h of card.statusHistory) {
+      entries.push({
+        ts: h.at ? tbFormatTimestamp(h.at) : '',
+        msg: `↔ Status: ${h.status}${h.note ? ` (${h.note})` : ''}`,
+      });
+    }
+  }
   if (card.runtimeMs != null) entries.push({ ts: '', msg: '⏱ Runtime: ' + tbDuration(card.runtimeMs) });
   if (card.tokensUsed != null) entries.push({ ts: '', msg: '🪙 Tokens used: ' + card.tokensUsed.toLocaleString() });
   if (card.costEstimate != null) entries.push({ ts: '', msg: '💰 Cost: $' + card.costEstimate.toFixed(4) });
@@ -9938,13 +10219,30 @@ function tbUpdateBulkBar() {
 
   // Enable/disable transition buttons based on what's selected
   const selectedCards = tbTasks.filter(t => tbSelectedIds.has(t.id));
-  const statuses = new Set(selectedCards.map(t => t.status));
 
   // Queued button: useful when any selected card can transition to queued
   const canToQueued = selectedCards.some(t =>
     (TB_TRANSITIONS[t.status] || []).includes('queued'));
   const qBtn = document.getElementById('tbBulkToQueued');
   if (qBtn) qBtn.disabled = !canToQueued;
+
+  // Running button
+  const canToRunning = selectedCards.some(t =>
+    (TB_TRANSITIONS[t.status] || []).includes('running'));
+  const rBtn = document.getElementById('tbBulkToRunning');
+  if (rBtn) rBtn.disabled = !canToRunning;
+
+  // Blocked button
+  const canToBlocked = selectedCards.some(t =>
+    (TB_TRANSITIONS[t.status] || []).includes('blocked'));
+  const blBtn = document.getElementById('tbBulkToBlocked');
+  if (blBtn) blBtn.disabled = !canToBlocked;
+
+  // Review button
+  const canToReview = selectedCards.some(t =>
+    (TB_TRANSITIONS[t.status] || []).includes('review'));
+  const rvBtn = document.getElementById('tbBulkToReview');
+  if (rvBtn) rvBtn.disabled = !canToReview;
 
   // Backlog button
   const canToBacklog = selectedCards.some(t =>
@@ -12473,12 +12771,22 @@ function tbApplyEvent(event) {
   );
 
   // Update summary counts inline
-  const cols = { backlog: 0, queued: 0, running: 0, done: 0, failed: 0 };
+  const cols = {
+    backlog: 0,
+    queued: 0,
+    running: 0,
+    blocked: 0,
+    review: 0,
+    done: 0,
+    failed: 0,
+  };
   for (const t of tbTasks) { cols[t.status] = (cols[t.status] || 0) + 1; }
   const el = (id) => document.getElementById(id);
   if (el('tbCountBacklog')) el('tbCountBacklog').textContent = cols.backlog;
   if (el('tbCountQueued')) el('tbCountQueued').textContent = cols.queued;
   if (el('tbCountRunning')) el('tbCountRunning').textContent = cols.running;
+  if (el('tbCountBlocked')) el('tbCountBlocked').textContent = cols.blocked;
+  if (el('tbCountReview')) el('tbCountReview').textContent = cols.review;
   if (el('tbCountDone')) el('tbCountDone').textContent = cols.done;
   if (el('tbCountFailed')) el('tbCountFailed').textContent = cols.failed;
 

--- a/dashboard/server/routes/task-board.ts
+++ b/dashboard/server/routes/task-board.ts
@@ -26,7 +26,9 @@ import type {
   TaskCard,
   TaskStatus,
   TaskPriority,
+  TaskAssigneeType,
   TaskBoardSummary,
+  TaskStatusHistoryEntry,
 } from '../types.js';
 
 import {
@@ -114,16 +116,27 @@ import type { CardExportFormat } from '../task-card-export.js';
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
-const VALID_STATUSES: TaskStatus[] = ['backlog', 'queued', 'running', 'done', 'failed'];
+const VALID_STATUSES: TaskStatus[] = [
+  'backlog',
+  'queued',
+  'running',
+  'blocked',
+  'review',
+  'done',
+  'failed',
+];
 const VALID_PRIORITIES: TaskPriority[] = ['critical', 'high', 'medium', 'low'];
+const VALID_ASSIGNEE_TYPES: TaskAssigneeType[] = ['human', 'nexus', 'agent'];
 
 /** Allowed state transitions (from → to[]). */
 const TRANSITIONS: Record<TaskStatus, TaskStatus[]> = {
-  backlog: ['queued', 'done'],
-  queued: ['running', 'backlog', 'done'],
-  running: ['done', 'failed'],
+  backlog: ['queued', 'blocked', 'review', 'done'],
+  queued: ['running', 'blocked', 'backlog', 'done'],
+  running: ['review', 'blocked', 'done', 'failed'],
+  blocked: ['queued', 'running', 'review', 'done'],
+  review: ['running', 'done', 'blocked'],
   done: ['backlog'],
-  failed: ['backlog', 'queued'],
+  failed: ['backlog', 'queued', 'blocked'],
 };
 
 // ─── Store helpers ───────────────────────────────────────────────────────────
@@ -132,14 +145,102 @@ function taskFilePath(dataDir: string): string {
   return path.join(dataDir, 'task-board.json');
 }
 
+function sanitizeStringList(
+  value: unknown,
+  opts: { maxItems: number; maxLen: number },
+): string[] {
+  if (!Array.isArray(value)) return [];
+  const out: string[] = [];
+  for (const item of value) {
+    if (typeof item !== 'string') continue;
+    const s = item.trim();
+    if (!s) continue;
+    out.push(s.slice(0, opts.maxLen));
+    if (out.length >= opts.maxItems) break;
+  }
+  return out;
+}
+
+function normalizeStatusHistory(card: TaskCard): TaskStatusHistoryEntry[] {
+  const history: TaskStatusHistoryEntry[] = [];
+  if (Array.isArray(card.statusHistory)) {
+    for (const entry of card.statusHistory) {
+      if (!entry || typeof entry !== 'object') continue;
+      const status = (entry as { status?: string }).status as TaskStatus;
+      const at = (entry as { at?: number }).at;
+      const by = (entry as { by?: string }).by;
+      const note = (entry as { note?: string | null }).note ?? null;
+      if (!VALID_STATUSES.includes(status)) continue;
+      if (typeof at !== 'number' || !Number.isFinite(at) || at <= 0) continue;
+      if (typeof by !== 'string' || !by.trim()) continue;
+      history.push({
+        status,
+        at: Math.trunc(at),
+        by: by.trim().slice(0, 80),
+        note: typeof note === 'string' ? note.slice(0, 200) : null,
+      });
+    }
+  }
+  if (history.length === 0) {
+    history.push({
+      status: card.status,
+      at: card.createdAt || Date.now(),
+      by: 'system',
+      note: 'initialized',
+    });
+  }
+  return history.sort((a, b) => a.at - b.at);
+}
+
+function normalizeTaskCard(raw: TaskCard): TaskCard {
+  const status: TaskStatus = VALID_STATUSES.includes(raw.status) ? raw.status : 'backlog';
+  const assigneeType: TaskAssigneeType = VALID_ASSIGNEE_TYPES.includes(raw.assigneeType as TaskAssigneeType)
+    ? (raw.assigneeType as TaskAssigneeType)
+    : 'agent';
+  const normalized: TaskCard = {
+    ...raw,
+    status,
+    missionId: raw.missionId ? String(raw.missionId).slice(0, 120) : null,
+    missionBrief: raw.missionBrief ? String(raw.missionBrief).slice(0, 300) : null,
+    assigneeType,
+    assigneeId: raw.assigneeId ? String(raw.assigneeId).slice(0, 120) : null,
+    dependencies: sanitizeStringList(raw.dependencies, { maxItems: 20, maxLen: 80 }),
+    artifactLinks: sanitizeStringList(raw.artifactLinks, { maxItems: 20, maxLen: 300 }),
+    replaySessionId: raw.replaySessionId ? String(raw.replaySessionId).slice(0, 120) : null,
+    statusHistory: [],
+  };
+  normalized.statusHistory = normalizeStatusHistory(normalized);
+  return normalized;
+}
+
+function appendStatusHistory(
+  card: TaskCard,
+  status: TaskStatus,
+  by: string,
+  note: string | null = null,
+  at = Date.now(),
+): void {
+  if (!card.statusHistory) card.statusHistory = [];
+  const last = card.statusHistory[card.statusHistory.length - 1];
+  if (last && last.status === status) return;
+  card.statusHistory.push({
+    status,
+    at,
+    by: by.slice(0, 80),
+    note: note ? note.slice(0, 200) : null,
+  });
+}
+
 export function loadTasks(dataDir: string): TaskCard[] {
   try {
     const fp = taskFilePath(dataDir);
     if (!fs.existsSync(fp)) return [];
     const raw = fs.readFileSync(fp, 'utf8');
     const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed)) return parsed as TaskCard[];
-    if (parsed && Array.isArray(parsed.tasks)) return parsed.tasks as TaskCard[];
+    if (Array.isArray(parsed)) return parsed.map((card) => normalizeTaskCard(card as TaskCard));
+    if (parsed && Array.isArray(parsed.tasks)) {
+      return parsed.tasks.map((card: TaskCard) => normalizeTaskCard(card));
+    }
     return [];
   } catch {
     return [];
@@ -251,7 +352,13 @@ export function computeMetrics(
 
   // Status counts
   const statusCounts: Record<TaskStatus, number> = {
-    backlog: 0, queued: 0, running: 0, done: 0, failed: 0,
+    backlog: 0,
+    queued: 0,
+    running: 0,
+    blocked: 0,
+    review: 0,
+    done: 0,
+    failed: 0,
   };
   for (const t of tasks) {
     statusCounts[t.status] = (statusCounts[t.status] ?? 0) + 1;
@@ -385,6 +492,8 @@ export function buildSummary(tasks: TaskCard[]): TaskBoardSummary {
     backlog: 0,
     queued: 0,
     running: 0,
+    blocked: 0,
+    review: 0,
     done: 0,
     failed: 0,
   };
@@ -394,7 +503,15 @@ export function buildSummary(tasks: TaskCard[]): TaskBoardSummary {
     columns[t.status] = (columns[t.status] ?? 0) + 1;
     const aid = t.agentId ?? '_unassigned';
     if (!byAgent[aid]) {
-      byAgent[aid] = { backlog: 0, queued: 0, running: 0, done: 0, failed: 0 };
+      byAgent[aid] = {
+        backlog: 0,
+        queued: 0,
+        running: 0,
+        blocked: 0,
+        review: 0,
+        done: 0,
+        failed: 0,
+      };
     }
     byAgent[aid][t.status] = (byAgent[aid][t.status] ?? 0) + 1;
   }
@@ -404,7 +521,13 @@ export function buildSummary(tasks: TaskCard[]): TaskBoardSummary {
 
 export function filterTasks(
   tasks: TaskCard[],
-  opts: { status?: string | null; agentId?: string | null; priority?: string | null },
+  opts: {
+    status?: string | null;
+    agentId?: string | null;
+    priority?: string | null;
+    missionId?: string | null;
+    assigneeType?: string | null;
+  },
 ): TaskCard[] {
   let out = tasks;
   if (opts.status && VALID_STATUSES.includes(opts.status as TaskStatus)) {
@@ -415,6 +538,12 @@ export function filterTasks(
   }
   if (opts.priority && VALID_PRIORITIES.includes(opts.priority as TaskPriority)) {
     out = out.filter((t) => t.priority === opts.priority);
+  }
+  if (opts.missionId) {
+    out = out.filter((t) => t.missionId === opts.missionId);
+  }
+  if (opts.assigneeType && VALID_ASSIGNEE_TYPES.includes(opts.assigneeType as TaskAssigneeType)) {
+    out = out.filter((t) => (t.assigneeType ?? 'agent') === opts.assigneeType);
   }
   return out;
 }
@@ -431,6 +560,13 @@ interface CreateInput {
   priority?: string;
   agentId?: string | null;
   status?: string;
+  missionId?: string | null;
+  missionBrief?: string | null;
+  assigneeType?: string | null;
+  assigneeId?: string | null;
+  dependencies?: unknown;
+  artifactLinks?: unknown;
+  replaySessionId?: string | null;
 }
 
 function validateCreate(body: CreateInput): { ok: true; card: TaskCard } | { ok: false; error: string } {
@@ -452,6 +588,30 @@ function validateCreate(body: CreateInput): { ok: true; card: TaskCard } | { ok:
   }
 
   const agentId = body.agentId?.trim() || null;
+  const missionId = body.missionId?.trim() || null;
+  if (missionId && missionId.length > 120) return { ok: false, error: 'missionId must be ≤ 120 chars' };
+
+  const missionBrief = body.missionBrief?.trim() || null;
+  if (missionBrief && missionBrief.length > 300) {
+    return { ok: false, error: 'missionBrief must be ≤ 300 chars' };
+  }
+
+  const assigneeType = (body.assigneeType ?? (agentId ? 'agent' : 'nexus')) as TaskAssigneeType;
+  if (!VALID_ASSIGNEE_TYPES.includes(assigneeType)) {
+    return { ok: false, error: `invalid assigneeType: ${assigneeType}` };
+  }
+  const assigneeId = (body.assigneeId ?? agentId ?? '').trim() || null;
+  if (assigneeId && assigneeId.length > 120) {
+    return { ok: false, error: 'assigneeId must be ≤ 120 chars' };
+  }
+
+  const dependencies = sanitizeStringList(body.dependencies, { maxItems: 20, maxLen: 80 });
+  const artifactLinks = sanitizeStringList(body.artifactLinks, { maxItems: 20, maxLen: 300 });
+  const replaySessionId = body.replaySessionId?.trim() || null;
+  if (replaySessionId && replaySessionId.length > 120) {
+    return { ok: false, error: 'replaySessionId must be ≤ 120 chars' };
+  }
+  const now = Date.now();
 
   const card: TaskCard = {
     id: crypto.randomUUID(),
@@ -460,8 +620,8 @@ function validateCreate(body: CreateInput): { ok: true; card: TaskCard } | { ok:
     description,
     priority,
     status,
-    createdAt: Date.now(),
-    queuedAt: status === 'queued' ? Date.now() : null,
+    createdAt: now,
+    queuedAt: status === 'queued' ? now : null,
     startedAt: null,
     completedAt: null,
     resultSummary: null,
@@ -469,6 +629,21 @@ function validateCreate(body: CreateInput): { ok: true; card: TaskCard } | { ok:
     error: null,
     costEstimate: null,
     runtimeMs: null,
+    missionId,
+    missionBrief,
+    assigneeType,
+    assigneeId,
+    dependencies,
+    artifactLinks,
+    replaySessionId,
+    statusHistory: [
+      {
+        status,
+        at: now,
+        by: 'create',
+        note: missionId ? `mission:${missionId}` : 'created',
+      },
+    ],
   };
 
   return { ok: true, card };
@@ -612,6 +787,7 @@ export function executeBatch(
           card.runtimeMs = now - card.startedAt;
         }
       }
+      appendStatusHistory(card, targetStatus, 'batch', null, now);
 
       results.push({ id, ok: true });
       succeeded++;
@@ -677,7 +853,7 @@ export async function handleTaskBoard(
   // ── GET /api/task-board/events (SSE) ─────────────────────────────────────
   // Real-time event stream for task mutations. Issue #219.
   // Supports optional subscription filters via query params:
-  //   ?status=running&agentId=oracle&priority=high
+  //   ?status=running&agentId=oracle&priority=high&missionId=mc-001&assigneeType=agent
   // Server-side filtering is applied before broadcasting to each client.
   if (url.startsWith('/api/task-board/events') && method === 'GET') {
     // Parse optional subscription filter from query string
@@ -686,6 +862,8 @@ export async function handleTaskBoard(
       status: evtParams.get('status'),
       agentId: evtParams.get('agentId'),
       priority: evtParams.get('priority'),
+      missionId: evtParams.get('missionId'),
+      assigneeType: evtParams.get('assigneeType'),
     });
 
     if (!addFilteredClient(res, filter)) {
@@ -713,6 +891,8 @@ export async function handleTaskBoard(
   //   ?status=running     — filter by status
   //   ?agentId=oracle     — filter by agent
   //   ?priority=high      — filter by priority
+  //   ?missionId=mc-001   — filter by mission id
+  //   ?assigneeType=agent — filter by owner type
   //   ?search=deploy      — substring search in title/description
   //   ?limit=500          — max cards to export (default 500, max 500)
   // Bounded: max 500 cards per export. Secret-safe: conservative field allowlist.
@@ -725,6 +905,8 @@ export async function handleTaskBoard(
     const status = exportParams.get('status') || undefined;
     const agentId = exportParams.get('agentId') || undefined;
     const priority = exportParams.get('priority') || undefined;
+    const missionId = exportParams.get('missionId') || undefined;
+    const assigneeType = exportParams.get('assigneeType') || undefined;
     const search = exportParams.get('search') || undefined;
 
     const tasks = loadTasks(dataDir);
@@ -734,6 +916,8 @@ export async function handleTaskBoard(
       status,
       agentId,
       priority,
+      missionId,
+      assigneeType,
       search,
     });
 
@@ -748,7 +932,8 @@ export async function handleTaskBoard(
   }
 
   // ── GET /api/task-board ────────────────────────────────────────────────────
-  // Returns filtered list of cards. Query params: status, agentId, priority.
+  // Returns filtered list of cards.
+  // Query params: status, agentId, priority, missionId, assigneeType.
   if (url.startsWith('/api/task-board') && !url.startsWith('/api/task-board/') && method === 'GET') {
     const params = new URL(url, 'http://localhost').searchParams;
     const tasks = loadTasks(dataDir);
@@ -756,6 +941,8 @@ export async function handleTaskBoard(
       status: params.get('status'),
       agentId: params.get('agentId'),
       priority: params.get('priority'),
+      missionId: params.get('missionId'),
+      assigneeType: params.get('assigneeType'),
     });
     sendJson(res, { tasks: filtered, total: filtered.length });
     return true;
@@ -1433,12 +1620,45 @@ export async function handleTaskBoard(
       if (newStatus === 'queued') card.queuedAt = now;
       if (newStatus === 'running') card.startedAt = now;
       if (newStatus === 'done' || newStatus === 'failed') card.completedAt = now;
+      const transitionNote =
+        typeof body.transitionNote === 'string' && body.transitionNote.trim()
+          ? body.transitionNote.trim()
+          : null;
+      appendStatusHistory(card, newStatus, 'patch', transitionNote, now);
     }
 
     // Mutable fields
     if (typeof body.title === 'string') card.title = (body.title as string).slice(0, 200);
     if (typeof body.description === 'string') card.description = (body.description as string).slice(0, 2000);
     if (typeof body.agentId === 'string') card.agentId = body.agentId || null;
+    if (typeof body.missionId === 'string') {
+      const v = body.missionId.trim();
+      card.missionId = v ? v.slice(0, 120) : null;
+    }
+    if (typeof body.missionBrief === 'string') {
+      const v = body.missionBrief.trim();
+      card.missionBrief = v ? v.slice(0, 300) : null;
+    }
+    if (
+      typeof body.assigneeType === 'string' &&
+      VALID_ASSIGNEE_TYPES.includes(body.assigneeType as TaskAssigneeType)
+    ) {
+      card.assigneeType = body.assigneeType as TaskAssigneeType;
+    }
+    if (typeof body.assigneeId === 'string') {
+      const v = body.assigneeId.trim();
+      card.assigneeId = v ? v.slice(0, 120) : null;
+    }
+    if (Array.isArray(body.dependencies)) {
+      card.dependencies = sanitizeStringList(body.dependencies, { maxItems: 20, maxLen: 80 });
+    }
+    if (Array.isArray(body.artifactLinks)) {
+      card.artifactLinks = sanitizeStringList(body.artifactLinks, { maxItems: 20, maxLen: 300 });
+    }
+    if (typeof body.replaySessionId === 'string') {
+      const v = body.replaySessionId.trim();
+      card.replaySessionId = v ? v.slice(0, 120) : null;
+    }
     if (typeof body.priority === 'string' && VALID_PRIORITIES.includes(body.priority as TaskPriority)) {
       card.priority = body.priority as TaskPriority;
     }

--- a/dashboard/server/task-board-events.ts
+++ b/dashboard/server/task-board-events.ts
@@ -14,7 +14,12 @@
  */
 
 import type { ServerResponse } from 'node:http';
-import type { TaskCard, TaskStatus, TaskPriority } from './types.js';
+import type {
+  TaskCard,
+  TaskStatus,
+  TaskPriority,
+  TaskAssigneeType,
+} from './types.js';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 
@@ -36,12 +41,23 @@ export interface SseSubscriptionFilter {
   status?: TaskStatus;
   agentId?: string;
   priority?: TaskPriority;
+  missionId?: string;
+  assigneeType?: TaskAssigneeType;
 }
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
-const VALID_STATUSES: readonly string[] = ['backlog', 'queued', 'running', 'done', 'failed'];
+const VALID_STATUSES: readonly string[] = [
+  'backlog',
+  'queued',
+  'running',
+  'blocked',
+  'review',
+  'done',
+  'failed',
+];
 const VALID_PRIORITIES: readonly string[] = ['critical', 'high', 'medium', 'low'];
+const VALID_ASSIGNEE_TYPES: readonly string[] = ['human', 'nexus', 'agent'];
 
 // ─── Event Bus ───────────────────────────────────────────────────────────────
 
@@ -73,6 +89,8 @@ export function parseSubscriptionFilter(params: {
   status?: string | null;
   agentId?: string | null;
   priority?: string | null;
+  missionId?: string | null;
+  assigneeType?: string | null;
 }): SseSubscriptionFilter {
   const filter: SseSubscriptionFilter = {};
   if (params.status && VALID_STATUSES.includes(params.status)) {
@@ -83,6 +101,12 @@ export function parseSubscriptionFilter(params: {
   }
   if (params.priority && VALID_PRIORITIES.includes(params.priority)) {
     filter.priority = params.priority as TaskPriority;
+  }
+  if (params.missionId && params.missionId.trim()) {
+    filter.missionId = params.missionId.trim();
+  }
+  if (params.assigneeType && VALID_ASSIGNEE_TYPES.includes(params.assigneeType)) {
+    filter.assigneeType = params.assigneeType as TaskAssigneeType;
   }
   return filter;
 }
@@ -95,6 +119,8 @@ export function matchesFilter(card: TaskCard, filter: SseSubscriptionFilter): bo
   if (filter.status && card.status !== filter.status) return false;
   if (filter.agentId && card.agentId !== filter.agentId) return false;
   if (filter.priority && card.priority !== filter.priority) return false;
+  if (filter.missionId && card.missionId !== filter.missionId) return false;
+  if (filter.assigneeType && (card.assigneeType ?? 'agent') !== filter.assigneeType) return false;
   return true;
 }
 

--- a/dashboard/server/task-card-export.ts
+++ b/dashboard/server/task-card-export.ts
@@ -11,7 +11,12 @@
  * No schema changes. No new dependencies. Additive only.
  */
 
-import type { TaskCard, TaskStatus, TaskPriority } from './types.js';
+import type {
+  TaskCard,
+  TaskStatus,
+  TaskPriority,
+  TaskAssigneeType,
+} from './types.js';
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -33,6 +38,8 @@ export interface CardExportQuery {
   status?: string | null;
   agentId?: string | null;
   priority?: string | null;
+  missionId?: string | null;
+  assigneeType?: string | null;
   search?: string | null;
 }
 
@@ -57,8 +64,10 @@ export interface CardExportResult {
  * Included fields:
  * - id: stable card identifier for cross-referencing (UUIDs leak no secrets)
  * - title, description, status, priority, agentId: user-facing metadata
+ * - missionId, missionBrief, assigneeType, assigneeId: mission/owner metadata
  * - createdAt, queuedAt, startedAt, completedAt, runtimeMs: timing info
  * - resultSummary: user-facing execution summary
+ * - dependencies, artifactLinks, replaySessionId: linkage metadata
  *
  * Excluded fields and rationale:
  * - error: may contain stack traces or internal paths
@@ -72,12 +81,19 @@ const EXPORT_FIELDS = [
   'status',
   'priority',
   'agentId',
+  'missionId',
+  'missionBrief',
+  'assigneeType',
+  'assigneeId',
   'createdAt',
   'queuedAt',
   'startedAt',
   'completedAt',
   'runtimeMs',
   'resultSummary',
+  'dependencies',
+  'artifactLinks',
+  'replaySessionId',
 ] as const;
 
 type ExportField = typeof EXPORT_FIELDS[number];
@@ -96,12 +112,19 @@ export function sanitizeCardForExport(card: TaskCard): Record<string, unknown> {
     status: card.status,
     priority: card.priority,
     agentId: card.agentId ?? '',
+    missionId: card.missionId ?? '',
+    missionBrief: card.missionBrief ?? '',
+    assigneeType: card.assigneeType ?? '',
+    assigneeId: card.assigneeId ?? '',
     createdAt: formatExportTs(card.createdAt),
     queuedAt: formatExportTs(card.queuedAt),
     startedAt: formatExportTs(card.startedAt),
     completedAt: formatExportTs(card.completedAt),
     runtimeMs: card.runtimeMs,
     resultSummary: card.resultSummary ?? '',
+    dependencies: Array.isArray(card.dependencies) ? card.dependencies.join('; ') : '',
+    artifactLinks: Array.isArray(card.artifactLinks) ? card.artifactLinks.join('; ') : '',
+    replaySessionId: card.replaySessionId ?? '',
   };
 }
 
@@ -132,8 +155,17 @@ export function csvEscapeCard(value: string | number | boolean | null | undefine
 
 // ─── Filter ──────────────────────────────────────────────────────────────────
 
-const VALID_STATUSES: TaskStatus[] = ['backlog', 'queued', 'running', 'done', 'failed'];
+const VALID_STATUSES: TaskStatus[] = [
+  'backlog',
+  'queued',
+  'running',
+  'blocked',
+  'review',
+  'done',
+  'failed',
+];
 const VALID_PRIORITIES: TaskPriority[] = ['critical', 'high', 'medium', 'low'];
+const VALID_ASSIGNEE_TYPES: TaskAssigneeType[] = ['human', 'nexus', 'agent'];
 
 /**
  * Filter task cards for export.
@@ -147,6 +179,8 @@ export function filterCardsForExport(
     status?: string | null;
     agentId?: string | null;
     priority?: string | null;
+    missionId?: string | null;
+    assigneeType?: string | null;
     search?: string | null;
   },
 ): TaskCard[] {
@@ -160,6 +194,12 @@ export function filterCardsForExport(
   }
   if (opts.priority && VALID_PRIORITIES.includes(opts.priority as TaskPriority)) {
     out = out.filter((t) => t.priority === opts.priority);
+  }
+  if (opts.missionId) {
+    out = out.filter((t) => t.missionId === opts.missionId);
+  }
+  if (opts.assigneeType && VALID_ASSIGNEE_TYPES.includes(opts.assigneeType as TaskAssigneeType)) {
+    out = out.filter((t) => (t.assigneeType ?? 'agent') === opts.assigneeType);
   }
   if (opts.search) {
     const q = opts.search.toLowerCase();
@@ -235,6 +275,8 @@ export function exportTaskCards(
     status: opts.status,
     agentId: opts.agentId,
     priority: opts.priority,
+    missionId: opts.missionId,
+    assigneeType: opts.assigneeType,
     search: opts.search,
   });
 

--- a/dashboard/server/types.ts
+++ b/dashboard/server/types.ts
@@ -711,10 +711,28 @@ export interface ReplaySessionListResponse {
 // ─── Task Board Domain (Issue #219) ──────────────────────────────────────────
 
 /** Valid task card statuses (Kanban columns). */
-export type TaskStatus = 'backlog' | 'queued' | 'running' | 'done' | 'failed';
+export type TaskStatus =
+  | 'backlog'
+  | 'queued'
+  | 'running'
+  | 'blocked'
+  | 'review'
+  | 'done'
+  | 'failed';
 
 /** Valid task card priorities. */
 export type TaskPriority = 'critical' | 'high' | 'medium' | 'low';
+
+/** Assignment owner type for mission-linked task cards. */
+export type TaskAssigneeType = 'human' | 'nexus' | 'agent';
+
+/** Status transition audit entry for task cards. */
+export interface TaskStatusHistoryEntry {
+  status: TaskStatus;
+  at: number;
+  by: string;
+  note: string | null;
+}
 
 /** A single task board card. */
 export interface TaskCard {
@@ -735,6 +753,22 @@ export interface TaskCard {
   costEstimate: number | null;
   /** Runtime in milliseconds (computed on completion, or null). Issue #219 — task detail modal. */
   runtimeMs: number | null;
+  /** Mission identifier used to tie card to mission brief and artifacts. */
+  missionId?: string | null;
+  /** Origin descriptor (usually mission brief title/path). */
+  missionBrief?: string | null;
+  /** Assignment owner dimension: human / nexus / agent. */
+  assigneeType?: TaskAssigneeType;
+  /** Owner identifier (person, nexus, or agent id). */
+  assigneeId?: string | null;
+  /** Upstream task IDs this card depends on. */
+  dependencies?: string[];
+  /** Linked artifacts (docs, commits, output paths, URLs). */
+  artifactLinks?: string[];
+  /** Optional replay session id reference. */
+  replaySessionId?: string | null;
+  /** Status transition audit trail. */
+  statusHistory?: TaskStatusHistoryEntry[];
 }
 
 /** Summary counts per column returned by the summary endpoint. */

--- a/dashboard/tests/unit/routes/task-board-card-export.test.ts
+++ b/dashboard/tests/unit/routes/task-board-card-export.test.ts
@@ -5,7 +5,7 @@
  * - CSV/JSON format correctness (column headers, field values, structure)
  * - Secret-safe allowlist (no internal fields leak — error, tokensUsed, costEstimate)
  * - Bounded export (max 500 cards)
- * - Filter parity with task board REST API (status, agentId, priority, search)
+ * - Filter parity with task board REST API (status, agentId, priority, missionId, assigneeType, search)
  * - API endpoint: GET /api/task-board/export
  * - CSV escaping edge cases (commas, quotes, newlines in text fields)
  * - Empty dataset export
@@ -101,12 +101,19 @@ describe('sanitizeCardForExport', () => {
     expect(safe).toHaveProperty('status');
     expect(safe).toHaveProperty('priority');
     expect(safe).toHaveProperty('agentId');
+    expect(safe).toHaveProperty('missionId');
+    expect(safe).toHaveProperty('missionBrief');
+    expect(safe).toHaveProperty('assigneeType');
+    expect(safe).toHaveProperty('assigneeId');
     expect(safe).toHaveProperty('createdAt');
     expect(safe).toHaveProperty('queuedAt');
     expect(safe).toHaveProperty('startedAt');
     expect(safe).toHaveProperty('completedAt');
     expect(safe).toHaveProperty('runtimeMs');
     expect(safe).toHaveProperty('resultSummary');
+    expect(safe).toHaveProperty('dependencies');
+    expect(safe).toHaveProperty('artifactLinks');
+    expect(safe).toHaveProperty('replaySessionId');
   });
 
   it('excludes sensitive/internal fields (error, tokensUsed, costEstimate)', () => {
@@ -187,7 +194,7 @@ describe('cardsToCsv', () => {
 
     expect(lines.length).toBe(2); // header + 1 data row
     expect(lines[0]).toBe(
-      'id,title,description,status,priority,agentId,createdAt,queuedAt,startedAt,completedAt,runtimeMs,resultSummary',
+      'id,title,description,status,priority,agentId,missionId,missionBrief,assigneeType,assigneeId,createdAt,queuedAt,startedAt,completedAt,runtimeMs,resultSummary,dependencies,artifactLinks,replaySessionId',
     );
   });
 
@@ -265,10 +272,42 @@ describe('cardsToJson', () => {
 
 describe('filterCardsForExport', () => {
   const cards: TaskCard[] = [
-    makeCard({ id: '1', status: 'running', agentId: 'oracle', priority: 'high', title: 'Deploy service' }),
-    makeCard({ id: '2', status: 'done', agentId: 'nexus', priority: 'medium', title: 'Write tests' }),
-    makeCard({ id: '3', status: 'failed', agentId: 'oracle', priority: 'critical', title: 'Fix deploy bug' }),
-    makeCard({ id: '4', status: 'backlog', agentId: null, priority: 'low', title: 'Cleanup docs' }),
+    makeCard({
+      id: '1',
+      status: 'running',
+      agentId: 'oracle',
+      priority: 'high',
+      title: 'Deploy service',
+      missionId: 'm-001',
+      assigneeType: 'agent',
+    }),
+    makeCard({
+      id: '2',
+      status: 'done',
+      agentId: 'nexus',
+      priority: 'medium',
+      title: 'Write tests',
+      missionId: 'm-002',
+      assigneeType: 'nexus',
+    }),
+    makeCard({
+      id: '3',
+      status: 'failed',
+      agentId: 'oracle',
+      priority: 'critical',
+      title: 'Fix deploy bug',
+      missionId: 'm-001',
+      assigneeType: 'human',
+    }),
+    makeCard({
+      id: '4',
+      status: 'backlog',
+      agentId: null,
+      priority: 'low',
+      title: 'Cleanup docs',
+      missionId: null,
+      assigneeType: 'nexus',
+    }),
   ];
 
   it('filters by status', () => {
@@ -287,6 +326,18 @@ describe('filterCardsForExport', () => {
     const result = filterCardsForExport(cards, { priority: 'critical' });
     expect(result).toHaveLength(1);
     expect(result[0].id).toBe('3');
+  });
+
+  it('filters by missionId', () => {
+    const result = filterCardsForExport(cards, { missionId: 'm-001' });
+    expect(result).toHaveLength(2);
+    expect(result.map((c) => c.id)).toEqual(['1', '3']);
+  });
+
+  it('filters by assigneeType', () => {
+    const result = filterCardsForExport(cards, { assigneeType: 'nexus' });
+    expect(result).toHaveLength(2);
+    expect(result.map((c) => c.id)).toEqual(['2', '4']);
   });
 
   it('filters by search (title substring)', () => {
@@ -318,6 +369,11 @@ describe('filterCardsForExport', () => {
 
   it('ignores invalid priority values', () => {
     const result = filterCardsForExport(cards, { priority: 'ultra' });
+    expect(result).toHaveLength(4);
+  });
+
+  it('ignores invalid assigneeType values', () => {
+    const result = filterCardsForExport(cards, { assigneeType: 'invalid' });
     expect(result).toHaveLength(4);
   });
 });
@@ -610,9 +666,10 @@ describe('secret safety', () => {
     const parsed = JSON.parse(json);
     const cardKeys = Object.keys(parsed.cards[0]).sort();
     const expectedKeys = [
-      'agentId', 'completedAt', 'createdAt', 'description', 'id',
-      'priority', 'queuedAt', 'resultSummary', 'runtimeMs', 'startedAt',
-      'status', 'title',
+      'agentId', 'artifactLinks', 'assigneeId', 'assigneeType', 'completedAt',
+      'createdAt', 'dependencies', 'description', 'id', 'missionBrief',
+      'missionId', 'priority', 'queuedAt', 'replaySessionId', 'resultSummary',
+      'runtimeMs', 'startedAt', 'status', 'title',
     ];
     expect(cardKeys).toEqual(expectedKeys);
   });

--- a/dashboard/tests/unit/routes/task-board-sse-filtering.test.ts
+++ b/dashboard/tests/unit/routes/task-board-sse-filtering.test.ts
@@ -127,7 +127,13 @@ describe('parseSubscriptionFilter', () => {
   });
 
   it('returns empty filter with null params', () => {
-    const f = parseSubscriptionFilter({ status: null, agentId: null, priority: null });
+    const f = parseSubscriptionFilter({
+      status: null,
+      agentId: null,
+      priority: null,
+      missionId: null,
+      assigneeType: null,
+    });
     expect(f).toEqual({});
   });
 
@@ -166,14 +172,46 @@ describe('parseSubscriptionFilter', () => {
     expect(f).toEqual({ priority: 'critical' });
   });
 
+  it('parses valid missionId', () => {
+    const f = parseSubscriptionFilter({ missionId: 'mc-001' });
+    expect(f).toEqual({ missionId: 'mc-001' });
+  });
+
+  it('trims missionId whitespace', () => {
+    const f = parseSubscriptionFilter({ missionId: '  mc-002  ' });
+    expect(f).toEqual({ missionId: 'mc-002' });
+  });
+
+  it('parses valid assigneeType', () => {
+    const f = parseSubscriptionFilter({ assigneeType: 'human' });
+    expect(f).toEqual({ assigneeType: 'human' });
+  });
+
+  it('ignores invalid assigneeType', () => {
+    const f = parseSubscriptionFilter({ assigneeType: 'robot' });
+    expect(f).toEqual({});
+  });
+
   it('ignores invalid priority', () => {
     const f = parseSubscriptionFilter({ priority: 'ultra' });
     expect(f).toEqual({});
   });
 
-  it('parses all three filters together', () => {
-    const f = parseSubscriptionFilter({ status: 'running', agentId: 'nexus', priority: 'high' });
-    expect(f).toEqual({ status: 'running', agentId: 'nexus', priority: 'high' });
+  it('parses all filters together', () => {
+    const f = parseSubscriptionFilter({
+      status: 'running',
+      agentId: 'nexus',
+      priority: 'high',
+      missionId: 'mc-003',
+      assigneeType: 'agent',
+    });
+    expect(f).toEqual({
+      status: 'running',
+      agentId: 'nexus',
+      priority: 'high',
+      missionId: 'mc-003',
+      assigneeType: 'agent',
+    });
   });
 
   it('only keeps valid fields in mixed input', () => {
@@ -182,7 +220,7 @@ describe('parseSubscriptionFilter', () => {
   });
 
   it('parses all valid statuses', () => {
-    for (const s of ['backlog', 'queued', 'running', 'done', 'failed']) {
+    for (const s of ['backlog', 'queued', 'running', 'blocked', 'review', 'done', 'failed']) {
       const f = parseSubscriptionFilter({ status: s });
       expect(f.status).toBe(s);
     }
@@ -199,7 +237,13 @@ describe('parseSubscriptionFilter', () => {
 // ─── matchesFilter ───────────────────────────────────────────────────────────
 
 describe('matchesFilter', () => {
-  const card = makeSampleCard({ status: 'running', agentId: 'oracle', priority: 'high' });
+  const card = makeSampleCard({
+    status: 'running',
+    agentId: 'oracle',
+    priority: 'high',
+    missionId: 'mc-100',
+    assigneeType: 'agent',
+  });
 
   it('empty filter matches everything', () => {
     expect(matchesFilter(card, {})).toBe(true);
@@ -230,11 +274,33 @@ describe('matchesFilter', () => {
   });
 
   it('all matching filters pass', () => {
-    expect(matchesFilter(card, { status: 'running', agentId: 'oracle', priority: 'high' })).toBe(true);
+    expect(matchesFilter(card, {
+      status: 'running',
+      agentId: 'oracle',
+      priority: 'high',
+      missionId: 'mc-100',
+      assigneeType: 'agent',
+    })).toBe(true);
   });
 
   it('one non-matching filter fails even when others match', () => {
     expect(matchesFilter(card, { status: 'running', agentId: 'oracle', priority: 'low' })).toBe(false);
+  });
+
+  it('matching missionId passes', () => {
+    expect(matchesFilter(card, { missionId: 'mc-100' })).toBe(true);
+  });
+
+  it('non-matching missionId fails', () => {
+    expect(matchesFilter(card, { missionId: 'mc-999' })).toBe(false);
+  });
+
+  it('matching assigneeType passes', () => {
+    expect(matchesFilter(card, { assigneeType: 'agent' })).toBe(true);
+  });
+
+  it('non-matching assigneeType fails', () => {
+    expect(matchesFilter(card, { assigneeType: 'human' })).toBe(false);
   });
 
   it('null agentId on card does not match agentId filter', () => {
@@ -441,15 +507,19 @@ describe('GET /api/task-board/events with filter query params', () => {
     expect(res._body).toContain('"priority":"critical"');
   });
 
-  it('connects with all three filter params', async () => {
+  it('connects with all filter params', async () => {
     const res = mockSseResponse();
-    const req = mockRequest({ url: '/api/task-board/events?status=done&agentId=sentinel&priority=high' });
+    const req = mockRequest({
+      url: '/api/task-board/events?status=done&agentId=sentinel&priority=high&missionId=mc-200&assigneeType=nexus',
+    });
     const handled = await handleTaskBoard(req, res, createDeps());
     expect(handled).toBe(true);
     const body = res._body;
     expect(body).toContain('"status":"done"');
     expect(body).toContain('"agentId":"sentinel"');
     expect(body).toContain('"priority":"high"');
+    expect(body).toContain('"missionId":"mc-200"');
+    expect(body).toContain('"assigneeType":"nexus"');
   });
 
   it('ignores invalid filter values gracefully', async () => {

--- a/dashboard/tests/unit/routes/task-board.test.ts
+++ b/dashboard/tests/unit/routes/task-board.test.ts
@@ -148,10 +148,38 @@ describe('buildSummary', () => {
 
 describe('filterTasks', () => {
   const tasks: TaskCard[] = [
-    makeSampleCard({ id: 'a', agentId: 'oracle', status: 'backlog', priority: 'high' }),
-    makeSampleCard({ id: 'b', agentId: 'sentinel', status: 'running', priority: 'low' }),
-    makeSampleCard({ id: 'c', agentId: 'oracle', status: 'running', priority: 'critical' }),
-    makeSampleCard({ id: 'd', agentId: null, status: 'done', priority: 'medium' }),
+    makeSampleCard({
+      id: 'a',
+      agentId: 'oracle',
+      status: 'backlog',
+      priority: 'high',
+      missionId: 'm-1',
+      assigneeType: 'agent',
+    }),
+    makeSampleCard({
+      id: 'b',
+      agentId: 'sentinel',
+      status: 'running',
+      priority: 'low',
+      missionId: 'm-1',
+      assigneeType: 'human',
+    }),
+    makeSampleCard({
+      id: 'c',
+      agentId: 'oracle',
+      status: 'running',
+      priority: 'critical',
+      missionId: 'm-2',
+      assigneeType: 'nexus',
+    }),
+    makeSampleCard({
+      id: 'd',
+      agentId: null,
+      status: 'done',
+      priority: 'medium',
+      missionId: null,
+      assigneeType: 'nexus',
+    }),
   ];
 
   it('returns all tasks with no filters', () => {
@@ -181,6 +209,18 @@ describe('filterTasks', () => {
     expect(result[0].id).toBe('c');
   });
 
+  it('filters by missionId', () => {
+    const result = filterTasks(tasks, { missionId: 'm-1' });
+    expect(result).toHaveLength(2);
+    expect(result.map((t) => t.id)).toEqual(['a', 'b']);
+  });
+
+  it('filters by assigneeType', () => {
+    const result = filterTasks(tasks, { assigneeType: 'nexus' });
+    expect(result).toHaveLength(2);
+    expect(result.map((t) => t.id)).toEqual(['c', 'd']);
+  });
+
   it('ignores invalid status', () => {
     const result = filterTasks(tasks, { status: 'invalid' });
     expect(result).toHaveLength(4); // no filtering applied
@@ -196,12 +236,24 @@ describe('isValidTransition', () => {
     expect(isValidTransition('queued', 'running')).toBe(true);
   });
 
+  it('allows queued → blocked', () => {
+    expect(isValidTransition('queued', 'blocked')).toBe(true);
+  });
+
   it('allows running → done', () => {
     expect(isValidTransition('running', 'done')).toBe(true);
   });
 
+  it('allows running → review', () => {
+    expect(isValidTransition('running', 'review')).toBe(true);
+  });
+
   it('allows running → failed', () => {
     expect(isValidTransition('running', 'failed')).toBe(true);
+  });
+
+  it('allows review → done', () => {
+    expect(isValidTransition('review', 'done')).toBe(true);
   });
 
   it('allows failed → backlog', () => {
@@ -231,6 +283,10 @@ describe('isValidTransition', () => {
 
   it('rejects queued → failed', () => {
     expect(isValidTransition('queued', 'failed')).toBe(false);
+  });
+
+  it('rejects done → review', () => {
+    expect(isValidTransition('done', 'review')).toBe(false);
   });
 });
 
@@ -307,6 +363,38 @@ describe('handleTaskBoard', () => {
       );
       const body = parseJsonBody(res);
       expect(body.tasks).toHaveLength(1);
+    });
+
+    it('filters by missionId query param', async () => {
+      seedTasks([
+        makeSampleCard({ id: '1', missionId: 'mission-a' }),
+        makeSampleCard({ id: '2', missionId: 'mission-b' }),
+      ]);
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board?missionId=mission-a' }),
+        res,
+        createDeps(),
+      );
+      const body = parseJsonBody<{ tasks: TaskCard[] }>(res);
+      expect(body.tasks).toHaveLength(1);
+      expect(body.tasks[0].id).toBe('1');
+    });
+
+    it('filters by assigneeType query param', async () => {
+      seedTasks([
+        makeSampleCard({ id: '1', assigneeType: 'human' }),
+        makeSampleCard({ id: '2', assigneeType: 'agent' }),
+      ]);
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board?assigneeType=human' }),
+        res,
+        createDeps(),
+      );
+      const body = parseJsonBody<{ tasks: TaskCard[] }>(res);
+      expect(body.tasks).toHaveLength(1);
+      expect(body.tasks[0].id).toBe('1');
     });
   });
 
@@ -408,6 +496,35 @@ describe('handleTaskBoard', () => {
       expect(body.card.priority).toBe('medium');
       expect(body.card.status).toBe('backlog');
     });
+
+    it('creates mission-linked card with owner, links, and status history', async () => {
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board', method: 'POST' }),
+        res,
+        depsWithBody({
+          title: 'Mission task',
+          missionId: 'mc-293',
+          missionBrief: 'Mission brief v2',
+          assigneeType: 'human',
+          assigneeId: 'zach',
+          dependencies: ['task-1', 'task-2'],
+          artifactLinks: ['https://example.com/doc'],
+          replaySessionId: 'replay-123',
+          status: 'queued',
+        }),
+      );
+      expect(res._statusCode).toBe(201);
+      const card = parseJsonBody<{ card: TaskCard }>(res).card;
+      expect(card.missionId).toBe('mc-293');
+      expect(card.assigneeType).toBe('human');
+      expect(card.assigneeId).toBe('zach');
+      expect(card.dependencies).toEqual(['task-1', 'task-2']);
+      expect(card.artifactLinks).toEqual(['https://example.com/doc']);
+      expect(card.replaySessionId).toBe('replay-123');
+      expect(card.statusHistory?.[0]?.status).toBe('queued');
+      expect(card.statusHistory?.[0]?.note).toContain('mission:mc-293');
+    });
   });
 
   describe('PATCH /api/task-board/:id', () => {
@@ -485,6 +602,42 @@ describe('handleTaskBoard', () => {
       expect(body.card.title).toBe('New');
       expect(body.card.priority).toBe('critical');
       expect(body.card.agentId).toBe('atlas');
+    });
+
+    it('updates mission-linked fields and appends status history on transition', async () => {
+      seedTasks([makeSampleCard({
+        id: 'card-1',
+        status: 'queued',
+        missionId: 'old-mission',
+        statusHistory: [{ status: 'queued', at: Date.now() - 1000, by: 'create', note: 'seed' }],
+      })]);
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/card-1', method: 'PATCH' }),
+        res,
+        depsWithBody({
+          status: 'running',
+          transitionNote: 'picked up',
+          missionId: 'new-mission',
+          missionBrief: 'Mission doc',
+          assigneeType: 'agent',
+          assigneeId: 'oracle',
+          dependencies: ['dep-1'],
+          artifactLinks: ['docs/spec.md'],
+          replaySessionId: 'replay-9',
+        }),
+      );
+      expect(res._statusCode).toBe(200);
+      const card = parseJsonBody<{ card: TaskCard }>(res).card;
+      expect(card.missionId).toBe('new-mission');
+      expect(card.assigneeType).toBe('agent');
+      expect(card.assigneeId).toBe('oracle');
+      expect(card.dependencies).toEqual(['dep-1']);
+      expect(card.artifactLinks).toEqual(['docs/spec.md']);
+      expect(card.replaySessionId).toBe('replay-9');
+      expect(card.status).toBe('running');
+      expect(card.statusHistory?.at(-1)?.status).toBe('running');
+      expect(card.statusHistory?.at(-1)?.note).toBe('picked up');
     });
   });
 


### PR DESCRIPTION
## Summary
- expand task board domain/status model with blocked and review lanes plus mission-linked ownership metadata
- add missionId/assigneeType filtering and propagation across REST list, SSE subscriptions, and task card export
- enhance task board UI for new lanes, filters, bulk transitions, mission/owner badges, and detail panels for dependencies/artifacts/status history
- persist and append status history on create/transition for richer task provenance
- extend unit coverage for task-board route, SSE filtering, and export allowlist/filter behavior

## Validation
- npm run build
- npx -p vitest@4.0.18 vitest run --config /tmp/vitest.taskboard.config.mjs

Closes #293
