### PR TITLE
feat: add self-improvement digest + approval workflow

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -166,6 +166,8 @@ See **[docs/API.md](docs/API.md)** for the complete API reference covering all e
 | `GET /api/costs` | Cost aggregation |
 | `POST /api/token-compaction/run` | Run deterministic 5-layer context compression |
 | `GET /api/token-compaction/metrics` | Per-session token/cost savings history |
+| `POST /api/self-improvement/generate` | Generate daily self-review digest with recommendations |
+| `GET /api/self-improvement/digests` | List historical digest runs and recommendation status |
 | `GET /api/live` | SSE real-time feed |
 
 ## Architecture

--- a/dashboard/docs/API.md
+++ b/dashboard/docs/API.md
@@ -17,6 +17,7 @@ Complete reference for all OpenClaw Dashboard HTTP endpoints.
 - [Task Board Endpoints](#task-board-endpoints)
 - [Model Routing Security Endpoints](#model-routing-security-endpoints)
 - [Token Compaction Endpoints](#token-compaction-endpoints)
+- [Self-Improvement Endpoints](#self-improvement-endpoints)
 - [Schemas](#schemas)
 
 ---
@@ -958,6 +959,96 @@ Returns persisted compaction run history with per-session savings summary.
 
 ---
 
+## Self-Improvement Endpoints
+
+Daily self-review digest generation + recommendation approvals (Issue #222).
+
+### `POST /api/self-improvement/generate`
+
+Generates a daily digest with actionable, diffable recommendations for one agent.
+
+**Request (optional):**
+```json
+{
+  "agentId": "oracle",
+  "date": "2026-02-21",
+  "minRecommendations": 3
+}
+```
+
+**Response (200):**
+```json
+{
+  "ok": true,
+  "digestPath": "memory/self-improvement/2026-02-21.md",
+  "digest": {
+    "id": "sid-2026-02-21-oracle-abc123",
+    "agentId": "oracle",
+    "date": "2026-02-21",
+    "approvedCount": 0,
+    "rejectedCount": 0,
+    "pendingCount": 3,
+    "recommendations": [
+      {
+        "id": "sir-123",
+        "type": "workflow_change",
+        "target": "souls/oracle/PRINCIPLES.md",
+        "status": "pending",
+        "diff": "--- a/souls/oracle/PRINCIPLES.md\n+++ b/souls/oracle/PRINCIPLES.md\n@@\n-...\n+..."
+      }
+    ]
+  }
+}
+```
+
+### `GET /api/self-improvement/digests`
+
+Lists stored digest runs.
+
+**Query params:**
+- `agentId` (optional)
+- `limit` (optional, `1..365`, default `30`)
+
+**Response (200):**
+```json
+{
+  "total": 1,
+  "digests": [
+    {
+      "id": "sid-2026-02-21-oracle-abc123",
+      "agentId": "oracle",
+      "date": "2026-02-21",
+      "approvedCount": 1,
+      "rejectedCount": 0,
+      "pendingCount": 2
+    }
+  ]
+}
+```
+
+### `GET /api/self-improvement/digests/:id`
+
+Returns one full digest record by ID.
+
+### `POST /api/self-improvement/recommendations/:id/approve`
+
+Explicitly approves and auto-applies a recommendation.
+
+**Request (optional):**
+```json
+{ "agentId": "oracle" }
+```
+
+### `POST /api/self-improvement/recommendations/:id/reject`
+
+Rejects a recommendation without applying any file changes.
+
+**Security note:**
+- approvals only apply when the target path is inside `souls/<agentId>/` or `memory/self-improvement/`
+- out-of-scope targets are rejected with no file mutation
+
+---
+
 ## Rate Limiting
 
 Per-IP, per-endpoint sliding window rate limits:
@@ -969,6 +1060,7 @@ Per-IP, per-endpoint sliding window rate limits:
 | `/api/usage` | 60 req | 60s |
 | `/api/system` | 60 req | 60s |
 | `/api/token-compaction*` | 30 req | 60s |
+| `/api/self-improvement*` | 20 req | 60s |
 | `/api/ventureos-agents` | 30 req | 60s |
 | `/api/ventureos-kpis` | 30 req | 60s |
 | `/api/rpg/*` | 20 req | 60s |

--- a/dashboard/server/middleware/rate-limit.ts
+++ b/dashboard/server/middleware/rate-limit.ts
@@ -95,6 +95,7 @@ export const LIMITS: Record<string, RateLimitConfig> = {
   '/api/usage':               { limit: 60, windowMs: 60000 },
   '/api/system':              { limit: 60, windowMs: 60000 },
   '/api/token-compaction':    { limit: 30, windowMs: 60000 },
+  '/api/self-improvement':    { limit: 20, windowMs: 60000 },
   '/api/replay':              { limit: 10, windowMs: 60000 },
   '/api/live':                { limit: 10, windowMs: 60000 },
   '/api/conversation':        { limit: 30, windowMs: 60000 },

--- a/dashboard/server/routes/self-improvement.ts
+++ b/dashboard/server/routes/self-improvement.ts
@@ -1,0 +1,144 @@
+/**
+ * Self-Improvement Digest API routes (Issue #222)
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import {
+  generateSelfImprovementDigest,
+  listSelfImprovementDigests,
+  loadSelfImprovementDigests,
+  setRecommendationStatus,
+} from '../self-improvement.js';
+
+export interface SelfImprovementRouteDeps {
+  dataDir: string;
+  workspaceDir: string;
+  defaultAgentId: string;
+  sendJson: (res: ServerResponse, data: unknown, status?: number) => void;
+  readRequestBody: (req: IncomingMessage) => Promise<string>;
+}
+
+function parseUrl(req: IncomingMessage): URL | null {
+  try {
+    return new URL(req.url ?? '', 'http://localhost');
+  } catch {
+    return null;
+  }
+}
+
+function parseJson<T>(raw: string): T | null {
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+function cleanId(raw: string | null | undefined): string {
+  return (raw ?? '').trim();
+}
+
+function parsePositiveInt(raw: string | null, fallback: number, min: number, max: number): number {
+  const parsed = Number.parseInt(String(raw ?? ''), 10);
+  if (Number.isNaN(parsed)) return fallback;
+  return Math.max(min, Math.min(parsed, max));
+}
+
+export function handleSelfImprovement(
+  req: IncomingMessage,
+  res: ServerResponse,
+  deps: SelfImprovementRouteDeps,
+): Promise<boolean> | boolean {
+  if (!req.url || !req.url.startsWith('/api/self-improvement')) return false;
+
+  const url = parseUrl(req);
+  if (!url) {
+    deps.sendJson(res, { ok: false, error: 'Bad request URL' }, 400);
+    return true;
+  }
+
+  // POST /api/self-improvement/generate
+  if (url.pathname === '/api/self-improvement/generate' && req.method === 'POST') {
+    return (async () => {
+      const body = parseJson<{ agentId?: string; date?: string; minRecommendations?: number }>(
+        await deps.readRequestBody(req),
+      ) ?? {};
+      const agentId = cleanId(body.agentId) || deps.defaultAgentId;
+      const minRecommendations = body.minRecommendations == null
+        ? 3
+        : parsePositiveInt(String(body.minRecommendations), 3, 1, 10);
+
+      const generated = generateSelfImprovementDigest({
+        dataDir: deps.dataDir,
+        workspaceDir: deps.workspaceDir,
+        agentId,
+        dateOverride: cleanId(body.date) || undefined,
+        minRecommendations,
+      });
+
+      deps.sendJson(res, { ok: true, digestPath: generated.digestPath, digest: generated.digest });
+      return true;
+    })();
+  }
+
+  // GET /api/self-improvement/digests
+  if (url.pathname === '/api/self-improvement/digests' && req.method === 'GET') {
+    const limit = parsePositiveInt(url.searchParams.get('limit'), 30, 1, 365);
+    const agentId = cleanId(url.searchParams.get('agentId')) || undefined;
+    const digests = listSelfImprovementDigests(deps.dataDir, { limit, agentId });
+    deps.sendJson(res, { total: digests.length, digests });
+    return true;
+  }
+
+  // GET /api/self-improvement/digests/:id
+  if (url.pathname.startsWith('/api/self-improvement/digests/') && req.method === 'GET') {
+    const digestId = cleanId(url.pathname.split('/api/self-improvement/digests/')[1]);
+    const digest = loadSelfImprovementDigests(deps.dataDir).find((entry) => entry.id === digestId);
+    if (!digest) {
+      deps.sendJson(res, { ok: false, error: 'Digest not found' }, 404);
+      return true;
+    }
+    deps.sendJson(res, { ok: true, digest });
+    return true;
+  }
+
+  // POST /api/self-improvement/recommendations/:id/approve
+  if (url.pathname.startsWith('/api/self-improvement/recommendations/') && req.method === 'POST') {
+    const parts = url.pathname.split('/api/self-improvement/recommendations/')[1]?.split('/') ?? [];
+    const recommendationId = cleanId(parts[0]);
+    const action = parts[1];
+    if (!recommendationId || (action !== 'approve' && action !== 'reject')) {
+      deps.sendJson(res, { ok: false, error: 'Invalid recommendation action route' }, 400);
+      return true;
+    }
+
+    return (async () => {
+      const body = parseJson<{ agentId?: string }>(await deps.readRequestBody(req)) ?? {};
+      const agentId = cleanId(body.agentId) || deps.defaultAgentId;
+      const result = setRecommendationStatus({
+        dataDir: deps.dataDir,
+        workspaceDir: deps.workspaceDir,
+        agentId,
+        recommendationId,
+        action,
+      });
+
+      if (!result.ok) {
+        deps.sendJson(res, { ok: false, error: result.message }, 400);
+        return true;
+      }
+
+      deps.sendJson(res, {
+        ok: true,
+        message: result.message,
+        digest: result.digest,
+        recommendation: result.recommendation,
+      });
+      return true;
+    })();
+  }
+
+  deps.sendJson(res, { ok: false, error: 'Not found' }, 404);
+  return true;
+}
+

--- a/dashboard/server/self-improvement.ts
+++ b/dashboard/server/self-improvement.ts
@@ -1,0 +1,619 @@
+/**
+ * Self-Improvement Digest Engine (Issue #222)
+ *
+ * Stores daily digest records and explicit recommendation approval/apply state.
+ * Recommendations are always scoped to the requesting agent's own workspace.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import crypto from 'node:crypto';
+
+export type RecommendationType =
+  | 'soul_edit'
+  | 'skill_add'
+  | 'skill_config'
+  | 'memory_restructure'
+  | 'workflow_change';
+
+export type RecommendationStatus = 'pending' | 'approved' | 'rejected' | 'applied';
+
+export interface ImprovementRecommendation {
+  id: string;
+  digestId: string;
+  type: RecommendationType;
+  target: string;
+  currentValue: string;
+  proposedValue: string;
+  rationale: string;
+  status: RecommendationStatus;
+  diff: string;
+  createdAt: string;
+  approvedAt?: string;
+  rejectedAt?: string;
+  appliedAt?: string;
+}
+
+export interface SelfImprovementDigestRecord {
+  id: string;
+  agentId: string;
+  date: string;
+  digestContent: string;
+  recommendations: ImprovementRecommendation[];
+  approvedCount: number;
+  rejectedCount: number;
+  pendingCount: number;
+  createdAt: string;
+  updatedAt: string;
+  sourceMetrics: {
+    totalTasks: number;
+    doneTasks: number;
+    failedTasks: number;
+    failureRate: number;
+    avgRuntimeMs: number;
+    staleRunningCount: number;
+  };
+}
+
+export interface GenerateDigestOptions {
+  dataDir: string;
+  workspaceDir: string;
+  agentId: string;
+  now?: () => Date;
+  minRecommendations?: number;
+  dateOverride?: string;
+}
+
+interface TaskCardLike {
+  id: string;
+  title: string;
+  status: string;
+  agentId: string | null;
+  runtimeMs: number | null;
+  startedAt: number | null;
+}
+
+interface TaskSignals {
+  totalTasks: number;
+  doneTasks: number;
+  failedTasks: number;
+  failureRate: number;
+  avgRuntimeMs: number;
+  staleRunningCount: number;
+}
+
+interface RecommendationDraft {
+  type: RecommendationType;
+  target: string;
+  rationale: string;
+  proposedValue: string;
+}
+
+const DIGESTS_FILE = 'self-improvement-digests.json';
+
+function nowIso(now: () => Date): string {
+  return now().toISOString();
+}
+
+function sanitizeAgentId(raw: string): string {
+  const cleaned = raw.trim().toLowerCase().replace(/[^a-z0-9_-]/g, '');
+  return cleaned || 'main';
+}
+
+function digestFilePath(dataDir: string): string {
+  return path.join(dataDir, DIGESTS_FILE);
+}
+
+function readJsonArray<T>(filePath: string): T[] {
+  try {
+    if (!fs.existsSync(filePath)) return [];
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as unknown;
+    if (!Array.isArray(parsed)) return [];
+    return parsed as T[];
+  } catch {
+    return [];
+  }
+}
+
+function writeJson(filePath: string, value: unknown): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, JSON.stringify(value, null, 2));
+}
+
+export function loadSelfImprovementDigests(dataDir: string): SelfImprovementDigestRecord[] {
+  return readJsonArray<SelfImprovementDigestRecord>(digestFilePath(dataDir))
+    .filter((digest) => typeof digest.id === 'string' && Array.isArray(digest.recommendations));
+}
+
+function saveSelfImprovementDigests(dataDir: string, digests: SelfImprovementDigestRecord[]): void {
+  const sorted = [...digests].sort((a, b) => b.createdAt.localeCompare(a.createdAt)).slice(0, 365);
+  writeJson(digestFilePath(dataDir), sorted);
+}
+
+function readTaskBoardSignals(dataDir: string, agentId: string, now: () => Date): TaskSignals {
+  const filePath = path.join(dataDir, 'task-board.json');
+  let tasks: TaskCardLike[] = [];
+  try {
+    if (fs.existsSync(filePath)) {
+      const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as { tasks?: Array<Record<string, unknown>> };
+      tasks = Array.isArray(parsed.tasks)
+        ? parsed.tasks.map((t): TaskCardLike => ({
+          id: String(t.id ?? ''),
+          title: String(t.title ?? ''),
+          status: String(t.status ?? 'unknown'),
+          agentId: t.agentId == null ? null : String(t.agentId),
+          runtimeMs: typeof t.runtimeMs === 'number' ? t.runtimeMs : null,
+          startedAt: typeof t.startedAt === 'number' ? t.startedAt : null,
+        }))
+        : [];
+    }
+  } catch {
+    tasks = [];
+  }
+
+  const relevant = tasks.filter((task) => task.agentId == null || sanitizeAgentId(task.agentId) === agentId);
+  const doneTasks = relevant.filter((task) => task.status === 'done').length;
+  const failedTasks = relevant.filter((task) => task.status === 'failed').length;
+  const runtimeValues = relevant
+    .map((task) => task.runtimeMs)
+    .filter((v): v is number => typeof v === 'number' && Number.isFinite(v) && v > 0);
+  const avgRuntimeMs = runtimeValues.length > 0
+    ? Math.round(runtimeValues.reduce((sum, value) => sum + value, 0) / runtimeValues.length)
+    : 0;
+
+  const staleCutoff = now().getTime() - (90 * 60 * 1000); // 90 minutes
+  const staleRunningCount = relevant.filter((task) => (
+    task.status === 'running'
+    && typeof task.startedAt === 'number'
+    && task.startedAt > 0
+    && task.startedAt < staleCutoff
+  )).length;
+
+  const totalTasks = relevant.length;
+  const failureRate = totalTasks > 0 ? failedTasks / totalTasks : 0;
+
+  return {
+    totalTasks,
+    doneTasks,
+    failedTasks,
+    failureRate: Number(failureRate.toFixed(4)),
+    avgRuntimeMs,
+    staleRunningCount,
+  };
+}
+
+function formatRuntime(ms: number): string {
+  if (ms <= 0) return 'n/a';
+  if (ms < 1000) return `${ms}ms`;
+  const seconds = Math.round(ms / 1000);
+  if (seconds < 120) return `${seconds}s`;
+  const minutes = Math.round(seconds / 60);
+  return `${minutes}m`;
+}
+
+function buildDigestId(agentId: string, date: string, now: () => Date): string {
+  const seed = `${agentId}:${date}:${nowIso(now)}`;
+  const hash = crypto.createHash('sha1').update(seed).digest('hex').slice(0, 10);
+  return `sid-${date}-${agentId}-${hash}`;
+}
+
+function buildRecommendationId(digestId: string, target: string, type: RecommendationType, index: number): string {
+  const hash = crypto.createHash('sha1').update(`${digestId}:${target}:${type}:${index}`).digest('hex').slice(0, 10);
+  return `sir-${hash}`;
+}
+
+function readFileIfExists(filePath: string): string {
+  try {
+    if (!fs.existsSync(filePath)) return '';
+    return fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return '';
+  }
+}
+
+function buildUnifiedDiff(target: string, currentValue: string, proposedValue: string): string {
+  const oldLines = currentValue ? currentValue.split('\n') : [''];
+  const newLines = proposedValue.split('\n');
+  const removed = oldLines.map((line) => `-${line}`).join('\n');
+  const added = newLines.map((line) => `+${line}`).join('\n');
+  return [
+    `--- a/${target}`,
+    `+++ b/${target}`,
+    '@@',
+    removed,
+    added,
+  ].join('\n');
+}
+
+function recommendationsFromSignals(agentId: string, signals: TaskSignals): RecommendationDraft[] {
+  const soulTarget = `souls/${agentId}/SOUL.md`;
+  const principlesTarget = `souls/${agentId}/PRINCIPLES.md`;
+  const playbookTarget = `memory/self-improvement/${agentId}-playbook.md`;
+  const queueTarget = `memory/self-improvement/${agentId}-queue.md`;
+
+  const drafts: RecommendationDraft[] = [];
+
+  if (signals.failureRate >= 0.15 || signals.failedTasks >= 3) {
+    drafts.push({
+      type: 'workflow_change',
+      target: principlesTarget,
+      rationale: `Failure rate is ${(signals.failureRate * 100).toFixed(1)}%; codify a tighter recovery loop after failed tasks.`,
+      proposedValue: [
+        '## Failure Recovery Loop',
+        '- After any failed task, record root cause in one sentence.',
+        '- Run a focused retry with one changed variable only.',
+        '- If two retries fail, escalate with explicit blocker + owner.',
+      ].join('\n'),
+    });
+  }
+
+  if (signals.avgRuntimeMs >= 120_000 || signals.staleRunningCount > 0) {
+    drafts.push({
+      type: 'skill_config',
+      target: soulTarget,
+      rationale: `Average runtime is ${formatRuntime(signals.avgRuntimeMs)} with ${signals.staleRunningCount} stale running tasks; enforce tighter execution budgets.`,
+      proposedValue: [
+        '## Execution Budget Guardrails',
+        '- Default implementation window: 45 minutes.',
+        '- If estimate exceeds window, split into two tracked tasks before coding.',
+        '- Emit checkpoint update every 20 minutes with current blocker.',
+      ].join('\n'),
+    });
+  }
+
+  drafts.push({
+    type: 'memory_restructure',
+    target: playbookTarget,
+    rationale: 'Create a stable daily reflection structure so improvements are easy to compare day-over-day.',
+    proposedValue: [
+      '# Daily Improvement Playbook',
+      '',
+      '## Reflection Checklist',
+      '- Top 2 wins with evidence',
+      '- Top 2 misses with root cause',
+      '- One rule change to test tomorrow',
+      '- One workflow optimization to test tomorrow',
+    ].join('\n'),
+  });
+
+  drafts.push({
+    type: 'skill_add',
+    target: queueTarget,
+    rationale: 'Track repeated questions and slow tasks in one queue to reduce repeated context misses.',
+    proposedValue: [
+      '# Improvement Queue',
+      '',
+      '| Date | Pattern | Proposed Fix | Owner | Status |',
+      '|------|---------|--------------|-------|--------|',
+      '| YYYY-MM-DD | repeated clarification on scope | add tighter intake checklist | self | pending |',
+    ].join('\n'),
+  });
+
+  drafts.push({
+    type: 'soul_edit',
+    target: soulTarget,
+    rationale: 'Harden explicit self-review expectations directly in the role card.',
+    proposedValue: [
+      '## Daily Self-Review Contract',
+      '- Generate one self-improvement digest every 24h.',
+      '- Include at least 3 concrete, diffable recommendations.',
+      '- Never auto-apply changes without explicit approval.',
+    ].join('\n'),
+  });
+
+  return drafts;
+}
+
+function toRecommendation(
+  draft: RecommendationDraft,
+  digestId: string,
+  index: number,
+  workspaceDir: string,
+  now: () => Date,
+): ImprovementRecommendation {
+  const absoluteTarget = path.join(workspaceDir, draft.target);
+  const existing = readFileIfExists(absoluteTarget);
+  const currentValue = existing.includes(draft.proposedValue) ? draft.proposedValue : '';
+  const createdAt = nowIso(now);
+  return {
+    id: buildRecommendationId(digestId, draft.target, draft.type, index),
+    digestId,
+    type: draft.type,
+    target: draft.target,
+    currentValue,
+    proposedValue: draft.proposedValue,
+    rationale: draft.rationale,
+    status: 'pending',
+    diff: buildUnifiedDiff(draft.target, currentValue, draft.proposedValue),
+    createdAt,
+  };
+}
+
+function ensureMinRecommendations(
+  drafts: RecommendationDraft[],
+  minRecommendations: number,
+): RecommendationDraft[] {
+  if (drafts.length >= minRecommendations) return drafts;
+
+  const fallback: RecommendationDraft[] = [
+    {
+      type: 'workflow_change',
+      target: 'memory/self-improvement/default-workflow.md',
+      rationale: 'Fallback recommendation to ensure minimum actionable set.',
+      proposedValue: [
+        '# Default Workflow Tune-Up',
+        '- Track assumptions explicitly before implementation.',
+        '- Add one measurable success metric for each task.',
+      ].join('\n'),
+    },
+    {
+      type: 'memory_restructure',
+      target: 'memory/self-improvement/default-memory.md',
+      rationale: 'Fallback recommendation to improve memory hygiene.',
+      proposedValue: [
+        '# Default Memory Hygiene',
+        '- Archive stale notes weekly.',
+        '- Keep active notes concise and evidence-linked.',
+      ].join('\n'),
+    },
+  ];
+
+  const out = [...drafts];
+  for (const candidate of fallback) {
+    if (out.length >= minRecommendations) break;
+    out.push(candidate);
+  }
+  return out;
+}
+
+function computeCounts(recommendations: ImprovementRecommendation[]): {
+  approvedCount: number;
+  rejectedCount: number;
+  pendingCount: number;
+} {
+  let approvedCount = 0;
+  let rejectedCount = 0;
+  let pendingCount = 0;
+  for (const recommendation of recommendations) {
+    if (recommendation.status === 'rejected') rejectedCount += 1;
+    else if (recommendation.status === 'pending') pendingCount += 1;
+    else approvedCount += 1; // approved + applied
+  }
+  return { approvedCount, rejectedCount, pendingCount };
+}
+
+function digestMarkdown(
+  digest: SelfImprovementDigestRecord,
+  recommendations: ImprovementRecommendation[],
+): string {
+  const wins: string[] = [];
+  if (digest.sourceMetrics.doneTasks > 0) wins.push(`Completed tasks: ${digest.sourceMetrics.doneTasks}`);
+  if (digest.sourceMetrics.failureRate < 0.15) wins.push(`Failure rate remained low (${(digest.sourceMetrics.failureRate * 100).toFixed(1)}%)`);
+  if (wins.length === 0) wins.push('No major wins detected today; focus on consistency improvements.');
+
+  const misses: string[] = [];
+  if (digest.sourceMetrics.failedTasks > 0) misses.push(`Failed tasks: ${digest.sourceMetrics.failedTasks}`);
+  if (digest.sourceMetrics.staleRunningCount > 0) misses.push(`Stale running tasks: ${digest.sourceMetrics.staleRunningCount}`);
+  if (digest.sourceMetrics.avgRuntimeMs > 120_000) misses.push(`Average runtime is high (${formatRuntime(digest.sourceMetrics.avgRuntimeMs)})`);
+  if (misses.length === 0) misses.push('No critical misses detected; maintain current operating rhythm.');
+
+  const recommendationLines = recommendations.map((rec, idx) => [
+    `### ${idx + 1}. ${rec.type} → \`${rec.target}\``,
+    `- ID: \`${rec.id}\``,
+    `- Status: \`${rec.status}\``,
+    `- Rationale: ${rec.rationale}`,
+    '',
+    '```diff',
+    rec.diff,
+    '```',
+  ].join('\n'));
+
+  return [
+    `# Self-Improvement Digest — ${digest.date}`,
+    '',
+    `- Agent: \`${digest.agentId}\``,
+    `- Digest ID: \`${digest.id}\``,
+    `- Created At: ${digest.createdAt}`,
+    '',
+    '## What Went Well',
+    ...wins.map((line) => `- ${line}`),
+    '',
+    '## What Did Not Go Well',
+    ...misses.map((line) => `- ${line}`),
+    '',
+    '## Recommendations',
+    ...recommendationLines,
+    '',
+    '## Approval Notes',
+    '- Recommendations are suggestions only.',
+    '- Nothing is auto-applied until explicitly approved.',
+  ].join('\n');
+}
+
+function writeDigestMarkdown(workspaceDir: string, date: string, content: string): string {
+  const relPath = path.join('memory', 'self-improvement', `${date}.md`);
+  const absPath = path.join(workspaceDir, relPath);
+  fs.mkdirSync(path.dirname(absPath), { recursive: true });
+  fs.writeFileSync(absPath, content);
+  return relPath;
+}
+
+function isPathWithin(parent: string, child: string): boolean {
+  const rel = path.relative(parent, child);
+  return rel !== '' && !rel.startsWith('..') && !path.isAbsolute(rel);
+}
+
+function isAllowedTargetForAgent(workspaceDir: string, agentId: string, target: string): boolean {
+  if (!target || target.includes('\0')) return false;
+  const normalizedTarget = target.replace(/\\/g, '/');
+  const absTarget = path.resolve(workspaceDir, normalizedTarget);
+  const soulRoot = path.resolve(workspaceDir, 'souls', agentId);
+  const memoryRoot = path.resolve(workspaceDir, 'memory', 'self-improvement');
+
+  if (absTarget === soulRoot || absTarget === memoryRoot) return false;
+  return isPathWithin(soulRoot, absTarget) || isPathWithin(memoryRoot, absTarget);
+}
+
+function applyRecommendationToWorkspace(
+  workspaceDir: string,
+  agentId: string,
+  recommendation: ImprovementRecommendation,
+): { applied: boolean; message: string } {
+  if (!isAllowedTargetForAgent(workspaceDir, agentId, recommendation.target)) {
+    return { applied: false, message: 'Recommendation target is outside allowed agent workspace scope' };
+  }
+
+  const absTarget = path.resolve(workspaceDir, recommendation.target);
+  const existing = readFileIfExists(absTarget);
+
+  let next: string;
+  if (existing.includes(recommendation.proposedValue)) {
+    next = existing;
+  } else if (recommendation.currentValue && existing.includes(recommendation.currentValue)) {
+    next = existing.replace(recommendation.currentValue, recommendation.proposedValue);
+  } else if (!existing.trim()) {
+    next = recommendation.proposedValue.trim() + '\n';
+  } else {
+    next = `${existing.replace(/\s+$/, '')}\n\n${recommendation.proposedValue.trim()}\n`;
+  }
+
+  fs.mkdirSync(path.dirname(absTarget), { recursive: true });
+  fs.writeFileSync(absTarget, next);
+  return { applied: true, message: 'Applied recommendation to target file' };
+}
+
+export function generateSelfImprovementDigest(
+  options: GenerateDigestOptions,
+): { digest: SelfImprovementDigestRecord; digestPath: string } {
+  const now = options.now ?? (() => new Date());
+  const agentId = sanitizeAgentId(options.agentId);
+  const date = options.dateOverride ?? nowIso(now).slice(0, 10);
+  const minRecommendations = Math.max(1, options.minRecommendations ?? 3);
+  const signals = readTaskBoardSignals(options.dataDir, agentId, now);
+
+  const digestId = buildDigestId(agentId, date, now);
+  const drafts = ensureMinRecommendations(recommendationsFromSignals(agentId, signals), minRecommendations).slice(0, 12);
+  const recommendations = drafts.map((draft, index) => (
+    toRecommendation(draft, digestId, index, options.workspaceDir, now)
+  ));
+
+  const createdAt = nowIso(now);
+  const digest: SelfImprovementDigestRecord = {
+    id: digestId,
+    agentId,
+    date,
+    digestContent: '',
+    recommendations,
+    approvedCount: 0,
+    rejectedCount: 0,
+    pendingCount: recommendations.length,
+    createdAt,
+    updatedAt: createdAt,
+    sourceMetrics: signals,
+  };
+
+  digest.digestContent = digestMarkdown(digest, recommendations);
+  const digestPath = writeDigestMarkdown(options.workspaceDir, date, digest.digestContent);
+
+  const allDigests = loadSelfImprovementDigests(options.dataDir).filter((entry) => !(entry.agentId === agentId && entry.date === date));
+  allDigests.push(digest);
+  saveSelfImprovementDigests(options.dataDir, allDigests);
+
+  return { digest, digestPath };
+}
+
+export function listSelfImprovementDigests(
+  dataDir: string,
+  opts: { agentId?: string; limit?: number } = {},
+): SelfImprovementDigestRecord[] {
+  const limit = Math.max(1, Math.min(opts.limit ?? 30, 365));
+  const agentId = opts.agentId ? sanitizeAgentId(opts.agentId) : undefined;
+  return loadSelfImprovementDigests(dataDir)
+    .filter((digest) => !agentId || digest.agentId === agentId)
+    .sort((a, b) => b.createdAt.localeCompare(a.createdAt))
+    .slice(0, limit);
+}
+
+function withUpdatedCounts(digest: SelfImprovementDigestRecord): SelfImprovementDigestRecord {
+  const counts = computeCounts(digest.recommendations);
+  return {
+    ...digest,
+    approvedCount: counts.approvedCount,
+    rejectedCount: counts.rejectedCount,
+    pendingCount: counts.pendingCount,
+  };
+}
+
+export function setRecommendationStatus(
+  options: {
+    dataDir: string;
+    workspaceDir: string;
+    agentId: string;
+    recommendationId: string;
+    action: 'approve' | 'reject';
+    now?: () => Date;
+  },
+): { ok: boolean; digest?: SelfImprovementDigestRecord; recommendation?: ImprovementRecommendation; message: string } {
+  const now = options.now ?? (() => new Date());
+  const agentId = sanitizeAgentId(options.agentId);
+  const digests = loadSelfImprovementDigests(options.dataDir);
+  let updatedDigest: SelfImprovementDigestRecord | undefined;
+  let updatedRecommendation: ImprovementRecommendation | undefined;
+
+  for (let i = 0; i < digests.length; i += 1) {
+    const digest = digests[i];
+    const recommendationIndex = digest.recommendations.findIndex((rec) => rec.id === options.recommendationId);
+    if (recommendationIndex < 0) continue;
+
+    if (digest.agentId !== agentId) {
+      return { ok: false, message: 'Recommendation does not belong to the requested agent scope' };
+    }
+
+    const recommendation = { ...digest.recommendations[recommendationIndex] };
+    if (recommendation.status === 'rejected' && options.action === 'reject') {
+      return { ok: false, message: 'Recommendation is already rejected' };
+    }
+    if (recommendation.status === 'applied' && options.action === 'approve') {
+      return { ok: false, message: 'Recommendation is already applied' };
+    }
+
+    if (options.action === 'reject') {
+      recommendation.status = 'rejected';
+      recommendation.rejectedAt = nowIso(now);
+    } else {
+      recommendation.status = 'approved';
+      recommendation.approvedAt = nowIso(now);
+      const applyResult = applyRecommendationToWorkspace(options.workspaceDir, agentId, recommendation);
+      if (!applyResult.applied) {
+        return { ok: false, message: applyResult.message };
+      }
+      recommendation.status = 'applied';
+      recommendation.appliedAt = nowIso(now);
+    }
+
+    const nextRecommendations = [...digest.recommendations];
+    nextRecommendations[recommendationIndex] = recommendation;
+    const refreshedDigest = withUpdatedCounts({
+      ...digest,
+      recommendations: nextRecommendations,
+      updatedAt: nowIso(now),
+    });
+
+    digests[i] = refreshedDigest;
+    updatedDigest = refreshedDigest;
+    updatedRecommendation = recommendation;
+    break;
+  }
+
+  if (!updatedDigest || !updatedRecommendation) {
+    return { ok: false, message: 'Recommendation not found' };
+  }
+
+  saveSelfImprovementDigests(options.dataDir, digests);
+  return {
+    ok: true,
+    digest: updatedDigest,
+    recommendation: updatedRecommendation,
+    message: options.action === 'approve' ? 'Recommendation approved and applied' : 'Recommendation rejected',
+  };
+}

--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -118,6 +118,7 @@ import { handleUnifiedSearch } from './routes/unified-search.js';
 import { handleObsidianConnector } from './routes/obsidian-connector.js';
 import { handleSharedContext } from './routes/shared-context.js';
 import { handleTokenCompaction } from './routes/token-compaction.js';
+import { handleSelfImprovement } from './routes/self-improvement.js';
 import { getSchedulerJobs } from './scheduler-jobs.js';
 
 // ─── Configuration ───────────────────────────────────────────────────────────
@@ -3184,6 +3185,20 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
     if (await handleTokenCompaction(req, res, { dataDir, sendJson, readRequestBody })) return;
   } catch {
     sendJson(res, { ok: false, error: 'Failed to process token compaction request' }, 500);
+    return;
+  }
+
+  try {
+    if (await handleSelfImprovement(req, res, {
+      dataDir,
+      workspaceDir: WORKSPACE_DIR,
+      defaultAgentId: AGENT_ID,
+      sendJson,
+      readRequestBody,
+    }))
+      return;
+  } catch {
+    sendJson(res, { ok: false, error: 'Failed to process self-improvement request' }, 500);
     return;
   }
 

--- a/dashboard/tests/unit/routes/self-improvement.test.ts
+++ b/dashboard/tests/unit/routes/self-improvement.test.ts
@@ -1,0 +1,85 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mockRequest, mockResponse, parseJsonBody } from '../../helpers.js';
+import { handleSelfImprovement, type SelfImprovementRouteDeps } from '../../../server/routes/self-improvement.js';
+
+const testRoot = path.join('/tmp', `test-self-improvement-route-${process.pid}`);
+const dataDir = path.join(testRoot, 'data');
+const workspaceDir = path.join(testRoot, 'workspace');
+
+function deps(body: unknown = {}): SelfImprovementRouteDeps {
+  return {
+    dataDir,
+    workspaceDir,
+    defaultAgentId: 'oracle',
+    sendJson: (res, data, status = 200) => {
+      res.writeHead(status, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(data));
+    },
+    readRequestBody: async () => JSON.stringify(body),
+  };
+}
+
+beforeEach(() => {
+  fs.rmSync(testRoot, { recursive: true, force: true });
+  fs.mkdirSync(path.join(dataDir), { recursive: true });
+  fs.mkdirSync(path.join(workspaceDir, 'souls', 'oracle'), { recursive: true });
+  fs.writeFileSync(path.join(workspaceDir, 'souls', 'oracle', 'SOUL.md'), '# SOUL\n');
+  fs.writeFileSync(path.join(workspaceDir, 'souls', 'oracle', 'PRINCIPLES.md'), '# PRINCIPLES\n');
+  fs.writeFileSync(path.join(dataDir, 'task-board.json'), JSON.stringify({ tasks: [] }));
+});
+
+afterEach(() => {
+  fs.rmSync(testRoot, { recursive: true, force: true });
+});
+
+describe('self-improvement routes', () => {
+  it('generates and lists digests', async () => {
+    const generateReq = mockRequest({ method: 'POST', url: '/api/self-improvement/generate' });
+    const generateRes = mockResponse();
+    const handledGenerate = await handleSelfImprovement(generateReq, generateRes, deps({ agentId: 'oracle' }));
+    expect(handledGenerate).toBe(true);
+    expect(generateRes._statusCode).toBe(200);
+    const generated = parseJsonBody<{ ok: boolean; digest: { id: string; recommendations: unknown[] } }>(generateRes);
+    expect(generated.ok).toBe(true);
+    expect(generated.digest.recommendations.length).toBeGreaterThanOrEqual(3);
+
+    const listReq = mockRequest({ method: 'GET', url: '/api/self-improvement/digests?agentId=oracle' });
+    const listRes = mockResponse();
+    const handledList = await handleSelfImprovement(listReq, listRes, deps());
+    expect(handledList).toBe(true);
+    expect(listRes._statusCode).toBe(200);
+    const listed = parseJsonBody<{ total: number }>(listRes);
+    expect(listed.total).toBe(1);
+  });
+
+  it('approves a recommendation through API', async () => {
+    const generateReq = mockRequest({ method: 'POST', url: '/api/self-improvement/generate' });
+    const generateRes = mockResponse();
+    await handleSelfImprovement(generateReq, generateRes, deps({ agentId: 'oracle' }));
+    const generated = parseJsonBody<{
+      digest: { recommendations: Array<{ id: string }> };
+    }>(generateRes);
+    const recommendationId = generated.digest.recommendations[0].id;
+
+    const approveReq = mockRequest({
+      method: 'POST',
+      url: `/api/self-improvement/recommendations/${recommendationId}/approve`,
+    });
+    const approveRes = mockResponse();
+    await handleSelfImprovement(approveReq, approveRes, deps({ agentId: 'oracle' }));
+    expect(approveRes._statusCode).toBe(200);
+    const body = parseJsonBody<{ ok: boolean; recommendation: { status: string } }>(approveRes);
+    expect(body.ok).toBe(true);
+    expect(body.recommendation.status).toBe('applied');
+  });
+
+  it('returns 404 when digest id does not exist', async () => {
+    const req = mockRequest({ method: 'GET', url: '/api/self-improvement/digests/not-found' });
+    const res = mockResponse();
+    await handleSelfImprovement(req, res, deps());
+    expect(res._statusCode).toBe(404);
+  });
+});
+

--- a/dashboard/tests/unit/self-improvement.test.ts
+++ b/dashboard/tests/unit/self-improvement.test.ts
@@ -1,0 +1,133 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { beforeEach, afterEach, describe, expect, it } from 'vitest';
+import {
+  generateSelfImprovementDigest,
+  loadSelfImprovementDigests,
+  setRecommendationStatus,
+} from '../../server/self-improvement.js';
+
+const testRoot = path.join('/tmp', `test-self-improvement-${process.pid}`);
+const dataDir = path.join(testRoot, 'data');
+const workspaceDir = path.join(testRoot, 'workspace');
+
+function fixedNow(): Date {
+  return new Date('2026-02-21T12:00:00.000Z');
+}
+
+beforeEach(() => {
+  fs.rmSync(testRoot, { recursive: true, force: true });
+  fs.mkdirSync(dataDir, { recursive: true });
+  fs.mkdirSync(path.join(workspaceDir, 'souls', 'oracle'), { recursive: true });
+  fs.writeFileSync(path.join(workspaceDir, 'souls', 'oracle', 'SOUL.md'), '# Oracle Soul\n');
+  fs.writeFileSync(path.join(workspaceDir, 'souls', 'oracle', 'PRINCIPLES.md'), '# Oracle Principles\n');
+  fs.writeFileSync(
+    path.join(dataDir, 'task-board.json'),
+    JSON.stringify({
+      tasks: [
+        { id: 't1', title: 'Task 1', status: 'done', agentId: 'oracle', runtimeMs: 30_000, startedAt: Date.parse('2026-02-21T11:00:00.000Z') },
+        { id: 't2', title: 'Task 2', status: 'failed', agentId: 'oracle', runtimeMs: 180_000, startedAt: Date.parse('2026-02-21T10:00:00.000Z') },
+      ],
+    }),
+  );
+});
+
+afterEach(() => {
+  fs.rmSync(testRoot, { recursive: true, force: true });
+});
+
+describe('self-improvement engine', () => {
+  it('generates a digest with at least 3 recommendations and writes markdown', () => {
+    const { digest, digestPath } = generateSelfImprovementDigest({
+      dataDir,
+      workspaceDir,
+      agentId: 'oracle',
+      now: fixedNow,
+    });
+
+    expect(digest.recommendations.length).toBeGreaterThanOrEqual(3);
+    expect(digest.pendingCount).toBeGreaterThanOrEqual(3);
+    expect(digest.digestContent).toContain('## Recommendations');
+    expect(fs.existsSync(path.join(workspaceDir, digestPath))).toBe(true);
+
+    const stored = loadSelfImprovementDigests(dataDir);
+    expect(stored).toHaveLength(1);
+    expect(stored[0].id).toBe(digest.id);
+  });
+
+  it('approves and applies a recommendation inside allowed scope', () => {
+    const generated = generateSelfImprovementDigest({
+      dataDir,
+      workspaceDir,
+      agentId: 'oracle',
+      now: fixedNow,
+    });
+
+    const recommendation = generated.digest.recommendations.find((rec) => rec.target.startsWith('souls/oracle/'));
+    expect(recommendation).toBeDefined();
+
+    const result = setRecommendationStatus({
+      dataDir,
+      workspaceDir,
+      agentId: 'oracle',
+      recommendationId: recommendation!.id,
+      action: 'approve',
+      now: fixedNow,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.recommendation?.status).toBe('applied');
+    const targetPath = path.join(workspaceDir, recommendation!.target);
+    const nextContent = fs.readFileSync(targetPath, 'utf8');
+    expect(nextContent).toContain(recommendation!.proposedValue.split('\n')[0]);
+  });
+
+  it('rejects recommendations and updates counts', () => {
+    const generated = generateSelfImprovementDigest({
+      dataDir,
+      workspaceDir,
+      agentId: 'oracle',
+      now: fixedNow,
+    });
+    const recommendation = generated.digest.recommendations[0];
+
+    const result = setRecommendationStatus({
+      dataDir,
+      workspaceDir,
+      agentId: 'oracle',
+      recommendationId: recommendation.id,
+      action: 'reject',
+      now: fixedNow,
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.recommendation?.status).toBe('rejected');
+    expect(result.digest?.rejectedCount).toBeGreaterThanOrEqual(1);
+  });
+
+  it('blocks recommendations targeting files outside agent scope', () => {
+    const generated = generateSelfImprovementDigest({
+      dataDir,
+      workspaceDir,
+      agentId: 'oracle',
+      now: fixedNow,
+    });
+    const first = generated.digest.recommendations[0];
+    const digests = loadSelfImprovementDigests(dataDir);
+    digests[0].recommendations[0].target = '../README.md';
+    fs.writeFileSync(path.join(dataDir, 'self-improvement-digests.json'), JSON.stringify(digests, null, 2));
+
+    const result = setRecommendationStatus({
+      dataDir,
+      workspaceDir,
+      agentId: 'oracle',
+      recommendationId: first.id,
+      action: 'approve',
+      now: fixedNow,
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.message).toContain('outside allowed agent workspace scope');
+  });
+});
+

--- a/docs/DOC_INDEX.md
+++ b/docs/DOC_INDEX.md
@@ -27,6 +27,7 @@
 - **docs/NEXUS_2_0_M6_PRODUCTION_READINESS_2026-02-21.md** – M6 readiness decision and evidence matrix
 - **docs/CRASH_RECOVERY_ACTIVE_TASKS.md** – active-tasks.md tracker, stale detection, and restart recovery flow (#223)
 - **docs/TOKEN_COMPACTION.md** – deterministic 5-layer token compression pipeline, metrics, and benchmark harness (#221)
+- **docs/SELF_IMPROVEMENT_DIGEST.md** – daily self-review digest flow, recommendation approvals, and scope guardrails (#222)
 
 ## VentureOS / Multi-Agent Orchestration
 - **docs/roles/VENTURE_OS.md** – venture studio OS overview (system vs persona)

--- a/docs/SELF_IMPROVEMENT_DIGEST.md
+++ b/docs/SELF_IMPROVEMENT_DIGEST.md
@@ -1,0 +1,45 @@
+# Self-Improvement Digest
+
+Issue: #222
+
+## Overview
+
+The self-improvement system creates a daily digest for each agent with actionable, diffable recommendations.
+
+Core behavior:
+- generate digest content in `memory/self-improvement/YYYY-MM-DD.md`
+- persist digest + recommendation state in `dashboard/data/self-improvement-digests.json`
+- require explicit approval before any file edits
+- auto-apply approved recommendations only when target paths are inside the agent's allowed scope
+
+## Data Model
+
+Each digest record stores:
+- `id`, `agentId`, `date`, `digestContent`
+- `recommendations[]`
+- `approvedCount`, `rejectedCount`, `pendingCount`
+- source metrics (`failureRate`, `avgRuntimeMs`, etc.)
+
+Each recommendation stores:
+- `id`, `digestId`
+- `type`: `soul_edit|skill_add|skill_config|memory_restructure|workflow_change`
+- `target`, `currentValue`, `proposedValue`, `diff`, `rationale`
+- `status`: `pending|approved|rejected|applied`
+
+## API
+
+- `POST /api/self-improvement/generate`
+- `GET /api/self-improvement/digests`
+- `GET /api/self-improvement/digests/:id`
+- `POST /api/self-improvement/recommendations/:id/approve`
+- `POST /api/self-improvement/recommendations/:id/reject`
+
+## Security Scope
+
+Approval auto-apply is path-restricted:
+- allowed: `souls/<agentId>/**`
+- allowed: `memory/self-improvement/**`
+- denied: any path outside those roots
+
+If a recommendation targets an out-of-scope path, approval fails and no file mutation is applied.
+


### PR DESCRIPTION
## Summary
- add a daily self-improvement digest engine with persisted recommendation state
- generate digest markdown at `memory/self-improvement/YYYY-MM-DD.md`
- add explicit approval workflow with guarded auto-apply on approval
- enforce scope limits so recommendations can only mutate agent-owned paths
- add dashboard API endpoints for generate/list/detail/approve/reject flows
- add unit tests and docs for behavior + security boundaries

## API
- `POST /api/self-improvement/generate`
- `GET /api/self-improvement/digests`
- `GET /api/self-improvement/digests/:id`
- `POST /api/self-improvement/recommendations/:id/approve`
- `POST /api/self-improvement/recommendations/:id/reject`

## Validation
- `cd dashboard && npx -y vitest@4.0.18 run --config /tmp/vitest.local.config.mjs tests/unit/self-improvement.test.ts tests/unit/routes/self-improvement.test.ts tests/unit/middleware/rate-limit.test.ts`
- `npm run -s build`

Closes #222
