### PR TITLE
[Nexus 2.0][MC-P2b] Mission log templates for Obsidian

### DIFF
--- a/dashboard/server/obsidian-note-templates.ts
+++ b/dashboard/server/obsidian-note-templates.ts
@@ -1,0 +1,167 @@
+export type ObsidianNoteTemplateKind =
+  | 'mission'
+  | 'pr-review'
+  | 'decision-log'
+  | 'blocker-log';
+
+export interface ObsidianTemplateFrontmatter {
+  missionId: string;
+  prNumber: number | null;
+  status: string;
+  owner: string;
+  updatedAt: string;
+}
+
+export interface ObsidianStructuredSections {
+  decisions: string[];
+  risks: string[];
+  nextActions: string[];
+}
+
+interface ObsidianTemplateContext {
+  title?: string;
+  summary?: string;
+}
+
+function yamlScalar(value: string | number | null): string {
+  if (value === null) return 'null';
+  if (typeof value === 'number') return Number.isFinite(value) ? String(value) : 'null';
+  if (/^[a-zA-Z0-9_.:/-]+$/.test(value)) return value;
+  return JSON.stringify(value);
+}
+
+function normalizeLine(value: string): string {
+  return value.replace(/\s+/g, ' ').trim();
+}
+
+function renderList(items: string[], fallback: string): string[] {
+  if (!items.length) return [`- ${fallback}`];
+  return items.map((item) => `- ${normalizeLine(item) || fallback}`);
+}
+
+export function isObsidianTemplateKind(value: string): value is ObsidianNoteTemplateKind {
+  return value === 'mission'
+    || value === 'pr-review'
+    || value === 'decision-log'
+    || value === 'blocker-log';
+}
+
+export function renderObsidianTemplateNote(
+  kind: ObsidianNoteTemplateKind,
+  frontmatter: ObsidianTemplateFrontmatter,
+  context: ObsidianTemplateContext = {},
+): string {
+  const missionId = normalizeLine(frontmatter.missionId) || 'mission-unknown';
+  const owner = normalizeLine(frontmatter.owner) || 'nexus';
+  const status = normalizeLine(frontmatter.status) || 'open';
+  const updatedAt = normalizeLine(frontmatter.updatedAt) || new Date().toISOString();
+  const title = normalizeLine(context.title || '') || missionId;
+  const summary = context.summary?.trim() || '_Pending mission context._';
+
+  const head = [
+    '---',
+    `missionId: ${yamlScalar(missionId)}`,
+    `prNumber: ${yamlScalar(frontmatter.prNumber)}`,
+    `status: ${yamlScalar(status)}`,
+    `owner: ${yamlScalar(owner)}`,
+    `updatedAt: ${yamlScalar(updatedAt)}`,
+    '---',
+    '',
+  ];
+
+  if (kind === 'pr-review') {
+    return [
+      ...head,
+      `# PR Review: ${title}`,
+      '',
+      '## Summary',
+      summary,
+      '',
+      '## Decisions',
+      '- _Pending decision_',
+      '',
+      '## Risks',
+      '- _No risks logged_',
+      '',
+      '## Next Actions',
+      '- _Assign reviewer and follow-up date_',
+      '',
+    ].join('\n');
+  }
+
+  if (kind === 'decision-log') {
+    return [
+      ...head,
+      `# Decision Log: ${title}`,
+      '',
+      '## Decision',
+      summary,
+      '',
+      '## Risks',
+      '- _No risks logged_',
+      '',
+      '## Next Actions',
+      '- _Track adoption + outcomes_',
+      '',
+    ].join('\n');
+  }
+
+  if (kind === 'blocker-log') {
+    return [
+      ...head,
+      `# Blocker Log: ${title}`,
+      '',
+      '## Blocker',
+      summary,
+      '',
+      '## Risks',
+      '- _Impact not yet assessed_',
+      '',
+      '## Next Actions',
+      '- _Escalate owner + unblock path_',
+      '',
+    ].join('\n');
+  }
+
+  return [
+    ...head,
+    `# Mission: ${title}`,
+    '',
+    '## Overview',
+    summary,
+    '',
+    '## Decisions',
+    '- _No decisions logged_',
+    '',
+    '## Risks',
+    '- _No risks logged_',
+    '',
+    '## Next Actions',
+    '- _Add immediate next action_',
+    '',
+  ].join('\n');
+}
+
+export function renderObsidianStructuredAppend(
+  sections: ObsidianStructuredSections,
+  updatedAtIso: string,
+): string {
+  const stamp = normalizeLine(updatedAtIso) || new Date().toISOString();
+  const decisions = sections.decisions.map(normalizeLine).filter(Boolean);
+  const risks = sections.risks.map(normalizeLine).filter(Boolean);
+  const nextActions = sections.nextActions.map(normalizeLine).filter(Boolean);
+
+  return [
+    `## Update (${stamp})`,
+    '',
+    '### Decisions',
+    ...renderList(decisions, '_No decision update_'),
+    '',
+    '### Risks',
+    ...renderList(risks, '_No risk update_'),
+    '',
+    '### Next Actions',
+    ...renderList(nextActions, '_No next-action update_'),
+    '',
+  ].join('\n');
+}

--- a/dashboard/server/routes/obsidian-connector.ts
+++ b/dashboard/server/routes/obsidian-connector.ts
@@ -18,6 +18,11 @@ import fs from 'node:fs';
 import os from 'node:os';
 import path from 'node:path';
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import {
+  isObsidianTemplateKind,
+  renderObsidianStructuredAppend,
+  renderObsidianTemplateNote,
+} from '../obsidian-note-templates.js';
 
 const DEFAULT_MISSION_FOLDER = 'VentureOS/Missions';
 const MAX_NOTE_SCAN = 2000;
@@ -242,6 +247,30 @@ function parseNoteTitle(body: string, fallback: string): string {
   return fallback;
 }
 
+function normalizeSectionItems(value: unknown): string[] {
+  if (Array.isArray(value)) {
+    return value
+      .map((item) => (typeof item === 'string' ? item.trim() : ''))
+      .filter((item) => !!item)
+      .slice(0, 20);
+  }
+  if (typeof value === 'string' && value.trim()) return [value.trim()];
+  return [];
+}
+
+function extractStructuredSections(body: Record<string, unknown>): {
+  decisions: string[];
+  risks: string[];
+  nextActions: string[];
+} | null {
+  const sectionsSource = isObject(body.sections) ? body.sections : body;
+  const decisions = normalizeSectionItems(sectionsSource.decisions);
+  const risks = normalizeSectionItems(sectionsSource.risks);
+  const nextActions = normalizeSectionItems(sectionsSource.nextActions);
+  if (!decisions.length && !risks.length && !nextActions.length) return null;
+  return { decisions, risks, nextActions };
+}
+
 export async function handleObsidianConnector(
   req: IncomingMessage,
   res: ServerResponse,
@@ -400,8 +429,16 @@ export async function handleObsidianConnector(
     }
     if (!isObject(body)) return sendError(deps, res, 400, 'body must be an object');
 
+    const templateRaw = typeof body.template === 'string' ? body.template.trim().toLowerCase() : '';
+    const template = templateRaw && isObsidianTemplateKind(templateRaw) ? templateRaw : null;
+    if (templateRaw && !template) {
+      return sendError(deps, res, 400, 'template must be one of: mission, pr-review, decision-log, blocker-log');
+    }
+    const structuredSections = extractStructuredSections(body);
     const markdown = typeof body.markdown === 'string' ? body.markdown : '';
-    if (!markdown.trim()) return sendError(deps, res, 400, 'markdown is required');
+    if (!markdown.trim() && !template && !structuredSections) {
+      return sendError(deps, res, 400, 'markdown, template, or structured sections are required');
+    }
 
     let relativePath: string | null = null;
     if (typeof body.relativePath === 'string' && body.relativePath.trim()) {
@@ -426,14 +463,46 @@ export async function handleObsidianConnector(
     fs.mkdirSync(path.dirname(targetPath), { recursive: true });
 
     let content = markdown;
-    if (!exists && typeof body.title === 'string' && body.title.trim()) {
+    const missionIdForTemplate = typeof body.missionId === 'string' && body.missionId.trim()
+      ? body.missionId.trim()
+      : path.basename(safeRelative, '.md');
+    const prNumber = typeof body.prNumber === 'number' && Number.isFinite(body.prNumber)
+      ? Math.trunc(body.prNumber)
+      : null;
+    const status = typeof body.status === 'string' && body.status.trim() ? body.status.trim() : 'open';
+    const owner = typeof body.owner === 'string' && body.owner.trim() ? body.owner.trim() : 'nexus';
+    const title = typeof body.title === 'string' && body.title.trim()
+      ? body.title.trim()
+      : missionIdForTemplate;
+    const updatedAtIso = new Date().toISOString();
+
+    if (!exists && template) {
+      content = renderObsidianTemplateNote(template, {
+        missionId: missionIdForTemplate,
+        prNumber,
+        status,
+        owner,
+        updatedAt: updatedAtIso,
+      }, {
+        title,
+        summary: markdown.trim() || undefined,
+      });
+    } else if (!exists && typeof body.title === 'string' && body.title.trim()) {
       const hasHeading = /^\s*#\s+/m.test(markdown) || /^\s*---\n/.test(markdown);
-      if (!hasHeading) {
-        content = `# ${body.title.trim().slice(0, 180)}\n\n${markdown}`;
-      }
+      if (!hasHeading) content = `# ${body.title.trim().slice(0, 180)}\n\n${markdown}`;
     }
+
+    const structuredAppend = structuredSections
+      ? renderObsidianStructuredAppend(structuredSections, updatedAtIso)
+      : '';
+    if (mode !== 'append' && !content.trim() && structuredAppend) content = structuredAppend;
+    let bytesWritten = Buffer.byteLength(content);
+
     if (mode === 'append' && exists) {
-      fs.appendFileSync(targetPath, `\n\n${content}`);
+      const appendBody = [content.trim(), structuredAppend.trim()].filter(Boolean).join('\n\n');
+      if (!appendBody) return sendError(deps, res, 400, 'append requires markdown or structured sections');
+      fs.appendFileSync(targetPath, `\n\n${appendBody}`);
+      bytesWritten = Buffer.byteLength(appendBody);
     } else {
       fs.writeFileSync(targetPath, content);
     }
@@ -443,7 +512,8 @@ export async function handleObsidianConnector(
       path: safeRelative,
       mode,
       created: !exists,
-      bytes: Buffer.byteLength(content),
+      bytes: bytesWritten,
+      template,
       updatedAt: Date.now(),
     });
     return true;

--- a/dashboard/server/routes/tactical-map-controls.ts
+++ b/dashboard/server/routes/tactical-map-controls.ts
@@ -10,8 +10,10 @@
  */
 
 import fs from 'node:fs';
+import os from 'node:os';
 import path from 'node:path';
 import type { IncomingMessage, ServerResponse } from 'node:http';
+import { renderObsidianTemplateNote } from '../obsidian-note-templates.js';
 
 const AGENT_IDS = ['oracle', 'atlas', 'sentinel', 'verifier', 'archivist', 'synth', 'echo', 'nexus'] as const;
 type AgentId = (typeof AGENT_IDS)[number];
@@ -38,6 +40,23 @@ type ControlStore = {
   missions: Record<string, PersistedMission>;
   missionOrder: string[];
 };
+
+type ObsidianConnectorConfig = {
+  version: number;
+  vaultId: string | null;
+  vaultPath: string | null;
+  missionFolder: string;
+  updatedAt: number;
+};
+
+type ObsidianMissionNoteResult = {
+  attempted: boolean;
+  created: boolean;
+  path: string | null;
+  reason?: string;
+};
+
+const DEFAULT_MISSION_FOLDER = 'VentureOS/Missions';
 
 export type TacticalMapControlDeps = {
   dataDir: string;
@@ -77,6 +96,119 @@ function createDefaultStore(nowIso: string): ControlStore {
     missions: {},
     missionOrder: [],
   };
+}
+
+function obsidianAppConfigPath(): string {
+  return process.env.OBSIDIAN_CONFIG_PATH
+    ?? path.join(os.homedir(), 'Library', 'Application Support', 'obsidian', 'obsidian.json');
+}
+
+function hasDotObsidianSegment(p: string): boolean {
+  return p.split(/[\\/]+/).some((seg) => seg === '.obsidian');
+}
+
+function normalizeRelativePath(input: string): string | null {
+  const raw = input.replace(/\\/g, '/').trim();
+  if (!raw || raw.startsWith('/')) return null;
+  const normalized = path.posix.normalize(raw).replace(/^\/+/, '');
+  if (!normalized || normalized === '.' || normalized === '..' || normalized.startsWith('../')) return null;
+  if (hasDotObsidianSegment(normalized)) return null;
+  return normalized;
+}
+
+function resolveInsideVault(vaultPath: string, relPath: string): string | null {
+  const resolvedVault = path.resolve(vaultPath);
+  const target = path.resolve(resolvedVault, relPath);
+  if (target !== resolvedVault && !target.startsWith(resolvedVault + path.sep)) return null;
+  if (hasDotObsidianSegment(path.relative(resolvedVault, target))) return null;
+  return target;
+}
+
+function safeMissionSlug(missionId: string): string {
+  const slug = missionId
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9_-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return (slug || 'mission').slice(0, 120);
+}
+
+function readObsidianConnectorConfig(dataDir: string): ObsidianConnectorConfig | null {
+  const fp = path.join(dataDir, 'obsidian-connector.json');
+  try {
+    if (!fs.existsSync(fp)) return null;
+    const parsed = JSON.parse(fs.readFileSync(fp, 'utf8')) as Record<string, unknown>;
+    const missionFolderRaw = typeof parsed.missionFolder === 'string'
+      ? parsed.missionFolder
+      : DEFAULT_MISSION_FOLDER;
+    const missionFolder = normalizeRelativePath(missionFolderRaw) || DEFAULT_MISSION_FOLDER;
+    return {
+      version: 1,
+      vaultId: typeof parsed.vaultId === 'string' && parsed.vaultId.trim() ? parsed.vaultId.trim() : null,
+      vaultPath: typeof parsed.vaultPath === 'string' && parsed.vaultPath.trim() ? path.resolve(parsed.vaultPath) : null,
+      missionFolder,
+      updatedAt: typeof parsed.updatedAt === 'number' ? parsed.updatedAt : Date.now(),
+    };
+  } catch {
+    return null;
+  }
+}
+
+function resolveVaultPath(config: ObsidianConnectorConfig): string | null {
+  if (config.vaultPath && fs.existsSync(config.vaultPath) && !hasDotObsidianSegment(config.vaultPath)) {
+    return path.resolve(config.vaultPath);
+  }
+  if (!config.vaultId) return null;
+  try {
+    const fp = obsidianAppConfigPath();
+    if (!fs.existsSync(fp)) return null;
+    const parsed = JSON.parse(fs.readFileSync(fp, 'utf8')) as Record<string, unknown>;
+    const vaults = parsed.vaults as Record<string, { path?: string }> | undefined;
+    const entry = vaults?.[config.vaultId];
+    if (!entry?.path) return null;
+    const resolved = path.resolve(entry.path);
+    if (!fs.existsSync(resolved) || hasDotObsidianSegment(resolved)) return null;
+    return resolved;
+  } catch {
+    return null;
+  }
+}
+
+function materializeMissionNote(
+  dataDir: string,
+  mission: PersistedMission,
+  nowIso: string,
+): ObsidianMissionNoteResult {
+  try {
+    const connector = readObsidianConnectorConfig(dataDir);
+    if (!connector) return { attempted: false, created: false, path: null, reason: 'connector_not_configured' };
+
+    const vaultPath = resolveVaultPath(connector);
+    if (!vaultPath) return { attempted: true, created: false, path: null, reason: 'vault_unavailable' };
+
+    const missionFolder = normalizeRelativePath(connector.missionFolder) || DEFAULT_MISSION_FOLDER;
+    const relativePath = `${missionFolder}/${safeMissionSlug(mission.missionId)}.md`;
+    const absolutePath = resolveInsideVault(vaultPath, relativePath);
+    if (!absolutePath) return { attempted: true, created: false, path: null, reason: 'unsafe_path' };
+    if (fs.existsSync(absolutePath)) return { attempted: true, created: false, path: relativePath, reason: 'already_exists' };
+
+    const template = renderObsidianTemplateNote('mission', {
+      missionId: mission.missionId,
+      prNumber: null,
+      status: 'open',
+      owner: mission.assignee,
+      updatedAt: nowIso,
+    }, {
+      title: mission.title,
+      summary: mission.description || '_No mission summary provided._',
+    });
+    fs.mkdirSync(path.dirname(absolutePath), { recursive: true });
+    fs.writeFileSync(absolutePath, template);
+    return { attempted: true, created: true, path: relativePath };
+  } catch {
+    return { attempted: true, created: false, path: null, reason: 'write_failed' };
+  }
 }
 
 function readStore(storePath: string, nowIso: string): ControlStore {
@@ -234,7 +366,8 @@ export async function handleTacticalMapControls(
       store.updatedAt = nowIso;
       writeStore(storePath, store);
 
-      deps.sendJson(res, { ok: true, missionId, mission }, 200);
+      const obsidianNote = materializeMissionNote(deps.dataDir, mission, nowIso);
+      deps.sendJson(res, { ok: true, missionId, mission, obsidianNote }, 200);
       return true;
     } catch {
       sendBadRequest('Invalid JSON body');

--- a/dashboard/tests/unit/routes/obsidian-connector.test.ts
+++ b/dashboard/tests/unit/routes/obsidian-connector.test.ts
@@ -192,5 +192,60 @@ describe('handleObsidianConnector', () => {
     expect(body.notes[0].missionId).toBe('mc-001');
     expect(body.notes[0].title).toContain('Launch Video');
   });
-});
 
+  it('creates template-based notes and appends structured updates', async () => {
+    await handleObsidianConnector(
+      mockRequest({ method: 'PUT', url: '/api/obsidian/config' }),
+      mockResponse(),
+      createDeps({ vaultId: 'alpha', missionFolder: 'VentureOS/Missions' }),
+    );
+
+    const createRes = mockResponse();
+    await handleObsidianConnector(
+      mockRequest({ method: 'POST', url: '/api/obsidian/notes/write' }),
+      createRes,
+      createDeps({
+        missionId: 'MC-300',
+        title: 'Mission Template',
+        template: 'mission',
+        status: 'active',
+        owner: 'oracle',
+      }),
+    );
+    expect(createRes._statusCode).toBe(200);
+
+    const notePath = path.join(vaultA, 'VentureOS', 'Missions', 'mc-300.md');
+    const created = fs.readFileSync(notePath, 'utf8');
+    expect(created).toContain('missionId: MC-300');
+    expect(created).toContain('prNumber: null');
+    expect(created).toContain('status: active');
+    expect(created).toContain('owner: oracle');
+    expect(created).toContain('## Decisions');
+    expect(created).toContain('## Risks');
+    expect(created).toContain('## Next Actions');
+
+    const appendRes = mockResponse();
+    await handleObsidianConnector(
+      mockRequest({ method: 'POST', url: '/api/obsidian/notes/write' }),
+      appendRes,
+      createDeps({
+        missionId: 'MC-300',
+        mode: 'append',
+        sections: {
+          decisions: ['Ship template adapter'],
+          risks: ['Need stronger source ranking'],
+          nextActions: ['Wire unified search'],
+        },
+      }),
+    );
+    expect(appendRes._statusCode).toBe(200);
+
+    const appended = fs.readFileSync(notePath, 'utf8');
+    expect(appended).toContain('### Decisions');
+    expect(appended).toContain('Ship template adapter');
+    expect(appended).toContain('### Risks');
+    expect(appended).toContain('Need stronger source ranking');
+    expect(appended).toContain('### Next Actions');
+    expect(appended).toContain('Wire unified search');
+  });
+});

--- a/dashboard/tests/unit/tactical-map-controls.test.ts
+++ b/dashboard/tests/unit/tactical-map-controls.test.ts
@@ -61,6 +61,60 @@ describe('tactical-map-controls route', () => {
     expect(listBody.missions[0].priority).toBe('high');
   });
 
+  it('materializes a mission template note when Obsidian connector is configured', async () => {
+    const dataDir = path.join(baseTmp, 'spawn-obsidian');
+    const vaultDir = path.join(baseTmp, 'obsidian-vault');
+    const obsidianConfigPath = path.join(baseTmp, 'obsidian.json');
+    fs.mkdirSync(vaultDir, { recursive: true });
+    fs.mkdirSync(dataDir, { recursive: true });
+    fs.writeFileSync(obsidianConfigPath, JSON.stringify({
+      vaults: {
+        main: { path: vaultDir, ts: Date.now(), open: true },
+      },
+    }));
+    fs.writeFileSync(path.join(dataDir, 'obsidian-connector.json'), JSON.stringify({
+      version: 1,
+      vaultId: 'main',
+      vaultPath: null,
+      missionFolder: 'VentureOS/Missions',
+      updatedAt: Date.now(),
+    }));
+
+    const previousObsidianConfig = process.env.OBSIDIAN_CONFIG_PATH;
+    process.env.OBSIDIAN_CONFIG_PATH = obsidianConfigPath;
+    try {
+      const spawnReq = mockRequest({ method: 'POST', url: '/api/tactical-map/missions/spawn' }) as any;
+      spawnReq._rawBody = JSON.stringify({
+        title: 'Launch Review',
+        description: 'Coordinate release readiness checks',
+        assignee: 'oracle',
+        priority: 'high',
+      });
+
+      const spawned = await runRoute(spawnReq, dataDir);
+      const spawnBody = parseJsonBody<{
+        missionId: string;
+        obsidianNote: { attempted: boolean; created: boolean; path: string | null };
+      }>(spawned.res);
+      expect(spawnBody.obsidianNote.attempted).toBe(true);
+      expect(spawnBody.obsidianNote.created).toBe(true);
+      expect(spawnBody.obsidianNote.path).toContain('VentureOS/Missions/');
+
+      const notePath = path.join(vaultDir, spawnBody.obsidianNote.path as string);
+      expect(fs.existsSync(notePath)).toBe(true);
+      const note = fs.readFileSync(notePath, 'utf8');
+      expect(note).toContain(`missionId: ${spawnBody.missionId}`);
+      expect(note).toContain('owner: oracle');
+      expect(note).toContain('# Mission: Launch Review');
+      expect(note).toContain('## Decisions');
+      expect(note).toContain('## Risks');
+      expect(note).toContain('## Next Actions');
+    } finally {
+      if (previousObsidianConfig == null) delete process.env.OBSIDIAN_CONFIG_PATH;
+      else process.env.OBSIDIAN_CONFIG_PATH = previousObsidianConfig;
+    }
+  });
+
   it('updates mission priority with persistence', async () => {
     const dataDir = path.join(baseTmp, 'priority');
 


### PR DESCRIPTION
## Summary
- add a reusable Obsidian note-template renderer for mission, PR review, decision log, and blocker log notes
- extend `POST /api/obsidian/notes/write` to support template-based note creation and structured append blocks (`Decisions`, `Risks`, `Next Actions`)
- auto-materialize a mission template note when `/api/tactical-map/missions/spawn` creates a mission (when Obsidian connector is configured)
- add targeted unit tests for template creation/append behavior and mission spawn materialization

## Acceptance Coverage
- New missions now auto-create a mission note from template when connector config + vault are available
- Structured updates append consistent sections for decisions/risks/next actions
- Required frontmatter keys are included in template notes: `missionId`, `prNumber`, `status`, `owner`, `updatedAt`

## Validation
- `npm run -s build`
- `npx -y vitest@4.0.18 run --config /tmp/vitest.local.config.mjs tests/unit/routes/obsidian-connector.test.ts tests/unit/tactical-map-controls.test.ts tests/integration/http-smoke.test.ts`

Closes #300
