### PR TITLE
[Nexus 2.0][MC-P2b] Add Obsidian Vault Connector

### DIFF
--- a/dashboard/server/routes/obsidian-connector.ts
+++ b/dashboard/server/routes/obsidian-connector.ts
@@ -1,0 +1,453 @@
+/**
+ * Obsidian Vault Connector — Issue #299
+ *
+ * Endpoints:
+ *   GET  /api/obsidian/vaults          Discover local Obsidian vaults.
+ *   GET  /api/obsidian/config          Read connector config.
+ *   PUT  /api/obsidian/config          Update connector config.
+ *   GET  /api/obsidian/notes           Index/search markdown notes.
+ *   POST /api/obsidian/notes/write     Safe markdown write adapter.
+ *
+ * Safety:
+ * - Never writes Obsidian app config internals.
+ * - Rejects writes targeting any `.obsidian/` path segment.
+ * - Enforces writes remain inside configured vault root.
+ */
+
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+const DEFAULT_MISSION_FOLDER = 'VentureOS/Missions';
+const MAX_NOTE_SCAN = 2000;
+const MAX_NOTE_BYTES = 128_000;
+const MAX_WRITE_BYTES = 512_000;
+
+interface ObsidianVaultMeta {
+  id: string;
+  name: string;
+  path: string;
+  exists: boolean;
+}
+
+interface ObsidianConnectorConfig {
+  version: number;
+  vaultId: string | null;
+  vaultPath: string | null;
+  missionFolder: string;
+  updatedAt: number;
+}
+
+interface ObsidianConnectorDeps {
+  dataDir: string;
+  sendJson: (res: ServerResponse, data: unknown, status?: number) => void;
+  readRequestBody: (req: IncomingMessage, opts?: { maxBytes?: number }) => Promise<string>;
+}
+
+function connectorConfigPath(dataDir: string): string {
+  return path.join(dataDir, 'obsidian-connector.json');
+}
+
+function obsidianAppConfigPath(): string {
+  return process.env.OBSIDIAN_CONFIG_PATH
+    ?? path.join(os.homedir(), 'Library', 'Application Support', 'obsidian', 'obsidian.json');
+}
+
+function defaultConnectorConfig(): ObsidianConnectorConfig {
+  return {
+    version: 1,
+    vaultId: null,
+    vaultPath: null,
+    missionFolder: DEFAULT_MISSION_FOLDER,
+    updatedAt: Date.now(),
+  };
+}
+
+function sendError(
+  deps: ObsidianConnectorDeps,
+  res: ServerResponse,
+  status: number,
+  error: string,
+): true {
+  deps.sendJson(res, { ok: false, error }, status);
+  return true;
+}
+
+function isObject(v: unknown): v is Record<string, unknown> {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+function hasDotObsidianSegment(p: string): boolean {
+  return p.split(/[\\/]+/).some((seg) => seg === '.obsidian');
+}
+
+function normalizeRelativePath(input: string): string | null {
+  const raw = input.replace(/\\/g, '/').trim();
+  if (!raw) return null;
+  if (raw.startsWith('/')) return null;
+  const normalized = path.posix.normalize(raw).replace(/^\/+/, '');
+  if (!normalized || normalized === '.' || normalized === '..' || normalized.startsWith('../')) {
+    return null;
+  }
+  if (hasDotObsidianSegment(normalized)) return null;
+  return normalized;
+}
+
+function resolveInsideVault(vaultPath: string, relPath: string): string | null {
+  const resolvedVault = path.resolve(vaultPath);
+  const target = path.resolve(resolvedVault, relPath);
+  if (target !== resolvedVault && !target.startsWith(resolvedVault + path.sep)) return null;
+  if (hasDotObsidianSegment(path.relative(resolvedVault, target))) return null;
+  return target;
+}
+
+function toPosixRelative(root: string, absolutePath: string): string {
+  return path.relative(root, absolutePath).split(path.sep).join('/');
+}
+
+function safeMissionSlug(missionId: string): string {
+  const slug = missionId
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return (slug || 'mission').slice(0, 120);
+}
+
+function parseFrontmatter(markdown: string): { frontmatter: Record<string, string>; body: string } {
+  if (!markdown.startsWith('---\n')) return { frontmatter: {}, body: markdown };
+  const end = markdown.indexOf('\n---\n', 4);
+  if (end < 0) return { frontmatter: {}, body: markdown };
+  const fmRaw = markdown.slice(4, end);
+  const body = markdown.slice(end + 5);
+  const frontmatter: Record<string, string> = {};
+  for (const line of fmRaw.split('\n')) {
+    const idx = line.indexOf(':');
+    if (idx <= 0) continue;
+    const key = line.slice(0, idx).trim();
+    const val = line.slice(idx + 1).trim();
+    if (key) frontmatter[key] = val;
+  }
+  return { frontmatter, body };
+}
+
+function loadVaults(): ObsidianVaultMeta[] {
+  try {
+    const fp = obsidianAppConfigPath();
+    if (!fs.existsSync(fp)) return [];
+    const parsed = JSON.parse(fs.readFileSync(fp, 'utf8')) as unknown;
+    if (!isObject(parsed) || !isObject(parsed.vaults)) return [];
+    const out: ObsidianVaultMeta[] = [];
+    for (const [id, raw] of Object.entries(parsed.vaults)) {
+      if (!isObject(raw)) continue;
+      const p = typeof raw.path === 'string' ? path.resolve(raw.path) : '';
+      if (!p) continue;
+      out.push({
+        id,
+        name: path.basename(p) || id,
+        path: p,
+        exists: fs.existsSync(p),
+      });
+    }
+    return out.sort((a, b) => a.name.localeCompare(b.name));
+  } catch {
+    return [];
+  }
+}
+
+function loadConnectorConfig(dataDir: string): ObsidianConnectorConfig {
+  const fp = connectorConfigPath(dataDir);
+  if (!fs.existsSync(fp)) return defaultConnectorConfig();
+  try {
+    const parsed = JSON.parse(fs.readFileSync(fp, 'utf8')) as unknown;
+    if (!isObject(parsed)) return defaultConnectorConfig();
+    const cfg: ObsidianConnectorConfig = {
+      version: 1,
+      vaultId: typeof parsed.vaultId === 'string' && parsed.vaultId.trim() ? parsed.vaultId.trim() : null,
+      vaultPath: typeof parsed.vaultPath === 'string' && parsed.vaultPath.trim() ? path.resolve(parsed.vaultPath) : null,
+      missionFolder: typeof parsed.missionFolder === 'string' ? parsed.missionFolder : DEFAULT_MISSION_FOLDER,
+      updatedAt: typeof parsed.updatedAt === 'number' && Number.isFinite(parsed.updatedAt)
+        ? Math.trunc(parsed.updatedAt)
+        : Date.now(),
+    };
+    const safeMissionFolder = normalizeRelativePath(cfg.missionFolder) || DEFAULT_MISSION_FOLDER;
+    cfg.missionFolder = safeMissionFolder;
+    return cfg;
+  } catch {
+    return defaultConnectorConfig();
+  }
+}
+
+function saveConnectorConfig(dataDir: string, cfg: ObsidianConnectorConfig): void {
+  const fp = connectorConfigPath(dataDir);
+  fs.mkdirSync(path.dirname(fp), { recursive: true });
+  fs.writeFileSync(fp, JSON.stringify(cfg, null, 2));
+}
+
+function resolveActiveVault(
+  cfg: ObsidianConnectorConfig,
+  vaults: ObsidianVaultMeta[],
+): ObsidianVaultMeta | null {
+  if (cfg.vaultPath && fs.existsSync(cfg.vaultPath) && !hasDotObsidianSegment(cfg.vaultPath)) {
+    const vaultPath = path.resolve(cfg.vaultPath);
+    const byPath = vaults.find((v) => path.resolve(v.path) === vaultPath);
+    return byPath || {
+      id: cfg.vaultId || 'custom',
+      name: path.basename(vaultPath),
+      path: vaultPath,
+      exists: true,
+    };
+  }
+  if (cfg.vaultId) {
+    const byId = vaults.find((v) => v.id === cfg.vaultId && v.exists);
+    if (byId) return byId;
+  }
+  return null;
+}
+
+function collectMarkdownFiles(rootDir: string, maxFiles = MAX_NOTE_SCAN): string[] {
+  const out: string[] = [];
+  if (!fs.existsSync(rootDir)) return out;
+  const stack = [rootDir];
+  while (stack.length > 0 && out.length < maxFiles) {
+    const dir = stack.pop() as string;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+    for (const e of entries) {
+      if (e.name.startsWith('.')) continue;
+      const full = path.join(dir, e.name);
+      if (hasDotObsidianSegment(full)) continue;
+      if (e.isDirectory()) {
+        stack.push(full);
+        continue;
+      }
+      if (e.isFile() && e.name.toLowerCase().endsWith('.md')) {
+        out.push(full);
+        if (out.length >= maxFiles) break;
+      }
+    }
+  }
+  return out;
+}
+
+function parseNoteTitle(body: string, fallback: string): string {
+  const firstHeading = body.match(/^#\s+(.+)$/m);
+  if (firstHeading?.[1]) return firstHeading[1].trim().slice(0, 200);
+  return fallback;
+}
+
+export async function handleObsidianConnector(
+  req: IncomingMessage,
+  res: ServerResponse,
+  deps: ObsidianConnectorDeps,
+): Promise<boolean> {
+  if (!req.url) return false;
+  const method = (req.method || 'GET').toUpperCase();
+  const url = new URL(req.url, 'http://localhost');
+  const pathname = url.pathname;
+  if (!pathname.startsWith('/api/obsidian')) return false;
+
+  // GET /api/obsidian/vaults
+  if (method === 'GET' && pathname === '/api/obsidian/vaults') {
+    const vaults = loadVaults();
+    deps.sendJson(res, {
+      ok: true,
+      updatedAt: Date.now(),
+      obsidianConfigPath: obsidianAppConfigPath(),
+      vaults,
+      count: vaults.length,
+    });
+    return true;
+  }
+
+  // GET /api/obsidian/config
+  if (method === 'GET' && pathname === '/api/obsidian/config') {
+    const config = loadConnectorConfig(deps.dataDir);
+    const vaults = loadVaults();
+    deps.sendJson(res, {
+      ok: true,
+      updatedAt: Date.now(),
+      config,
+      activeVault: resolveActiveVault(config, vaults),
+      vaults,
+    });
+    return true;
+  }
+
+  // PUT /api/obsidian/config
+  if (method === 'PUT' && pathname === '/api/obsidian/config') {
+    let body: unknown;
+    try {
+      const raw = await deps.readRequestBody(req, { maxBytes: 64_000 });
+      body = JSON.parse(raw);
+    } catch {
+      return sendError(deps, res, 400, 'invalid JSON body');
+    }
+    if (!isObject(body)) return sendError(deps, res, 400, 'body must be an object');
+
+    const current = loadConnectorConfig(deps.dataDir);
+    const vaults = loadVaults();
+    const next: ObsidianConnectorConfig = { ...current, updatedAt: Date.now() };
+
+    if (typeof body.missionFolder === 'string') {
+      const normalized = normalizeRelativePath(body.missionFolder);
+      if (!normalized) return sendError(deps, res, 400, 'missionFolder must be a safe relative path');
+      next.missionFolder = normalized;
+    }
+
+    const vaultIdValue = typeof body.vaultId === 'string' ? body.vaultId.trim() : '';
+    if (vaultIdValue) {
+      const v = vaults.find((x) => x.id === vaultIdValue);
+      if (!v) return sendError(deps, res, 400, `unknown vaultId: ${vaultIdValue}`);
+      if (!v.exists) return sendError(deps, res, 400, `vault path does not exist: ${v.path}`);
+      next.vaultId = v.id;
+      next.vaultPath = path.resolve(v.path);
+    } else if (typeof body.vaultPath === 'string' && body.vaultPath.trim()) {
+      const resolved = path.resolve(body.vaultPath.trim());
+      if (!fs.existsSync(resolved) || !fs.statSync(resolved).isDirectory()) {
+        return sendError(deps, res, 400, 'vaultPath must exist and be a directory');
+      }
+      if (hasDotObsidianSegment(resolved)) {
+        return sendError(deps, res, 400, 'vaultPath cannot point inside .obsidian');
+      }
+      const known = vaults.find((x) => path.resolve(x.path) === resolved);
+      next.vaultId = known?.id || null;
+      next.vaultPath = resolved;
+    }
+
+    saveConnectorConfig(deps.dataDir, next);
+    deps.sendJson(res, {
+      ok: true,
+      config: next,
+      activeVault: resolveActiveVault(next, vaults),
+    });
+    return true;
+  }
+
+  // GET /api/obsidian/notes
+  if (method === 'GET' && pathname === '/api/obsidian/notes') {
+    const config = loadConnectorConfig(deps.dataDir);
+    const activeVault = resolveActiveVault(config, loadVaults());
+    if (!activeVault) return sendError(deps, res, 400, 'connector is not configured with a valid vault');
+
+    const q = (url.searchParams.get('q') || '').trim().toLowerCase();
+    const limit = Math.max(1, Math.min(Number(url.searchParams.get('limit')) || 100, 500));
+    const folderParam = url.searchParams.get('folder');
+    const folder = folderParam ? normalizeRelativePath(folderParam) : config.missionFolder;
+    if (!folder) return sendError(deps, res, 400, 'folder must be a safe relative path');
+    const targetDir = resolveInsideVault(activeVault.path, folder);
+    if (!targetDir) return sendError(deps, res, 400, 'folder resolves outside configured vault');
+
+    const files = collectMarkdownFiles(targetDir, MAX_NOTE_SCAN);
+    const results = [];
+    for (const filePath of files) {
+      if (results.length >= limit) break;
+      let raw = '';
+      let st: fs.Stats;
+      try {
+        st = fs.statSync(filePath);
+        raw = fs.readFileSync(filePath, 'utf8').slice(0, MAX_NOTE_BYTES);
+      } catch {
+        continue;
+      }
+      const relPath = toPosixRelative(activeVault.path, filePath);
+      const { frontmatter, body } = parseFrontmatter(raw);
+      const title = parseNoteTitle(body, path.basename(filePath, '.md'));
+      const snippet = body.replace(/\s+/g, ' ').trim().slice(0, 280);
+      const hay = `${relPath} ${title} ${snippet} ${frontmatter.missionId || ''}`.toLowerCase();
+      if (q && !hay.includes(q)) continue;
+
+      results.push({
+        path: relPath,
+        title,
+        missionId: frontmatter.missionId || null,
+        status: frontmatter.status || null,
+        owner: frontmatter.owner || null,
+        updatedAt: st.mtimeMs,
+        snippet,
+      });
+    }
+
+    results.sort((a, b) => b.updatedAt - a.updatedAt);
+    deps.sendJson(res, {
+      ok: true,
+      vault: { id: activeVault.id, name: activeVault.name, path: activeVault.path },
+      folder,
+      total: results.length,
+      notes: results,
+    });
+    return true;
+  }
+
+  // POST /api/obsidian/notes/write
+  if (method === 'POST' && pathname === '/api/obsidian/notes/write') {
+    const config = loadConnectorConfig(deps.dataDir);
+    const activeVault = resolveActiveVault(config, loadVaults());
+    if (!activeVault) return sendError(deps, res, 400, 'connector is not configured with a valid vault');
+
+    let body: unknown;
+    try {
+      const raw = await deps.readRequestBody(req, { maxBytes: MAX_WRITE_BYTES });
+      body = JSON.parse(raw);
+    } catch {
+      return sendError(deps, res, 400, 'invalid JSON body');
+    }
+    if (!isObject(body)) return sendError(deps, res, 400, 'body must be an object');
+
+    const markdown = typeof body.markdown === 'string' ? body.markdown : '';
+    if (!markdown.trim()) return sendError(deps, res, 400, 'markdown is required');
+
+    let relativePath: string | null = null;
+    if (typeof body.relativePath === 'string' && body.relativePath.trim()) {
+      relativePath = normalizeRelativePath(body.relativePath);
+      if (!relativePath) return sendError(deps, res, 400, 'relativePath must be a safe relative path');
+      if (!relativePath.toLowerCase().endsWith('.md')) relativePath += '.md';
+    } else if (typeof body.missionId === 'string' && body.missionId.trim()) {
+      const missionSlug = safeMissionSlug(body.missionId);
+      relativePath = `${config.missionFolder}/${missionSlug}.md`;
+    } else {
+      return sendError(deps, res, 400, 'relativePath or missionId is required');
+    }
+
+    const safeRelative = normalizeRelativePath(relativePath);
+    if (!safeRelative) return sendError(deps, res, 400, 'note path is invalid');
+    const targetPath = resolveInsideVault(activeVault.path, safeRelative);
+    if (!targetPath) return sendError(deps, res, 400, 'note path resolves outside configured vault');
+    if (hasDotObsidianSegment(targetPath)) return sendError(deps, res, 400, 'writes to .obsidian are forbidden');
+
+    const mode = body.mode === 'append' ? 'append' : 'overwrite';
+    const exists = fs.existsSync(targetPath);
+    fs.mkdirSync(path.dirname(targetPath), { recursive: true });
+
+    let content = markdown;
+    if (!exists && typeof body.title === 'string' && body.title.trim()) {
+      const hasHeading = /^\s*#\s+/m.test(markdown) || /^\s*---\n/.test(markdown);
+      if (!hasHeading) {
+        content = `# ${body.title.trim().slice(0, 180)}\n\n${markdown}`;
+      }
+    }
+    if (mode === 'append' && exists) {
+      fs.appendFileSync(targetPath, `\n\n${content}`);
+    } else {
+      fs.writeFileSync(targetPath, content);
+    }
+
+    deps.sendJson(res, {
+      ok: true,
+      path: safeRelative,
+      mode,
+      created: !exists,
+      bytes: Buffer.byteLength(content),
+      updatedAt: Date.now(),
+    });
+    return true;
+  }
+
+  return false;
+}

--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -113,6 +113,7 @@ import { handleChangelog } from './routes/changelog.js';
 import { handleTaskBoard } from './routes/task-board.js';
 import { emitTaskEvent } from './task-board-events.js';
 import { handleMemoryState } from './routes/memory-state.js';
+import { handleObsidianConnector } from './routes/obsidian-connector.js';
 import { handleSharedContext } from './routes/shared-context.js';
 import { getSchedulerJobs } from './scheduler-jobs.js';
 
@@ -2972,6 +2973,17 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
       dbPath: process.env.OBSERVATIONS_DB_PATH ?? path.join(dataDir, 'observations.db'),
       defaultAgentId: AGENT_ID,
       sendJson,
+    })) return;
+  } catch {
+    // ignore
+  }
+
+  // Obsidian Vault Connector — Issue #299
+  try {
+    if (await handleObsidianConnector(req, res, {
+      dataDir,
+      sendJson,
+      readRequestBody,
     })) return;
   } catch {
     // ignore

--- a/dashboard/tests/integration/http-smoke.test.ts
+++ b/dashboard/tests/integration/http-smoke.test.ts
@@ -13,6 +13,7 @@ let tmpRoot: string;
 let server: Server | undefined;
 let authCookie = '';
 let workflowDir = '';
+let obsidianVaultDir = '';
 
 async function waitForServer(url: string, attempts: number = 30): Promise<void> {
   for (let i = 0; i < attempts; i++) {
@@ -48,6 +49,7 @@ beforeAll(async () => {
   fs.mkdirSync(workflowDir, { recursive: true });
 
   const rpgRootDir = path.join(tmpRoot, 'rpg-root');
+  obsidianVaultDir = path.join(tmpRoot, 'obsidian-vault');
 
   fs.mkdirSync(kpiDir, { recursive: true });
   fs.mkdirSync(obsDir, { recursive: true });
@@ -55,6 +57,7 @@ beforeAll(async () => {
   fs.mkdirSync(sessionsDir, { recursive: true });
   fs.mkdirSync(workspaceDir, { recursive: true });
   fs.mkdirSync(rpgRootDir, { recursive: true });
+  fs.mkdirSync(obsidianVaultDir, { recursive: true });
 
   // RPG test fixtures (Issue #145)
   fs.writeFileSync(path.join(rpgRootDir, 'README.md'), '# RPG Test Fixture');
@@ -154,6 +157,13 @@ beforeAll(async () => {
   process.env.VENTUREOS_RPG_ROOT = rpgRootDir;
   process.env.VENTUREOS_AGENTS = 'main,oracle';
   process.env.VENTUREOS_OFFICE_VIEW_ENABLED = '1';
+  process.env.OBSIDIAN_CONFIG_PATH = path.join(tmpRoot, 'obsidian.json');
+
+  fs.writeFileSync(process.env.OBSIDIAN_CONFIG_PATH, JSON.stringify({
+    vaults: {
+      main: { path: obsidianVaultDir, ts: Date.now(), open: true },
+    },
+  }));
 
   const mod = (await import('../../server/server.js')) as { server?: Server; default?: { server?: Server } };
   server = mod.server ?? mod.default?.server;
@@ -344,6 +354,29 @@ describe('Dashboard HTTP smoke tests', () => {
     expect(wfRes.status).toBe(200);
     const wf = await wfRes.json();
     expect(wf.totals?.totalWorkflowRuns).toBeGreaterThanOrEqual(1);
+
+    const cfgRes = await fetch(`${BASE_URL}/api/obsidian/config`, {
+      method: 'PUT',
+      headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ vaultId: 'main', missionFolder: 'VentureOS/Missions' }),
+    });
+    expect(cfgRes.status).toBe(200);
+
+    const writeRes = await fetch(`${BASE_URL}/api/obsidian/notes/write`, {
+      method: 'POST',
+      headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        missionId: 'mc-obs-smoke',
+        title: 'Obsidian Smoke Mission',
+        markdown: 'Connector smoke write',
+      }),
+    });
+    expect(writeRes.status).toBe(200);
+
+    const notesRes = await fetch(`${BASE_URL}/api/obsidian/notes?q=smoke`, { headers: authHeaders() });
+    expect(notesRes.status).toBe(200);
+    const notes = await notesRes.json();
+    expect(notes.total).toBeGreaterThanOrEqual(1);
   });
 
   it('reports system metrics and redirects unauthenticated dashboard access', async () => {

--- a/dashboard/tests/unit/routes/obsidian-connector.test.ts
+++ b/dashboard/tests/unit/routes/obsidian-connector.test.ts
@@ -1,0 +1,196 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { mockRequest, mockResponse, parseJsonBody } from '../../helpers.js';
+import { handleObsidianConnector } from '../../../server/routes/obsidian-connector.js';
+import type { ServerResponse } from 'node:http';
+
+let tmpDir: string;
+let dataDir: string;
+let vaultA: string;
+let vaultB: string;
+let obsidianConfigPath: string;
+let prevObsidianConfigPath: string | undefined;
+
+function createDeps(body?: unknown) {
+  return {
+    dataDir,
+    sendJson: (res: ServerResponse, data: unknown, status = 200) => {
+      (res as any).writeHead(status, { 'Content-Type': 'application/json' });
+      (res as any).end(JSON.stringify(data));
+    },
+    readRequestBody: async () => (body == null ? '' : JSON.stringify(body)),
+  };
+}
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'obsidian-connector-test-'));
+  dataDir = path.join(tmpDir, 'data');
+  vaultA = path.join(tmpDir, 'AlphaVault');
+  vaultB = path.join(tmpDir, 'BetaVault');
+  fs.mkdirSync(dataDir, { recursive: true });
+  fs.mkdirSync(vaultA, { recursive: true });
+  fs.mkdirSync(vaultB, { recursive: true });
+
+  obsidianConfigPath = path.join(tmpDir, 'obsidian.json');
+  fs.writeFileSync(obsidianConfigPath, JSON.stringify({
+    vaults: {
+      alpha: { path: vaultA, ts: Date.now(), open: true },
+      beta: { path: vaultB, ts: Date.now(), open: false },
+    },
+  }));
+
+  prevObsidianConfigPath = process.env.OBSIDIAN_CONFIG_PATH;
+  process.env.OBSIDIAN_CONFIG_PATH = obsidianConfigPath;
+});
+
+afterEach(() => {
+  if (prevObsidianConfigPath == null) delete process.env.OBSIDIAN_CONFIG_PATH;
+  else process.env.OBSIDIAN_CONFIG_PATH = prevObsidianConfigPath;
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('handleObsidianConnector', () => {
+  it('returns false for non-obsidian URLs', async () => {
+    const handled = await handleObsidianConnector(
+      mockRequest({ method: 'GET', url: '/api/sessions' }),
+      mockResponse(),
+      createDeps(),
+    );
+    expect(handled).toBe(false);
+  });
+
+  it('discovers vaults from obsidian.json', async () => {
+    const res = mockResponse();
+    const handled = await handleObsidianConnector(
+      mockRequest({ method: 'GET', url: '/api/obsidian/vaults' }),
+      res,
+      createDeps(),
+    );
+    expect(handled).toBe(true);
+    expect(res._statusCode).toBe(200);
+    const body = parseJsonBody<{ vaults: Array<{ id: string; path: string }>; count: number }>(res);
+    expect(body.count).toBe(2);
+    expect(body.vaults.some((v) => v.id === 'alpha' && v.path === vaultA)).toBe(true);
+  });
+
+  it('persists connector config and rejects unsafe mission folders', async () => {
+    const okRes = mockResponse();
+    await handleObsidianConnector(
+      mockRequest({ method: 'PUT', url: '/api/obsidian/config' }),
+      okRes,
+      createDeps({ vaultId: 'alpha', missionFolder: 'VentureOS/Missions' }),
+    );
+    expect(okRes._statusCode).toBe(200);
+    const okBody = parseJsonBody<{ config: { vaultId: string; missionFolder: string } }>(okRes);
+    expect(okBody.config.vaultId).toBe('alpha');
+    expect(okBody.config.missionFolder).toBe('VentureOS/Missions');
+
+    const badRes = mockResponse();
+    await handleObsidianConnector(
+      mockRequest({ method: 'PUT', url: '/api/obsidian/config' }),
+      badRes,
+      createDeps({ missionFolder: '.obsidian/plugins' }),
+    );
+    expect(badRes._statusCode).toBe(400);
+    expect(parseJsonBody<{ error: string }>(badRes).error).toContain('missionFolder');
+  });
+
+  it('writes and appends mission notes inside configured vault', async () => {
+    await handleObsidianConnector(
+      mockRequest({ method: 'PUT', url: '/api/obsidian/config' }),
+      mockResponse(),
+      createDeps({ vaultId: 'alpha', missionFolder: 'VentureOS/Missions' }),
+    );
+
+    const writeRes = mockResponse();
+    await handleObsidianConnector(
+      mockRequest({ method: 'POST', url: '/api/obsidian/notes/write' }),
+      writeRes,
+      createDeps({
+        missionId: 'MC-299',
+        title: 'Mission Connector',
+        markdown: 'Initial update.',
+      }),
+    );
+    expect(writeRes._statusCode).toBe(200);
+    const first = parseJsonBody<{ path: string; created: boolean }>(writeRes);
+    expect(first.path).toBe('VentureOS/Missions/mc-299.md');
+    expect(first.created).toBe(true);
+
+    const notePath = path.join(vaultA, 'VentureOS', 'Missions', 'mc-299.md');
+    expect(fs.existsSync(notePath)).toBe(true);
+
+    const appendRes = mockResponse();
+    await handleObsidianConnector(
+      mockRequest({ method: 'POST', url: '/api/obsidian/notes/write' }),
+      appendRes,
+      createDeps({
+        missionId: 'MC-299',
+        markdown: 'Second update.',
+        mode: 'append',
+      }),
+    );
+    expect(appendRes._statusCode).toBe(200);
+    const text = fs.readFileSync(notePath, 'utf8');
+    expect(text).toContain('Initial update.');
+    expect(text).toContain('Second update.');
+  });
+
+  it('blocks writes to .obsidian internals', async () => {
+    await handleObsidianConnector(
+      mockRequest({ method: 'PUT', url: '/api/obsidian/config' }),
+      mockResponse(),
+      createDeps({ vaultId: 'alpha', missionFolder: 'VentureOS/Missions' }),
+    );
+
+    const res = mockResponse();
+    await handleObsidianConnector(
+      mockRequest({ method: 'POST', url: '/api/obsidian/notes/write' }),
+      res,
+      createDeps({
+        relativePath: '.obsidian/plugins/unsafe.md',
+        markdown: 'bad write',
+      }),
+    );
+    expect(res._statusCode).toBe(400);
+    expect(parseJsonBody<{ error: string }>(res).error.toLowerCase()).toContain('path');
+  });
+
+  it('indexes notes for search bridge', async () => {
+    await handleObsidianConnector(
+      mockRequest({ method: 'PUT', url: '/api/obsidian/config' }),
+      mockResponse(),
+      createDeps({ vaultId: 'alpha', missionFolder: 'VentureOS/Missions' }),
+    );
+
+    const folder = path.join(vaultA, 'VentureOS', 'Missions');
+    fs.mkdirSync(folder, { recursive: true });
+    fs.writeFileSync(path.join(folder, 'mc-001.md'), [
+      '---',
+      'missionId: mc-001',
+      'status: running',
+      'owner: nexus',
+      '---',
+      '',
+      '# Launch Video',
+      '',
+      'Prepare launch timeline and script.',
+    ].join('\n'));
+    fs.writeFileSync(path.join(folder, 'mc-002.md'), '# Unrelated\n\nBacklog cleanup.');
+
+    const res = mockResponse();
+    await handleObsidianConnector(
+      mockRequest({ method: 'GET', url: '/api/obsidian/notes?q=launch&limit=10' }),
+      res,
+      createDeps(),
+    );
+    expect(res._statusCode).toBe(200);
+    const body = parseJsonBody<{ total: number; notes: Array<{ missionId: string | null; title: string }> }>(res);
+    expect(body.total).toBe(1);
+    expect(body.notes[0].missionId).toBe('mc-001');
+    expect(body.notes[0].title).toContain('Launch Video');
+  });
+});
+


### PR DESCRIPTION
## Summary
- add a new Obsidian connector route module with vault discovery, connector config, note indexing/search, and safe note write endpoints
- wire connector routes into the dashboard server request pipeline
- add unit coverage for config validation, safe path enforcement, mission note writes, and note search indexing
- extend HTTP smoke coverage with an Obsidian config + write + search roundtrip

## Endpoints
- `GET /api/obsidian/vaults`
- `GET /api/obsidian/config`
- `PUT /api/obsidian/config`
- `GET /api/obsidian/notes`
- `POST /api/obsidian/notes/write`

## Validation
- `npm run -s build`
- `npx -y vitest@4.0.18 run --config /tmp/vitest.local.config.mjs tests/unit/routes/obsidian-connector.test.ts tests/integration/http-smoke.test.ts`

Closes #299
