### PR TITLE
feat: token compaction pipeline + savings telemetry

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -164,6 +164,8 @@ See **[docs/API.md](docs/API.md)** for the complete API reference covering all e
 | `GET /api/mission-control` | Mission Control overview |
 | `GET /api/sessions` | Active session list |
 | `GET /api/costs` | Cost aggregation |
+| `POST /api/token-compaction/run` | Run deterministic 5-layer context compression |
+| `GET /api/token-compaction/metrics` | Per-session token/cost savings history |
 | `GET /api/live` | SSE real-time feed |
 
 ## Architecture

--- a/dashboard/docs/API.md
+++ b/dashboard/docs/API.md
@@ -16,6 +16,7 @@ Complete reference for all OpenClaw Dashboard HTTP endpoints.
 - [Action Endpoints](#action-endpoints)
 - [Task Board Endpoints](#task-board-endpoints)
 - [Model Routing Security Endpoints](#model-routing-security-endpoints)
+- [Token Compaction Endpoints](#token-compaction-endpoints)
 - [Schemas](#schemas)
 
 ---
@@ -842,6 +843,121 @@ Returns recent prompt-injection detection routing events.
 
 ---
 
+## Token Compaction Endpoints
+
+Deterministic, no-LLM context compression telemetry (Issue #221).
+
+### `POST /api/token-compaction/run`
+
+Runs the 5-layer token-compaction pipeline on an input file set.
+
+**Request:**
+```json
+{
+  "sessionId": "sess-abc",
+  "agentId": "oracle",
+  "files": [
+    {
+      "path": "src/main.ts",
+      "content": "// comment\nexport const x = 1;\n",
+      "priority": 2,
+      "updatedAtMs": 1700000000000
+    }
+  ],
+  "compression": {
+    "level": "standard",
+    "protected_files": ["SOUL.md", "*.key"],
+    "max_processing_ms": 200
+  }
+}
+```
+
+**Response (200):**
+```json
+{
+  "ok": true,
+  "result": {
+    "bundledContext": "F:src/main.ts (p=2,u=2026-02-21T09:00:00.000Z)\nexport const x = 1;",
+    "files": [
+      {
+        "path": "src/main.ts",
+        "protected": false,
+        "layersApplied": [
+          "whitespace-normalization",
+          "comment-stripping",
+          "deduplication",
+          "priority-pruning"
+        ],
+        "originalChars": 31,
+        "compressedChars": 20,
+        "content": "export const x = 1;"
+      }
+    ],
+    "metrics": {
+      "sessionId": "sess-abc",
+      "agentId": "oracle",
+      "level": "standard",
+      "preTokens": 12,
+      "postTokens": 7,
+      "reductionPct": 41.67,
+      "estimatedSavingsUsd": 0.000015,
+      "timedOut": false
+    }
+  }
+}
+```
+
+**Validation errors (400):**
+- missing `files[]`
+- malformed file entries
+- `files.length > 500`
+
+### `GET /api/token-compaction/metrics`
+
+Returns persisted compaction run history with per-session savings summary.
+
+**Query params:**
+- `limit` (optional, `1..500`, default `100`)
+- `sessionId` (optional)
+- `agentId` (optional)
+
+**Response (200):**
+```json
+{
+  "updatedAt": 1700000000000,
+  "total": 2,
+  "metrics": [
+    {
+      "sessionId": "sess-abc",
+      "agentId": "oracle",
+      "level": "standard",
+      "preTokens": 1200,
+      "postTokens": 310,
+      "reductionPct": 74.17,
+      "estimatedSavingsUsd": 0.00267,
+      "timedOut": false
+    }
+  ],
+  "summary": {
+    "preTokens": 1200,
+    "postTokens": 310,
+    "savedTokens": 890,
+    "avgReductionPct": 74.17,
+    "estimatedSavingsUsd": 0.00267,
+    "bySession": {
+      "sess-abc": {
+        "runs": 2,
+        "preTokens": 2200,
+        "postTokens": 620,
+        "savedTokens": 1580
+      }
+    }
+  }
+}
+```
+
+---
+
 ## Rate Limiting
 
 Per-IP, per-endpoint sliding window rate limits:
@@ -852,6 +968,7 @@ Per-IP, per-endpoint sliding window rate limits:
 | `/api/costs` | 60 req | 60s |
 | `/api/usage` | 60 req | 60s |
 | `/api/system` | 60 req | 60s |
+| `/api/token-compaction*` | 30 req | 60s |
 | `/api/ventureos-agents` | 30 req | 60s |
 | `/api/ventureos-kpis` | 30 req | 60s |
 | `/api/rpg/*` | 20 req | 60s |

--- a/dashboard/server/middleware/rate-limit.ts
+++ b/dashboard/server/middleware/rate-limit.ts
@@ -94,6 +94,7 @@ export const LIMITS: Record<string, RateLimitConfig> = {
   '/api/costs':               { limit: 60, windowMs: 60000 },
   '/api/usage':               { limit: 60, windowMs: 60000 },
   '/api/system':              { limit: 60, windowMs: 60000 },
+  '/api/token-compaction':    { limit: 30, windowMs: 60000 },
   '/api/replay':              { limit: 10, windowMs: 60000 },
   '/api/live':                { limit: 10, windowMs: 60000 },
   '/api/conversation':        { limit: 30, windowMs: 60000 },

--- a/dashboard/server/routes/token-compaction.ts
+++ b/dashboard/server/routes/token-compaction.ts
@@ -1,0 +1,206 @@
+/**
+ * Token Compaction API routes (Issue #221)
+ *
+ * Endpoints:
+ *   POST /api/token-compaction/run
+ *   GET  /api/token-compaction/metrics
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import {
+  runTokenCompaction,
+  type CompactionMetrics,
+  type CompactorFileInput,
+  type CompressionLevel,
+} from '../../../lib/token-compactor.js';
+
+export interface TokenCompactionDeps {
+  dataDir: string;
+  sendJson: (res: ServerResponse, data: unknown, status?: number) => void;
+  readRequestBody: (req: IncomingMessage) => Promise<string>;
+}
+
+interface TokenCompactionRunPayload {
+  sessionId?: string;
+  agentId?: string;
+  files: CompactorFileInput[];
+  compression?: {
+    level?: CompressionLevel;
+    protected_files?: string[];
+    max_processing_ms?: number;
+  };
+}
+
+interface TokenCompactionMetricRecord extends CompactionMetrics {
+  createdAtMs: number;
+}
+
+const METRICS_FILE = 'token-compaction-metrics.json';
+const MAX_STORED_METRICS = 1000;
+
+function readMetricsFile(filePath: string): TokenCompactionMetricRecord[] {
+  try {
+    if (!fs.existsSync(filePath)) return [];
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed
+      .map((entry) => entry as Partial<TokenCompactionMetricRecord>)
+      .filter((entry) => typeof entry?.sessionId === 'string' && typeof entry?.createdAtMs === 'number')
+      .map((entry) => entry as TokenCompactionMetricRecord);
+  } catch {
+    return [];
+  }
+}
+
+function writeMetricsFile(filePath: string, metrics: TokenCompactionMetricRecord[]): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(metrics.slice(-MAX_STORED_METRICS), null, 2));
+}
+
+function appendMetric(filePath: string, metric: CompactionMetrics): void {
+  const history = readMetricsFile(filePath);
+  history.push({ ...metric, createdAtMs: Date.now() });
+  writeMetricsFile(filePath, history);
+}
+
+function parseUrl(req: IncomingMessage): URL | null {
+  try {
+    return new URL(req.url ?? '', 'http://localhost');
+  } catch {
+    return null;
+  }
+}
+
+function parseJsonSafely<T>(raw: string): T | null {
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+function clampInt(value: string | null, fallback: number, min: number, max: number): number {
+  const parsed = Number.parseInt(String(value ?? ''), 10);
+  if (Number.isNaN(parsed)) return fallback;
+  return Math.max(min, Math.min(max, parsed));
+}
+
+function normalizeLevel(levelRaw: string | undefined): CompressionLevel {
+  if (levelRaw === 'conservative' || levelRaw === 'aggressive' || levelRaw === 'standard') return levelRaw;
+  return 'standard';
+}
+
+export function handleTokenCompaction(
+  req: IncomingMessage,
+  res: ServerResponse,
+  deps: TokenCompactionDeps,
+): Promise<boolean> | boolean {
+  if (!req.url || !req.url.startsWith('/api/token-compaction')) return false;
+
+  const url = parseUrl(req);
+  if (!url) {
+    deps.sendJson(res, { ok: false, error: 'Bad request URL' }, 400);
+    return true;
+  }
+
+  const metricsPath = path.join(deps.dataDir, METRICS_FILE);
+
+  if (url.pathname === '/api/token-compaction/metrics' && req.method === 'GET') {
+    const limit = clampInt(url.searchParams.get('limit'), 100, 1, 500);
+    const sessionId = (url.searchParams.get('sessionId') ?? '').trim();
+    const agentId = (url.searchParams.get('agentId') ?? '').trim();
+
+    const history = readMetricsFile(metricsPath)
+      .filter((metric) => (!sessionId || metric.sessionId === sessionId))
+      .filter((metric) => (!agentId || metric.agentId === agentId))
+      .sort((a, b) => b.createdAtMs - a.createdAtMs)
+      .slice(0, limit);
+
+    const preTokens = history.reduce((sum, metric) => sum + metric.preTokens, 0);
+    const postTokens = history.reduce((sum, metric) => sum + metric.postTokens, 0);
+    const savedTokens = Math.max(0, preTokens - postTokens);
+    const estimatedSavingsUsd = history.reduce((sum, metric) => sum + metric.estimatedSavingsUsd, 0);
+    const bySession: Record<string, { runs: number; preTokens: number; postTokens: number; savedTokens: number }> = {};
+
+    for (const metric of history) {
+      const sid = metric.sessionId;
+      if (!bySession[sid]) {
+        bySession[sid] = { runs: 0, preTokens: 0, postTokens: 0, savedTokens: 0 };
+      }
+      bySession[sid].runs += 1;
+      bySession[sid].preTokens += metric.preTokens;
+      bySession[sid].postTokens += metric.postTokens;
+      bySession[sid].savedTokens += Math.max(0, metric.preTokens - metric.postTokens);
+    }
+
+    deps.sendJson(res, {
+      updatedAt: Date.now(),
+      total: history.length,
+      metrics: history,
+      summary: {
+        preTokens,
+        postTokens,
+        savedTokens,
+        avgReductionPct: preTokens > 0 ? Number(((savedTokens / preTokens) * 100).toFixed(2)) : 0,
+        estimatedSavingsUsd: Number(estimatedSavingsUsd.toFixed(6)),
+        bySession,
+      },
+    });
+    return true;
+  }
+
+  if (url.pathname === '/api/token-compaction/run' && req.method === 'POST') {
+    return (async () => {
+      const rawBody = await deps.readRequestBody(req);
+      const payload = parseJsonSafely<TokenCompactionRunPayload>(rawBody);
+      if (!payload || !Array.isArray(payload.files)) {
+        deps.sendJson(res, { ok: false, error: 'Invalid payload: files[] is required' }, 400);
+        return true;
+      }
+
+      if (payload.files.length > 500) {
+        deps.sendJson(res, { ok: false, error: 'Too many files (max 500)' }, 400);
+        return true;
+      }
+
+      const normalizedFiles: CompactorFileInput[] = [];
+      for (const file of payload.files) {
+        if (!file || typeof file.path !== 'string' || typeof file.content !== 'string') {
+          deps.sendJson(res, { ok: false, error: 'Invalid file entry: expected { path, content }' }, 400);
+          return true;
+        }
+        normalizedFiles.push({
+          path: file.path,
+          content: file.content,
+          priority: Number.isFinite(file.priority) ? Number(file.priority) : undefined,
+          updatedAtMs: Number.isFinite(file.updatedAtMs) ? Number(file.updatedAtMs) : undefined,
+        });
+      }
+
+      const result = runTokenCompaction(normalizedFiles, {
+        level: normalizeLevel(payload.compression?.level),
+        protectedFiles: Array.isArray(payload.compression?.protected_files)
+          ? payload.compression?.protected_files.filter((v): v is string => typeof v === 'string')
+          : undefined,
+        maxProcessingMs: payload.compression?.max_processing_ms
+          ? clampInt(String(payload.compression.max_processing_ms), 200, 25, 5000)
+          : undefined,
+        sessionId: payload.sessionId,
+        agentId: payload.agentId,
+      });
+
+      appendMetric(metricsPath, result.metrics);
+      deps.sendJson(res, {
+        ok: true,
+        result,
+      });
+      return true;
+    })();
+  }
+
+  deps.sendJson(res, { ok: false, error: 'Not found' }, 404);
+  return true;
+}
+

--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -117,6 +117,7 @@ import { handleMemoryState } from './routes/memory-state.js';
 import { handleUnifiedSearch } from './routes/unified-search.js';
 import { handleObsidianConnector } from './routes/obsidian-connector.js';
 import { handleSharedContext } from './routes/shared-context.js';
+import { handleTokenCompaction } from './routes/token-compaction.js';
 import { getSchedulerJobs } from './scheduler-jobs.js';
 
 // ─── Configuration ───────────────────────────────────────────────────────────
@@ -3176,6 +3177,13 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
     } catch {
       sendJson(res, { error: 'Failed to load model-routing security metrics' }, 500);
     }
+    return;
+  }
+
+  try {
+    if (await handleTokenCompaction(req, res, { dataDir, sendJson, readRequestBody })) return;
+  } catch {
+    sendJson(res, { ok: false, error: 'Failed to process token compaction request' }, 500);
     return;
   }
 

--- a/dashboard/tests/unit/routes/token-compaction.test.ts
+++ b/dashboard/tests/unit/routes/token-compaction.test.ts
@@ -1,0 +1,103 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import { mockRequest, mockResponse, parseJsonBody } from '../../helpers.js';
+import { handleTokenCompaction, type TokenCompactionDeps } from '../../../server/routes/token-compaction.js';
+
+const testRootDir = path.join('/tmp', `test-token-compaction-${process.pid}`);
+const testDataDir = path.join(testRootDir, 'data');
+
+function createDeps(body: unknown = {}): TokenCompactionDeps {
+  return {
+    dataDir: testDataDir,
+    sendJson: (res, data, status = 200) => {
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+    },
+    readRequestBody: async () => JSON.stringify(body),
+  };
+}
+
+beforeEach(() => {
+  fs.rmSync(testRootDir, { recursive: true, force: true });
+  fs.mkdirSync(testDataDir, { recursive: true });
+});
+
+afterEach(() => {
+  fs.rmSync(testRootDir, { recursive: true, force: true });
+});
+
+describe('token-compaction route', () => {
+  it('runs compaction and stores metrics', async () => {
+    const req = mockRequest({
+      method: 'POST',
+      url: '/api/token-compaction/run',
+    });
+    const res = mockResponse();
+    const deps = createDeps({
+      sessionId: 'sess-a',
+      agentId: 'oracle',
+      compression: { level: 'standard', protected_files: ['SOUL.md'] },
+      files: [
+        { path: 'src/a.ts', content: '// comment\nconst a = 1;\n'.repeat(50), priority: 1 },
+        { path: 'souls/oracle/SOUL.md', content: '# protected\nkeep me\n' },
+      ],
+    });
+
+    const handled = await handleTokenCompaction(req, res, deps);
+    expect(handled).toBe(true);
+    expect(res._statusCode).toBe(200);
+
+    const body = parseJsonBody<{ ok: boolean; result: { metrics: { preTokens: number; postTokens: number } } }>(res);
+    expect(body.ok).toBe(true);
+    expect(body.result.metrics.preTokens).toBeGreaterThan(body.result.metrics.postTokens);
+
+    const metricsReq = mockRequest({ method: 'GET', url: '/api/token-compaction/metrics?sessionId=sess-a' });
+    const metricsRes = mockResponse();
+    const handledMetrics = await handleTokenCompaction(metricsReq, metricsRes, createDeps());
+    expect(handledMetrics).toBe(true);
+    expect(metricsRes._statusCode).toBe(200);
+
+    const metricsBody = parseJsonBody<{
+      total: number;
+      summary: { savedTokens: number; bySession: Record<string, { runs: number }> };
+    }>(metricsRes);
+    expect(metricsBody.total).toBe(1);
+    expect(metricsBody.summary.savedTokens).toBeGreaterThan(0);
+    expect(metricsBody.summary.bySession['sess-a']?.runs).toBe(1);
+  });
+
+  it('returns validation errors for malformed payloads', async () => {
+    const req = mockRequest({ method: 'POST', url: '/api/token-compaction/run' });
+    const res = mockResponse();
+    const handled = await handleTokenCompaction(req, res, createDeps({ foo: 'bar' }));
+    expect(handled).toBe(true);
+    expect(res._statusCode).toBe(400);
+  });
+
+  it('filters metrics by agent', async () => {
+    const run = async (sessionId: string, agentId: string): Promise<void> => {
+      const req = mockRequest({ method: 'POST', url: '/api/token-compaction/run' });
+      const res = mockResponse();
+      await handleTokenCompaction(req, res, createDeps({
+        sessionId,
+        agentId,
+        files: [{ path: `${agentId}.ts`, content: '// comment\nconst z = 1;\n'.repeat(10) }],
+      }));
+      expect(res._statusCode).toBe(200);
+    };
+
+    await run('sess-1', 'oracle');
+    await run('sess-2', 'atlas');
+
+    const req = mockRequest({ method: 'GET', url: '/api/token-compaction/metrics?agentId=atlas' });
+    const res = mockResponse();
+    await handleTokenCompaction(req, res, createDeps());
+    expect(res._statusCode).toBe(200);
+
+    const body = parseJsonBody<{ total: number; metrics: Array<{ agentId?: string }> }>(res);
+    expect(body.total).toBe(1);
+    expect(body.metrics[0]?.agentId).toBe('atlas');
+  });
+});
+

--- a/docs/DOC_INDEX.md
+++ b/docs/DOC_INDEX.md
@@ -26,6 +26,7 @@
 - **docs/NEXUS_2_0_M4_OBSERVABILITY.md** – M4 replay authority surfaces (explain + control-health)
 - **docs/NEXUS_2_0_M6_PRODUCTION_READINESS_2026-02-21.md** – M6 readiness decision and evidence matrix
 - **docs/CRASH_RECOVERY_ACTIVE_TASKS.md** – active-tasks.md tracker, stale detection, and restart recovery flow (#223)
+- **docs/TOKEN_COMPACTION.md** – deterministic 5-layer token compression pipeline, metrics, and benchmark harness (#221)
 
 ## VentureOS / Multi-Agent Orchestration
 - **docs/roles/VENTURE_OS.md** – venture studio OS overview (system vs persona)

--- a/docs/TOKEN_COMPACTION.md
+++ b/docs/TOKEN_COMPACTION.md
@@ -1,0 +1,66 @@
+# Token Compaction Pipeline
+
+Issue: #221
+
+## Purpose
+
+`lib/token-compactor.ts` provides deterministic, zero-LLM context compression for workspace file payloads before prompt assembly.
+
+Primary goals:
+- reduce prompt token load by 50%+ at `standard` level
+- keep protected files unmodified
+- complete inside a bounded processing window (`maxProcessingMs`, default `200ms`)
+
+## Layers
+
+The pipeline applies 5 ordered layers:
+
+1. `whitespace-normalization`
+2. `comment-stripping`
+3. `deduplication` (cross-file repeated block removal)
+4. `abbreviation` (bundle metadata shortening)
+5. `priority-pruning` (drops low-score context first)
+
+## Levels
+
+- `conservative` → target `50%` reduction
+- `standard` → target `70%` reduction
+- `aggressive` → target `90%` reduction
+
+Targets are best-effort; protected/non-text content and minimum retention floors can reduce achievable savings.
+
+## Protected Files
+
+Default protected globs:
+
+- `SOUL.md`
+- `PRINCIPLES.md`
+- `*.key`
+
+Protected files are passed through byte-for-byte and flagged with `skippedReason: "protected-file-pattern"`.
+
+## Metrics
+
+Each run returns:
+
+- `preTokens` / `postTokens`
+- `compressionRatio`
+- `reductionPct` and `targetReductionPct`
+- `layerContributions[]` (`preTokens`, `postTokens`, `savedTokens`, `savedPct` per layer)
+- `estimatedSavingsUsd`
+- `timedOut` when processing budget is exceeded
+
+The dashboard route `POST /api/token-compaction/run` persists metrics to `dashboard/data/token-compaction-metrics.json`, and `GET /api/token-compaction/metrics` provides per-session summaries.
+
+## Benchmark Harness
+
+Run a local benchmark over a representative workspace:
+
+```bash
+npm run bench:token-compaction -- /path/to/workspace 300
+```
+
+Arguments:
+- `workspacePath` (optional, default current directory)
+- `maxFiles` (optional, default `200`, range `10..2000`)
+

--- a/lib/__tests__/token-compactor.test.ts
+++ b/lib/__tests__/token-compactor.test.ts
@@ -1,0 +1,141 @@
+import {
+  runTokenCompaction,
+  estimateTokens,
+  isProtectedFile,
+  type CompactorFileInput,
+} from '../token-compactor';
+
+function fixedNow(): Date {
+  return new Date('2026-02-21T12:00:00.000Z');
+}
+
+describe('token-compactor', () => {
+  it('detects protected file globs', () => {
+    expect(isProtectedFile('souls/oracle/SOUL.md', ['SOUL.md'])).toBe(true);
+    expect(isProtectedFile('config/secret.key', ['*.key'])).toBe(true);
+    expect(isProtectedFile('src/main.ts', ['*.key'])).toBe(false);
+  });
+
+  it('is deterministic for identical inputs', () => {
+    const files: CompactorFileInput[] = [
+      {
+        path: 'src/a.ts',
+        content: `
+          // comment one
+          export const A = 1;
+
+          export const B = 2;
+        `,
+        priority: 1,
+      },
+      {
+        path: 'src/b.ts',
+        content: `
+          // comment two
+          export const C = 3;
+        `,
+        priority: 2,
+      },
+    ];
+
+    const a = runTokenCompaction(files, { now: fixedNow, level: 'standard' });
+    const b = runTokenCompaction(files, { now: fixedNow, level: 'standard' });
+
+    expect(a.bundledContext).toBe(b.bundledContext);
+    expect(a.files).toEqual(b.files);
+    expect(a.metrics).toEqual(b.metrics);
+  });
+
+  it('preserves protected files exactly', () => {
+    const protectedContent = `
+      # core profile
+      Keep every line exactly as-is
+    `;
+    const result = runTokenCompaction(
+      [
+        { path: 'souls/oracle/SOUL.md', content: protectedContent },
+        { path: 'src/worker.ts', content: '// comment\nexport const x = 1;' },
+      ],
+      { now: fixedNow, protectedFiles: ['SOUL.md'], level: 'standard' },
+    );
+
+    const protectedOut = result.files.find((f) => f.path.endsWith('SOUL.md'));
+    expect(protectedOut).toBeDefined();
+    expect(protectedOut?.content).toBe(protectedContent);
+    expect(protectedOut?.skippedReason).toBe('protected-file-pattern');
+  });
+
+  it('achieves >50% reduction at standard level on representative workspace sample', () => {
+    const sharedBlock = [
+      'function longSharedBlock() {',
+      '  const map = new Map<string, number>();',
+      '  for (let i = 0; i < 120; i += 1) {',
+      '    map.set(`key-${i}`, i * 2);',
+      '  }',
+      '  return Array.from(map.entries());',
+      '}',
+      '',
+      'const REPEATED_BANNER = "VENTUREOS_TOKEN_COMPACTOR_TEST_DATA";',
+      '',
+    ].join('\n');
+
+    const files: CompactorFileInput[] = Array.from({ length: 8 }, (_, i) => ({
+      path: `src/module-${i}.ts`,
+      priority: i === 0 ? 5 : 0,
+      updatedAtMs: Date.parse(`2026-02-${String(21 - i).padStart(2, '0')}T09:00:00.000Z`),
+      content: `
+        // module ${i}
+        ${sharedBlock}
+        ${sharedBlock}
+        export const value${i} = ${i};
+      `,
+    }));
+
+    const result = runTokenCompaction(files, { now: fixedNow, level: 'standard' });
+
+    expect(result.metrics.reductionPct).toBeGreaterThanOrEqual(50);
+    expect(result.metrics.preTokens).toBeGreaterThan(result.metrics.postTokens);
+    expect(result.metrics.layerContributions).toHaveLength(5);
+    expect(result.metrics.durationMs).toBeLessThanOrEqual(200);
+  });
+
+  it('prunes low-priority files first', () => {
+    const lowContent = `${'const low = 1;\n'.repeat(600)}\n`;
+    const highContent = `${'const high = 2;\n'.repeat(600)}\n`;
+    const result = runTokenCompaction(
+      [
+        { path: 'src/high.ts', content: highContent, priority: 10, updatedAtMs: Date.parse('2026-02-21T10:00:00.000Z') },
+        { path: 'src/low.ts', content: lowContent, priority: -1, updatedAtMs: Date.parse('2025-12-01T10:00:00.000Z') },
+      ],
+      { now: fixedNow, level: 'aggressive' },
+    );
+
+    const high = result.files.find((f) => f.path === 'src/high.ts');
+    const low = result.files.find((f) => f.path === 'src/low.ts');
+    expect(high?.skippedReason).not.toBe('priority-pruned');
+    expect(low?.skippedReason).toBe('priority-pruned');
+  });
+
+  it('returns timeout metadata when the budget is exhausted', () => {
+    const noisy = `${'// comment\nconst v = "x";\n'.repeat(3000)}\n`;
+    const result = runTokenCompaction(
+      [
+        { path: 'src/a.ts', content: noisy },
+        { path: 'src/b.ts', content: noisy },
+        { path: 'src/c.ts', content: noisy },
+      ],
+      {
+        now: (() => {
+          let calls = 0;
+          return () => new Date(Date.parse('2026-02-21T12:00:00.000Z') + calls++ * 120);
+        })(),
+        maxProcessingMs: 100,
+      },
+    );
+
+    expect(result.metrics.timedOut).toBe(true);
+    expect(estimateTokens(result.bundledContext)).toBe(result.metrics.postTokens);
+    expect(result.files.some((f) => f.skippedReason === 'max-processing-ms-exceeded')).toBe(true);
+  });
+});
+

--- a/lib/token-compactor.ts
+++ b/lib/token-compactor.ts
@@ -1,0 +1,525 @@
+/**
+ * Token Compactor (Issue #221)
+ *
+ * Deterministic, zero-LLM prompt-context compression pipeline with five layers:
+ * 1) whitespace normalization
+ * 2) comment stripping
+ * 3) cross-file deduplication
+ * 4) abbreviation (bundle metadata)
+ * 5) priority pruning
+ */
+
+import crypto from 'node:crypto';
+import path from 'node:path';
+
+export type CompressionLevel = 'conservative' | 'standard' | 'aggressive';
+export type CompactionLayer =
+  | 'whitespace-normalization'
+  | 'comment-stripping'
+  | 'deduplication'
+  | 'abbreviation'
+  | 'priority-pruning';
+
+export interface CompactorConfig {
+  level?: CompressionLevel;
+  protectedFiles?: string[];
+  maxProcessingMs?: number;
+  now?: () => Date;
+  sessionId?: string;
+  agentId?: string;
+  costPer1kTokensUsd?: number;
+}
+
+export interface CompactorFileInput {
+  path: string;
+  content: string;
+  /** Higher number = higher retention priority. Default 0. */
+  priority?: number;
+  /** Optional recency signal in epoch milliseconds. Higher = more recent. */
+  updatedAtMs?: number;
+}
+
+export interface CompactorFileOutput {
+  path: string;
+  protected: boolean;
+  skippedReason?: 'protected-file-pattern' | 'non-text-file' | 'priority-pruned' | 'max-processing-ms-exceeded';
+  layersApplied: CompactionLayer[];
+  originalChars: number;
+  compressedChars: number;
+  content: string;
+}
+
+export interface LayerContribution {
+  layer: CompactionLayer;
+  preTokens: number;
+  postTokens: number;
+  savedTokens: number;
+  savedPct: number;
+}
+
+export interface CompactionMetrics {
+  sessionId: string;
+  agentId?: string;
+  level: CompressionLevel;
+  startedAt: string;
+  completedAt: string;
+  timestamp: string;
+  durationMs: number;
+  preTokens: number;
+  postTokens: number;
+  compressionRatio: number;
+  reductionPct: number;
+  targetReductionPct: number;
+  layersApplied: CompactionLayer[];
+  layerContributions: LayerContribution[];
+  estimatedSavingsUsd: number;
+  timedOut: boolean;
+}
+
+export interface CompactionResult {
+  files: CompactorFileOutput[];
+  bundledContext: string;
+  metrics: CompactionMetrics;
+}
+
+interface WorkingFile {
+  readonly index: number;
+  readonly path: string;
+  readonly originalContent: string;
+  readonly priority: number;
+  readonly updatedAtMs?: number;
+  readonly originalChars: number;
+  readonly originalTokens: number;
+  readonly protectedByPattern: boolean;
+  readonly textFile: boolean;
+  content: string;
+  pruned: boolean;
+  layersApplied: Set<CompactionLayer>;
+}
+
+interface ScoreEntry {
+  index: number;
+  score: number;
+}
+
+const DEFAULT_LEVEL: CompressionLevel = 'standard';
+const DEFAULT_MAX_PROCESSING_MS = 200;
+const DEFAULT_PROTECTED_FILES = ['SOUL.md', 'PRINCIPLES.md', '*.key'];
+const DEFAULT_COST_PER_1K_TOKENS_USD = 0.003;
+const COMPACTION_LAYERS: CompactionLayer[] = [
+  'whitespace-normalization',
+  'comment-stripping',
+  'deduplication',
+  'abbreviation',
+  'priority-pruning',
+];
+
+const TARGET_REDUCTION_BY_LEVEL: Record<CompressionLevel, number> = {
+  conservative: 0.5,
+  standard: 0.7,
+  aggressive: 0.9,
+};
+
+const MIN_RETAINED_NON_PROTECTED_BY_LEVEL: Record<CompressionLevel, number> = {
+  conservative: 2,
+  standard: 1,
+  aggressive: 1,
+};
+
+const NON_TEXT_EXTENSIONS = new Set([
+  '.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg', '.ico', '.pdf',
+  '.zip', '.gz', '.tar', '.tgz', '.mov', '.mp4', '.wav', '.mp3',
+  '.wasm', '.node', '.sqlite', '.db',
+]);
+
+const COMMENT_STRIP_EXTENSIONS = new Set([
+  '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs',
+  '.java', '.go', '.rs', '.c', '.cc', '.cpp', '.h', '.hpp', '.kt', '.swift',
+  '.py', '.sh', '.bash', '.zsh', '.yml', '.yaml', '.rb',
+]);
+
+function nowMs(now: () => Date): number {
+  return now().getTime();
+}
+
+export function estimateTokens(text: string): number {
+  if (!text) return 0;
+  return Math.ceil(text.length / 4);
+}
+
+function escapeRegex(raw: string): string {
+  return raw.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}
+
+function wildcardToRegex(pattern: string): RegExp {
+  const escaped = pattern
+    .split('*')
+    .map((part) => part.split('?').map(escapeRegex).join('.'))
+    .join('.*');
+  return new RegExp(`^${escaped}$`, 'i');
+}
+
+export function isProtectedFile(filePath: string, patterns: string[]): boolean {
+  const normalized = filePath.replace(/\\/g, '/');
+  const base = path.basename(normalized);
+  for (const pattern of patterns) {
+    const normalizedPattern = pattern.replace(/\\/g, '/');
+    const rx = wildcardToRegex(normalizedPattern);
+    if (rx.test(normalized) || rx.test(base)) return true;
+  }
+  return false;
+}
+
+function isTextFile(filePath: string): boolean {
+  const ext = path.extname(filePath).toLowerCase();
+  if (!ext) return true;
+  return !NON_TEXT_EXTENSIONS.has(ext);
+}
+
+function normalizeWhitespace(content: string): string {
+  return content
+    .replace(/\r\n/g, '\n')
+    .replace(/[ \t]+$/gm, '')
+    .replace(/\n{3,}/g, '\n\n')
+    .trim();
+}
+
+function stripComments(content: string, filePath: string): string {
+  const ext = path.extname(filePath).toLowerCase();
+  if (!COMMENT_STRIP_EXTENSIONS.has(ext) || ext === '.md') return content;
+
+  let out = content;
+
+  if ([
+    '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs',
+    '.java', '.go', '.rs', '.c', '.cc', '.cpp', '.h', '.hpp', '.kt', '.swift',
+  ].includes(ext)) {
+    out = out.replace(/\/\*[\s\S]*?\*\//g, '');
+    out = out.replace(/(^|[^:])\/\/.*$/gm, '$1');
+  }
+
+  if (['.py', '.sh', '.bash', '.zsh', '.yml', '.yaml', '.rb'].includes(ext)) {
+    out = out
+      .split('\n')
+      .filter((line) => {
+        const trimmed = line.trim();
+        if (trimmed.startsWith('#!')) return true; // keep shebangs
+        return !trimmed.startsWith('#');
+      })
+      .join('\n');
+  }
+
+  return out;
+}
+
+function normalizeBlockForDedup(block: string): string {
+  return normalizeWhitespace(block).toLowerCase();
+}
+
+function splitIntoDedupBlocks(content: string): string[] {
+  if (!content.trim()) return [];
+  return content.split(/\n\s*\n/g);
+}
+
+function createWorkingFiles(
+  files: CompactorFileInput[],
+  protectedPatterns: string[],
+): WorkingFile[] {
+  return files
+    .map((input, index): WorkingFile => {
+      const filePath = input.path.trim();
+      const content = typeof input.content === 'string' ? input.content : String(input.content ?? '');
+      const priority = Number.isFinite(input.priority) ? Number(input.priority) : 0;
+      const updatedAtMs = Number.isFinite(input.updatedAtMs) ? Number(input.updatedAtMs) : undefined;
+      return {
+        index,
+        path: filePath,
+        originalContent: content,
+        priority,
+        updatedAtMs,
+        originalChars: content.length,
+        originalTokens: estimateTokens(content),
+        protectedByPattern: isProtectedFile(filePath, protectedPatterns),
+        textFile: isTextFile(filePath),
+        content,
+        pruned: false,
+        layersApplied: new Set<CompactionLayer>(),
+      };
+    })
+    .sort((a, b) => a.path.localeCompare(b.path));
+}
+
+function applyLayerContribution(
+  metrics: LayerContribution[],
+  layer: CompactionLayer,
+  preTokens: number,
+  postTokens: number,
+): void {
+  const saved = Math.max(0, preTokens - postTokens);
+  const savedPct = preTokens > 0 ? (saved / preTokens) * 100 : 0;
+  metrics.push({
+    layer,
+    preTokens,
+    postTokens,
+    savedTokens: saved,
+    savedPct: Number(savedPct.toFixed(2)),
+  });
+}
+
+function toHeader(file: WorkingFile, abbreviated: boolean): string {
+  const updated = file.updatedAtMs ? new Date(file.updatedAtMs).toISOString() : 'n/a';
+  if (abbreviated) return `F:${file.path} (p=${file.priority},u=${updated})`;
+  return `FILE:${file.path} (priority=${file.priority}, updatedAt=${updated})`;
+}
+
+function buildBundle(files: WorkingFile[], opts: { abbreviatedHeaders: boolean; includePruned: boolean }): string {
+  const lines: string[] = [];
+  for (const file of files) {
+    if (!opts.includePruned && file.pruned) continue;
+    if (!file.content) continue;
+    lines.push(`${toHeader(file, opts.abbreviatedHeaders)}\n${file.content}`);
+  }
+  return lines.join('\n\n');
+}
+
+function applyCrossFileDedup(files: WorkingFile[], deadlineMs: number, now: () => Date): boolean {
+  const seenBlocks = new Set<string>();
+  for (const file of files) {
+    if (file.protectedByPattern || !file.textFile) continue;
+    if (nowMs(now) > deadlineMs) return false;
+
+    const blocks = splitIntoDedupBlocks(file.content);
+    if (blocks.length === 0) continue;
+    const kept: string[] = [];
+
+    for (const block of blocks) {
+      const normalized = normalizeBlockForDedup(block);
+      if (!normalized) continue;
+      if (nowMs(now) > deadlineMs) return false;
+      if (normalized.length < 80) {
+        kept.push(block);
+        continue;
+      }
+      const digest = crypto.createHash('sha1').update(normalized).digest('hex');
+      if (seenBlocks.has(digest)) continue;
+      seenBlocks.add(digest);
+      kept.push(block);
+    }
+
+    file.content = kept.join('\n\n');
+    file.layersApplied.add('deduplication');
+  }
+  return true;
+}
+
+function scoreForPruning(file: WorkingFile, nowMsValue: number): number {
+  const priorityScore = Math.max(-10, Math.min(10, file.priority)) * 3;
+  const ageDays = file.updatedAtMs
+    ? Math.max(0, (nowMsValue - file.updatedAtMs) / (24 * 60 * 60 * 1000))
+    : 10;
+  const recencyScore = file.updatedAtMs ? Math.max(0, 4 - ageDays / 3) : 0.5;
+  const tokenWeight = Math.max(0, 2 - file.originalTokens / 1500);
+  return priorityScore + recencyScore + tokenWeight;
+}
+
+function applyPriorityPruning(files: WorkingFile[], level: CompressionLevel, preTokens: number, nowValue: number): void {
+  const targetReduction = TARGET_REDUCTION_BY_LEVEL[level];
+  const targetPostTokens = Math.floor(preTokens * (1 - targetReduction));
+  const protectedTokens = files
+    .filter((file) => file.protectedByPattern || !file.textFile)
+    .reduce((sum, file) => sum + estimateTokens(file.content), 0);
+
+  const candidates = files.filter((file) => !file.protectedByPattern && file.textFile && file.content.length > 0);
+  if (candidates.length === 0) return;
+
+  const totalCurrentTokens = files.reduce((sum, file) => sum + estimateTokens(file.content), 0);
+  const effectiveTarget = Math.max(protectedTokens, targetPostTokens);
+  if (totalCurrentTokens <= effectiveTarget) {
+    for (const file of candidates) file.layersApplied.add('priority-pruning');
+    return;
+  }
+
+  const minRetained = Math.min(
+    candidates.length,
+    Math.max(1, MIN_RETAINED_NON_PROTECTED_BY_LEVEL[level]),
+  );
+
+  const sortedByPrunePriority: ScoreEntry[] = candidates
+    .map((file) => ({ index: file.index, score: scoreForPruning(file, nowValue) }))
+    .sort((a, b) => {
+      if (a.score === b.score) return a.index - b.index;
+      return a.score - b.score;
+    });
+
+  const byIndex = new Map(files.map((file) => [file.index, file]));
+  let currentTokens = totalCurrentTokens;
+  let retainedCandidates = candidates.length;
+
+  for (const candidate of sortedByPrunePriority) {
+    if (currentTokens <= effectiveTarget) break;
+    if (retainedCandidates <= minRetained) break;
+    const file = byIndex.get(candidate.index);
+    if (!file || file.pruned || !file.content) continue;
+    file.pruned = true;
+    currentTokens -= estimateTokens(file.content);
+    retainedCandidates -= 1;
+  }
+
+  for (const file of candidates) {
+    file.layersApplied.add('priority-pruning');
+  }
+}
+
+function createDefaultSessionId(files: WorkingFile[], now: () => Date): string {
+  const digestSeed = files
+    .map((f) => `${f.path}:${f.originalChars}:${f.priority}:${f.updatedAtMs ?? 'na'}`)
+    .join('|');
+  const digest = crypto.createHash('sha1').update(digestSeed).digest('hex').slice(0, 10);
+  const stamp = now().toISOString().replace(/[-:.TZ]/g, '');
+  return `cmp-${stamp}-${digest}`;
+}
+
+export function runTokenCompaction(
+  inputFiles: CompactorFileInput[],
+  config: CompactorConfig = {},
+): CompactionResult {
+  const now = config.now ?? (() => new Date());
+  const startedAtIso = now().toISOString();
+  const startedMs = nowMs(now);
+  const maxProcessingMs = Math.max(25, config.maxProcessingMs ?? DEFAULT_MAX_PROCESSING_MS);
+  const deadlineMs = startedMs + maxProcessingMs;
+  const level = config.level ?? DEFAULT_LEVEL;
+  const protectedPatterns = config.protectedFiles ?? DEFAULT_PROTECTED_FILES;
+  const costPer1kTokensUsd = config.costPer1kTokensUsd ?? DEFAULT_COST_PER_1K_TOKENS_USD;
+
+  const files = createWorkingFiles(inputFiles, protectedPatterns);
+  const sessionId = config.sessionId || createDefaultSessionId(files, now);
+
+  const layerContributions: LayerContribution[] = [];
+  const layersApplied = new Set<CompactionLayer>();
+  let timedOut = false;
+
+  const preBundle = buildBundle(files.map((file) => ({ ...file, content: file.originalContent } as WorkingFile)), {
+    abbreviatedHeaders: false,
+    includePruned: true,
+  });
+  const preTokens = estimateTokens(preBundle);
+  let lastTokens = preTokens;
+
+  // Layer 1: Whitespace normalization
+  for (const file of files) {
+    if (file.protectedByPattern || !file.textFile) continue;
+    if (nowMs(now) > deadlineMs) {
+      timedOut = true;
+      break;
+    }
+    file.content = normalizeWhitespace(file.content);
+    file.layersApplied.add('whitespace-normalization');
+  }
+  const afterWhitespaceTokens = estimateTokens(buildBundle(files, { abbreviatedHeaders: false, includePruned: true }));
+  applyLayerContribution(layerContributions, 'whitespace-normalization', lastTokens, afterWhitespaceTokens);
+  layersApplied.add('whitespace-normalization');
+  lastTokens = afterWhitespaceTokens;
+
+  // Layer 2: Comment stripping
+  if (!timedOut) {
+    for (const file of files) {
+      if (file.protectedByPattern || !file.textFile) continue;
+      if (nowMs(now) > deadlineMs) {
+        timedOut = true;
+        break;
+      }
+      file.content = stripComments(file.content, file.path);
+      file.layersApplied.add('comment-stripping');
+    }
+  }
+  const afterCommentTokens = estimateTokens(buildBundle(files, { abbreviatedHeaders: false, includePruned: true }));
+  applyLayerContribution(layerContributions, 'comment-stripping', lastTokens, afterCommentTokens);
+  layersApplied.add('comment-stripping');
+  lastTokens = afterCommentTokens;
+
+  // Layer 3: Cross-file deduplication
+  if (!timedOut) {
+    const complete = applyCrossFileDedup(files, deadlineMs, now);
+    if (!complete) timedOut = true;
+  }
+  const afterDedupeTokens = estimateTokens(buildBundle(files, { abbreviatedHeaders: false, includePruned: true }));
+  applyLayerContribution(layerContributions, 'deduplication', lastTokens, afterDedupeTokens);
+  layersApplied.add('deduplication');
+  lastTokens = afterDedupeTokens;
+
+  // Layer 4: Abbreviation (metadata header compaction)
+  const afterAbbreviationTokens = estimateTokens(buildBundle(files, { abbreviatedHeaders: true, includePruned: true }));
+  applyLayerContribution(layerContributions, 'abbreviation', lastTokens, afterAbbreviationTokens);
+  layersApplied.add('abbreviation');
+  lastTokens = afterAbbreviationTokens;
+
+  // Layer 5: Priority pruning
+  if (!timedOut && nowMs(now) <= deadlineMs) {
+    applyPriorityPruning(files, level, preTokens, startedMs);
+  } else {
+    timedOut = true;
+  }
+  const postBundle = buildBundle(files, { abbreviatedHeaders: true, includePruned: false });
+  const postTokens = estimateTokens(postBundle);
+  applyLayerContribution(layerContributions, 'priority-pruning', lastTokens, postTokens);
+  layersApplied.add('priority-pruning');
+
+  for (const file of files) {
+    if (timedOut && file.layersApplied.size === 0 && !file.protectedByPattern && file.textFile) {
+      // Budget exhausted before any transformation reached this file.
+      file.content = file.originalContent;
+    }
+  }
+
+  const completedMs = nowMs(now);
+  const durationMs = Math.max(0, completedMs - startedMs);
+  const compressionRatio = preTokens > 0 ? postTokens / preTokens : 1;
+  const reductionPct = preTokens > 0 ? ((preTokens - postTokens) / preTokens) * 100 : 0;
+  const estimatedSavingsUsd = ((preTokens - postTokens) / 1000) * costPer1kTokensUsd;
+
+  const outputs: CompactorFileOutput[] = files.map((file) => {
+    const isProtected = file.protectedByPattern;
+    const nonText = !file.textFile;
+    let skippedReason: CompactorFileOutput['skippedReason'];
+
+    if (isProtected) skippedReason = 'protected-file-pattern';
+    else if (nonText) skippedReason = 'non-text-file';
+    else if (file.pruned) skippedReason = 'priority-pruned';
+    else if (timedOut && file.layersApplied.size === 0) skippedReason = 'max-processing-ms-exceeded';
+
+    return {
+      path: file.path,
+      protected: isProtected,
+      skippedReason,
+      layersApplied: COMPACTION_LAYERS.filter((layer) => file.layersApplied.has(layer)),
+      originalChars: file.originalChars,
+      compressedChars: file.pruned ? 0 : file.content.length,
+      content: file.pruned ? '' : file.content,
+    };
+  });
+
+  return {
+    files: outputs,
+    bundledContext: postBundle,
+    metrics: {
+      sessionId,
+      agentId: config.agentId,
+      level,
+      startedAt: startedAtIso,
+      completedAt: new Date(completedMs).toISOString(),
+      timestamp: new Date(completedMs).toISOString(),
+      durationMs,
+      preTokens,
+      postTokens,
+      compressionRatio: Number(compressionRatio.toFixed(4)),
+      reductionPct: Number(reductionPct.toFixed(2)),
+      targetReductionPct: Number((TARGET_REDUCTION_BY_LEVEL[level] * 100).toFixed(2)),
+      layersApplied: COMPACTION_LAYERS.filter((layer) => layersApplied.has(layer)),
+      layerContributions,
+      estimatedSavingsUsd: Number(Math.max(0, estimatedSavingsUsd).toFixed(6)),
+      timedOut,
+    },
+  };
+}
+

--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "test:perf:memory": "cd tactical-map && PERF=1 npx playwright test tests/performance/memory-leak.test.ts",
     "test:perf:network": "cd tactical-map && PERF=1 npx playwright test tests/performance/network-latency.test.ts",
     "test:a11y": "cd tactical-map && npx playwright test tests/accessibility/",
-    "bench": "cd tactical-map && ./scripts/run-benchmarks.sh"
+    "bench": "cd tactical-map && ./scripts/run-benchmarks.sh",
+    "bench:token-compaction": "node -r ts-node/register ./scripts/benchmark-token-compactor.ts"
   },
   "dependencies": {
     "ajv": "^8.17.1",

--- a/scripts/benchmark-token-compactor.ts
+++ b/scripts/benchmark-token-compactor.ts
@@ -1,0 +1,147 @@
+/**
+ * Benchmark harness for token compaction (Issue #221).
+ *
+ * Usage:
+ *   node -r ts-node/register ./scripts/benchmark-token-compactor.ts [workspacePath] [maxFiles]
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { runTokenCompaction, type CompressionLevel, type CompactorFileInput } from '../lib/token-compactor';
+
+const EXCLUDED_DIRS = new Set([
+  '.git',
+  'node_modules',
+  'dist',
+  'build',
+  'coverage',
+  '.next',
+  '.turbo',
+  '.cache',
+]);
+
+const TEXT_EXTENSIONS = new Set([
+  '.ts', '.tsx', '.js', '.jsx', '.mjs', '.cjs',
+  '.json', '.md', '.yml', '.yaml', '.txt', '.sql', '.sh', '.py', '.go', '.rs',
+  '.java', '.kt', '.rb', '.php', '.c', '.cc', '.cpp', '.h', '.hpp',
+]);
+
+function isTextPath(filePath: string): boolean {
+  const ext = path.extname(filePath).toLowerCase();
+  if (!ext) return true;
+  return TEXT_EXTENSIONS.has(ext);
+}
+
+function walkWorkspace(root: string, maxFiles: number): string[] {
+  const out: string[] = [];
+  const stack: string[] = [root];
+
+  while (stack.length > 0 && out.length < maxFiles) {
+    const dir = stack.pop() as string;
+    let entries: fs.Dirent[];
+    try {
+      entries = fs.readdirSync(dir, { withFileTypes: true });
+    } catch {
+      continue;
+    }
+
+    for (const entry of entries) {
+      if (out.length >= maxFiles) break;
+      const fullPath = path.join(dir, entry.name);
+      if (entry.isDirectory()) {
+        if (EXCLUDED_DIRS.has(entry.name)) continue;
+        stack.push(fullPath);
+        continue;
+      }
+      if (!entry.isFile()) continue;
+      if (!isTextPath(fullPath)) continue;
+      out.push(fullPath);
+    }
+  }
+
+  return out;
+}
+
+function priorityForPath(relativePath: string): number {
+  const normalized = relativePath.replace(/\\/g, '/').toLowerCase();
+  if (normalized.endsWith('/soul.md') || normalized.includes('/souls/')) return 9;
+  if (normalized.startsWith('docs/')) return 5;
+  if (normalized.startsWith('lib/') || normalized.startsWith('dashboard/server/')) return 3;
+  return 0;
+}
+
+function collectInputs(workspacePath: string, maxFiles: number): CompactorFileInput[] {
+  const files = walkWorkspace(workspacePath, maxFiles);
+  const inputs: CompactorFileInput[] = [];
+
+  for (const absPath of files) {
+    let stat: fs.Stats;
+    try {
+      stat = fs.statSync(absPath);
+    } catch {
+      continue;
+    }
+    if (stat.size > 100_000) continue; // keep benchmark bounded
+
+    let content: string;
+    try {
+      content = fs.readFileSync(absPath, 'utf8');
+    } catch {
+      continue;
+    }
+
+    const rel = path.relative(workspacePath, absPath);
+    inputs.push({
+      path: rel,
+      content,
+      priority: priorityForPath(rel),
+      updatedAtMs: stat.mtimeMs,
+    });
+  }
+
+  return inputs;
+}
+
+function runLevel(inputs: CompactorFileInput[], level: CompressionLevel): void {
+  const started = Date.now();
+  const result = runTokenCompaction(inputs, {
+    level,
+    protectedFiles: ['SOUL.md', 'PRINCIPLES.md', '*.key'],
+    maxProcessingMs: 2_000,
+  });
+  const elapsed = Date.now() - started;
+
+  const reduction = result.metrics.reductionPct.toFixed(2);
+  const pre = result.metrics.preTokens;
+  const post = result.metrics.postTokens;
+  const savingsUsd = result.metrics.estimatedSavingsUsd.toFixed(6);
+
+  console.log(
+    `${level.padEnd(12)} pre=${String(pre).padStart(8)} post=${String(post).padStart(8)} `
+      + `reduction=${reduction.padStart(6)}% savings=$${savingsUsd} duration=${elapsed}ms`,
+  );
+}
+
+function main(): void {
+  const workspacePath = path.resolve(process.argv[2] ?? process.cwd());
+  const maxFilesRaw = Number.parseInt(process.argv[3] ?? '200', 10);
+  const maxFiles = Number.isFinite(maxFilesRaw) ? Math.max(10, Math.min(maxFilesRaw, 2000)) : 200;
+
+  const inputs = collectInputs(workspacePath, maxFiles);
+  if (inputs.length === 0) {
+    console.error('No eligible text files found for benchmark.');
+    process.exitCode = 1;
+    return;
+  }
+
+  console.log(`Token compaction benchmark`);
+  console.log(`workspace=${workspacePath}`);
+  console.log(`files=${inputs.length}`);
+  console.log('');
+  runLevel(inputs, 'conservative');
+  runLevel(inputs, 'standard');
+  runLevel(inputs, 'aggressive');
+}
+
+main();
+


### PR DESCRIPTION
## Summary
- implement deterministic 5-layer token compaction pipeline (`lib/token-compactor.ts`)
- add compaction metrics with per-layer contribution + estimated USD savings
- add dashboard APIs for execution + persisted telemetry:
  - `POST /api/token-compaction/run`
  - `GET /api/token-compaction/metrics`
- add benchmark harness (`npm run bench:token-compaction -- <workspace> <maxFiles>`)
- add tests and docs for compactor + route behavior

## Validation
- `npx jest lib/__tests__/token-compactor.test.ts --runInBand`
- `cd dashboard && npx -y vitest@4.0.18 run --config /tmp/vitest.local.config.mjs tests/unit/routes/token-compaction.test.ts tests/unit/middleware/rate-limit.test.ts`
- `npm run -s build`
- `npm run -s bench:token-compaction -- /Users/zachgonser/ventureos 120`

## Benchmark Snapshot (local)
- conservative: 49.94% reduction
- standard: 69.59% reduction
- aggressive: 89.77% reduction

Closes #221
