### PR TITLE
feat: add WebMCP structured site tool integration

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -170,6 +170,8 @@ See **[docs/API.md](docs/API.md)** for the complete API reference covering all e
 | `GET /api/self-improvement/digests` | List historical digest runs and recommendation status |
 | `POST /api/code-factory/preflight` | Compute PR risk tier and required checks from path policy |
 | `GET /api/code-factory/harness-gaps` | Track unresolved production regressions awaiting tests |
+| `POST /api/webmcp/discover` | Discover structured WebMCP tools for a website |
+| `POST /api/webmcp/invoke` | Invoke discovered WebMCP tool with typed args + fallback |
 | `GET /api/live` | SSE real-time feed |
 
 ## Architecture

--- a/dashboard/docs/API.md
+++ b/dashboard/docs/API.md
@@ -19,6 +19,7 @@ Complete reference for all OpenClaw Dashboard HTTP endpoints.
 - [Token Compaction Endpoints](#token-compaction-endpoints)
 - [Self-Improvement Endpoints](#self-improvement-endpoints)
 - [Code Factory Endpoints](#code-factory-endpoints)
+- [WebMCP Endpoints](#webmcp-endpoints)
 - [Schemas](#schemas)
 
 ---
@@ -1111,6 +1112,49 @@ Updates a harness-gap record (for example, marking `testCaseAdded: true`).
 
 ---
 
+## WebMCP Endpoints
+
+Structured website-tool integration with cache + browser fallback (Issue #225).
+
+### `GET /api/webmcp/sites`
+
+Returns default site profiles and current WebMCP telemetry.
+
+### `GET /api/webmcp/metrics`
+
+Returns discovery/invocation/fallback counters.
+
+### `POST /api/webmcp/discover`
+
+Discovers tools from a WebMCP-compatible site manifest.
+
+**Request:**
+```json
+{
+  "siteUrl": "https://example-site.com",
+  "forceRefresh": false
+}
+```
+
+### `POST /api/webmcp/invoke`
+
+Invokes a structured tool with typed parameters.
+
+**Request:**
+```json
+{
+  "siteUrl": "https://example-site.com",
+  "toolName": "search_catalog",
+  "args": { "query": "ventureos" }
+}
+```
+
+**Response behaviors:**
+- `source: "webmcp"` when tool invocation succeeds over WebMCP
+- `source: "fallback"` when discovery/invoke is unavailable and browser automation fallback is used
+
+---
+
 ## Rate Limiting
 
 Per-IP, per-endpoint sliding window rate limits:
@@ -1124,6 +1168,7 @@ Per-IP, per-endpoint sliding window rate limits:
 | `/api/token-compaction*` | 30 req | 60s |
 | `/api/self-improvement*` | 20 req | 60s |
 | `/api/code-factory*` | 20 req | 60s |
+| `/api/webmcp*` | 30 req | 60s |
 | `/api/ventureos-agents` | 30 req | 60s |
 | `/api/ventureos-kpis` | 30 req | 60s |
 | `/api/rpg/*` | 20 req | 60s |

--- a/dashboard/server/middleware/rate-limit.ts
+++ b/dashboard/server/middleware/rate-limit.ts
@@ -97,6 +97,7 @@ export const LIMITS: Record<string, RateLimitConfig> = {
   '/api/token-compaction':    { limit: 30, windowMs: 60000 },
   '/api/self-improvement':    { limit: 20, windowMs: 60000 },
   '/api/code-factory':        { limit: 20, windowMs: 60000 },
+  '/api/webmcp':              { limit: 30, windowMs: 60000 },
   '/api/replay':              { limit: 10, windowMs: 60000 },
   '/api/live':                { limit: 10, windowMs: 60000 },
   '/api/conversation':        { limit: 30, windowMs: 60000 },

--- a/dashboard/server/routes/webmcp.ts
+++ b/dashboard/server/routes/webmcp.ts
@@ -1,0 +1,116 @@
+/**
+ * WebMCP integration routes (Issue #225)
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { getDefaultWebMcpClient } from '../../../lib/webmcp-client.js';
+
+export interface WebMcpRouteDeps {
+  sendJson: (res: ServerResponse, data: unknown, status?: number) => void;
+  readRequestBody: (req: IncomingMessage) => Promise<string>;
+}
+
+function parseUrl(req: IncomingMessage): URL | null {
+  try {
+    return new URL(req.url ?? '', 'http://localhost');
+  } catch {
+    return null;
+  }
+}
+
+function parseJson<T>(raw: string): T | null {
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+function cleanString(raw: unknown): string {
+  return typeof raw === 'string' ? raw.trim() : '';
+}
+
+export function handleWebMcp(
+  req: IncomingMessage,
+  res: ServerResponse,
+  deps: WebMcpRouteDeps,
+): Promise<boolean> | boolean {
+  if (!req.url || !req.url.startsWith('/api/webmcp')) return false;
+  const url = parseUrl(req);
+  if (!url) {
+    deps.sendJson(res, { ok: false, error: 'Bad request URL' }, 400);
+    return true;
+  }
+  const client = getDefaultWebMcpClient();
+
+  if (url.pathname === '/api/webmcp/sites' && req.method === 'GET') {
+    deps.sendJson(res, {
+      sites: client.getSiteProfiles(),
+      metrics: client.getMetrics(),
+    });
+    return true;
+  }
+
+  if (url.pathname === '/api/webmcp/metrics' && req.method === 'GET') {
+    deps.sendJson(res, {
+      metrics: client.getMetrics(),
+    });
+    return true;
+  }
+
+  if (url.pathname === '/api/webmcp/discover' && req.method === 'POST') {
+    return (async () => {
+      const body = parseJson<{ siteUrl?: string; forceRefresh?: boolean }>(
+        await deps.readRequestBody(req),
+      ) ?? {};
+      const siteUrl = cleanString(body.siteUrl);
+      if (!siteUrl) {
+        deps.sendJson(res, { ok: false, error: 'siteUrl is required' }, 400);
+        return true;
+      }
+      try {
+        const result = await client.discoverTools(siteUrl, { forceRefresh: Boolean(body.forceRefresh) });
+        deps.sendJson(res, { ok: true, discovery: result });
+      } catch (error: unknown) {
+        const msg = error instanceof Error ? error.message : 'Discovery failed';
+        deps.sendJson(res, { ok: false, error: msg }, 500);
+      }
+      return true;
+    })();
+  }
+
+  if (url.pathname === '/api/webmcp/invoke' && req.method === 'POST') {
+    return (async () => {
+      const body = parseJson<{ siteUrl?: string; toolName?: string; args?: Record<string, unknown> }>(
+        await deps.readRequestBody(req),
+      ) ?? {};
+      const siteUrl = cleanString(body.siteUrl);
+      const toolName = cleanString(body.toolName);
+      if (!siteUrl || !toolName) {
+        deps.sendJson(res, { ok: false, error: 'siteUrl and toolName are required' }, 400);
+        return true;
+      }
+
+      const args = (body.args && typeof body.args === 'object' && !Array.isArray(body.args))
+        ? body.args
+        : {};
+
+      try {
+        const result = await client.invokeTool({
+          siteUrl,
+          toolName,
+          args,
+        });
+        deps.sendJson(res, { ok: true, invocation: result });
+      } catch (error: unknown) {
+        const msg = error instanceof Error ? error.message : 'Invocation failed';
+        deps.sendJson(res, { ok: false, error: msg }, 500);
+      }
+      return true;
+    })();
+  }
+
+  deps.sendJson(res, { ok: false, error: 'Not found' }, 404);
+  return true;
+}
+

--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -120,6 +120,7 @@ import { handleSharedContext } from './routes/shared-context.js';
 import { handleTokenCompaction } from './routes/token-compaction.js';
 import { handleSelfImprovement } from './routes/self-improvement.js';
 import { handleCodeFactory } from './routes/code-factory.js';
+import { handleWebMcp } from './routes/webmcp.js';
 import { getSchedulerJobs } from './scheduler-jobs.js';
 
 // ─── Configuration ───────────────────────────────────────────────────────────
@@ -3207,6 +3208,13 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
     if (await handleCodeFactory(req, res, { dataDir, workspaceDir: WORKSPACE_DIR, sendJson, readRequestBody })) return;
   } catch {
     sendJson(res, { ok: false, error: 'Failed to process code-factory request' }, 500);
+    return;
+  }
+
+  try {
+    if (await handleWebMcp(req, res, { sendJson, readRequestBody })) return;
+  } catch {
+    sendJson(res, { ok: false, error: 'Failed to process WebMCP request' }, 500);
     return;
   }
 

--- a/dashboard/tests/unit/routes/webmcp.test.ts
+++ b/dashboard/tests/unit/routes/webmcp.test.ts
@@ -1,0 +1,134 @@
+import http from 'node:http';
+import { once } from 'node:events';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mockRequest, mockResponse, parseJsonBody } from '../../helpers.js';
+import { handleWebMcp } from '../../../server/routes/webmcp.js';
+import { resetDefaultWebMcpClient } from '../../../../lib/webmcp-client.js';
+
+interface MockSite {
+  url: string;
+  close: () => Promise<void>;
+}
+
+async function startMockSite(): Promise<MockSite> {
+  const server = http.createServer((req, res) => {
+    if (req.url === '/.well-known/webmcp.json' && req.method === 'GET') {
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({
+        tools: [
+          {
+            name: 'search',
+            inputSchema: {
+              type: 'object',
+              required: ['query'],
+              properties: { query: { type: 'string' } },
+            },
+          },
+        ],
+      }));
+      return;
+    }
+    if (req.url === '/.well-known/webmcp/invoke' && req.method === 'POST') {
+      let body = '';
+      req.on('data', (chunk) => { body += chunk.toString(); });
+      req.on('end', () => {
+        const payload = JSON.parse(body || '{}') as { tool?: string; arguments?: Record<string, unknown> };
+        res.setHeader('Content-Type', 'application/json');
+        res.end(JSON.stringify({
+          ok: true,
+          tool: payload.tool,
+          args: payload.arguments,
+        }));
+      });
+      return;
+    }
+    res.statusCode = 404;
+    res.end('not found');
+  });
+
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('invalid address');
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    close: async () => {
+      server.close();
+      await once(server, 'close');
+    },
+  };
+}
+
+beforeEach(() => {
+  resetDefaultWebMcpClient();
+});
+
+afterEach(() => {
+  resetDefaultWebMcpClient();
+});
+
+describe('webmcp routes', () => {
+  it('discovers tools from compliant site', async () => {
+    const site = await startMockSite();
+    const req = mockRequest({ method: 'POST', url: '/api/webmcp/discover' });
+    const res = mockResponse();
+    const handled = await handleWebMcp(req, res, {
+      sendJson: (r, d, s = 200) => {
+        r.writeHead(s, { 'Content-Type': 'application/json' });
+        r.end(JSON.stringify(d));
+      },
+      readRequestBody: async () => JSON.stringify({ siteUrl: site.url }),
+    });
+
+    expect(handled).toBe(true);
+    expect(res._statusCode).toBe(200);
+    const body = parseJsonBody<{ ok: boolean; discovery: { tools: unknown[] } }>(res);
+    expect(body.ok).toBe(true);
+    expect(body.discovery.tools.length).toBe(1);
+    await site.close();
+  });
+
+  it('invokes discovered tool via structured request', async () => {
+    const site = await startMockSite();
+    const req = mockRequest({ method: 'POST', url: '/api/webmcp/invoke' });
+    const res = mockResponse();
+    await handleWebMcp(req, res, {
+      sendJson: (r, d, s = 200) => {
+        r.writeHead(s, { 'Content-Type': 'application/json' });
+        r.end(JSON.stringify(d));
+      },
+      readRequestBody: async () => JSON.stringify({
+        siteUrl: site.url,
+        toolName: 'search',
+        args: { query: 'ventureos' },
+      }),
+    });
+
+    expect(res._statusCode).toBe(200);
+    const body = parseJsonBody<{ invocation: { source: string; ok: boolean } }>(res);
+    expect(body.invocation.source).toBe('webmcp');
+    expect(body.invocation.ok).toBe(true);
+    await site.close();
+  });
+
+  it('falls back when WebMCP is unavailable', async () => {
+    const req = mockRequest({ method: 'POST', url: '/api/webmcp/invoke' });
+    const res = mockResponse();
+    await handleWebMcp(req, res, {
+      sendJson: (r, d, s = 200) => {
+        r.writeHead(s, { 'Content-Type': 'application/json' });
+        r.end(JSON.stringify(d));
+      },
+      readRequestBody: async () => JSON.stringify({
+        siteUrl: 'https://example.com',
+        toolName: 'search',
+        args: { query: 'x' },
+      }),
+    });
+    expect(res._statusCode).toBe(200);
+    const body = parseJsonBody<{ invocation: { source: string; fallback?: { strategy: string } } }>(res);
+    expect(body.invocation.source).toBe('fallback');
+    expect(body.invocation.fallback?.strategy).toBe('browser-automation-fallback');
+  });
+});
+

--- a/docs/DOC_INDEX.md
+++ b/docs/DOC_INDEX.md
@@ -29,6 +29,7 @@
 - **docs/TOKEN_COMPACTION.md** – deterministic 5-layer token compression pipeline, metrics, and benchmark harness (#221)
 - **docs/SELF_IMPROVEMENT_DIGEST.md** – daily self-review digest flow, recommendation approvals, and scope guardrails (#222)
 - **docs/CODE_FACTORY_PIPELINE.md** – risk-tiered CI policy, SHA-discipline, auto-remediation, and harness-gap tracker (#220)
+- **docs/WEBMCP_INTEGRATION.md** – structured website tool discovery/invocation with cache + browser fallback (#225)
 
 ## VentureOS / Multi-Agent Orchestration
 - **docs/roles/VENTURE_OS.md** – venture studio OS overview (system vs persona)

--- a/docs/WEBMCP_INTEGRATION.md
+++ b/docs/WEBMCP_INTEGRATION.md
@@ -1,0 +1,37 @@
+# WebMCP Integration
+
+Issue: #225
+
+## Scope
+
+This adds a structured WebMCP client path with cache + fallback:
+
+- `lib/webmcp-client.ts`
+- `dashboard/server/routes/webmcp.ts`
+
+## Capabilities
+
+- tool discovery from WebMCP-compatible manifests
+- typed tool invocation (JSON-schema-style arg validation)
+- per-site discovery cache to avoid repeated schema fetches
+- fallback to browser automation when discovery/invocation fails
+
+## Default Site Profiles
+
+Configured discovery profiles:
+
+- `https://webmachinelearning.github.io/webmcp/`
+- `https://usechar.ai/`
+- `https://docs.mcp-b.ai/`
+
+## API
+
+- `GET /api/webmcp/sites`
+- `GET /api/webmcp/metrics`
+- `POST /api/webmcp/discover`
+- `POST /api/webmcp/invoke`
+
+## Notes on Standard Maturity
+
+The current WebMCP proposal is still evolving. This implementation keeps transport and site handling adapter-driven so additional discovery/invocation mechanisms can be added without changing caller contracts.
+

--- a/lib/__tests__/webmcp-client.test.ts
+++ b/lib/__tests__/webmcp-client.test.ts
@@ -1,0 +1,220 @@
+import http from 'node:http';
+import { once } from 'node:events';
+import {
+  WebMcpClient,
+  HttpManifestWebMcpAdapter,
+  type WebMcpToolDefinition,
+} from '../webmcp-client';
+
+interface MockSite {
+  url: string;
+  close: () => Promise<void>;
+  requests: { discovery: number; invoke: number };
+}
+
+async function startMockSite(options: {
+  tools: WebMcpToolDefinition[];
+  invokeResult?: Record<string, unknown>;
+  manifestPath?: string;
+  invokePath?: string;
+}): Promise<MockSite> {
+  const manifestPath = options.manifestPath ?? '/.well-known/webmcp.json';
+  const invokePath = options.invokePath ?? '/.well-known/webmcp/invoke';
+  const requests = { discovery: 0, invoke: 0 };
+
+  const server = http.createServer((req, res) => {
+    if (req.url === manifestPath && req.method === 'GET') {
+      requests.discovery += 1;
+      res.setHeader('Content-Type', 'application/json');
+      res.end(JSON.stringify({
+        tools: options.tools,
+        invoke_url: invokePath,
+      }));
+      return;
+    }
+
+    if (req.url === invokePath && req.method === 'POST') {
+      requests.invoke += 1;
+      let body = '';
+      req.on('data', (chunk) => { body += chunk.toString(); });
+      req.on('end', () => {
+        res.setHeader('Content-Type', 'application/json');
+        const payload = JSON.parse(body || '{}') as { tool?: string; arguments?: Record<string, unknown> };
+        res.end(JSON.stringify({
+          ok: true,
+          tool: payload.tool ?? '',
+          args: payload.arguments ?? {},
+          ...(options.invokeResult ?? {}),
+        }));
+      });
+      return;
+    }
+
+    res.statusCode = 404;
+    res.end('not found');
+  });
+
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  const address = server.address();
+  if (!address || typeof address === 'string') throw new Error('Unexpected address');
+  return {
+    url: `http://127.0.0.1:${address.port}`,
+    requests,
+    close: async () => {
+      server.close();
+      await once(server, 'close');
+    },
+  };
+}
+
+describe('WebMcpClient', () => {
+  it('discovers tools and serves cached discovery on repeated calls', async () => {
+    const site = await startMockSite({
+      tools: [
+        {
+          name: 'search_catalog',
+          description: 'Search product catalog',
+          inputSchema: {
+            type: 'object',
+            required: ['query'],
+            properties: { query: { type: 'string' } },
+          },
+        },
+      ],
+    });
+
+    const client = new WebMcpClient({
+      adapters: [new HttpManifestWebMcpAdapter()],
+      cacheTtlMs: 60_000,
+    });
+
+    const first = await client.discoverTools(site.url);
+    const second = await client.discoverTools(site.url);
+
+    expect(first.tools).toHaveLength(1);
+    expect(first.cached).toBe(false);
+    expect(second.cached).toBe(true);
+    expect(site.requests.discovery).toBe(1);
+
+    await site.close();
+  });
+
+  it('invokes discovered tools with typed arguments', async () => {
+    const site = await startMockSite({
+      tools: [
+        {
+          name: 'book_flight',
+          inputSchema: {
+            type: 'object',
+            required: ['origin', 'destination'],
+            properties: {
+              origin: { type: 'string' },
+              destination: { type: 'string' },
+            },
+          },
+        },
+      ],
+      invokeResult: { bookingId: 'BKG-123' },
+    });
+
+    const client = new WebMcpClient({
+      adapters: [new HttpManifestWebMcpAdapter()],
+    });
+
+    const result = await client.invokeTool({
+      siteUrl: site.url,
+      toolName: 'book_flight',
+      args: { origin: 'SFO', destination: 'JFK' },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.source).toBe('webmcp');
+    expect((result.result as { bookingId?: string }).bookingId).toBe('BKG-123');
+    expect(site.requests.invoke).toBe(1);
+
+    await site.close();
+  });
+
+  it('returns schema validation errors for invalid args', async () => {
+    const site = await startMockSite({
+      tools: [
+        {
+          name: 'send_message',
+          inputSchema: {
+            type: 'object',
+            required: ['text'],
+            properties: { text: { type: 'string' } },
+          },
+        },
+      ],
+    });
+    const client = new WebMcpClient({
+      adapters: [new HttpManifestWebMcpAdapter()],
+    });
+
+    const result = await client.invokeTool({
+      siteUrl: site.url,
+      toolName: 'send_message',
+      args: { text: 42 as unknown as string },
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('Invalid type');
+    expect(site.requests.invoke).toBe(0);
+    await site.close();
+  });
+
+  it('falls back to browser automation when WebMCP is unavailable', async () => {
+    const client = new WebMcpClient({
+      adapters: [new HttpManifestWebMcpAdapter()],
+      fallbackInvoker: async (input) => ({
+        strategy: 'browser-automation-fallback',
+        reason: input.reason,
+        siteUrl: input.siteUrl,
+        toolName: input.toolName,
+        actionHint: 'Fallback executed',
+        payload: input.args,
+      }),
+    });
+
+    const result = await client.invokeTool({
+      siteUrl: 'https://example.com',
+      toolName: 'nonexistent_tool',
+      args: { q: 'hello' },
+    });
+
+    expect(result.ok).toBe(true);
+    expect(result.source).toBe('fallback');
+    expect(result.fallback?.strategy).toBe('browser-automation-fallback');
+  });
+
+  it('supports structured invocation across three independent sites', async () => {
+    const sites = await Promise.all([
+      startMockSite({
+        tools: [{ name: 'checkout', inputSchema: { type: 'object', required: ['cartId'], properties: { cartId: { type: 'string' } } } }],
+      }),
+      startMockSite({
+        tools: [{ name: 'create_ticket', inputSchema: { type: 'object', required: ['subject'], properties: { subject: { type: 'string' } } } }],
+      }),
+      startMockSite({
+        tools: [{ name: 'reserve_slot', inputSchema: { type: 'object', required: ['date'], properties: { date: { type: 'string' } } } }],
+      }),
+    ]);
+
+    const client = new WebMcpClient({
+      adapters: [new HttpManifestWebMcpAdapter()],
+    });
+
+    const r1 = await client.invokeTool({ siteUrl: sites[0].url, toolName: 'checkout', args: { cartId: 'c1' } });
+    const r2 = await client.invokeTool({ siteUrl: sites[1].url, toolName: 'create_ticket', args: { subject: 'Need help' } });
+    const r3 = await client.invokeTool({ siteUrl: sites[2].url, toolName: 'reserve_slot', args: { date: '2026-03-01' } });
+
+    expect(r1.ok && r1.source === 'webmcp').toBe(true);
+    expect(r2.ok && r2.source === 'webmcp').toBe(true);
+    expect(r3.ok && r3.source === 'webmcp').toBe(true);
+
+    await Promise.all(sites.map((site) => site.close()));
+  });
+});
+

--- a/lib/webmcp-client.ts
+++ b/lib/webmcp-client.ts
@@ -1,0 +1,484 @@
+/**
+ * WebMCP client abstraction (Issue #225)
+ *
+ * - typed tool discovery from WebMCP-compatible manifests
+ * - invocation with schema validation
+ * - discovery schema cache
+ * - graceful fallback to browser automation
+ */
+
+export interface WebMcpToolDefinition {
+  name: string;
+  description?: string;
+  inputSchema: Record<string, unknown>;
+  outputSchema?: Record<string, unknown>;
+}
+
+export interface WebMcpSiteProfile {
+  id: string;
+  label: string;
+  siteUrl: string;
+}
+
+export interface WebMcpDiscoveryResult {
+  siteUrl: string;
+  tools: WebMcpToolDefinition[];
+  adapter: string;
+  cached: boolean;
+  discoveredAt: string;
+}
+
+export interface WebMcpInvokeRequest {
+  siteUrl: string;
+  toolName: string;
+  args: Record<string, unknown>;
+}
+
+export interface BrowserFallbackResult {
+  strategy: 'browser-automation-fallback';
+  reason: string;
+  siteUrl: string;
+  toolName: string;
+  actionHint: string;
+  payload: Record<string, unknown>;
+}
+
+export interface WebMcpInvokeResult {
+  ok: boolean;
+  source: 'webmcp' | 'fallback';
+  siteUrl: string;
+  toolName: string;
+  result?: unknown;
+  error?: string;
+  fallback?: BrowserFallbackResult;
+}
+
+export interface WebMcpMetrics {
+  discovered: number;
+  cacheHits: number;
+  invoked: number;
+  fallbackInvoked: number;
+  errors: number;
+  updatedAt: string | null;
+  perSite: Record<string, { discovered: number; invoked: number; fallbackInvoked: number }>;
+}
+
+export interface WebMcpAdapterDiscovery {
+  tools: WebMcpToolDefinition[];
+  invokeUrl?: string;
+}
+
+export interface WebMcpAdapter {
+  name: string;
+  canHandle(siteUrl: string): boolean;
+  discover(siteUrl: string): Promise<WebMcpAdapterDiscovery | null>;
+  invoke(siteUrl: string, toolName: string, args: Record<string, unknown>, ctx: { invokeUrl?: string }): Promise<unknown>;
+}
+
+export interface WebMcpClientOptions {
+  adapters?: WebMcpAdapter[];
+  cacheTtlMs?: number;
+  now?: () => Date;
+  fallbackInvoker?: (input: {
+    siteUrl: string;
+    toolName: string;
+    args: Record<string, unknown>;
+    reason: string;
+  }) => Promise<BrowserFallbackResult>;
+  siteProfiles?: WebMcpSiteProfile[];
+}
+
+interface CacheEntry {
+  siteUrl: string;
+  adapter: string;
+  tools: WebMcpToolDefinition[];
+  invokeUrl?: string;
+  discoveredAt: string;
+  expiresAtMs: number;
+}
+
+const DEFAULT_CACHE_TTL_MS = 10 * 60 * 1000;
+
+export const DEFAULT_WEBMCP_SITE_PROFILES: WebMcpSiteProfile[] = [
+  {
+    id: 'webmcp-spec-site',
+    label: 'WebMCP Spec Site',
+    siteUrl: 'https://webmachinelearning.github.io/webmcp/',
+  },
+  {
+    id: 'usechar',
+    label: 'UseChar',
+    siteUrl: 'https://usechar.ai/',
+  },
+  {
+    id: 'mcpb-docs',
+    label: 'MCP-B Docs',
+    siteUrl: 'https://docs.mcp-b.ai/',
+  },
+];
+
+function normalizeSiteUrl(siteUrl: string): string {
+  const u = new URL(siteUrl);
+  return `${u.protocol}//${u.host}`;
+}
+
+function nowIso(now: () => Date): string {
+  return now().toISOString();
+}
+
+function getToolSchema(tool: WebMcpToolDefinition): Record<string, unknown> {
+  return (tool.inputSchema && typeof tool.inputSchema === 'object')
+    ? tool.inputSchema
+    : {};
+}
+
+function validateType(value: unknown, type: string): boolean {
+  if (type === 'string') return typeof value === 'string';
+  if (type === 'number') return typeof value === 'number' && Number.isFinite(value);
+  if (type === 'integer') return typeof value === 'number' && Number.isInteger(value);
+  if (type === 'boolean') return typeof value === 'boolean';
+  if (type === 'array') return Array.isArray(value);
+  if (type === 'object') return typeof value === 'object' && value != null && !Array.isArray(value);
+  return true;
+}
+
+function validateArgs(args: Record<string, unknown>, schema: Record<string, unknown>): { ok: boolean; error?: string } {
+  const required = Array.isArray(schema.required) ? schema.required.filter((v): v is string => typeof v === 'string') : [];
+  const properties = (schema.properties && typeof schema.properties === 'object')
+    ? schema.properties as Record<string, { type?: string }>
+    : {};
+
+  for (const field of required) {
+    if (!(field in args)) return { ok: false, error: `Missing required argument: ${field}` };
+  }
+  for (const [field, property] of Object.entries(properties)) {
+    if (!(field in args)) continue;
+    const expectedType = typeof property.type === 'string' ? property.type : '';
+    if (expectedType && !validateType(args[field], expectedType)) {
+      return {
+        ok: false,
+        error: `Invalid type for ${field}: expected ${expectedType}`,
+      };
+    }
+  }
+  return { ok: true };
+}
+
+function normalizeTool(raw: unknown): WebMcpToolDefinition | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const record = raw as Record<string, unknown>;
+  const name = typeof record.name === 'string' ? record.name.trim() : '';
+  if (!name) return null;
+
+  const inputSchema = (
+    (record.inputSchema && typeof record.inputSchema === 'object' && !Array.isArray(record.inputSchema))
+      ? record.inputSchema
+      : (record.input_schema && typeof record.input_schema === 'object' && !Array.isArray(record.input_schema))
+        ? record.input_schema
+        : (record.parameters && typeof record.parameters === 'object' && !Array.isArray(record.parameters))
+          ? record.parameters
+          : {}
+  ) as Record<string, unknown>;
+
+  const outputSchema = (
+    (record.outputSchema && typeof record.outputSchema === 'object' && !Array.isArray(record.outputSchema))
+      ? record.outputSchema
+      : (record.output_schema && typeof record.output_schema === 'object' && !Array.isArray(record.output_schema))
+        ? record.output_schema
+        : undefined
+  ) as Record<string, unknown> | undefined;
+
+  return {
+    name,
+    description: typeof record.description === 'string' ? record.description : undefined,
+    inputSchema,
+    outputSchema,
+  };
+}
+
+export class HttpManifestWebMcpAdapter implements WebMcpAdapter {
+  readonly name = 'http-manifest';
+  private readonly discoveryPaths: string[];
+  private readonly defaultInvokePath: string;
+  private readonly fetchFn: typeof fetch;
+
+  constructor(options: {
+    discoveryPaths?: string[];
+    defaultInvokePath?: string;
+    fetchFn?: typeof fetch;
+  } = {}) {
+    this.discoveryPaths = options.discoveryPaths ?? [
+      '/.well-known/webmcp.json',
+      '/.well-known/webmcp/tools.json',
+      '/webmcp.json',
+    ];
+    this.defaultInvokePath = options.defaultInvokePath ?? '/.well-known/webmcp/invoke';
+    this.fetchFn = options.fetchFn ?? fetch;
+  }
+
+  canHandle(siteUrl: string): boolean {
+    try {
+      const u = new URL(siteUrl);
+      return u.protocol === 'https:' || u.protocol === 'http:';
+    } catch {
+      return false;
+    }
+  }
+
+  async discover(siteUrl: string): Promise<WebMcpAdapterDiscovery | null> {
+    const base = normalizeSiteUrl(siteUrl);
+    for (const pathName of this.discoveryPaths) {
+      try {
+        const res = await this.fetchFn(`${base}${pathName}`, {
+          method: 'GET',
+          headers: { Accept: 'application/json' },
+        });
+        if (!res.ok) continue;
+        const payload = await res.json() as unknown;
+        const parsed = this.parseDiscoveryPayload(payload);
+        if (parsed.tools.length === 0) continue;
+        return parsed;
+      } catch {
+        // Try next endpoint.
+      }
+    }
+    return null;
+  }
+
+  async invoke(
+    siteUrl: string,
+    toolName: string,
+    args: Record<string, unknown>,
+    ctx: { invokeUrl?: string },
+  ): Promise<unknown> {
+    const base = normalizeSiteUrl(siteUrl);
+    const invokeUrl = ctx.invokeUrl ? `${base}${ctx.invokeUrl.startsWith('/') ? '' : '/'}${ctx.invokeUrl}` : `${base}${this.defaultInvokePath}`;
+    const res = await this.fetchFn(invokeUrl, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', Accept: 'application/json' },
+      body: JSON.stringify({
+        tool: toolName,
+        arguments: args,
+      }),
+    });
+    if (!res.ok) {
+      throw new Error(`WebMCP invoke failed: ${res.status}`);
+    }
+    return await res.json() as unknown;
+  }
+
+  private parseDiscoveryPayload(payload: unknown): WebMcpAdapterDiscovery {
+    const record = (payload && typeof payload === 'object' && !Array.isArray(payload))
+      ? payload as Record<string, unknown>
+      : {};
+    const rawTools = Array.isArray(record.tools)
+      ? record.tools
+      : Array.isArray(record.capabilities)
+        ? record.capabilities
+        : [];
+    const tools = rawTools
+      .map((raw) => normalizeTool(raw))
+      .filter((tool): tool is WebMcpToolDefinition => tool != null);
+    const invokeUrl = typeof record.invoke_url === 'string'
+      ? record.invoke_url
+      : typeof record.invokeUrl === 'string'
+        ? record.invokeUrl
+        : undefined;
+    return { tools, invokeUrl };
+  }
+}
+
+export class WebMcpClient {
+  private readonly adapters: WebMcpAdapter[];
+  private readonly cache = new Map<string, CacheEntry>();
+  private readonly cacheTtlMs: number;
+  private readonly now: () => Date;
+  private readonly fallbackInvoker: WebMcpClientOptions['fallbackInvoker'];
+  private readonly metrics: WebMcpMetrics = {
+    discovered: 0,
+    cacheHits: 0,
+    invoked: 0,
+    fallbackInvoked: 0,
+    errors: 0,
+    updatedAt: null,
+    perSite: {},
+  };
+  private readonly siteProfiles: WebMcpSiteProfile[];
+
+  constructor(options: WebMcpClientOptions = {}) {
+    this.adapters = options.adapters ?? [new HttpManifestWebMcpAdapter()];
+    this.cacheTtlMs = Math.max(5_000, options.cacheTtlMs ?? DEFAULT_CACHE_TTL_MS);
+    this.now = options.now ?? (() => new Date());
+    this.fallbackInvoker = options.fallbackInvoker ?? (async (input) => ({
+      strategy: 'browser-automation-fallback',
+      reason: input.reason,
+      siteUrl: input.siteUrl,
+      toolName: input.toolName,
+      actionHint: `Use browser automation for ${input.toolName} on ${input.siteUrl}`,
+      payload: input.args,
+    }));
+    this.siteProfiles = options.siteProfiles ?? DEFAULT_WEBMCP_SITE_PROFILES;
+  }
+
+  getSiteProfiles(): WebMcpSiteProfile[] {
+    return [...this.siteProfiles];
+  }
+
+  getMetrics(): WebMcpMetrics {
+    return {
+      ...this.metrics,
+      perSite: { ...this.metrics.perSite },
+    };
+  }
+
+  clearCache(): void {
+    this.cache.clear();
+  }
+
+  async discoverTools(siteUrlRaw: string, opts: { forceRefresh?: boolean } = {}): Promise<WebMcpDiscoveryResult> {
+    const siteUrl = normalizeSiteUrl(siteUrlRaw);
+    const nowMs = this.now().getTime();
+    const cached = this.cache.get(siteUrl);
+    if (!opts.forceRefresh && cached && cached.expiresAtMs > nowMs) {
+      this.metrics.cacheHits += 1;
+      this.bumpSiteMetric(siteUrl, 'discovered');
+      this.touchMetrics();
+      return {
+        siteUrl,
+        tools: cached.tools,
+        adapter: cached.adapter,
+        cached: true,
+        discoveredAt: cached.discoveredAt,
+      };
+    }
+
+    for (const adapter of this.adapters) {
+      if (!adapter.canHandle(siteUrl)) continue;
+      try {
+        const discovery = await adapter.discover(siteUrl);
+        if (!discovery || discovery.tools.length === 0) continue;
+        const discoveredAt = nowIso(this.now);
+        const entry: CacheEntry = {
+          siteUrl,
+          adapter: adapter.name,
+          tools: discovery.tools,
+          invokeUrl: discovery.invokeUrl,
+          discoveredAt,
+          expiresAtMs: this.now().getTime() + this.cacheTtlMs,
+        };
+        this.cache.set(siteUrl, entry);
+        this.metrics.discovered += 1;
+        this.bumpSiteMetric(siteUrl, 'discovered');
+        this.touchMetrics();
+        return {
+          siteUrl,
+          tools: discovery.tools,
+          adapter: adapter.name,
+          cached: false,
+          discoveredAt,
+        };
+      } catch {
+        this.metrics.errors += 1;
+      }
+    }
+
+    this.touchMetrics();
+    return {
+      siteUrl,
+      tools: [],
+      adapter: 'none',
+      cached: false,
+      discoveredAt: nowIso(this.now),
+    };
+  }
+
+  async invokeTool(input: WebMcpInvokeRequest): Promise<WebMcpInvokeResult> {
+    const siteUrl = normalizeSiteUrl(input.siteUrl);
+    this.metrics.invoked += 1;
+    this.bumpSiteMetric(siteUrl, 'invoked');
+
+    const discovery = await this.discoverTools(siteUrl);
+    const tool = discovery.tools.find((item) => item.name === input.toolName);
+    if (!tool) {
+      return this.invokeFallback(siteUrl, input.toolName, input.args, 'tool_not_found_or_webmcp_unavailable');
+    }
+
+    const validation = validateArgs(input.args, getToolSchema(tool));
+    if (!validation.ok) {
+      this.metrics.errors += 1;
+      this.touchMetrics();
+      return {
+        ok: false,
+        source: 'webmcp',
+        siteUrl,
+        toolName: input.toolName,
+        error: validation.error ?? 'schema_validation_failed',
+      };
+    }
+
+    const cacheEntry = this.cache.get(siteUrl);
+    const adapter = this.adapters.find((item) => item.name === (cacheEntry?.adapter ?? discovery.adapter));
+    if (!adapter) {
+      return this.invokeFallback(siteUrl, input.toolName, input.args, 'adapter_unavailable');
+    }
+
+    try {
+      const result = await adapter.invoke(siteUrl, input.toolName, input.args, {
+        invokeUrl: cacheEntry?.invokeUrl,
+      });
+      this.touchMetrics();
+      return {
+        ok: true,
+        source: 'webmcp',
+        siteUrl,
+        toolName: input.toolName,
+        result,
+      };
+    } catch {
+      this.metrics.errors += 1;
+      return this.invokeFallback(siteUrl, input.toolName, input.args, 'invoke_error');
+    }
+  }
+
+  private async invokeFallback(
+    siteUrl: string,
+    toolName: string,
+    args: Record<string, unknown>,
+    reason: string,
+  ): Promise<WebMcpInvokeResult> {
+    this.metrics.fallbackInvoked += 1;
+    this.bumpSiteMetric(siteUrl, 'fallbackInvoked');
+    this.touchMetrics();
+    const fallback = await this.fallbackInvoker?.({ siteUrl, toolName, args, reason });
+    return {
+      ok: true,
+      source: 'fallback',
+      siteUrl,
+      toolName,
+      fallback,
+      result: fallback,
+    };
+  }
+
+  private bumpSiteMetric(siteUrl: string, key: 'discovered' | 'invoked' | 'fallbackInvoked'): void {
+    const current = this.metrics.perSite[siteUrl] ?? { discovered: 0, invoked: 0, fallbackInvoked: 0 };
+    current[key] += 1;
+    this.metrics.perSite[siteUrl] = current;
+  }
+
+  private touchMetrics(): void {
+    this.metrics.updatedAt = nowIso(this.now);
+  }
+}
+
+let defaultWebMcpClient: WebMcpClient | null = null;
+
+export function getDefaultWebMcpClient(): WebMcpClient {
+  if (!defaultWebMcpClient) defaultWebMcpClient = new WebMcpClient();
+  return defaultWebMcpClient;
+}
+
+export function resetDefaultWebMcpClient(): void {
+  defaultWebMcpClient = null;
+}
+


### PR DESCRIPTION
## Summary
- add WebMCP client with:
  - tool discovery from WebMCP-compatible manifests
  - typed invocation (schema validation)
  - discovery cache (TTL)
  - browser-automation fallback when WebMCP is unavailable
- add dashboard WebMCP endpoints:
  - `GET /api/webmcp/sites`
  - `GET /api/webmcp/metrics`
  - `POST /api/webmcp/discover`
  - `POST /api/webmcp/invoke`
- add default site profiles and telemetry surfaces
- add tests and docs for discovery/invoke/fallback behavior

## Validation
- `npx jest lib/__tests__/webmcp-client.test.ts --runInBand`
- `cd dashboard && npx -y vitest@4.0.18 run --config /tmp/vitest.local.config.mjs tests/unit/routes/webmcp.test.ts tests/unit/middleware/rate-limit.test.ts`
- `npm run -s build`

Closes #225
