### PR TITLE
docs: publish M6 production readiness report

### DIFF
--- a/docs/DOC_INDEX.md
+++ b/docs/DOC_INDEX.md
@@ -23,6 +23,7 @@
 - **docs/process/PROJECT_PLAN.md** – milestones + success metrics
 - **docs/process/FEATURE_BACKLOG.md** – backlog by workstream
 - **docs/NEXUS_2_0_M4_OBSERVABILITY.md** – M4 replay authority surfaces (explain + control-health)
+- **docs/NEXUS_2_0_M6_PRODUCTION_READINESS_2026-02-21.md** – M6 readiness decision and evidence matrix
 
 ## VentureOS / Multi-Agent Orchestration
 - **docs/roles/VENTURE_OS.md** – venture studio OS overview (system vs persona)

--- a/docs/NEXUS_2_0_M6_PRODUCTION_READINESS_2026-02-21.md
+++ b/docs/NEXUS_2_0_M6_PRODUCTION_READINESS_2026-02-21.md
@@ -1,0 +1,53 @@
+# Nexus 2.0 M6 — Production Readiness Report
+
+Date: 2026-02-21  
+Issue: #289
+
+## Decision
+
+Status: **NO-GO** (conditional)
+
+Reason: M2 (`#285`, Nexus Authority Plane) is still open, so readiness is blocked on authority-gate completion even though M1/M3/M4/M5 are complete.
+
+## Milestone Evidence
+
+- M1 Contract Foundation (`#284`) — **Closed** on 2026-02-19
+- M2 Nexus Authority Plane (`#285`) — **Open** (blocking)
+- M3 Competition Engine (`#286`) — **Closed** on 2026-02-20
+- M4 Observability + Replay Authority (`#287`) — **Closed** on 2026-02-21
+- M5 Deployment Safety (`#288`) — **Closed** on 2026-02-21
+
+## Acceptance Matrix
+
+- Contract determinism: **Pass** (M1 complete)
+- Competition and arbitration baseline: **Pass** (M3 complete)
+- Replay authority visibility:
+  - `GET /api/replay/explain` added and tested
+  - `GET /api/replay/control-health` added and tested
+  - Status: **Pass** (M4 complete)
+- Deployment safety:
+  - `scripts/preflight-routing.sh`
+  - `scripts/lint-dangerous-config.sh`
+  - `scripts/rollback-last-known-good.sh`
+  - CI dry-run preflight + safety tests wired
+  - Status: **Pass** (M5 complete)
+- Explicit authority boundary enforcement end-to-end: **Fail / Pending** (M2 open)
+
+## Risk Register Closeout (M6 Scope)
+
+- R1 Schema drift between role definitions and runtime contracts: **Mitigated**
+- R2 Implicit routing / non-deterministic behavior: **Partially mitigated** (blocked on M2 completion)
+- R3 Competition optimizes verbosity over utility: **Mitigated to baseline** (M3 in place; continue monitoring)
+- R4 Token/config coupling instability: **Mitigated** (M5 controls in place)
+
+## Go Criteria Gap
+
+Before GO, complete:
+
+1. Close M2 (`#285`) with verified policy gate + authority map behavior.
+2. Re-run acceptance matrix post-M2 merge and record evidence in issue comments.
+3. Publish final GO addendum referencing M2 verification artifacts.
+
+## Recommended Next Step
+
+Execute `#285` next, then re-issue this report as a short GO addendum.


### PR DESCRIPTION
## Summary
- add explicit M6 production readiness report with a concrete GO/NO-GO decision dated 2026-02-21
- map readiness evidence against M1-M5 issue outcomes and remaining milestone blocker(s)
- include acceptance matrix, risk closeout summary, and required actions to transition to GO
- add report to docs index for ongoing operations visibility

## Testing
- docs-only change (no runtime code paths modified)

Closes #289
