### PR TITLE
[Nexus 2.0][MC-P3] Content Pipeline Templates

### DIFF
--- a/dashboard/client/index.html
+++ b/dashboard/client/index.html
@@ -1423,6 +1423,70 @@ body {
   border-color: var(--accent);
 }
 
+.tb-template-panel {
+  padding: 16px;
+}
+
+.tb-template-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  margin-bottom: 12px;
+}
+
+.tb-template-grid {
+  display: grid;
+  grid-template-columns: 1.2fr 1fr;
+  gap: 12px;
+}
+
+.tb-template-meta {
+  margin-top: 8px;
+  font-size: 12px;
+  color: var(--text-muted);
+  line-height: 1.45;
+}
+
+.tb-template-stage-list {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.tb-template-stage-row {
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px;
+  background: var(--bg-card);
+  display: grid;
+  grid-template-columns: 1.3fr 130px 1fr;
+  gap: 10px;
+  align-items: start;
+}
+
+.tb-template-stage-title {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text-primary);
+  margin-bottom: 4px;
+}
+
+.tb-template-stage-meta {
+  font-size: 11px;
+  color: var(--text-muted);
+  line-height: 1.4;
+}
+
+.tb-template-stage-empty {
+  font-size: 12px;
+  color: var(--text-muted);
+  border: 1px dashed var(--border);
+  border-radius: 10px;
+  padding: 10px;
+}
+
 .tb-card-transitions {
   display: flex;
   gap: 4px;
@@ -1456,9 +1520,11 @@ body {
 
 @media (max-width: 1200px) {
   .tb-board { grid-template-columns: repeat(3, 1fr); }
+  .tb-template-grid { grid-template-columns: 1fr; }
 }
 @media (max-width: 768px) {
   .tb-board { grid-template-columns: 1fr; }
+  .tb-template-stage-row { grid-template-columns: 1fr; }
 }
 
 /* ─── Task Detail Modal — Issue #219, Phase 5 ──────────────────────── */
@@ -5548,6 +5614,66 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
         </div>
       </div>
 
+      <!-- Pipeline templates (Issue #297) -->
+      <div class="card mb-24 tb-template-panel">
+        <div class="tb-template-header">
+          <div>
+            <h3 class="card-title" style="margin-bottom:2px;">Pipeline Templates</h3>
+            <div style="font-size:12px;color:var(--text-muted);">Create a full mission pipeline from reusable stage templates</div>
+          </div>
+          <div style="display:flex;gap:8px;">
+            <button onclick="tbLoadPipelineTemplates()" class="tb-btn tb-btn-secondary" style="padding:6px 10px;font-size:12px;">↻ Refresh</button>
+            <button id="tbPipelineDeleteBtn" onclick="tbDeleteSelectedTemplate()" class="tb-btn tb-btn-secondary" style="display:none;padding:6px 10px;font-size:12px;border-color:rgba(239,68,68,0.4);color:var(--red);">🗑 Delete Custom</button>
+          </div>
+        </div>
+
+        <div class="tb-template-grid">
+          <div>
+            <label class="tb-label">Template</label>
+            <select id="tbPipelineTemplate" class="tb-input" onchange="tbOnTemplateChange()">
+              <option value="">Loading templates…</option>
+            </select>
+            <div id="tbPipelineTemplateMeta" class="tb-template-meta"></div>
+          </div>
+          <div>
+            <div style="display:grid;grid-template-columns:1fr 1fr;gap:8px;">
+              <div style="grid-column:1/-1;">
+                <label class="tb-label">Pipeline Name</label>
+                <input id="tbPipelineName" class="tb-input" placeholder="e.g. Launch Video Sprint" maxlength="160">
+              </div>
+              <div>
+                <label class="tb-label">Mission ID</label>
+                <input id="tbPipelineMissionId" class="tb-input" placeholder="e.g. mc-297" maxlength="120">
+              </div>
+              <div>
+                <label class="tb-label">Mission Origin</label>
+                <input id="tbPipelineMissionBrief" class="tb-input" placeholder="Mission brief / objective" maxlength="300">
+              </div>
+              <div>
+                <label class="tb-label">Default Owner Type</label>
+                <select id="tbPipelineAssigneeType" class="tb-input">
+                  <option value="" selected>Inherit template</option>
+                  <option value="human">Human</option>
+                  <option value="nexus">Nexus</option>
+                  <option value="agent">Agent</option>
+                </select>
+              </div>
+              <div>
+                <label class="tb-label">Default Owner ID</label>
+                <input id="tbPipelineAssigneeId" class="tb-input" placeholder="optional default owner id" maxlength="120">
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <div id="tbPipelineStageOverrides" class="tb-template-stage-list"></div>
+
+        <div style="display:flex;justify-content:flex-end;gap:8px;margin-top:12px;">
+          <button onclick="tbResetPipelineForm()" class="tb-btn tb-btn-secondary">Reset</button>
+          <button onclick="tbCreatePipelineFromTemplate()" class="tb-btn tb-btn-primary">Create Pipeline</button>
+        </div>
+      </div>
+
       <!-- Task Metrics Dashboard — Issue #219, Phase 7 -->
       <div class="mb-24">
         <div class="tb-metrics-toggle" id="tbMetricsToggle" onclick="tbToggleMetrics()">
@@ -6277,6 +6403,7 @@ document.querySelectorAll('.nav-item').forEach(item => {
     }
     if (page === 'taskboard') {
       tbRefresh();
+      tbLoadPipelineTemplates(tbPipelineTemplateId);
     }
     if (page === 'logs') {
       loadLogSources();
@@ -10065,6 +10192,9 @@ let tbAutoRefreshTimer = null;
 // ── Filter state (Issue #219 — SSE subscription filtering) ──────────────────
 let tbActiveFilters = { status: '', agentId: '', priority: '', missionId: '', assigneeType: '' };
 let tbKnownAgents = new Set(); // populated from task data
+let tbPipelineTemplates = [];
+let tbPipelineTemplateId = '';
+let tbPipelineTemplatesLoading = false;
 
 /** Build URL query string from active filters (empty fields omitted). */
 function tbFilterQueryString() {
@@ -10132,6 +10262,261 @@ function tbPopulateAgentFilter(tasks) {
   el.value = current;
 }
 
+function tbFindTemplate(id) {
+  if (!id) return null;
+  return tbPipelineTemplates.find((t) => t.id === id) || null;
+}
+
+function tbTemplateOwnerLabel(stage) {
+  const ownerType = stage?.assigneeType || 'unassigned';
+  const ownerId = stage?.assigneeId || '';
+  return ownerId ? `${ownerType}: ${ownerId}` : ownerType;
+}
+
+function tbReadStageAssignments(template) {
+  const out = {};
+  if (!template || !Array.isArray(template.stages)) return out;
+  for (const stage of template.stages) {
+    const typeEl = document.getElementById(`tbStageAssigneeType-${stage.id}`);
+    const idEl = document.getElementById(`tbStageAssigneeId-${stage.id}`);
+    const assigneeType = typeEl ? (typeEl.value || '').trim() : '';
+    const assigneeId = idEl ? (idEl.value || '').trim() : '';
+    if (!assigneeType && !assigneeId) continue;
+    const entry = {};
+    if (assigneeType) entry.assigneeType = assigneeType;
+    if (assigneeId) entry.assigneeId = assigneeId;
+    out[stage.id] = entry;
+  }
+  return out;
+}
+
+function tbRenderTemplateDetails() {
+  const template = tbFindTemplate(tbPipelineTemplateId);
+  const metaEl = document.getElementById('tbPipelineTemplateMeta');
+  const stagesEl = document.getElementById('tbPipelineStageOverrides');
+  const deleteBtn = document.getElementById('tbPipelineDeleteBtn');
+  const pipelineNameEl = document.getElementById('tbPipelineName');
+
+  if (!metaEl || !stagesEl) return;
+  if (!template) {
+    metaEl.innerHTML = '<span style="color:var(--red);">No template selected.</span>';
+    stagesEl.innerHTML = '<div class="tb-template-stage-empty">Template stages will appear here.</div>';
+    if (deleteBtn) deleteBtn.style.display = 'none';
+    return;
+  }
+
+  if (deleteBtn) deleteBtn.style.display = template.source === 'custom' ? '' : 'none';
+
+  const tags = Array.isArray(template.tags) && template.tags.length > 0
+    ? template.tags.map((t) => `<span class="tb-badge" style="background:rgba(99,102,241,0.12);color:var(--accent);">${tbEsc(t)}</span>`).join(' ')
+    : '<span style="color:var(--text-muted);">No tags</span>';
+  const description = template.description
+    ? `<div style="margin-top:6px;">${tbEsc(template.description)}</div>`
+    : '';
+
+  metaEl.innerHTML = `
+    <div><b>${tbEsc(template.name)}</b> <span style="color:var(--text-muted);">(${tbEsc(template.source)})</span></div>
+    ${description}
+    <div style="margin-top:6px;">${tags}</div>
+    <div style="margin-top:6px;">${template.stages.length} stages · Category: ${tbEsc(template.category || 'general')}</div>
+  `;
+
+  const savedAssignments = tbReadStageAssignments(template);
+  stagesEl.innerHTML = template.stages.map((stage, idx) => {
+    const handoff = stage.handoffContract
+      ? `<div class="tb-template-stage-meta" style="margin-top:4px;">🔁 ${tbEsc(stage.handoffContract)}</div>`
+      : '';
+    const desc = stage.description
+      ? `<div class="tb-template-stage-meta" style="margin-top:4px;">${tbEsc(stage.description)}</div>`
+      : '';
+    const approval = stage.requiresApproval
+      ? '<div class="tb-template-stage-meta" style="margin-top:4px;color:var(--yellow);">Requires approval before completion</div>'
+      : '';
+    return `
+      <div class="tb-template-stage-row">
+        <div>
+          <div class="tb-template-stage-title">${idx + 1}. ${tbEsc(stage.title)}</div>
+          <div class="tb-template-stage-meta">Stage ID: <span class="mono">${tbEsc(stage.id)}</span> · Default owner: ${tbEsc(tbTemplateOwnerLabel(stage))}</div>
+          ${desc}
+          ${handoff}
+          ${approval}
+        </div>
+        <div>
+          <label class="tb-label" style="margin-bottom:4px;font-size:11px;">Owner Type Override</label>
+          <select id="tbStageAssigneeType-${stage.id}" class="tb-input" style="padding:6px 8px;font-size:12px;">
+            <option value="">Inherit</option>
+            <option value="human">Human</option>
+            <option value="nexus">Nexus</option>
+            <option value="agent">Agent</option>
+          </select>
+        </div>
+        <div>
+          <label class="tb-label" style="margin-bottom:4px;font-size:11px;">Owner ID Override</label>
+          <input id="tbStageAssigneeId-${stage.id}" class="tb-input" style="padding:6px 8px;font-size:12px;" maxlength="120" placeholder="optional owner id">
+        </div>
+      </div>
+    `;
+  }).join('');
+
+  for (const stage of template.stages) {
+    const existing = savedAssignments[stage.id] || null;
+    const typeEl = document.getElementById(`tbStageAssigneeType-${stage.id}`);
+    const idEl = document.getElementById(`tbStageAssigneeId-${stage.id}`);
+    if (typeEl && existing?.assigneeType) typeEl.value = existing.assigneeType;
+    if (idEl && existing?.assigneeId) idEl.value = existing.assigneeId;
+  }
+
+  if (pipelineNameEl && !pipelineNameEl.value.trim()) {
+    pipelineNameEl.value = template.name || '';
+  }
+}
+
+function tbOnTemplateChange() {
+  const selectEl = document.getElementById('tbPipelineTemplate');
+  tbPipelineTemplateId = selectEl ? (selectEl.value || '') : '';
+  tbRenderTemplateDetails();
+}
+
+async function tbLoadPipelineTemplates(preferredId) {
+  if (tbPipelineTemplatesLoading) return;
+  const selectEl = document.getElementById('tbPipelineTemplate');
+  const metaEl = document.getElementById('tbPipelineTemplateMeta');
+  const stagesEl = document.getElementById('tbPipelineStageOverrides');
+  if (!selectEl) return;
+
+  tbPipelineTemplatesLoading = true;
+  selectEl.disabled = true;
+  selectEl.innerHTML = '<option value="">Loading templates…</option>';
+  if (metaEl) metaEl.textContent = '';
+  if (stagesEl) stagesEl.innerHTML = '<div class="tb-template-stage-empty">Loading stage templates…</div>';
+
+  try {
+    const res = await fetch('/api/task-board/templates');
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    const body = await res.json();
+    const templates = Array.isArray(body.templates) ? body.templates : [];
+    tbPipelineTemplates = templates;
+
+    if (templates.length === 0) {
+      tbPipelineTemplateId = '';
+      selectEl.innerHTML = '<option value="">No templates available</option>';
+      if (metaEl) metaEl.innerHTML = '<span style="color:var(--text-muted);">No templates found.</span>';
+      if (stagesEl) stagesEl.innerHTML = '<div class="tb-template-stage-empty">Add or import templates to create pipelines.</div>';
+      return;
+    }
+
+    selectEl.innerHTML = templates
+      .map((tpl) => `<option value="${tbEsc(tpl.id)}">${tbEsc(tpl.name)}${tpl.source === 'custom' ? ' (custom)' : ''}</option>`)
+      .join('');
+
+    const requestedId = preferredId || tbPipelineTemplateId;
+    const requestedExists = templates.some((tpl) => tpl.id === requestedId);
+    tbPipelineTemplateId = requestedExists ? requestedId : templates[0].id;
+    selectEl.value = tbPipelineTemplateId;
+    tbRenderTemplateDetails();
+  } catch (e) {
+    tbPipelineTemplates = [];
+    tbPipelineTemplateId = '';
+    selectEl.innerHTML = '<option value="">Failed to load templates</option>';
+    if (metaEl) metaEl.innerHTML = `<span style="color:var(--red);">Template load failed: ${tbEsc(e.message || 'unknown error')}</span>`;
+    if (stagesEl) stagesEl.innerHTML = '<div class="tb-template-stage-empty">Retry template fetch to continue.</div>';
+  } finally {
+    selectEl.disabled = false;
+    tbPipelineTemplatesLoading = false;
+  }
+}
+
+function tbResetPipelineForm() {
+  const template = tbFindTemplate(tbPipelineTemplateId);
+  const pipelineNameEl = document.getElementById('tbPipelineName');
+  const missionIdEl = document.getElementById('tbPipelineMissionId');
+  const missionBriefEl = document.getElementById('tbPipelineMissionBrief');
+  const assigneeTypeEl = document.getElementById('tbPipelineAssigneeType');
+  const assigneeIdEl = document.getElementById('tbPipelineAssigneeId');
+  if (pipelineNameEl) pipelineNameEl.value = template?.name || '';
+  if (missionIdEl) missionIdEl.value = '';
+  if (missionBriefEl) missionBriefEl.value = '';
+  if (assigneeTypeEl) assigneeTypeEl.value = '';
+  if (assigneeIdEl) assigneeIdEl.value = '';
+  tbRenderTemplateDetails();
+  if (template && Array.isArray(template.stages)) {
+    for (const stage of template.stages) {
+      const typeEl = document.getElementById(`tbStageAssigneeType-${stage.id}`);
+      const idEl = document.getElementById(`tbStageAssigneeId-${stage.id}`);
+      if (typeEl) typeEl.value = '';
+      if (idEl) idEl.value = '';
+    }
+  }
+}
+
+async function tbDeleteSelectedTemplate() {
+  const template = tbFindTemplate(tbPipelineTemplateId);
+  if (!template) {
+    tbShowToast('Select a template first.', 'error');
+    return;
+  }
+  if (template.source !== 'custom') {
+    tbShowToast('System templates cannot be deleted.', 'error');
+    return;
+  }
+  if (!confirm(`Delete custom template "${template.name}"?`)) return;
+
+  try {
+    const res = await fetch('/api/task-board/templates/' + encodeURIComponent(template.id), { method: 'DELETE' });
+    if (!res.ok) {
+      const err = await res.json().catch(() => ({}));
+      tbShowToast('Delete failed: ' + (err.error || res.statusText), 'error');
+      return;
+    }
+    tbShowToast('Deleted template: ' + template.name, 'success');
+    await tbLoadPipelineTemplates('');
+  } catch (e) {
+    tbShowToast('Network error: ' + e.message, 'error');
+  }
+}
+
+async function tbCreatePipelineFromTemplate() {
+  const template = tbFindTemplate(tbPipelineTemplateId);
+  if (!template) {
+    tbShowToast('Select a template first.', 'error');
+    return;
+  }
+
+  const pipelineName = (document.getElementById('tbPipelineName') || {}).value?.trim?.() || '';
+  const missionId = (document.getElementById('tbPipelineMissionId') || {}).value?.trim?.() || '';
+  const missionBrief = (document.getElementById('tbPipelineMissionBrief') || {}).value?.trim?.() || '';
+  const assigneeType = (document.getElementById('tbPipelineAssigneeType') || {}).value || '';
+  const assigneeId = (document.getElementById('tbPipelineAssigneeId') || {}).value?.trim?.() || '';
+  const stageAssignments = tbReadStageAssignments(template);
+
+  const body = {
+    templateId: template.id,
+    pipelineName: pipelineName || undefined,
+    missionId: missionId || null,
+    missionBrief: missionBrief || null,
+    assigneeType: assigneeType || null,
+    assigneeId: assigneeId || null,
+    stageAssignments: Object.keys(stageAssignments).length > 0 ? stageAssignments : undefined,
+  };
+
+  try {
+    const res = await fetch('/api/task-board/pipelines/from-template', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+    const payload = await res.json().catch(() => ({}));
+    if (!res.ok) {
+      tbShowToast('Pipeline create failed: ' + (payload.error || res.statusText), 'error');
+      return;
+    }
+    tbShowToast(`Pipeline created: ${payload.created || 0} cards`, 'success');
+    await tbRefresh();
+  } catch (e) {
+    tbShowToast('Network error: ' + e.message, 'error');
+  }
+}
+
 async function tbRefresh() {
   try {
     const qs = tbFilterQueryString();
@@ -10155,6 +10540,9 @@ async function tbRefresh() {
 
     // Populate agent filter dropdown from all task data
     tbPopulateAgentFilter(tbTasks);
+    if (tbPipelineTemplates.length === 0 && !tbPipelineTemplatesLoading) {
+      tbLoadPipelineTemplates(tbPipelineTemplateId);
+    }
 
     tbRenderBoard();
 

--- a/dashboard/server/routes/task-board.ts
+++ b/dashboard/server/routes/task-board.ts
@@ -29,6 +29,8 @@ import type {
   TaskAssigneeType,
   TaskBoardSummary,
   TaskStatusHistoryEntry,
+  TaskPipelineTemplate,
+  TaskPipelineStageTemplate,
 } from '../types.js';
 
 import {
@@ -127,6 +129,102 @@ const VALID_STATUSES: TaskStatus[] = [
 ];
 const VALID_PRIORITIES: TaskPriority[] = ['critical', 'high', 'medium', 'low'];
 const VALID_ASSIGNEE_TYPES: TaskAssigneeType[] = ['human', 'nexus', 'agent'];
+const TEMPLATE_ID_RE = /^[a-z0-9][a-z0-9-_]{1,63}$/;
+const STAGE_ID_RE = /^[a-z0-9][a-z0-9-_]{1,63}$/;
+const TEMPLATE_TAG_RE = /^#?[a-z0-9][a-z0-9:_-]{0,31}$/i;
+
+const SYSTEM_TEMPLATE_EPOCH = 1_700_000_000_000;
+const SYSTEM_PIPELINE_TEMPLATES: TaskPipelineTemplate[] = [
+  {
+    id: 'content-idea-script-publish',
+    name: 'Content: Idea -> Script -> Publish',
+    description: 'Reusable multi-stage content production flow with explicit handoff contracts.',
+    category: 'content',
+    tags: ['#content', '#pipeline', '#publish'],
+    source: 'system',
+    createdAt: SYSTEM_TEMPLATE_EPOCH,
+    updatedAt: SYSTEM_TEMPLATE_EPOCH,
+    stages: [
+      {
+        id: 'idea',
+        title: 'Idea Brief',
+        assigneeType: 'nexus',
+        assigneeId: 'nexus',
+        handoffContract: 'Produce a concise concept brief with audience + outcome.',
+      },
+      {
+        id: 'script',
+        title: 'Script Draft',
+        assigneeType: 'agent',
+        assigneeId: 'synth',
+        handoffContract: 'Deliver script draft with structure, hooks, and call-to-action.',
+      },
+      {
+        id: 'thumbnail',
+        title: 'Thumbnail Direction',
+        assigneeType: 'agent',
+        assigneeId: 'synth',
+        handoffContract: 'Provide visual direction and copy variants for thumbnail selection.',
+      },
+      {
+        id: 'filming',
+        title: 'Filming / Capture',
+        assigneeType: 'human',
+        assigneeId: null,
+        handoffContract: 'Capture footage/assets following approved script and direction.',
+      },
+      {
+        id: 'publish',
+        title: 'Publish + Distribution',
+        assigneeType: 'nexus',
+        assigneeId: 'nexus',
+        handoffContract: 'Publish artifact, attach links, and verify live distribution.',
+        requiresApproval: true,
+      },
+    ],
+  },
+  {
+    id: 'generic-research-build-ship',
+    name: 'Generic: Research -> Build -> Ship',
+    description: 'General-purpose template for non-content execution pipelines.',
+    category: 'generic',
+    tags: ['#generic', '#delivery'],
+    source: 'system',
+    createdAt: SYSTEM_TEMPLATE_EPOCH,
+    updatedAt: SYSTEM_TEMPLATE_EPOCH,
+    stages: [
+      {
+        id: 'research',
+        title: 'Research and Scope',
+        assigneeType: 'agent',
+        assigneeId: 'oracle',
+        handoffContract: 'Document assumptions, constraints, and acceptance boundaries.',
+      },
+      {
+        id: 'implementation',
+        title: 'Implementation',
+        assigneeType: 'agent',
+        assigneeId: 'synth',
+        handoffContract: 'Produce implementation artifacts linked to mission context.',
+      },
+      {
+        id: 'verification',
+        title: 'Verification',
+        assigneeType: 'agent',
+        assigneeId: 'verifier',
+        handoffContract: 'Attach validation evidence and explicit pass/fail verdict.',
+      },
+      {
+        id: 'ship',
+        title: 'Ship / Rollout',
+        assigneeType: 'nexus',
+        assigneeId: 'nexus',
+        handoffContract: 'Record release outcome and final source-of-truth links.',
+        requiresApproval: true,
+      },
+    ],
+  },
+];
 
 /** Allowed state transitions (from → to[]). */
 const TRANSITIONS: Record<TaskStatus, TaskStatus[]> = {
@@ -252,6 +350,399 @@ function saveTasks(dataDir: string, tasks: TaskCard[]): void {
   const dir = path.dirname(fp);
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(fp, JSON.stringify({ tasks, updatedAt: Date.now() }, null, 2));
+}
+
+// ─── Pipeline Template Store (Issue #297) ───────────────────────────────────
+
+function pipelineTemplateFilePath(dataDir: string): string {
+  return path.join(dataDir, 'task-board-templates.json');
+}
+
+function compactSlug(raw: string, fallback: string): string {
+  const s = raw
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9\-_ ]+/g, '')
+    .replace(/\s+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return s || fallback;
+}
+
+function normalizeTag(tag: string): string | null {
+  const t = tag.trim();
+  if (!t) return null;
+  if (!TEMPLATE_TAG_RE.test(t)) return null;
+  const canonical = t.startsWith('#') ? t.toLowerCase() : `#${t.toLowerCase()}`;
+  return canonical.slice(0, 32);
+}
+
+function normalizeTemplateStage(
+  raw: unknown,
+  idx: number,
+): TaskPipelineStageTemplate | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const title = String((raw as { title?: string }).title ?? '').trim();
+  if (!title) return null;
+  if (title.length > 120) return null;
+
+  const idRaw = String((raw as { id?: string }).id ?? '').trim();
+  const stageId = compactSlug(idRaw || title, `stage-${idx + 1}`).slice(0, 64);
+  if (!STAGE_ID_RE.test(stageId)) return null;
+
+  const descriptionRaw = (raw as { description?: unknown }).description;
+  const description = typeof descriptionRaw === 'string' && descriptionRaw.trim()
+    ? descriptionRaw.trim().slice(0, 400)
+    : null;
+
+  const assigneeTypeRaw = (raw as { assigneeType?: unknown }).assigneeType;
+  const assigneeType = typeof assigneeTypeRaw === 'string' &&
+    VALID_ASSIGNEE_TYPES.includes(assigneeTypeRaw as TaskAssigneeType)
+    ? (assigneeTypeRaw as TaskAssigneeType)
+    : undefined;
+
+  const assigneeIdRaw = (raw as { assigneeId?: unknown }).assigneeId;
+  const assigneeId = typeof assigneeIdRaw === 'string' && assigneeIdRaw.trim()
+    ? assigneeIdRaw.trim().slice(0, 120)
+    : null;
+
+  const handoffRaw = (raw as { handoffContract?: unknown }).handoffContract;
+  const handoffContract = typeof handoffRaw === 'string' && handoffRaw.trim()
+    ? handoffRaw.trim().slice(0, 240)
+    : null;
+
+  return {
+    id: stageId,
+    title,
+    description,
+    assigneeType,
+    assigneeId,
+    handoffContract,
+    requiresApproval: (raw as { requiresApproval?: unknown }).requiresApproval === true,
+  };
+}
+
+function normalizePipelineTemplate(
+  raw: unknown,
+  source: 'system' | 'custom',
+): TaskPipelineTemplate | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const name = String((raw as { name?: string }).name ?? '').trim();
+  if (!name || name.length > 120) return null;
+
+  const idRaw = String((raw as { id?: string }).id ?? '').trim();
+  const id = compactSlug(idRaw || name, source === 'system' ? 'template' : 'custom-template').slice(0, 64);
+  if (!TEMPLATE_ID_RE.test(id)) return null;
+
+  const stagesRaw = (raw as { stages?: unknown }).stages;
+  if (!Array.isArray(stagesRaw) || stagesRaw.length < 2 || stagesRaw.length > 20) return null;
+  const stages: TaskPipelineStageTemplate[] = [];
+  const seenStageIds = new Set<string>();
+  for (let i = 0; i < stagesRaw.length; i++) {
+    const stage = normalizeTemplateStage(stagesRaw[i], i);
+    if (!stage) return null;
+    if (seenStageIds.has(stage.id)) return null;
+    seenStageIds.add(stage.id);
+    stages.push(stage);
+  }
+
+  const descriptionRaw = (raw as { description?: unknown }).description;
+  const categoryRaw = (raw as { category?: unknown }).category;
+  const tagsRaw = sanitizeStringList((raw as { tags?: unknown }).tags, { maxItems: 12, maxLen: 32 });
+  const tags = tagsRaw
+    .map((t) => normalizeTag(t))
+    .filter((t): t is string => !!t);
+
+  const createdAtRaw = (raw as { createdAt?: unknown }).createdAt;
+  const updatedAtRaw = (raw as { updatedAt?: unknown }).updatedAt;
+  const now = Date.now();
+  const createdAt = typeof createdAtRaw === 'number' && Number.isFinite(createdAtRaw) && createdAtRaw > 0
+    ? Math.trunc(createdAtRaw)
+    : now;
+  const updatedAt = typeof updatedAtRaw === 'number' && Number.isFinite(updatedAtRaw) && updatedAtRaw > 0
+    ? Math.trunc(updatedAtRaw)
+    : now;
+
+  return {
+    id,
+    name,
+    description: typeof descriptionRaw === 'string' && descriptionRaw.trim()
+      ? descriptionRaw.trim().slice(0, 600)
+      : null,
+    category: typeof categoryRaw === 'string' && categoryRaw.trim()
+      ? categoryRaw.trim().slice(0, 80)
+      : null,
+    tags,
+    stages,
+    createdAt,
+    updatedAt,
+    source,
+  };
+}
+
+function loadCustomPipelineTemplates(dataDir: string): TaskPipelineTemplate[] {
+  try {
+    const fp = pipelineTemplateFilePath(dataDir);
+    if (!fs.existsSync(fp)) return [];
+    const raw = fs.readFileSync(fp, 'utf8');
+    const parsed = JSON.parse(raw);
+    const arr = Array.isArray(parsed)
+      ? parsed
+      : (parsed && Array.isArray(parsed.templates) ? parsed.templates : []);
+    const out: TaskPipelineTemplate[] = [];
+    for (const item of arr) {
+      const tpl = normalizePipelineTemplate(item, 'custom');
+      if (tpl) out.push(tpl);
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}
+
+function saveCustomPipelineTemplates(dataDir: string, templates: TaskPipelineTemplate[]): void {
+  const fp = pipelineTemplateFilePath(dataDir);
+  const dir = path.dirname(fp);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  fs.writeFileSync(
+    fp,
+    JSON.stringify({ templates, updatedAt: Date.now() }, null, 2),
+  );
+}
+
+export function loadPipelineTemplates(dataDir: string): TaskPipelineTemplate[] {
+  const map = new Map<string, TaskPipelineTemplate>();
+  for (const sysTpl of SYSTEM_PIPELINE_TEMPLATES) {
+    map.set(sysTpl.id, sysTpl);
+  }
+  for (const customTpl of loadCustomPipelineTemplates(dataDir)) {
+    map.set(customTpl.id, customTpl);
+  }
+  return [...map.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+interface TemplateUpsertInput {
+  id?: string;
+  name?: string;
+  description?: string | null;
+  category?: string | null;
+  tags?: unknown;
+  stages?: unknown;
+}
+
+function validateTemplateUpsert(body: unknown): { ok: true; template: TaskPipelineTemplate } | { ok: false; error: string } {
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return { ok: false, error: 'body must be an object' };
+  }
+
+  const input = body as TemplateUpsertInput;
+  const name = String(input.name ?? '').trim();
+  if (!name) return { ok: false, error: 'name is required' };
+  if (name.length > 120) return { ok: false, error: 'name must be ≤ 120 chars' };
+
+  const idSeed = String(input.id ?? '').trim() || name;
+  const id = compactSlug(idSeed, 'custom-template').slice(0, 64);
+  if (!TEMPLATE_ID_RE.test(id)) {
+    return { ok: false, error: 'id must match [a-z0-9][a-z0-9-_]{1,63}' };
+  }
+
+  if (!Array.isArray(input.stages)) {
+    return { ok: false, error: 'stages must be an array' };
+  }
+  if (input.stages.length < 2 || input.stages.length > 20) {
+    return { ok: false, error: 'stages must contain between 2 and 20 entries' };
+  }
+
+  const stages: TaskPipelineStageTemplate[] = [];
+  const seenIds = new Set<string>();
+  for (let i = 0; i < input.stages.length; i++) {
+    const stage = normalizeTemplateStage(input.stages[i], i);
+    if (!stage) return { ok: false, error: `invalid stage at index ${i}` };
+    if (seenIds.has(stage.id)) return { ok: false, error: `duplicate stage id: ${stage.id}` };
+    seenIds.add(stage.id);
+    stages.push(stage);
+  }
+
+  const tags = sanitizeStringList(input.tags, { maxItems: 12, maxLen: 32 })
+    .map((t) => normalizeTag(t))
+    .filter((t): t is string => !!t);
+
+  const description = typeof input.description === 'string' && input.description.trim()
+    ? input.description.trim().slice(0, 600)
+    : null;
+  const category = typeof input.category === 'string' && input.category.trim()
+    ? input.category.trim().slice(0, 80)
+    : null;
+
+  const now = Date.now();
+  return {
+    ok: true,
+    template: {
+      id,
+      name,
+      description,
+      category,
+      tags,
+      stages,
+      createdAt: now,
+      updatedAt: now,
+      source: 'custom',
+    },
+  };
+}
+
+interface PipelineFromTemplateInput {
+  templateId?: string;
+  pipelineName?: string;
+  missionId?: string | null;
+  missionBrief?: string | null;
+  assigneeType?: string | null;
+  assigneeId?: string | null;
+  stageAssignments?: Record<string, { assigneeType?: string; assigneeId?: string | null }>;
+}
+
+interface PipelineFromTemplateResult {
+  ok: boolean;
+  error?: string;
+  pipelineId?: string;
+  templateId?: string;
+  created?: number;
+  cards?: TaskCard[];
+}
+
+function instantiatePipelineFromTemplate(
+  dataDir: string,
+  input: PipelineFromTemplateInput,
+  emitEvent?: TaskBoardDeps['emitEvent'],
+): PipelineFromTemplateResult {
+  const templateId = String(input.templateId ?? '').trim();
+  if (!templateId) return { ok: false, error: 'templateId is required' };
+
+  const template = loadPipelineTemplates(dataDir).find((t) => t.id === templateId);
+  if (!template) return { ok: false, error: `template not found: ${templateId}` };
+
+  const pipelineName = String(input.pipelineName ?? '').trim() || template.name;
+  if (pipelineName.length > 160) return { ok: false, error: 'pipelineName must be ≤ 160 chars' };
+
+  const missionId = input.missionId?.trim() || null;
+  if (missionId && missionId.length > 120) return { ok: false, error: 'missionId must be ≤ 120 chars' };
+  const missionBrief = input.missionBrief?.trim() || pipelineName;
+  if (missionBrief && missionBrief.length > 300) {
+    return { ok: false, error: 'missionBrief must be ≤ 300 chars' };
+  }
+
+  const defaultAssigneeType = typeof input.assigneeType === 'string' &&
+    VALID_ASSIGNEE_TYPES.includes(input.assigneeType as TaskAssigneeType)
+    ? (input.assigneeType as TaskAssigneeType)
+    : null;
+  const defaultAssigneeId = input.assigneeId?.trim() || null;
+  if (defaultAssigneeId && defaultAssigneeId.length > 120) {
+    return { ok: false, error: 'assigneeId must be ≤ 120 chars' };
+  }
+
+  const stageAssignments = (input.stageAssignments && typeof input.stageAssignments === 'object')
+    ? input.stageAssignments
+    : {};
+
+  const tasks = loadTasks(dataDir);
+  const pipelineId = `pl-${Date.now().toString(36)}-${crypto.randomBytes(3).toString('hex')}`;
+  const created: TaskCard[] = [];
+  let prevCardId: string | null = null;
+  const nowBase = Date.now();
+
+  for (let i = 0; i < template.stages.length; i++) {
+    const stage = template.stages[i];
+    const overrideRaw = stageAssignments[stage.id];
+    if (overrideRaw != null && (typeof overrideRaw !== 'object' || Array.isArray(overrideRaw))) {
+      return { ok: false, error: `stageAssignments.${stage.id} must be an object` };
+    }
+    const override = (overrideRaw ?? null) as { assigneeType?: unknown; assigneeId?: unknown } | null;
+
+    let overrideAssigneeType: TaskAssigneeType | null = null;
+    if (override?.assigneeType != null) {
+      if (typeof override.assigneeType !== 'string') {
+        return { ok: false, error: `stageAssignments.${stage.id}.assigneeType must be a string` };
+      }
+      if (!VALID_ASSIGNEE_TYPES.includes(override.assigneeType as TaskAssigneeType)) {
+        return { ok: false, error: `invalid assigneeType for stage ${stage.id}: ${override.assigneeType}` };
+      }
+      overrideAssigneeType = override.assigneeType as TaskAssigneeType;
+    }
+
+    const effectiveAssigneeType = overrideAssigneeType ?? stage.assigneeType ?? defaultAssigneeType ?? 'nexus';
+    let overrideAssigneeId: string | null = null;
+    if (override?.assigneeId != null) {
+      if (typeof override.assigneeId !== 'string') {
+        return { ok: false, error: `stageAssignments.${stage.id}.assigneeId must be a string` };
+      }
+      overrideAssigneeId = override.assigneeId.trim();
+      if (overrideAssigneeId.length > 120) {
+        return { ok: false, error: `stageAssignments.${stage.id}.assigneeId must be ≤ 120 chars` };
+      }
+    }
+    const effectiveAssigneeId = (overrideAssigneeId || stage.assigneeId || defaultAssigneeId || null);
+    const agentId = effectiveAssigneeType === 'agent' ? effectiveAssigneeId : null;
+
+    const descriptionBits = [];
+    if (stage.description) descriptionBits.push(stage.description);
+    if (stage.handoffContract) descriptionBits.push(`Handoff Contract: ${stage.handoffContract}`);
+    if (stage.requiresApproval) {
+      descriptionBits.push('Approval Required: human final arbiter sign-off required before stage completion.');
+    }
+
+    const createdAt = nowBase + i;
+    const status: TaskStatus = i === 0 ? 'queued' : 'backlog';
+    const card: TaskCard = {
+      id: crypto.randomUUID(),
+      agentId,
+      title: `${pipelineName} — ${stage.title}`,
+      description: descriptionBits.join('\n\n'),
+      priority: i === 0 ? 'high' : 'medium',
+      status,
+      createdAt,
+      queuedAt: status === 'queued' ? createdAt : null,
+      startedAt: null,
+      completedAt: null,
+      resultSummary: null,
+      tokensUsed: null,
+      error: null,
+      costEstimate: null,
+      runtimeMs: null,
+      missionId,
+      missionBrief,
+      assigneeType: effectiveAssigneeType,
+      assigneeId: effectiveAssigneeId,
+      dependencies: prevCardId ? [prevCardId] : [],
+      artifactLinks: [
+        `pipeline:${pipelineId}`,
+        `template:${template.id}`,
+        `stage:${stage.id}`,
+      ],
+      replaySessionId: null,
+      statusHistory: [
+        {
+          status,
+          at: createdAt,
+          by: 'pipeline-template',
+          note: `pipeline:${pipelineId} stage:${stage.id}`,
+        },
+      ],
+    };
+    prevCardId = card.id;
+    tasks.push(card);
+    created.push(card);
+  }
+
+  saveTasks(dataDir, tasks);
+  for (const card of created) emitEvent?.('task:created', card);
+
+  return {
+    ok: true,
+    pipelineId,
+    templateId: template.id,
+    created: created.length,
+    cards: created,
+  };
 }
 
 // ─── Metrics & Stuck-Task Detection (Issue #219 — Task Metrics Dashboard) ────
@@ -882,6 +1373,97 @@ export async function handleTaskBoard(
       removeClient(res);
     });
 
+    return true;
+  }
+
+  // ── GET/POST/DELETE /api/task-board/templates — Issue #297 ───────────────
+  // Pipeline template registry for reusable task-board instantiation flows.
+  // Generic schema: stages + optional assignee + handoff contract metadata.
+  if (url === '/api/task-board/templates' && method === 'GET') {
+    const templates = loadPipelineTemplates(dataDir);
+    sendJson(res, { templates, total: templates.length });
+    return true;
+  }
+
+  if (url === '/api/task-board/templates' && method === 'POST') {
+    let body: unknown;
+    try {
+      const raw = await readRequestBody(req, { maxBytes: 65536 });
+      body = JSON.parse(raw);
+    } catch {
+      sendJson(res, { error: 'invalid JSON body' }, 400);
+      return true;
+    }
+
+    const validated = validateTemplateUpsert(body);
+    if (!validated.ok) {
+      sendJson(res, { error: validated.error }, 400);
+      return true;
+    }
+
+    if (SYSTEM_PIPELINE_TEMPLATES.some((t) => t.id === validated.template.id)) {
+      sendJson(res, { error: `cannot overwrite system template: ${validated.template.id}` }, 409);
+      return true;
+    }
+
+    const custom = loadCustomPipelineTemplates(dataDir);
+    const existingIdx = custom.findIndex((t) => t.id === validated.template.id);
+    const existingCreatedAt = existingIdx >= 0 ? custom[existingIdx].createdAt : validated.template.createdAt;
+    const nextTemplate: TaskPipelineTemplate = {
+      ...validated.template,
+      createdAt: existingCreatedAt,
+      updatedAt: Date.now(),
+    };
+
+    if (existingIdx >= 0) custom[existingIdx] = nextTemplate;
+    else custom.push(nextTemplate);
+    saveCustomPipelineTemplates(dataDir, custom);
+
+    sendJson(res, { template: nextTemplate, total: custom.length }, existingIdx >= 0 ? 200 : 201);
+    return true;
+  }
+
+  if (url.startsWith('/api/task-board/templates/') && method === 'DELETE') {
+    const id = (url.split('/api/task-board/templates/')[1]?.split('?')[0] ?? '').trim();
+    if (!id) {
+      sendJson(res, { error: 'template id is required' }, 400);
+      return true;
+    }
+    if (SYSTEM_PIPELINE_TEMPLATES.some((t) => t.id === id)) {
+      sendJson(res, { error: 'system templates cannot be deleted' }, 409);
+      return true;
+    }
+
+    const custom = loadCustomPipelineTemplates(dataDir);
+    const next = custom.filter((t) => t.id !== id);
+    if (next.length === custom.length) {
+      sendJson(res, { error: 'template not found' }, 404);
+      return true;
+    }
+    saveCustomPipelineTemplates(dataDir, next);
+    sendJson(res, { ok: true, deletedId: id, total: next.length });
+    return true;
+  }
+
+  // ── POST /api/task-board/pipelines/from-template — Issue #297 ─────────────
+  // Instantiate a mission-linked pipeline from a reusable template.
+  // Cards are created with dependency chain + owner assignments + audit notes.
+  if (url === '/api/task-board/pipelines/from-template' && method === 'POST') {
+    let body: PipelineFromTemplateInput;
+    try {
+      const raw = await readRequestBody(req, { maxBytes: 65536 });
+      body = JSON.parse(raw) as PipelineFromTemplateInput;
+    } catch {
+      sendJson(res, { error: 'invalid JSON body' }, 400);
+      return true;
+    }
+
+    const result = instantiatePipelineFromTemplate(dataDir, body, deps.emitEvent);
+    if (!result.ok) {
+      sendJson(res, { error: result.error }, 400);
+      return true;
+    }
+    sendJson(res, result, 201);
     return true;
   }
 

--- a/dashboard/server/types.ts
+++ b/dashboard/server/types.ts
@@ -779,6 +779,30 @@ export interface TaskBoardSummary {
   total: number;
 }
 
+/** Reusable stage template used to instantiate mission pipelines on the task board. */
+export interface TaskPipelineStageTemplate {
+  id: string;
+  title: string;
+  description?: string | null;
+  assigneeType?: TaskAssigneeType;
+  assigneeId?: string | null;
+  handoffContract?: string | null;
+  requiresApproval?: boolean;
+}
+
+/** Reusable pipeline template (generic board schema; not domain hardcoded). */
+export interface TaskPipelineTemplate {
+  id: string;
+  name: string;
+  description?: string | null;
+  category?: string | null;
+  tags: string[];
+  stages: TaskPipelineStageTemplate[];
+  createdAt: number;
+  updatedAt: number;
+  source: 'system' | 'custom';
+}
+
 /** Dependencies injected into Task Board route handlers. */
 export interface TaskBoardDeps {
   dataDir: string;

--- a/dashboard/tests/unit/routes/task-board.test.ts
+++ b/dashboard/tests/unit/routes/task-board.test.ts
@@ -398,6 +398,131 @@ describe('handleTaskBoard', () => {
     });
   });
 
+  describe('pipeline templates (Issue #297)', () => {
+    it('lists system templates', async () => {
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/templates', method: 'GET' }),
+        res,
+        createDeps(),
+      );
+      expect(res._statusCode).toBe(200);
+      const body = parseJsonBody<{ templates: Array<{ id: string }>; total: number }>(res);
+      expect(body.total).toBeGreaterThan(0);
+      expect(body.templates.some((t) => t.id === 'content-idea-script-publish')).toBe(true);
+    });
+
+    it('creates and deletes a custom template', async () => {
+      const createRes = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/templates', method: 'POST' }),
+        createRes,
+        depsWithBody({
+          name: 'My Quick Pipeline',
+          tags: ['ops'],
+          stages: [
+            { title: 'Plan', assigneeType: 'nexus', assigneeId: 'nexus' },
+            { title: 'Execute', assigneeType: 'agent', assigneeId: 'synth' },
+          ],
+        }),
+      );
+      expect(createRes._statusCode).toBe(201);
+      const created = parseJsonBody<{ template: { id: string } }>(createRes);
+      expect(created.template.id).toBe('my-quick-pipeline');
+
+      const listRes = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/templates', method: 'GET' }),
+        listRes,
+        createDeps(),
+      );
+      const listBody = parseJsonBody<{ templates: Array<{ id: string }> }>(listRes);
+      expect(listBody.templates.some((t) => t.id === created.template.id)).toBe(true);
+
+      const deleteRes = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: `/api/task-board/templates/${created.template.id}`, method: 'DELETE' }),
+        deleteRes,
+        createDeps(),
+      );
+      expect(deleteRes._statusCode).toBe(200);
+      expect(parseJsonBody(deleteRes).ok).toBe(true);
+    });
+
+    it('prevents overwriting or deleting system templates', async () => {
+      const overwriteRes = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/templates', method: 'POST' }),
+        overwriteRes,
+        depsWithBody({
+          id: 'content-idea-script-publish',
+          name: 'Override attempt',
+          stages: [
+            { title: 'Plan' },
+            { title: 'Execute' },
+          ],
+        }),
+      );
+      expect(overwriteRes._statusCode).toBe(409);
+      expect(parseJsonBody<{ error: string }>(overwriteRes).error).toContain('cannot overwrite system template');
+
+      const deleteRes = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/templates/content-idea-script-publish', method: 'DELETE' }),
+        deleteRes,
+        createDeps(),
+      );
+      expect(deleteRes._statusCode).toBe(409);
+      expect(parseJsonBody<{ error: string }>(deleteRes).error).toContain('system templates cannot be deleted');
+    });
+
+    it('instantiates a pipeline from template with dependency chain and audit note', async () => {
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/pipelines/from-template', method: 'POST' }),
+        res,
+        depsWithBody({
+          templateId: 'content-idea-script-publish',
+          pipelineName: 'Launch Video',
+          missionId: 'mc-297',
+          missionBrief: 'Creator launch',
+          assigneeType: 'nexus',
+          assigneeId: 'nexus',
+          stageAssignments: {
+            script: { assigneeType: 'agent', assigneeId: 'synth' },
+          },
+        }),
+      );
+      expect(res._statusCode).toBe(201);
+      const body = parseJsonBody<{ created: number; cards: TaskCard[] }>(res);
+      expect(body.created).toBeGreaterThanOrEqual(2);
+      expect(body.cards[0].status).toBe('queued');
+      expect(body.cards[1].dependencies?.[0]).toBe(body.cards[0].id);
+      expect(body.cards[0].statusHistory?.[0]?.note).toContain('pipeline:');
+      expect(body.cards.some((c) => c.assigneeType === 'agent' && c.assigneeId === 'synth')).toBe(true);
+
+      const persisted = loadTasks(testDataDir);
+      expect(persisted.length).toBe(body.created);
+      expect(persisted[0].missionId).toBe('mc-297');
+    });
+
+    it('rejects invalid stage assignment overrides during instantiation', async () => {
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/pipelines/from-template', method: 'POST' }),
+        res,
+        depsWithBody({
+          templateId: 'content-idea-script-publish',
+          stageAssignments: {
+            script: { assigneeType: 'super-agent' },
+          },
+        }),
+      );
+      expect(res._statusCode).toBe(400);
+      expect(parseJsonBody<{ error: string }>(res).error).toContain('invalid assigneeType for stage script');
+    });
+  });
+
   describe('GET /api/task-board/summary', () => {
     it('returns summary with column counts', async () => {
       seedTasks([


### PR DESCRIPTION
## Summary
- add reusable task-board pipeline template types and persistence (`task-board-templates.json`)
- add template APIs: list/create/delete plus pipeline instantiation endpoint
- instantiate pipelines as chained mission-linked cards with owner assignments, handoff contract context, and status-history audit notes
- add Task Board UI panel to load templates, preview stages/handoff contracts, apply default + per-stage owner overrides, and instantiate pipeline cards quickly
- harden validation for stage assignment overrides and system-template immutability

## Validation
- `npm run -s build`
- `npx -p vitest@4.0.18 vitest run --config /tmp/vitest.taskboard.config.mjs`

Closes #297
