### PR TITLE
feat: add visual explainer canvas skill

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -172,6 +172,7 @@ See **[docs/API.md](docs/API.md)** for the complete API reference covering all e
 | `GET /api/code-factory/harness-gaps` | Track unresolved production regressions awaiting tests |
 | `POST /api/webmcp/discover` | Discover structured WebMCP tools for a website |
 | `POST /api/webmcp/invoke` | Invoke discovered WebMCP tool with typed args + fallback |
+| `POST /api/visual-explainer/render` | Render slash-command explain/visualize output as interactive HTML |
 | `GET /api/live` | SSE real-time feed |
 
 ## Architecture

--- a/dashboard/client/visual-explainer.html
+++ b/dashboard/client/visual-explainer.html
@@ -1,0 +1,161 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>VentureOS Visual Explainer</title>
+  <style>
+    :root {
+      --bg: #060c18;
+      --panel: #0f1a2d;
+      --line: #223550;
+      --text: #e5f0ff;
+      --muted: #8ca5c7;
+      --accent: #17d2a2;
+      --accent2: #58a5ff;
+    }
+    * { box-sizing: border-box; }
+    body {
+      margin: 0;
+      font-family: "IBM Plex Sans", sans-serif;
+      color: var(--text);
+      background:
+        radial-gradient(circle at 10% 10%, #16315a, transparent 45%),
+        radial-gradient(circle at 90% 0%, #0f2748, transparent 38%),
+        var(--bg);
+      min-height: 100vh;
+      display: grid;
+      grid-template-rows: auto 1fr;
+    }
+    header {
+      padding: 18px 20px 10px;
+      border-bottom: 1px solid var(--line);
+      background: rgba(9, 15, 27, 0.85);
+      backdrop-filter: blur(8px);
+    }
+    h1 { margin: 0; font-size: 20px; }
+    .sub { margin-top: 6px; font-size: 13px; color: var(--muted); }
+    main { padding: 16px 20px 22px; display: grid; gap: 12px; }
+    .panel {
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      background: linear-gradient(180deg, rgba(16, 26, 45, .95), rgba(11, 18, 32, .95));
+      box-shadow: 0 24px 50px rgba(0,0,0,.25);
+      padding: 14px;
+    }
+    .controls { display: grid; gap: 10px; grid-template-columns: 1fr auto auto; }
+    input, select, button {
+      border-radius: 10px;
+      border: 1px solid var(--line);
+      background: #0b1322;
+      color: var(--text);
+      padding: 10px 12px;
+      font-size: 14px;
+    }
+    button {
+      background: linear-gradient(135deg, var(--accent), var(--accent2));
+      border: none;
+      color: #032031;
+      font-weight: 700;
+      cursor: pointer;
+    }
+    .samples { display: flex; gap: 8px; flex-wrap: wrap; }
+    .samples button {
+      background: #112036;
+      color: var(--text);
+      border: 1px solid var(--line);
+      font-weight: 500;
+    }
+    .meta { font-size: 12px; color: var(--muted); margin-top: 8px; }
+    iframe {
+      width: 100%;
+      min-height: 72vh;
+      border: 1px solid var(--line);
+      border-radius: 14px;
+      background: #0a1120;
+    }
+    @media (max-width: 860px) {
+      .controls { grid-template-columns: 1fr; }
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Visual Explainer Canvas Skill</h1>
+    <div class="sub">Use `/explain` or `/visualize` commands to generate interactive patterns.</div>
+  </header>
+  <main>
+    <section class="panel">
+      <div class="controls">
+        <input id="commandInput" value="/explain VentureOS roadmap > now > next > risk" />
+        <select id="patternSelect">
+          <option value="">Auto Pattern</option>
+          <option value="table">table</option>
+          <option value="flow">flow</option>
+          <option value="timeline">timeline</option>
+          <option value="hierarchy">hierarchy</option>
+          <option value="comparison">comparison</option>
+        </select>
+        <button id="renderBtn">Render</button>
+      </div>
+      <div class="samples" style="margin-top:10px;">
+        <button data-cmd="/visualize onboarding, activation, retention --pattern=timeline">Timeline</button>
+        <button data-cmd="/visualize baseline, optimized --pattern=comparison">Comparison</button>
+        <button data-cmd="/visualize intake > classify > route > execute --pattern=flow">Flow</button>
+        <button data-cmd="/visualize objective > strategy > tasks --pattern=hierarchy">Hierarchy</button>
+        <button data-cmd="/visualize market, signal, action --pattern=table">Table</button>
+      </div>
+      <div class="meta" id="statusMeta">Ready.</div>
+    </section>
+    <section>
+      <iframe id="canvasFrame" title="Visual Explainer Canvas"></iframe>
+    </section>
+  </main>
+
+  <script>
+    async function authFetch(url, opts = {}) {
+      const headers = Object.assign({}, opts.headers || {});
+      const token = localStorage.getItem('dashboardToken') || '';
+      if (token && !headers['Authorization']) headers['Authorization'] = 'Bearer ' + token;
+      return fetch(url, Object.assign({}, opts, { headers, credentials: 'include' }));
+    }
+
+    async function renderExplainer() {
+      const command = document.getElementById('commandInput').value.trim();
+      const pattern = document.getElementById('patternSelect').value;
+      const frame = document.getElementById('canvasFrame');
+      const status = document.getElementById('statusMeta');
+      if (!command) return;
+      const t0 = performance.now();
+      status.textContent = 'Rendering...';
+      try {
+        const res = await authFetch('/api/visual-explainer/render', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ command, pattern: pattern || undefined }),
+        });
+        const data = await res.json();
+        if (!data.ok) throw new Error(data.error || 'Render failed');
+        frame.srcdoc = data.render.html;
+        const elapsed = Math.round(performance.now() - t0);
+        status.textContent = 'Pattern: ' + data.render.pattern + ' · Rendered in ' + elapsed + 'ms';
+      } catch (err) {
+        status.textContent = 'Render failed: ' + (err && err.message ? err.message : 'unknown error');
+      }
+    }
+
+    document.getElementById('renderBtn').addEventListener('click', renderExplainer);
+    document.getElementById('commandInput').addEventListener('keydown', (event) => {
+      if (event.key === 'Enter') renderExplainer();
+    });
+    document.querySelectorAll('.samples button').forEach((button) => {
+      button.addEventListener('click', () => {
+        document.getElementById('commandInput').value = button.getAttribute('data-cmd') || '';
+        renderExplainer();
+      });
+    });
+    renderExplainer();
+  </script>
+</body>
+</html>
+

--- a/dashboard/docs/API.md
+++ b/dashboard/docs/API.md
@@ -20,6 +20,7 @@ Complete reference for all OpenClaw Dashboard HTTP endpoints.
 - [Self-Improvement Endpoints](#self-improvement-endpoints)
 - [Code Factory Endpoints](#code-factory-endpoints)
 - [WebMCP Endpoints](#webmcp-endpoints)
+- [Visual Explainer Endpoints](#visual-explainer-endpoints)
 - [Schemas](#schemas)
 
 ---
@@ -1155,6 +1156,50 @@ Invokes a structured tool with typed parameters.
 
 ---
 
+## Visual Explainer Endpoints
+
+Slash-command visual rendering with interactive HTML patterns (Issue #226).
+
+### `GET /api/visual-explainer/patterns`
+
+Returns supported pattern identifiers:
+- `table`
+- `flow`
+- `timeline`
+- `hierarchy`
+- `comparison`
+
+### `POST /api/visual-explainer/render`
+
+Renders `/explain` or `/visualize` command output into a Canvas-ready HTML payload.
+
+**Request:**
+```json
+{
+  "command": "/visualize intake > classify > route --pattern=flow",
+  "title": "Routing Overview"
+}
+```
+
+**Response (200):**
+```json
+{
+  "ok": true,
+  "render": {
+    "pattern": "flow",
+    "title": "Routing Overview",
+    "renderTimeMs": 8,
+    "html": "<!doctype html>..."
+  }
+}
+```
+
+The rendered HTML includes:
+- expandable sections (`<details>`)
+- hover tooltips via `data-tip`
+
+---
+
 ## Rate Limiting
 
 Per-IP, per-endpoint sliding window rate limits:
@@ -1169,6 +1214,7 @@ Per-IP, per-endpoint sliding window rate limits:
 | `/api/self-improvement*` | 20 req | 60s |
 | `/api/code-factory*` | 20 req | 60s |
 | `/api/webmcp*` | 30 req | 60s |
+| `/api/visual-explainer*` | 30 req | 60s |
 | `/api/ventureos-agents` | 30 req | 60s |
 | `/api/ventureos-kpis` | 30 req | 60s |
 | `/api/rpg/*` | 20 req | 60s |

--- a/dashboard/server/middleware/rate-limit.ts
+++ b/dashboard/server/middleware/rate-limit.ts
@@ -98,6 +98,7 @@ export const LIMITS: Record<string, RateLimitConfig> = {
   '/api/self-improvement':    { limit: 20, windowMs: 60000 },
   '/api/code-factory':        { limit: 20, windowMs: 60000 },
   '/api/webmcp':              { limit: 30, windowMs: 60000 },
+  '/api/visual-explainer':    { limit: 30, windowMs: 60000 },
   '/api/replay':              { limit: 10, windowMs: 60000 },
   '/api/live':                { limit: 10, windowMs: 60000 },
   '/api/conversation':        { limit: 30, windowMs: 60000 },

--- a/dashboard/server/routes/visual-explainer.ts
+++ b/dashboard/server/routes/visual-explainer.ts
@@ -1,0 +1,78 @@
+/**
+ * Visual Explainer routes (Issue #226)
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { listVisualPatterns, renderVisualExplainer, type VisualPatternType } from '../visual-explainer.js';
+
+export interface VisualExplainerRouteDeps {
+  sendJson: (res: ServerResponse, data: unknown, status?: number) => void;
+  readRequestBody: (req: IncomingMessage) => Promise<string>;
+}
+
+function parseUrl(req: IncomingMessage): URL | null {
+  try {
+    return new URL(req.url ?? '', 'http://localhost');
+  } catch {
+    return null;
+  }
+}
+
+function parseJson<T>(raw: string): T | null {
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+function isPattern(raw: unknown): raw is VisualPatternType {
+  return raw === 'table' || raw === 'flow' || raw === 'timeline' || raw === 'hierarchy' || raw === 'comparison';
+}
+
+export function handleVisualExplainer(
+  req: IncomingMessage,
+  res: ServerResponse,
+  deps: VisualExplainerRouteDeps,
+): Promise<boolean> | boolean {
+  if (!req.url || !req.url.startsWith('/api/visual-explainer')) return false;
+  const parsed = parseUrl(req);
+  if (!parsed) {
+    deps.sendJson(res, { ok: false, error: 'Bad request URL' }, 400);
+    return true;
+  }
+
+  if (parsed.pathname === '/api/visual-explainer/patterns' && req.method === 'GET') {
+    deps.sendJson(res, {
+      patterns: listVisualPatterns(),
+    });
+    return true;
+  }
+
+  if (parsed.pathname === '/api/visual-explainer/render' && req.method === 'POST') {
+    return (async () => {
+      const body = parseJson<{ command?: string; title?: string; pattern?: string }>(
+        await deps.readRequestBody(req),
+      ) ?? {};
+      const command = (body.command ?? '').trim();
+      if (!command) {
+        deps.sendJson(res, { ok: false, error: 'command is required' }, 400);
+        return true;
+      }
+      const rendered = renderVisualExplainer({
+        command,
+        title: body.title?.trim() || undefined,
+        pattern: isPattern(body.pattern) ? body.pattern : undefined,
+      });
+      deps.sendJson(res, {
+        ok: true,
+        render: rendered,
+      });
+      return true;
+    })();
+  }
+
+  deps.sendJson(res, { ok: false, error: 'Not found' }, 404);
+  return true;
+}
+

--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -121,6 +121,7 @@ import { handleTokenCompaction } from './routes/token-compaction.js';
 import { handleSelfImprovement } from './routes/self-improvement.js';
 import { handleCodeFactory } from './routes/code-factory.js';
 import { handleWebMcp } from './routes/webmcp.js';
+import { handleVisualExplainer } from './routes/visual-explainer.js';
 import { getSchedulerJobs } from './scheduler-jobs.js';
 
 // ─── Configuration ───────────────────────────────────────────────────────────
@@ -146,6 +147,7 @@ const scrapeScript: string = path.join(WORKSPACE_DIR, 'scripts', 'scrape-claude-
 // Client HTML paths — served from client/ directory
 const htmlPath: string = path.join(import.meta.dirname, '..', 'client', 'index.html');
 const loginHtmlPath: string = path.join(import.meta.dirname, '..', 'client', 'login.html');
+const visualExplainerHtmlPath: string = path.join(import.meta.dirname, '..', 'client', 'visual-explainer.html');
 const clientAssetsDir: string = path.join(import.meta.dirname, '..', 'client', 'assets');
 
 const VENTUREOS_AGENTS: string[] = (
@@ -3218,6 +3220,13 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
     return;
   }
 
+  try {
+    if (await handleVisualExplainer(req, res, { sendJson, readRequestBody })) return;
+  } catch {
+    sendJson(res, { ok: false, error: 'Failed to process visual-explainer request' }, 500);
+    return;
+  }
+
   // VentureOS API aliases
   if (req.url === '/api/ventureos-mission-control') {
     if (
@@ -4110,7 +4119,8 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
     }
 
     try {
-      const html: string = fs.readFileSync(htmlPath, 'utf8');
+      const wantsVisualExplainer = req.url === '/visual-explainer' || req.url.startsWith('/visual-explainer?');
+      const html: string = fs.readFileSync(wantsVisualExplainer ? visualExplainerHtmlPath : htmlPath, 'utf8');
       res.writeHead(200, {
         'Content-Type': 'text/html; charset=utf-8',
         'Cache-Control': 'no-store, no-cache, must-revalidate',

--- a/dashboard/server/visual-explainer.ts
+++ b/dashboard/server/visual-explainer.ts
@@ -1,0 +1,263 @@
+/**
+ * Visual Explainer Canvas Skill (Issue #226)
+ *
+ * Builds interactive HTML fragments for complex explanations.
+ */
+
+export type VisualPatternType = 'table' | 'flow' | 'timeline' | 'hierarchy' | 'comparison';
+
+export interface VisualExplainerInput {
+  command: string;
+  title?: string;
+  pattern?: VisualPatternType;
+}
+
+export interface VisualExplainerRenderResult {
+  html: string;
+  pattern: VisualPatternType;
+  title: string;
+  renderTimeMs: number;
+}
+
+export interface ParsedVisualCommand {
+  mode: 'explain' | 'visualize';
+  subject: string;
+  requestedPattern?: VisualPatternType;
+}
+
+const PATTERNS: VisualPatternType[] = ['table', 'flow', 'timeline', 'hierarchy', 'comparison'];
+
+function escapeHtml(raw: string): string {
+  return raw
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function slug(raw: string): string {
+  return raw.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/^-+|-+$/g, '') || 'topic';
+}
+
+function splitSubject(subject: string): string[] {
+  return subject
+    .split(/[,|>]/)
+    .map((part) => part.trim())
+    .filter(Boolean);
+}
+
+export function parseVisualCommand(commandRaw: string): ParsedVisualCommand | null {
+  const command = commandRaw.trim();
+  if (!command.startsWith('/')) return null;
+  const explainMatch = command.match(/^\/explain\s+(.+)$/i);
+  if (explainMatch) {
+    return {
+      mode: 'explain',
+      subject: explainMatch[1].trim(),
+    };
+  }
+  const visualizeMatch = command.match(/^\/visualize\s+(.+)$/i);
+  if (visualizeMatch) {
+    const body = visualizeMatch[1].trim();
+    const patternMatch = body.match(/\s+--pattern=(table|flow|timeline|hierarchy|comparison)\s*$/i);
+    return {
+      mode: 'visualize',
+      subject: patternMatch ? body.replace(patternMatch[0], '').trim() : body,
+      requestedPattern: patternMatch ? patternMatch[1].toLowerCase() as VisualPatternType : undefined,
+    };
+  }
+  return null;
+}
+
+export function listVisualPatterns(): VisualPatternType[] {
+  return [...PATTERNS];
+}
+
+function pickPattern(parsed: ParsedVisualCommand | null, forced?: VisualPatternType): VisualPatternType {
+  if (forced) return forced;
+  if (parsed?.requestedPattern) return parsed.requestedPattern;
+  if (parsed?.mode === 'explain') return 'hierarchy';
+  return 'flow';
+}
+
+function buildTablePattern(subject: string): string {
+  const entries = splitSubject(subject);
+  const rows = (entries.length > 0 ? entries : ['Context', 'Signal', 'Action']).map((entry, index) => `
+      <tr>
+        <td class="mono">S${index + 1}</td>
+        <td>${escapeHtml(entry)}</td>
+        <td><span class="tip" data-tip="Convert this signal into an explicit next action.">Interpretation</span></td>
+      </tr>
+  `).join('');
+  return `
+    <section class="card">
+      <h3>Signal Table</h3>
+      <table>
+        <thead><tr><th>ID</th><th>Signal</th><th>Meaning</th></tr></thead>
+        <tbody>${rows}</tbody>
+      </table>
+    </section>
+  `;
+}
+
+function buildFlowPattern(subject: string): string {
+  const steps = splitSubject(subject);
+  const nodes = (steps.length > 0 ? steps : ['Input', 'Transform', 'Decision', 'Output']).map((step, index) => `
+      <div class="flow-node">
+        <div class="flow-index">${index + 1}</div>
+        <div><span class="tip" data-tip="Step ${index + 1}: align this transition before advancing.">${escapeHtml(step)}</span></div>
+      </div>
+      ${index < (steps.length > 0 ? steps.length : 4) - 1 ? '<div class="flow-arrow">→</div>' : ''}
+  `).join('');
+  return `
+    <section class="card">
+      <h3>Flow</h3>
+      <div class="flow-wrap">${nodes}</div>
+    </section>
+  `;
+}
+
+function buildTimelinePattern(subject: string): string {
+  const events = splitSubject(subject);
+  const items = (events.length > 0 ? events : ['Now', 'Next', 'Soon', 'Later']).map((event, index) => `
+      <li>
+        <span class="time-dot"></span>
+        <div>
+          <div class="mono">T+${index}</div>
+          <div>${escapeHtml(event)}</div>
+        </div>
+      </li>
+  `).join('');
+  return `
+    <section class="card">
+      <h3>Timeline</h3>
+      <ol class="timeline">${items}</ol>
+    </section>
+  `;
+}
+
+function buildHierarchyPattern(subject: string): string {
+  const nodes = splitSubject(subject);
+  const safe = nodes.length > 0 ? nodes : ['Goal', 'Strategy', 'Execution'];
+  const children = safe.slice(1).map((entry) => `<li>${escapeHtml(entry)}</li>`).join('');
+  return `
+    <section class="card">
+      <h3>Hierarchy</h3>
+      <details open>
+        <summary>${escapeHtml(safe[0])}</summary>
+        <ul class="hierarchy">${children}</ul>
+      </details>
+    </section>
+  `;
+}
+
+function buildComparisonPattern(subject: string): string {
+  const entries = splitSubject(subject);
+  const left = entries[0] ?? 'Option A';
+  const right = entries[1] ?? 'Option B';
+  return `
+    <section class="card comparison">
+      <h3>Comparison</h3>
+      <div class="compare-grid">
+        <article>
+          <h4>${escapeHtml(left)}</h4>
+          <p class="tip" data-tip="Strengths, risks, and resource profile for this path.">Profile</p>
+        </article>
+        <article>
+          <h4>${escapeHtml(right)}</h4>
+          <p class="tip" data-tip="Contrast this option against the left side.">Profile</p>
+        </article>
+      </div>
+    </section>
+  `;
+}
+
+function renderPattern(pattern: VisualPatternType, subject: string): string {
+  if (pattern === 'table') return buildTablePattern(subject);
+  if (pattern === 'flow') return buildFlowPattern(subject);
+  if (pattern === 'timeline') return buildTimelinePattern(subject);
+  if (pattern === 'hierarchy') return buildHierarchyPattern(subject);
+  return buildComparisonPattern(subject);
+}
+
+export function renderVisualExplainer(input: VisualExplainerInput): VisualExplainerRenderResult {
+  const started = Date.now();
+  const parsed = parseVisualCommand(input.command);
+  const subject = parsed?.subject ?? input.command.trim();
+  const pattern = pickPattern(parsed, input.pattern);
+  const title = input.title?.trim() || subject || 'Visual Explainer';
+
+  const html = `
+<!doctype html>
+<html>
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>${escapeHtml(title)}</title>
+  <style>
+    :root {
+      --bg: #070b14;
+      --panel: #11192b;
+      --line: #21314a;
+      --text: #e8f1ff;
+      --muted: #8ba3c7;
+      --accent: #18d4a3;
+      --accent2: #4fa3ff;
+    }
+    body { margin:0; padding:20px; background:radial-gradient(circle at 0% 0%, #10203e, var(--bg)); color:var(--text); font-family: "IBM Plex Sans", sans-serif; }
+    h1 { margin: 0 0 14px; font-size: 24px; }
+    h3 { margin: 0 0 12px; font-size: 17px; color: var(--accent); }
+    .meta { color: var(--muted); margin-bottom: 14px; font-size: 13px; }
+    .card { border:1px solid var(--line); border-radius: 14px; background: linear-gradient(180deg, #121d33, #0e1627); padding: 14px; box-shadow: 0 18px 50px rgba(0,0,0,.22); }
+    .mono { font-family: "JetBrains Mono", monospace; font-size: 12px; color: var(--muted); }
+    .tip { border-bottom: 1px dashed var(--accent2); cursor: help; position: relative; }
+    .tip:hover::after {
+      content: attr(data-tip);
+      position: absolute;
+      top: 100%;
+      left: 0;
+      margin-top: 6px;
+      background: #0b1322;
+      border: 1px solid var(--line);
+      color: var(--text);
+      padding: 6px 8px;
+      border-radius: 8px;
+      font-size: 12px;
+      width: 220px;
+      z-index: 2;
+    }
+    table { width:100%; border-collapse: collapse; font-size: 14px; }
+    th, td { border-bottom: 1px solid var(--line); text-align: left; padding: 8px 6px; }
+    .flow-wrap { display:flex; flex-wrap:wrap; gap:8px; align-items:center; }
+    .flow-node { border:1px solid var(--line); background:#0b1424; border-radius:10px; padding:10px 12px; display:flex; gap:8px; align-items:center; }
+    .flow-index { background:var(--accent2); color:#001933; font-weight:700; border-radius:999px; width:22px; height:22px; display:flex; align-items:center; justify-content:center; font-size:12px; }
+    .flow-arrow { color:var(--accent); font-size:20px; }
+    .timeline { list-style:none; padding:0; margin:0; display:grid; gap:10px; }
+    .timeline li { display:flex; gap:10px; align-items:flex-start; }
+    .time-dot { width:10px; height:10px; margin-top:4px; border-radius:50%; background:var(--accent); box-shadow:0 0 0 4px rgba(24,212,163,.2); }
+    .hierarchy { margin-top:10px; display:grid; gap:6px; }
+    .compare-grid { display:grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap:10px; }
+    .compare-grid article { border:1px solid var(--line); border-radius:10px; padding:10px; background:#0b1424; }
+    @media (max-width: 760px) { .compare-grid { grid-template-columns: 1fr; } }
+  </style>
+</head>
+<body>
+  <h1>${escapeHtml(title)}</h1>
+  <div class="meta">Pattern: <span class="mono">${pattern}</span> · Generated from command <span class="mono">${escapeHtml(input.command)}</span></div>
+  ${renderPattern(pattern, subject)}
+  <details style="margin-top:12px">
+    <summary>Pattern Library</summary>
+    <p class="mono">${PATTERNS.join(' · ')}</p>
+  </details>
+</body>
+</html>
+  `.trim();
+
+  return {
+    html,
+    pattern,
+    title,
+    renderTimeMs: Math.max(0, Date.now() - started),
+  };
+}

--- a/dashboard/tests/unit/routes/visual-explainer.test.ts
+++ b/dashboard/tests/unit/routes/visual-explainer.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import { mockRequest, mockResponse, parseJsonBody } from '../../helpers.js';
+import { handleVisualExplainer } from '../../../server/routes/visual-explainer.js';
+
+const deps = (body: unknown = {}) => ({
+  sendJson: (res: ReturnType<typeof mockResponse>, data: unknown, status = 200) => {
+    res.writeHead(status, { 'Content-Type': 'application/json' });
+    res.end(JSON.stringify(data));
+  },
+  readRequestBody: async () => JSON.stringify(body),
+});
+
+describe('visual-explainer routes', () => {
+  it('returns pattern catalog', async () => {
+    const req = mockRequest({ method: 'GET', url: '/api/visual-explainer/patterns' });
+    const res = mockResponse();
+    const handled = await handleVisualExplainer(req, res, deps());
+    expect(handled).toBe(true);
+    const body = parseJsonBody<{ patterns: string[] }>(res);
+    expect(body.patterns).toHaveLength(5);
+  });
+
+  it('renders command output', async () => {
+    const req = mockRequest({ method: 'POST', url: '/api/visual-explainer/render' });
+    const res = mockResponse();
+    await handleVisualExplainer(req, res, deps({
+      command: '/visualize a > b > c --pattern=timeline',
+    }));
+    expect(res._statusCode).toBe(200);
+    const body = parseJsonBody<{ ok: boolean; render: { html: string; renderTimeMs: number } }>(res);
+    expect(body.ok).toBe(true);
+    expect(body.render.html).toContain('<html>');
+    expect(body.render.renderTimeMs).toBeLessThan(3000);
+  });
+
+  it('validates missing command', async () => {
+    const req = mockRequest({ method: 'POST', url: '/api/visual-explainer/render' });
+    const res = mockResponse();
+    await handleVisualExplainer(req, res, deps({ title: 'missing command' }));
+    expect(res._statusCode).toBe(400);
+  });
+});
+

--- a/dashboard/tests/unit/visual-explainer.test.ts
+++ b/dashboard/tests/unit/visual-explainer.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { listVisualPatterns, parseVisualCommand, renderVisualExplainer } from '../../server/visual-explainer.js';
+
+describe('visual-explainer core', () => {
+  it('supports at least five distinct patterns', () => {
+    expect(listVisualPatterns()).toEqual(['table', 'flow', 'timeline', 'hierarchy', 'comparison']);
+  });
+
+  it('parses slash commands', () => {
+    const explain = parseVisualCommand('/explain product strategy > roadmap');
+    const visualize = parseVisualCommand('/visualize A, B --pattern=comparison');
+    expect(explain?.mode).toBe('explain');
+    expect(explain?.subject).toContain('product strategy');
+    expect(visualize?.requestedPattern).toBe('comparison');
+  });
+
+  it('renders interactive HTML output', () => {
+    const rendered = renderVisualExplainer({
+      command: '/visualize intake > classify > route --pattern=flow',
+    });
+    expect(rendered.renderTimeMs).toBeLessThan(3000);
+    expect(rendered.pattern).toBe('flow');
+    expect(rendered.html).toContain('<details');
+    expect(rendered.html).toContain('data-tip=');
+  });
+});
+

--- a/docs/DOC_INDEX.md
+++ b/docs/DOC_INDEX.md
@@ -30,6 +30,7 @@
 - **docs/SELF_IMPROVEMENT_DIGEST.md** – daily self-review digest flow, recommendation approvals, and scope guardrails (#222)
 - **docs/CODE_FACTORY_PIPELINE.md** – risk-tiered CI policy, SHA-discipline, auto-remediation, and harness-gap tracker (#220)
 - **docs/WEBMCP_INTEGRATION.md** – structured website tool discovery/invocation with cache + browser fallback (#225)
+- **docs/VISUAL_EXPLAINER_CANVAS.md** – slash-command visual explainer skill with 5 interactive HTML patterns (#226)
 
 ## VentureOS / Multi-Agent Orchestration
 - **docs/roles/VENTURE_OS.md** – venture studio OS overview (system vs persona)

--- a/docs/VISUAL_EXPLAINER_CANVAS.md
+++ b/docs/VISUAL_EXPLAINER_CANVAS.md
@@ -1,0 +1,28 @@
+# Visual Explainer Canvas Skill
+
+Issue: #226
+
+## Delivered
+
+- visual pattern renderer with 5 templates:
+  - `table`
+  - `flow`
+  - `timeline`
+  - `hierarchy`
+  - `comparison`
+- slash command parsing:
+  - `/explain <topic>`
+  - `/visualize <data> [--pattern=...]`
+- interactive output features:
+  - expandable sections (`<details>`)
+  - hover tooltips (`data-tip`)
+- dashboard API:
+  - `GET /api/visual-explainer/patterns`
+  - `POST /api/visual-explainer/render`
+- dedicated UI surface:
+  - `/visual-explainer` (auth-gated dashboard page)
+
+## Performance
+
+Rendering is pure in-process HTML generation and is designed to complete well under 3 seconds (typically single-digit ms in tests).
+


### PR DESCRIPTION
## Summary
- add visual-explainer skill engine with slash command parsing:
  - `/explain <topic>`
  - `/visualize <data> [--pattern=...]`
- implement 5 interactive visual patterns:
  - table, flow, timeline, hierarchy, comparison
- add API endpoints:
  - `GET /api/visual-explainer/patterns`
  - `POST /api/visual-explainer/render`
- add auth-gated dashboard page `/visual-explainer` with command bar + live render viewport
- add tests and docs for rendering, commands, and route behavior

## Validation
- `cd dashboard && npx -y vitest@4.0.18 run --config /tmp/vitest.local.config.mjs tests/unit/visual-explainer.test.ts tests/unit/routes/visual-explainer.test.ts tests/unit/middleware/rate-limit.test.ts`
- `npm run -s build`

Closes #226
