### PR TITLE
[Task Board] Crash recovery + active task tracking

### DIFF
--- a/dashboard/docs/API.md
+++ b/dashboard/docs/API.md
@@ -731,6 +731,56 @@ Manual retry endpoint for failed cards.
 }
 ```
 
+### `GET /api/task-board/active`
+
+Returns the current `memory/active-tasks.md` snapshot plus stale-task detection.
+
+**Query params:**
+- `staleAfterMs` (optional) — threshold for stale detection (default 30m, max 24h)
+
+**Response (200):**
+```json
+{
+  "snapshot": {
+    "updatedAt": "2026-02-21T09:00:00.000Z",
+    "active": [
+      {
+        "taskId": "task-123",
+        "status": "RUNNING",
+        "assigneeId": "oracle",
+        "startedAt": "2026-02-21T08:45:00.000Z",
+        "updatedAt": "2026-02-21T08:59:00.000Z"
+      }
+    ],
+    "completed": []
+  },
+  "staleAfterMs": 1800000,
+  "staleCount": 0,
+  "stale": []
+}
+```
+
+### `POST /api/task-board/recovery/resume`
+
+Requeues running tasks found in the active-task snapshot. Used for crash/restart recovery.
+
+**Request (optional):**
+```json
+{
+  "agentId": "oracle",
+  "limit": 20
+}
+```
+
+**Response (200):**
+```json
+{
+  "resumedCount": 2,
+  "resumedIds": ["task-123", "task-456"],
+  "consideredRunning": 3
+}
+```
+
 ---
 
 ## Model Routing Security Endpoints

--- a/dashboard/server/active-tasks.ts
+++ b/dashboard/server/active-tasks.ts
@@ -1,0 +1,270 @@
+/**
+ * Active Task Tracker (Issue #223)
+ *
+ * Maintains a human-readable markdown "save game" file at:
+ *   <workspace>/memory/active-tasks.md
+ *
+ * Source of truth remains task-board.json. This file is a synchronized view
+ * for crash recovery and operator visibility.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import type { TaskCard, TaskPriority, TaskStatus } from './types.js';
+
+const ACTIVE_TASKS_FILENAME = 'active-tasks.md';
+const MAX_COMPLETED_ITEMS = 100;
+const DEFAULT_STALE_AFTER_MS = 30 * 60 * 1000;
+
+type ActiveStatus = 'RUNNING' | 'QUEUED' | 'BLOCKED' | 'REVIEW';
+type CompletedStatus = 'DONE' | 'FAILED';
+
+export interface ActiveTaskEntry {
+  taskId: string;
+  title: string;
+  status: ActiveStatus;
+  priority: TaskPriority;
+  assigneeId: string | null;
+  startedAt: string;
+  updatedAt: string;
+}
+
+export interface CompletedTaskEntry {
+  taskId: string;
+  title: string;
+  status: CompletedStatus;
+  completedAt: string;
+}
+
+export interface ActiveTaskSnapshot {
+  updatedAt: string;
+  active: ActiveTaskEntry[];
+  completed: CompletedTaskEntry[];
+}
+
+export interface StaleTaskEntry extends ActiveTaskEntry {
+  staleMs: number;
+}
+
+function toIso(ts: number | null | undefined): string {
+  if (!ts || !Number.isFinite(ts) || ts <= 0) return new Date(0).toISOString();
+  return new Date(ts).toISOString();
+}
+
+function statusToActive(status: TaskStatus): ActiveStatus | null {
+  if (status === 'running') return 'RUNNING';
+  if (status === 'queued') return 'QUEUED';
+  if (status === 'blocked') return 'BLOCKED';
+  if (status === 'review') return 'REVIEW';
+  return null;
+}
+
+function statusToCompleted(status: TaskStatus): CompletedStatus | null {
+  if (status === 'done') return 'DONE';
+  if (status === 'failed') return 'FAILED';
+  return null;
+}
+
+function latestUpdateAt(card: TaskCard): number {
+  const historyTs = Array.isArray(card.statusHistory) && card.statusHistory.length > 0
+    ? card.statusHistory[card.statusHistory.length - 1].at
+    : 0;
+  return Math.max(
+    card.completedAt ?? 0,
+    card.startedAt ?? 0,
+    card.queuedAt ?? 0,
+    card.createdAt ?? 0,
+    historyTs ?? 0,
+  );
+}
+
+function titleForMarkdown(raw: string): string {
+  return raw.replace(/\s+/g, ' ').trim().slice(0, 200) || 'Untitled task';
+}
+
+export function activeTasksFilePath(dataDir: string): string {
+  const workspaceDir = path.dirname(dataDir);
+  return path.join(workspaceDir, 'memory', ACTIVE_TASKS_FILENAME);
+}
+
+export function buildActiveTaskSnapshot(tasks: TaskCard[], now = Date.now()): ActiveTaskSnapshot {
+  const active: ActiveTaskEntry[] = [];
+  const completed: CompletedTaskEntry[] = [];
+
+  for (const card of tasks) {
+    const activeStatus = statusToActive(card.status);
+    if (activeStatus) {
+      const startedAtTs = card.startedAt ?? card.queuedAt ?? card.createdAt;
+      active.push({
+        taskId: card.id,
+        title: titleForMarkdown(card.title),
+        status: activeStatus,
+        priority: card.priority,
+        assigneeId: card.assigneeId ?? card.agentId ?? null,
+        startedAt: toIso(startedAtTs),
+        updatedAt: toIso(latestUpdateAt(card)),
+      });
+      continue;
+    }
+
+    const completedStatus = statusToCompleted(card.status);
+    if (completedStatus) {
+      completed.push({
+        taskId: card.id,
+        title: titleForMarkdown(card.title),
+        status: completedStatus,
+        completedAt: toIso(card.completedAt ?? latestUpdateAt(card)),
+      });
+    }
+  }
+
+  active.sort((a, b) => {
+    const aStart = Date.parse(a.startedAt);
+    const bStart = Date.parse(b.startedAt);
+    return aStart - bStart;
+  });
+  completed.sort((a, b) => Date.parse(b.completedAt) - Date.parse(a.completedAt));
+
+  return {
+    updatedAt: toIso(now),
+    active,
+    completed: completed.slice(0, MAX_COMPLETED_ITEMS),
+  };
+}
+
+export function renderActiveTaskMarkdown(snapshot: ActiveTaskSnapshot): string {
+  const out: string[] = [];
+  out.push('# Active Tasks');
+  out.push('');
+  out.push(`_Last updated: ${snapshot.updatedAt}_`);
+  out.push('');
+  out.push('## Active Tasks');
+  if (snapshot.active.length === 0) {
+    out.push('- None');
+  } else {
+    for (const entry of snapshot.active) {
+      out.push(
+        `- [${entry.status}] ${entry.title} (taskId: ${entry.taskId}, priority: ${entry.priority}, assignee: ${entry.assigneeId ?? 'unassigned'}, started: ${entry.startedAt}, updated: ${entry.updatedAt})`,
+      );
+    }
+  }
+  out.push('');
+  out.push('## Recently Completed');
+  if (snapshot.completed.length === 0) {
+    out.push('- None');
+  } else {
+    for (const entry of snapshot.completed) {
+      out.push(
+        `- [${entry.status}] ${entry.title} (taskId: ${entry.taskId}, completed: ${entry.completedAt})`,
+      );
+    }
+  }
+  out.push('');
+  return out.join('\n');
+}
+
+export function writeActiveTasksFromCards(dataDir: string, tasks: TaskCard[]): void {
+  const fp = activeTasksFilePath(dataDir);
+  const dir = path.dirname(fp);
+  if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  const snapshot = buildActiveTaskSnapshot(tasks);
+  fs.writeFileSync(fp, renderActiveTaskMarkdown(snapshot));
+}
+
+function parseActiveTaskLine(line: string): ActiveTaskEntry | null {
+  const match = line.match(/^- \[(RUNNING|QUEUED|BLOCKED|REVIEW)\] (.+?) \(taskId: ([^,)\s]+), priority: (critical|high|medium|low), assignee: ([^,)]*), started: ([^,)]*), updated: ([^)]+)\)$/);
+  if (!match) return null;
+  const [, status, title, taskId, priority, assignee, startedAt, updatedAt] = match;
+  return {
+    taskId,
+    title: title.trim(),
+    status: status as ActiveStatus,
+    priority: priority as TaskPriority,
+    assigneeId: assignee === 'unassigned' ? null : assignee,
+    startedAt,
+    updatedAt,
+  };
+}
+
+function parseCompletedLine(line: string): CompletedTaskEntry | null {
+  const match = line.match(/^- \[(DONE|FAILED)\] (.+?) \(taskId: ([^,)\s]+), completed: ([^)]+)\)$/);
+  if (!match) return null;
+  const [, status, title, taskId, completedAt] = match;
+  return {
+    taskId,
+    title: title.trim(),
+    status: status as CompletedStatus,
+    completedAt,
+  };
+}
+
+export function readActiveTaskSnapshot(dataDir: string): ActiveTaskSnapshot {
+  const fp = activeTasksFilePath(dataDir);
+  if (!fs.existsSync(fp)) {
+    return { updatedAt: new Date(0).toISOString(), active: [], completed: [] };
+  }
+
+  try {
+    const text = fs.readFileSync(fp, 'utf8');
+    const lines = text.split('\n');
+    const active: ActiveTaskEntry[] = [];
+    const completed: CompletedTaskEntry[] = [];
+    let section: 'none' | 'active' | 'completed' = 'none';
+    let updatedAt = new Date(0).toISOString();
+
+    for (const rawLine of lines) {
+      const line = rawLine.trim();
+      if (!line) continue;
+      if (line.startsWith('_Last updated:') && line.endsWith('_')) {
+        const ts = line.replace(/^_Last updated:\s*/, '').replace(/_$/, '').trim();
+        if (Date.parse(ts) > 0) updatedAt = ts;
+        continue;
+      }
+      if (line === '## Active Tasks') {
+        section = 'active';
+        continue;
+      }
+      if (line === '## Recently Completed') {
+        section = 'completed';
+        continue;
+      }
+      if (line === '- None') continue;
+
+      if (section === 'active') {
+        const parsed = parseActiveTaskLine(line);
+        if (parsed) active.push(parsed);
+      } else if (section === 'completed') {
+        const parsed = parseCompletedLine(line);
+        if (parsed) completed.push(parsed);
+      }
+    }
+
+    return { updatedAt, active, completed };
+  } catch {
+    return { updatedAt: new Date(0).toISOString(), active: [], completed: [] };
+  }
+}
+
+export function detectStaleTasks(
+  snapshot: ActiveTaskSnapshot,
+  opts: { staleAfterMs?: number; now?: number } = {},
+): StaleTaskEntry[] {
+  const staleAfterMs = opts.staleAfterMs ?? DEFAULT_STALE_AFTER_MS;
+  const now = opts.now ?? Date.now();
+  const stale: StaleTaskEntry[] = [];
+
+  for (const task of snapshot.active) {
+    const updatedMs = Date.parse(task.updatedAt);
+    if (!Number.isFinite(updatedMs)) continue;
+    const delta = now - updatedMs;
+    if (delta > staleAfterMs) {
+      stale.push({
+        ...task,
+        staleMs: delta,
+      });
+    }
+  }
+
+  stale.sort((a, b) => b.staleMs - a.staleMs);
+  return stale;
+}

--- a/dashboard/server/routes/task-board.ts
+++ b/dashboard/server/routes/task-board.ts
@@ -115,6 +115,11 @@ import {
   CARD_EXPORT_MAX_ITEMS,
 } from '../task-card-export.js';
 import type { CardExportFormat } from '../task-card-export.js';
+import {
+  readActiveTaskSnapshot,
+  detectStaleTasks,
+  writeActiveTasksFromCards,
+} from '../active-tasks.js';
 
 // ─── Constants ───────────────────────────────────────────────────────────────
 
@@ -356,6 +361,16 @@ function saveTasks(dataDir: string, tasks: TaskCard[]): void {
   const dir = path.dirname(fp);
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
   fs.writeFileSync(fp, JSON.stringify({ tasks, updatedAt: Date.now() }, null, 2));
+}
+
+function saveTasksWithActiveTracker(dataDir: string, tasks: TaskCard[]): void {
+  saveTasks(dataDir, tasks);
+  // Keep memory/active-tasks.md in sync with task-board status changes.
+  try {
+    writeActiveTasksFromCards(dataDir, tasks);
+  } catch {
+    // Non-critical — task-board.json remains source of truth.
+  }
 }
 
 // ─── Pipeline Template Store (Issue #297) ───────────────────────────────────
@@ -739,7 +754,7 @@ function instantiatePipelineFromTemplate(
     created.push(card);
   }
 
-  saveTasks(dataDir, tasks);
+  saveTasksWithActiveTracker(dataDir, tasks);
   for (const card of created) emitEvent?.('task:created', card);
 
   return {
@@ -1292,7 +1307,7 @@ export function executeBatch(
     }
 
     // Persist all changes
-    saveTasks(dataDir, tasks);
+    saveTasksWithActiveTracker(dataDir, tasks);
   } else if (action === 'archive') {
     const toRemove: string[] = [];
 
@@ -1321,7 +1336,7 @@ export function executeBatch(
     if (toRemove.length > 0) {
       const removeSet = new Set(toRemove);
       const remaining = tasks.filter((t) => !removeSet.has(t.id));
-      saveTasks(dataDir, remaining);
+      saveTasksWithActiveTracker(dataDir, remaining);
     }
   }
 
@@ -1357,6 +1372,17 @@ export interface HeartbeatPickupResult {
   existingRunning: number;
   scannedQueued: number;
   skipped: HeartbeatPickupSkipped;
+}
+
+interface RecoveryResumeInput {
+  agentId?: string;
+  limit?: number;
+}
+
+export interface RecoveryResumeResult {
+  resumedCount: number;
+  resumedIds: string[];
+  consideredRunning: number;
 }
 
 function canRunByDependency(card: TaskCard, byId: Map<string, TaskCard>): boolean {
@@ -1461,7 +1487,7 @@ export function pickupQueuedTasksForAgent(
       appendStatusHistory(card, 'running', 'heartbeat', 'auto-picked from queue', now);
       emitEvent?.('task:updated', card);
     }
-    saveTasks(dataDir, tasks);
+    saveTasksWithActiveTracker(dataDir, tasks);
   }
 
   return {
@@ -1471,6 +1497,57 @@ export function pickupQueuedTasksForAgent(
     existingRunning: runningTasks.length,
     scannedQueued: candidates.length,
     skipped,
+  };
+}
+
+export function resumeRunningTasksFromSnapshot(
+  dataDir: string,
+  input: RecoveryResumeInput = {},
+  emitEvent?: TaskBoardDeps['emitEvent'],
+): RecoveryResumeResult {
+  const tasks = loadTasks(dataDir);
+  const snapshot = readActiveTaskSnapshot(dataDir);
+  const activeIds = new Set(snapshot.active.map((item) => item.taskId));
+  const agentId = typeof input.agentId === 'string' && input.agentId.trim()
+    ? input.agentId.trim()
+    : null;
+  const rawLimit = Number(input.limit ?? 50);
+  const limit = Number.isFinite(rawLimit)
+    ? Math.max(1, Math.min(Math.trunc(rawLimit), 100))
+    : 50;
+
+  const running = tasks
+    .filter((task) => task.status === 'running')
+    .filter((task) => {
+      if (agentId && task.agentId !== agentId && task.assigneeId !== agentId) return false;
+      if (activeIds.size === 0) return true;
+      return activeIds.has(task.id);
+    })
+    .sort((a, b) => (a.startedAt ?? a.createdAt) - (b.startedAt ?? b.createdAt));
+
+  const resumed = running.slice(0, limit);
+  if (resumed.length === 0) {
+    return {
+      resumedCount: 0,
+      resumedIds: [],
+      consideredRunning: running.length,
+    };
+  }
+
+  const now = Date.now();
+  for (const task of resumed) {
+    task.status = 'queued';
+    task.queuedAt = now;
+    task.startedAt = null;
+    appendStatusHistory(task, 'queued', 'recovery', 'auto-resume after restart', now);
+    emitEvent?.('task:updated', task);
+  }
+  saveTasksWithActiveTracker(dataDir, tasks);
+
+  return {
+    resumedCount: resumed.length,
+    resumedIds: resumed.map((task) => task.id),
+    consideredRunning: running.length,
   };
 }
 
@@ -1723,6 +1800,52 @@ export async function handleTaskBoard(
       sendJson(res, result, 400);
       return true;
     }
+    sendJson(res, result);
+    return true;
+  }
+
+  // ── GET /api/task-board/active — Issue #223 ─────────────────────────────
+  // Read active-task tracker snapshot + stale detection for dashboard display.
+  // Query params:
+  //   ?staleAfterMs=1800000 — stale threshold (default 30m, max 24h)
+  if (url.startsWith('/api/task-board/active') && method === 'GET') {
+    const params = new URL(url, 'http://localhost').searchParams;
+    const staleAfterMs = params.has('staleAfterMs')
+      ? Math.max(1000, Math.min(Number(params.get('staleAfterMs')) || 30 * 60 * 1000, 24 * 60 * 60 * 1000))
+      : 30 * 60 * 1000;
+    const snapshot = readActiveTaskSnapshot(dataDir);
+    const stale = detectStaleTasks(snapshot, { staleAfterMs });
+    sendJson(res, {
+      snapshot,
+      staleAfterMs,
+      staleCount: stale.length,
+      stale,
+    });
+    return true;
+  }
+
+  // ── POST /api/task-board/recovery/resume — Issue #223 ───────────────────
+  // Re-queue running work from active-tasks snapshot after restart.
+  // Optional body:
+  //   { "agentId": "oracle", "limit": 20 }
+  if (url === '/api/task-board/recovery/resume' && method === 'POST') {
+    let body: RecoveryResumeInput = {};
+    try {
+      const raw = await readRequestBody(req, { maxBytes: 4096 });
+      if (raw.trim()) {
+        const parsed = JSON.parse(raw);
+        if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+          sendJson(res, { error: 'request body must be a JSON object' }, 400);
+          return true;
+        }
+        body = parsed as RecoveryResumeInput;
+      }
+    } catch {
+      sendJson(res, { error: 'invalid JSON body' }, 400);
+      return true;
+    }
+
+    const result = resumeRunningTasksFromSnapshot(dataDir, body, deps.emitEvent);
     sendJson(res, result);
     return true;
   }
@@ -2328,7 +2451,7 @@ export async function handleTaskBoard(
 
     const tasks = loadTasks(dataDir);
     tasks.push(result.card);
-    saveTasks(dataDir, tasks);
+    saveTasksWithActiveTracker(dataDir, tasks);
     deps.emitEvent?.('task:created', result.card);
     sendJson(res, { card: result.card }, 201);
     return true;
@@ -2387,7 +2510,7 @@ export async function handleTaskBoard(
     appendStatusHistory(card, 'queued', 'retry', retryNote ?? 'manual retry from failed', now);
 
     tasks[idx] = card;
-    saveTasks(dataDir, tasks);
+    saveTasksWithActiveTracker(dataDir, tasks);
     deps.emitEvent?.('task:updated', card);
     sendJson(res, { card });
     return true;
@@ -2496,7 +2619,7 @@ export async function handleTaskBoard(
     }
 
     tasks[idx] = card;
-    saveTasks(dataDir, tasks);
+    saveTasksWithActiveTracker(dataDir, tasks);
     deps.emitEvent?.('task:updated', card);
     sendJson(res, { card });
     return true;
@@ -2517,7 +2640,7 @@ export async function handleTaskBoard(
 
     const deletedCard = tasks[idx];
     tasks.splice(idx, 1);
-    saveTasks(dataDir, tasks);
+    saveTasksWithActiveTracker(dataDir, tasks);
     deps.emitEvent?.('task:deleted', deletedCard);
     sendJson(res, { ok: true });
     return true;

--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -111,7 +111,7 @@ import { handleProgressionApi } from './routes/progression.js';
 import { handleProgressionV2Api } from '../../lib/progression-http-v2.js';
 import { getDefaultModelRouter } from '../../lib/model-router.js';
 import { handleChangelog } from './routes/changelog.js';
-import { handleTaskBoard } from './routes/task-board.js';
+import { handleTaskBoard, resumeRunningTasksFromSnapshot } from './routes/task-board.js';
 import { emitTaskEvent } from './task-board-events.js';
 import { handleMemoryState } from './routes/memory-state.js';
 import { handleUnifiedSearch } from './routes/unified-search.js';
@@ -162,6 +162,19 @@ try {
   fs.mkdirSync(dataDir, { recursive: true });
 } catch {
   // may exist
+}
+
+// Crash recovery (Issue #223): re-queue running tasks from active-tasks.md
+// so heartbeat workers can resume after restart without losing work context.
+try {
+  const recovery = resumeRunningTasksFromSnapshot(dataDir, {
+    limit: 50,
+  });
+  if (recovery.resumedCount > 0) {
+    logInfo('dashboard', 'task_recovery', 'Recovered running tasks on startup', { ...recovery });
+  }
+} catch {
+  // Non-critical: dashboard can still start without recovery.
 }
 
 // ─── Utility Functions ───────────────────────────────────────────────────────

--- a/dashboard/tests/unit/active-tasks.test.ts
+++ b/dashboard/tests/unit/active-tasks.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { TaskCard } from '../../server/types.js';
+import {
+  activeTasksFilePath,
+  buildActiveTaskSnapshot,
+  renderActiveTaskMarkdown,
+  writeActiveTasksFromCards,
+  readActiveTaskSnapshot,
+  detectStaleTasks,
+} from '../../server/active-tasks.js';
+
+const testRoot = path.join('/tmp', `test-active-tasks-${process.pid}`);
+const dataDir = path.join(testRoot, 'data');
+
+function makeCard(overrides: Partial<TaskCard> = {}): TaskCard {
+  return {
+    id: `task-${Math.random().toString(36).slice(2, 9)}`,
+    agentId: 'oracle',
+    title: 'Test task',
+    description: 'desc',
+    priority: 'medium',
+    status: 'backlog',
+    createdAt: Date.now(),
+    queuedAt: null,
+    startedAt: null,
+    completedAt: null,
+    resultSummary: null,
+    tokensUsed: null,
+    error: null,
+    costEstimate: null,
+    runtimeMs: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  fs.rmSync(testRoot, { recursive: true, force: true });
+  fs.mkdirSync(dataDir, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(testRoot, { recursive: true, force: true });
+});
+
+describe('active-task tracker', () => {
+  it('builds active/completed snapshot from task-board cards', () => {
+    const now = Date.now();
+    const cards: TaskCard[] = [
+      makeCard({
+        id: 'queued-1',
+        status: 'queued',
+        priority: 'high',
+        assigneeId: 'oracle',
+        createdAt: now - 20000,
+        queuedAt: now - 19000,
+      }),
+      makeCard({
+        id: 'run-1',
+        status: 'running',
+        priority: 'critical',
+        assigneeId: 'atlas',
+        createdAt: now - 10000,
+        startedAt: now - 9000,
+      }),
+      makeCard({
+        id: 'done-1',
+        status: 'done',
+        completedAt: now - 1000,
+      }),
+    ];
+
+    const snapshot = buildActiveTaskSnapshot(cards, now);
+    expect(snapshot.active.length).toBe(2);
+    expect(snapshot.completed.length).toBe(1);
+    expect(snapshot.active.some((item) => item.taskId === 'run-1' && item.status === 'RUNNING')).toBe(true);
+    expect(snapshot.completed[0].taskId).toBe('done-1');
+  });
+
+  it('writes and reads canonical markdown snapshot', () => {
+    const cards: TaskCard[] = [
+      makeCard({ id: 'run-1', status: 'running', startedAt: Date.now() - 5000, assigneeId: 'oracle' }),
+      makeCard({ id: 'failed-1', status: 'failed', completedAt: Date.now() - 1000 }),
+    ];
+
+    writeActiveTasksFromCards(dataDir, cards);
+
+    const fp = activeTasksFilePath(dataDir);
+    expect(fs.existsSync(fp)).toBe(true);
+    const text = fs.readFileSync(fp, 'utf8');
+    expect(text).toContain('## Active Tasks');
+    expect(text).toContain('## Recently Completed');
+
+    const parsed = readActiveTaskSnapshot(dataDir);
+    expect(parsed.active.length).toBe(1);
+    expect(parsed.completed.length).toBe(1);
+    expect(parsed.active[0].taskId).toBe('run-1');
+    expect(parsed.completed[0].status).toBe('FAILED');
+  });
+
+  it('detects stale active tasks using threshold', () => {
+    const now = Date.now();
+    const markdown = renderActiveTaskMarkdown({
+      updatedAt: new Date(now).toISOString(),
+      active: [
+        {
+          taskId: 'stale-1',
+          title: 'Old running',
+          status: 'RUNNING',
+          priority: 'medium',
+          assigneeId: 'oracle',
+          startedAt: new Date(now - 60 * 60 * 1000).toISOString(),
+          updatedAt: new Date(now - 45 * 60 * 1000).toISOString(),
+        },
+      ],
+      completed: [],
+    });
+    const fp = activeTasksFilePath(dataDir);
+    fs.mkdirSync(path.dirname(fp), { recursive: true });
+    fs.writeFileSync(fp, markdown);
+
+    const snapshot = readActiveTaskSnapshot(dataDir);
+    const stale = detectStaleTasks(snapshot, { staleAfterMs: 30 * 60 * 1000, now });
+    expect(stale.length).toBe(1);
+    expect(stale[0].taskId).toBe('stale-1');
+    expect(stale[0].staleMs).toBeGreaterThan(30 * 60 * 1000);
+  });
+});

--- a/dashboard/tests/unit/routes/task-board.test.ts
+++ b/dashboard/tests/unit/routes/task-board.test.ts
@@ -13,10 +13,13 @@ import {
   filterTasks,
   isValidTransition,
   pickupQueuedTasksForAgent,
+  resumeRunningTasksFromSnapshot,
 } from '../../../server/routes/task-board.js';
 import type { TaskBoardDeps, TaskCard, TaskStatus } from '../../../server/types.js';
+import { activeTasksFilePath, readActiveTaskSnapshot } from '../../../server/active-tasks.js';
 
-const testDataDir = path.join('/tmp', 'test-task-board-' + process.pid);
+const testRootDir = path.join('/tmp', 'test-task-board-' + process.pid);
+const testDataDir = path.join(testRootDir, 'data');
 
 function createDeps(overrides: Partial<TaskBoardDeps> = {}): TaskBoardDeps {
   return {
@@ -88,15 +91,13 @@ function makeSampleCard(overrides: Partial<TaskCard> = {}): TaskCard {
 }
 
 beforeEach(() => {
+  fs.rmSync(testRootDir, { recursive: true, force: true });
   fs.mkdirSync(testDataDir, { recursive: true });
-  // Clean
-  const fp = path.join(testDataDir, 'task-board.json');
-  if (fs.existsSync(fp)) fs.unlinkSync(fp);
 });
 
 afterEach(() => {
   try {
-    fs.rmSync(testDataDir, { recursive: true, force: true });
+    fs.rmSync(testRootDir, { recursive: true, force: true });
   } catch {
     // ignore
   }
@@ -417,6 +418,34 @@ describe('pickupQueuedTasksForAgent', () => {
   });
 });
 
+describe('resumeRunningTasksFromSnapshot', () => {
+  it('requeues running tasks from active snapshot for recovery', () => {
+    const run1 = makeSampleCard({
+      id: 'run-1',
+      status: 'running',
+      startedAt: Date.now() - 20000,
+      assigneeId: 'oracle',
+      agentId: 'oracle',
+    });
+    const run2 = makeSampleCard({
+      id: 'run-2',
+      status: 'running',
+      startedAt: Date.now() - 10000,
+      assigneeId: 'atlas',
+      agentId: 'atlas',
+    });
+    seedTasks([run1, run2]);
+
+    const result = resumeRunningTasksFromSnapshot(testDataDir, { agentId: 'oracle' });
+    expect(result.resumedCount).toBe(1);
+    expect(result.resumedIds).toEqual(['run-1']);
+
+    const persisted = loadTasks(testDataDir);
+    expect(persisted.find((t) => t.id === 'run-1')?.status).toBe('queued');
+    expect(persisted.find((t) => t.id === 'run-2')?.status).toBe('running');
+  });
+});
+
 describe('loadTasks', () => {
   it('returns empty array when file does not exist', () => {
     expect(loadTasks('/tmp/nonexistent-xyz-' + Date.now())).toEqual([]);
@@ -707,6 +736,83 @@ describe('handleTaskBoard', () => {
       );
       expect(res._statusCode).toBe(400);
       expect(parseJsonBody<{ error: string }>(res).error).toContain('JSON object');
+    });
+  });
+
+  describe('active task tracker routes (Issue #223)', () => {
+    it('returns active-task snapshot and stale metadata', async () => {
+      seedTasks([
+        makeSampleCard({
+          id: 'run-1',
+          status: 'running',
+          assigneeId: 'oracle',
+          createdAt: Date.now() - 10 * 60 * 1000,
+          startedAt: Date.now() - 10 * 60 * 1000,
+        }),
+      ]);
+      // Trigger a write path so active-tasks.md is synced.
+      const patchRes = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/run-1', method: 'PATCH' }),
+        patchRes,
+        depsWithBody({ title: 'keep-running' }),
+      );
+      expect(patchRes._statusCode).toBe(200);
+
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/active?staleAfterMs=1000', method: 'GET' }),
+        res,
+        createDeps(),
+      );
+      expect(res._statusCode).toBe(200);
+      const body = parseJsonBody<{ snapshot: { active: TaskCard[] }; staleCount: number }>(res);
+      expect(body.snapshot.active.length).toBeGreaterThanOrEqual(1);
+      expect(body.staleCount).toBeGreaterThanOrEqual(1);
+    });
+
+    it('requeues running tasks via recovery resume endpoint', async () => {
+      seedTasks([
+        makeSampleCard({
+          id: 'run-1',
+          status: 'running',
+          assigneeId: 'oracle',
+          agentId: 'oracle',
+          startedAt: Date.now() - 20000,
+        }),
+      ]);
+      const fp = activeTasksFilePath(testDataDir);
+      fs.mkdirSync(path.dirname(fp), { recursive: true });
+      fs.writeFileSync(
+        fp,
+        [
+          '# Active Tasks',
+          '',
+          `_Last updated: ${new Date().toISOString()}_`,
+          '',
+          '## Active Tasks',
+          `- [RUNNING] Recover me (taskId: run-1, priority: medium, assignee: oracle, started: ${new Date(Date.now() - 20000).toISOString()}, updated: ${new Date().toISOString()})`,
+          '',
+          '## Recently Completed',
+          '- None',
+          '',
+        ].join('\n'),
+      );
+
+      const res = mockResponse();
+      await handleTaskBoard(
+        mockRequest({ url: '/api/task-board/recovery/resume', method: 'POST' }),
+        res,
+        depsWithBody({ agentId: 'oracle' }),
+      );
+      expect(res._statusCode).toBe(200);
+      const body = parseJsonBody<{ resumedCount: number; resumedIds: string[] }>(res);
+      expect(body.resumedCount).toBe(1);
+      expect(body.resumedIds).toEqual(['run-1']);
+      expect(loadTasks(testDataDir).find((t) => t.id === 'run-1')?.status).toBe('queued');
+
+      const snapshot = readActiveTaskSnapshot(testDataDir);
+      expect(snapshot.active.some((entry) => entry.taskId === 'run-1')).toBe(true);
     });
   });
 

--- a/docs/CRASH_RECOVERY_ACTIVE_TASKS.md
+++ b/docs/CRASH_RECOVERY_ACTIVE_TASKS.md
@@ -1,0 +1,42 @@
+# Crash Recovery & Active Task Tracking (Issue #223)
+
+## Overview
+
+VentureOS now maintains a markdown "save game" file at `memory/active-tasks.md` that mirrors in-progress Task Board work.
+
+This enables:
+- human-readable active task visibility
+- stale task detection
+- restart recovery that re-queues running work
+
+## File Lifecycle
+
+- Source of truth: `data/task-board.json`
+- Tracker mirror: `memory/active-tasks.md`
+- Sync trigger: every Task Board mutation (create/update/delete/batch/pipeline/heartbeat/retry)
+
+The tracker is generated with two sections:
+- `## Active Tasks` (`RUNNING`, `QUEUED`, `BLOCKED`, `REVIEW`)
+- `## Recently Completed` (`DONE`, `FAILED`)
+
+## Recovery Behavior
+
+- On dashboard startup, recovery runs automatically:
+  - reads `memory/active-tasks.md`
+  - finds running task IDs
+  - re-queues matching `running` cards so heartbeat workers can resume
+- Recovery appends task status history entries with actor `recovery`
+
+## APIs
+
+- `GET /api/task-board/active`
+  - returns active-task snapshot + stale detection
+- `POST /api/task-board/recovery/resume`
+  - manually triggers recovery re-queue (supports `agentId` + `limit`)
+
+## Stale Detection
+
+Default stale threshold is 30 minutes (`1800000ms`).
+
+- configurable per request via `staleAfterMs`
+- stale tasks are ranked by longest time since last update

--- a/docs/DOC_INDEX.md
+++ b/docs/DOC_INDEX.md
@@ -25,6 +25,7 @@
 - **docs/NEXUS_2_0_M2_AUTHORITY_PLANE.md** – M2 authority map, policy gate, and override path
 - **docs/NEXUS_2_0_M4_OBSERVABILITY.md** – M4 replay authority surfaces (explain + control-health)
 - **docs/NEXUS_2_0_M6_PRODUCTION_READINESS_2026-02-21.md** – M6 readiness decision and evidence matrix
+- **docs/CRASH_RECOVERY_ACTIVE_TASKS.md** – active-tasks.md tracker, stale detection, and restart recovery flow (#223)
 
 ## VentureOS / Multi-Agent Orchestration
 - **docs/roles/VENTURE_OS.md** – venture studio OS overview (system vs persona)


### PR DESCRIPTION
## Summary
- add active-task tracker module `dashboard/server/active-tasks.ts` to maintain `memory/active-tasks.md` from task-board state
- sync tracker on all task-board mutations (CRUD, batch ops, heartbeat pickup, retries, pipeline instantiation)
- add stale-task detection API: `GET /api/task-board/active`
- add recovery API: `POST /api/task-board/recovery/resume`
- add startup auto-recovery in dashboard server using active-task snapshot
- add tests:
  - `dashboard/tests/unit/active-tasks.test.ts`
  - expanded `dashboard/tests/unit/routes/task-board.test.ts`
- document flow and endpoints in:
  - `docs/CRASH_RECOVERY_ACTIVE_TASKS.md`
  - `dashboard/docs/API.md`
  - `docs/DOC_INDEX.md`

## Validation
- `cd dashboard && npx -y vitest@4.0.18 run --config /tmp/vitest.local.config.mjs tests/unit/active-tasks.test.ts tests/unit/routes/task-board.test.ts`
- `npm run -s build`

Closes #223
