### PR TITLE
feat: implement proposal->mission->step closed-loop lifecycle

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -173,6 +173,9 @@ See **[docs/API.md](docs/API.md)** for the complete API reference covering all e
 | `POST /api/webmcp/discover` | Discover structured WebMCP tools for a website |
 | `POST /api/webmcp/invoke` | Invoke discovered WebMCP tool with typed args + fallback |
 | `POST /api/visual-explainer/render` | Render slash-command explain/visualize output as interactive HTML |
+| `POST /api/proposal-lifecycle/proposals` | Submit structured proposal for human review before mission execution |
+| `POST /api/proposal-lifecycle/proposals/:proposalId/review` | Approve/reject/modify proposal and create mission on approval |
+| `GET /api/proposal-lifecycle/summary` | Read proposal queue + active mission progress for Mission Control |
 | `GET /api/live` | SSE real-time feed |
 
 ## Architecture

--- a/dashboard/client/index.html
+++ b/dashboard/client/index.html
@@ -4783,6 +4783,17 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
         </div>
       </div>
 
+      <div class="grid grid-2 mb-24" style="align-items:start;">
+        <div class="card">
+          <h3 class="card-title">Proposal Queue</h3>
+          <div id="mcProposalQueue"></div>
+        </div>
+        <div class="card">
+          <h3 class="card-title">Active Proposal Missions</h3>
+          <div id="mcLifecycleMissions"></div>
+        </div>
+      </div>
+
       <div class="card mb-24">
         <h3 class="card-title">Team Status</h3>
         <div id="mcTeamGrid" style="display:grid;grid-template-columns:repeat(3,1fr);gap:12px;"></div>
@@ -6466,6 +6477,7 @@ let ventureosKpis = null;
 let workflowPatterns = null;
 let ventureosAgents = null;
 let missionControl = null;
+let proposalLifecycleSummary = null;
 let schedulerJobs = [];
 let ventureFeatureFlags = { officeViewEnabled: false, updatedAt: 0 };
 let missionOfficeTasks = [];
@@ -8157,17 +8169,19 @@ function renderBarChart(el, items, opts = {}) {
 
 async function fetchMissionControlNow() {
   try {
-    const [mc, kpis, agents, scheduler, flags] = await Promise.all([
+    const [mc, kpis, agents, scheduler, flags, lifecycle] = await Promise.all([
       fetchJson('/api/ventureos-mission-control'),
       fetchJson('/api/ventureos-kpis?days=7'),
       fetchJson('/api/ventureos-agents'),
       fetchJson('/api/scheduler-jobs'),
       fetchJson('/api/ventureos-feature-flags').catch(() => null),
+      fetchJson('/api/proposal-lifecycle/summary').catch(() => null),
     ]);
     missionControl = mc;
     ventureosKpis = kpis;
     ventureosAgents = agents;
     schedulerJobs = Array.isArray(scheduler) ? scheduler : [];
+    proposalLifecycleSummary = lifecycle?.summary || null;
     if (flags && typeof flags === 'object') {
       ventureFeatureFlags = {
         officeViewEnabled: !!flags.officeViewEnabled,
@@ -8205,13 +8219,17 @@ async function fetchVentureosNow() {
 
 async function fetchAgentsNow() {
   try {
-    const [agents, mc] = await Promise.all([
+    const [agents, mc, lifecycle] = await Promise.all([
       fetchJson('/api/ventureos-agents'),
       fetchJson('/api/ventureos-mission-control').catch(() => null),
+      fetchJson('/api/proposal-lifecycle/summary').catch(() => null),
     ]);
     ventureosAgents = agents;
     if (mc && typeof mc === 'object' && !mc.error) {
       missionControl = mc;
+    }
+    if (lifecycle && lifecycle.summary) {
+      proposalLifecycleSummary = lifecycle.summary;
     }
     updateDashboard();
   } catch (e) {
@@ -8602,6 +8620,69 @@ function updateMissionControl() {
       </div>`;
     }).join('');
     listEl.innerHTML = items || '<div class="empty-state-text">No recent completions found</div>';
+  }
+
+  const proposalQueueEl = document.getElementById('mcProposalQueue');
+  if (proposalQueueEl) {
+    const queue = proposalLifecycleSummary?.pendingProposals || [];
+    const cards = queue.map((proposal) => {
+      const skills = (proposal.requiredSkills || []).slice(0, 4).map((skill) => (
+        `<span class="tb-badge" style="background:rgba(96,165,250,0.14);color:var(--cyan);">${escapeHtml(skill)}</span>`
+      )).join('');
+      const riskColor = proposal.riskAssessment?.level === 'critical'
+        ? 'var(--red)'
+        : proposal.riskAssessment?.level === 'high'
+          ? 'var(--yellow)'
+          : 'var(--green)';
+      const riskLabel = (proposal.riskAssessment?.level || 'unknown').toUpperCase();
+      return `<div style="padding:12px;border:1px solid var(--border);border-radius:12px;background:var(--bg-tertiary);margin-bottom:10px;">
+        <div style="display:flex;align-items:flex-start;justify-content:space-between;gap:10px;">
+          <div style="font-weight:800;">${escapeHtml(proposal.title || proposal.goal || proposal.proposalId)}</div>
+          <div class="mono" style="font-size:11px;color:${riskColor};font-weight:800;">${escapeHtml(riskLabel)}</div>
+        </div>
+        <div style="font-size:12px;color:var(--text-muted);margin-top:4px;">${escapeHtml(proposal.goal || '')}</div>
+        <div style="font-size:11px;color:var(--text-muted);margin-top:6px;">By ${escapeHtml(proposal.submittedByAgentId || 'agent')} · ${timeAgo(proposal.updatedAt)}</div>
+        <div style="display:flex;gap:6px;flex-wrap:wrap;margin-top:8px;">${skills}</div>
+      </div>`;
+    }).join('');
+    proposalQueueEl.innerHTML = cards || '<div class="empty-state-text">No proposals awaiting review</div>';
+  }
+
+  const lifecycleEl = document.getElementById('mcLifecycleMissions');
+  if (lifecycleEl) {
+    const missions = proposalLifecycleSummary?.activeMissions || [];
+    const cards = missions.map((mission) => {
+      const done = (mission.steps || []).filter((step) => step.status === 'completed').length;
+      const total = (mission.steps || []).length || 1;
+      const pct = Math.round((done / total) * 100);
+      const stepRows = (mission.steps || []).slice(0, 5).map((step) => {
+        const status = (step.status || 'pending').toUpperCase();
+        const color = step.status === 'completed'
+          ? 'var(--green)'
+          : step.status === 'running'
+            ? 'var(--yellow)'
+            : step.status === 'failed'
+              ? 'var(--red)'
+              : 'var(--text-muted)';
+        return `<div style="display:flex;justify-content:space-between;gap:8px;font-size:12px;margin-top:4px;">
+          <span style="color:var(--text-secondary);">${escapeHtml(step.agentId || 'agent')} · ${escapeHtml(step.title || step.stepId || '')}</span>
+          <span class="mono" style="color:${color};font-weight:800;">${escapeHtml(status)}</span>
+        </div>`;
+      }).join('');
+      const current = mission.currentStepId ? `Current: ${mission.currentStepId}` : 'Awaiting next step';
+      return `<div style="padding:12px;border:1px solid var(--border);border-radius:12px;background:var(--bg-tertiary);margin-bottom:10px;">
+        <div style="display:flex;justify-content:space-between;align-items:center;gap:10px;">
+          <div style="font-weight:800;">${escapeHtml(mission.title || mission.missionId)}</div>
+          <div class="mono" style="font-size:11px;color:var(--accent);font-weight:800;">${escapeHtml((mission.status || '').toUpperCase())}</div>
+        </div>
+        <div style="margin-top:8px;height:8px;background:rgba(99,102,241,0.14);border-radius:999px;overflow:hidden;">
+          <div style="height:100%;width:${pct}%;background:linear-gradient(90deg,var(--accent),var(--cyan));"></div>
+        </div>
+        <div style="font-size:11px;color:var(--text-muted);margin-top:6px;">${done}/${total} steps · ${pct}% · ${escapeHtml(current)}</div>
+        <div style="margin-top:6px;">${stepRows}</div>
+      </div>`;
+    }).join('');
+    lifecycleEl.innerHTML = cards || '<div class="empty-state-text">No active proposal missions</div>';
   }
 
   const schedulerEl = document.getElementById('mcSchedulerJobs');

--- a/dashboard/docs/API.md
+++ b/dashboard/docs/API.md
@@ -21,6 +21,7 @@ Complete reference for all OpenClaw Dashboard HTTP endpoints.
 - [Code Factory Endpoints](#code-factory-endpoints)
 - [WebMCP Endpoints](#webmcp-endpoints)
 - [Visual Explainer Endpoints](#visual-explainer-endpoints)
+- [Proposal Lifecycle Endpoints](#proposal-lifecycle-endpoints)
 - [Schemas](#schemas)
 
 ---
@@ -1200,6 +1201,93 @@ The rendered HTML includes:
 
 ---
 
+## Proposal Lifecycle Endpoints
+
+Closed-loop proposal → mission → step orchestration with human approval gate and live event streaming (Issue #227).
+
+### `POST /api/proposal-lifecycle/proposals`
+
+Submit a structured work proposal from an agent.
+
+**Request:**
+```json
+{
+  "title": "Ship partner onboarding flow",
+  "goal": "Implement and verify onboarding automation",
+  "submittedByAgentId": "echo",
+  "estimatedCostUsd": 8.5,
+  "requiredSkills": ["backend", "qa", "docs"],
+  "riskAssessment": {
+    "level": "medium",
+    "summary": "API contract drift risk",
+    "mitigations": ["contract tests", "staged rollout"]
+  },
+  "steps": [
+    {
+      "stepId": "build",
+      "title": "Implement workflow",
+      "description": "Create onboarding orchestration",
+      "agentId": "synth"
+    },
+    {
+      "stepId": "verify",
+      "title": "Run validation",
+      "description": "Execute QA + acceptance tests",
+      "agentId": "verifier",
+      "dependsOnStepIds": ["build"]
+    }
+  ]
+}
+```
+
+### `GET /api/proposal-lifecycle/proposals`
+
+List proposals (`?status=pending|approved|rejected|needs_changes&limit=50`).
+
+### `POST /api/proposal-lifecycle/proposals/:proposalId/review`
+
+Human review decision. Approval is required before mission execution.
+
+**Request:**
+```json
+{
+  "action": "approve",
+  "reviewerId": "human",
+  "notes": "Approved for execution",
+  "autoStart": true
+}
+```
+
+### `GET /api/proposal-lifecycle/missions`
+
+List derived missions (`?status=pending|running|completed|failed|blocked`).
+
+### `GET /api/proposal-lifecycle/missions/:missionId`
+
+Get mission detail including step states and current step pointer.
+
+### `POST /api/proposal-lifecycle/missions/:missionId/start`
+
+Manually start an approved mission (if not auto-started during review).
+
+### `GET /api/proposal-lifecycle/events`
+
+Query lifecycle events (`?missionId=...&proposalId=...&limit=100`).
+
+### `GET /api/proposal-lifecycle/summary`
+
+Dashboard summary payload:
+- pending proposal queue
+- active proposal missions
+- recent event timeline
+
+### `GET /api/proposal-lifecycle/events/stream`
+
+WebSocket stream endpoint for real-time lifecycle events.
+If requested over plain HTTP, returns `426 Upgrade Required`.
+
+---
+
 ## Rate Limiting
 
 Per-IP, per-endpoint sliding window rate limits:
@@ -1215,6 +1303,7 @@ Per-IP, per-endpoint sliding window rate limits:
 | `/api/code-factory*` | 20 req | 60s |
 | `/api/webmcp*` | 30 req | 60s |
 | `/api/visual-explainer*` | 30 req | 60s |
+| `/api/proposal-lifecycle*` | 30 req | 60s |
 | `/api/ventureos-agents` | 30 req | 60s |
 | `/api/ventureos-kpis` | 30 req | 60s |
 | `/api/rpg/*` | 20 req | 60s |

--- a/dashboard/server/middleware/rate-limit.ts
+++ b/dashboard/server/middleware/rate-limit.ts
@@ -99,6 +99,7 @@ export const LIMITS: Record<string, RateLimitConfig> = {
   '/api/code-factory':        { limit: 20, windowMs: 60000 },
   '/api/webmcp':              { limit: 30, windowMs: 60000 },
   '/api/visual-explainer':    { limit: 30, windowMs: 60000 },
+  '/api/proposal-lifecycle':  { limit: 30, windowMs: 60000 },
   '/api/replay':              { limit: 10, windowMs: 60000 },
   '/api/live':                { limit: 10, windowMs: 60000 },
   '/api/conversation':        { limit: 30, windowMs: 60000 },

--- a/dashboard/server/proposal-lifecycle.ts
+++ b/dashboard/server/proposal-lifecycle.ts
@@ -1,0 +1,792 @@
+/**
+ * Proposal → Mission → Step closed-loop lifecycle engine (Issue #227).
+ *
+ * Responsibilities:
+ * - Track structured proposals with explicit approval gate.
+ * - Materialize approved proposals into mission step plans.
+ * - Execute mission steps in dependency order with cross-agent handoffs.
+ * - Persist history + event log for dashboard/API consumers.
+ */
+
+import crypto from 'node:crypto';
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export type ProposalStatus = 'pending' | 'approved' | 'rejected' | 'needs_changes';
+export type ProposalRiskLevel = 'low' | 'medium' | 'high' | 'critical';
+export type MissionStatus = 'pending' | 'running' | 'completed' | 'failed' | 'blocked';
+export type StepStatus = 'pending' | 'running' | 'completed' | 'failed' | 'blocked';
+export type ProposalReviewAction = 'approve' | 'reject' | 'modify';
+
+export interface ProposalRiskAssessment {
+  level: ProposalRiskLevel;
+  summary: string;
+  mitigations: string[];
+}
+
+export interface ProposalStepTemplate {
+  stepId: string;
+  title: string;
+  description: string;
+  agentId: string;
+  dependsOnStepIds: string[];
+  expectedOutcome?: string;
+  simulateFailure?: boolean;
+}
+
+export interface WorkProposal {
+  proposalId: string;
+  title: string;
+  goal: string;
+  submittedByAgentId: string;
+  estimatedCostUsd: number;
+  requiredSkills: string[];
+  riskAssessment: ProposalRiskAssessment;
+  steps: ProposalStepTemplate[];
+  status: ProposalStatus;
+  missionId?: string;
+  createdAt: string;
+  updatedAt: string;
+  review?: {
+    action: ProposalReviewAction;
+    reviewerId: string;
+    notes?: string;
+    reviewedAt: string;
+  };
+}
+
+export interface MissionStep {
+  stepId: string;
+  order: number;
+  title: string;
+  description: string;
+  agentId: string;
+  dependsOnStepIds: string[];
+  status: StepStatus;
+  expectedOutcome?: string;
+  startedAt?: string;
+  finishedAt?: string;
+  summary?: string;
+  error?: string;
+  simulateFailure?: boolean;
+}
+
+export interface ProposalMission {
+  missionId: string;
+  proposalId: string;
+  title: string;
+  status: MissionStatus;
+  createdAt: string;
+  updatedAt: string;
+  startedAt?: string;
+  finishedAt?: string;
+  currentStepId?: string;
+  steps: MissionStep[];
+}
+
+export type ProposalLifecycleEventType =
+  | 'proposal.submitted'
+  | 'proposal.reviewed'
+  | 'mission.created'
+  | 'mission.started'
+  | 'step.assigned'
+  | 'step.started'
+  | 'step.completed'
+  | 'step.failed'
+  | 'step.handoff'
+  | 'mission.completed'
+  | 'mission.failed';
+
+export interface ProposalLifecycleEvent {
+  eventId: string;
+  type: ProposalLifecycleEventType;
+  ts: string;
+  proposalId?: string;
+  missionId?: string;
+  stepId?: string;
+  agentId?: string;
+  toAgentId?: string;
+  payload?: Record<string, unknown>;
+}
+
+interface ProposalLifecycleStore {
+  version: 1;
+  proposals: WorkProposal[];
+  missions: ProposalMission[];
+  events: ProposalLifecycleEvent[];
+}
+
+export interface SubmitProposalInput {
+  title: string;
+  goal: string;
+  submittedByAgentId: string;
+  estimatedCostUsd: number;
+  requiredSkills: string[];
+  riskAssessment: ProposalRiskAssessment;
+  steps: Array<{
+    stepId?: string;
+    title: string;
+    description: string;
+    agentId: string;
+    dependsOnStepIds?: string[];
+    expectedOutcome?: string;
+    simulateFailure?: boolean;
+  }>;
+}
+
+export interface ProposalPatchInput {
+  title?: string;
+  goal?: string;
+  estimatedCostUsd?: number;
+  requiredSkills?: string[];
+  riskAssessment?: Partial<ProposalRiskAssessment>;
+  steps?: SubmitProposalInput['steps'];
+}
+
+export interface ReviewProposalInput {
+  action: ProposalReviewAction;
+  reviewerId: string;
+  notes?: string;
+  modifications?: ProposalPatchInput;
+  autoStart?: boolean;
+}
+
+export interface StartMissionInput {
+  missionId: string;
+}
+
+export interface ProposalLifecycleSummary {
+  pendingProposals: WorkProposal[];
+  activeMissions: ProposalMission[];
+  recentEvents: ProposalLifecycleEvent[];
+  stats: {
+    totalProposals: number;
+    totalMissions: number;
+    pendingApprovals: number;
+    runningMissions: number;
+  };
+}
+
+interface ProposalLifecycleEngineOptions {
+  now?: () => Date;
+  stepDelayMs?: number;
+}
+
+const STORE_FILE = 'proposal-lifecycle.json';
+const MAX_EVENTS = 2000;
+const DEFAULT_STEP_DELAY_MS = 30;
+
+function nowIso(now: () => Date): string {
+  return now().toISOString();
+}
+
+function sanitizeText(input: unknown, fallback = ''): string {
+  if (typeof input !== 'string') return fallback;
+  return input.trim();
+}
+
+function sanitizeId(input: unknown, fallbackPrefix: string): string {
+  const cleaned = sanitizeText(input)
+    .toLowerCase()
+    .replace(/[^a-z0-9._-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+  return cleaned || `${fallbackPrefix}-${crypto.randomUUID().slice(0, 8)}`;
+}
+
+function clampNonNegativeNumber(input: unknown, fallback = 0): number {
+  const n = Number(input);
+  if (!Number.isFinite(n)) return fallback;
+  return Math.max(0, n);
+}
+
+function uniqueStrings(values: unknown[], limit = 30): string[] {
+  const out: string[] = [];
+  const seen = new Set<string>();
+  for (const value of values) {
+    const normalized = sanitizeText(value).toLowerCase();
+    if (!normalized || seen.has(normalized)) continue;
+    seen.add(normalized);
+    out.push(normalized);
+    if (out.length >= limit) break;
+  }
+  return out;
+}
+
+function deepClone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function readStore(storePath: string): ProposalLifecycleStore {
+  try {
+    if (!fs.existsSync(storePath)) {
+      return { version: 1, proposals: [], missions: [], events: [] };
+    }
+    const raw = JSON.parse(fs.readFileSync(storePath, 'utf8')) as Partial<ProposalLifecycleStore>;
+    return {
+      version: 1,
+      proposals: Array.isArray(raw.proposals) ? raw.proposals : [],
+      missions: Array.isArray(raw.missions) ? raw.missions : [],
+      events: Array.isArray(raw.events) ? raw.events : [],
+    };
+  } catch {
+    return { version: 1, proposals: [], missions: [], events: [] };
+  }
+}
+
+function normalizeRiskAssessment(input: Partial<ProposalRiskAssessment> | undefined): ProposalRiskAssessment {
+  const levelRaw = sanitizeText(input?.level, 'medium').toLowerCase();
+  const level: ProposalRiskLevel =
+    levelRaw === 'low' || levelRaw === 'medium' || levelRaw === 'high' || levelRaw === 'critical'
+      ? levelRaw
+      : 'medium';
+
+  return {
+    level,
+    summary: sanitizeText(input?.summary, 'Risk review pending'),
+    mitigations: uniqueStrings(Array.isArray(input?.mitigations) ? input.mitigations : []),
+  };
+}
+
+function normalizeSteps(stepsInput: SubmitProposalInput['steps']): ProposalStepTemplate[] {
+  if (!Array.isArray(stepsInput) || stepsInput.length === 0) {
+    throw new Error('Proposal must define at least one step');
+  }
+
+  const normalized = stepsInput.map((raw, idx) => {
+    const stepId = sanitizeId(raw.stepId, `step-${idx + 1}`);
+    const title = sanitizeText(raw.title);
+    const description = sanitizeText(raw.description);
+    const agentId = sanitizeId(raw.agentId, 'agent');
+
+    if (!title) throw new Error(`Step ${idx + 1} is missing title`);
+    if (!description) throw new Error(`Step ${idx + 1} is missing description`);
+
+    return {
+      stepId,
+      title,
+      description,
+      agentId,
+      dependsOnStepIds: Array.isArray(raw.dependsOnStepIds)
+        ? raw.dependsOnStepIds.map((value) => sanitizeId(value, 'step')).filter(Boolean)
+        : [],
+      expectedOutcome: sanitizeText(raw.expectedOutcome) || undefined,
+      simulateFailure: raw.simulateFailure === true,
+    } satisfies ProposalStepTemplate;
+  });
+
+  const existingIds = new Set(normalized.map((s) => s.stepId));
+  for (const step of normalized) {
+    step.dependsOnStepIds = step.dependsOnStepIds.filter((id) => id !== step.stepId && existingIds.has(id));
+  }
+
+  // Default to sequential chain when dependencies are omitted.
+  for (let i = 0; i < normalized.length; i += 1) {
+    if (normalized[i].dependsOnStepIds.length === 0 && i > 0) {
+      normalized[i].dependsOnStepIds = [normalized[i - 1].stepId];
+    }
+  }
+
+  return normalized;
+}
+
+function proposalToMission(proposal: WorkProposal, ts: string): ProposalMission {
+  return {
+    missionId: `mission-${crypto.randomUUID().slice(0, 8)}`,
+    proposalId: proposal.proposalId,
+    title: proposal.title,
+    status: 'pending',
+    createdAt: ts,
+    updatedAt: ts,
+    steps: proposal.steps.map((step, index) => ({
+      stepId: step.stepId,
+      order: index + 1,
+      title: step.title,
+      description: step.description,
+      agentId: step.agentId,
+      dependsOnStepIds: step.dependsOnStepIds.slice(),
+      status: 'pending',
+      expectedOutcome: step.expectedOutcome,
+      simulateFailure: step.simulateFailure,
+    })),
+  };
+}
+
+function dependenciesSatisfied(step: MissionStep, completedStepIds: Set<string>): boolean {
+  return step.dependsOnStepIds.every((dep) => completedStepIds.has(dep));
+}
+
+function delay(ms: number): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export class ProposalLifecycleEngine extends EventEmitter {
+  private readonly storePath: string;
+  private readonly now: () => Date;
+  private readonly stepDelayMs: number;
+  private readonly runningMissions = new Set<string>();
+  private store: ProposalLifecycleStore;
+
+  constructor(dataDir: string, opts: ProposalLifecycleEngineOptions = {}) {
+    super();
+    this.storePath = path.join(dataDir, STORE_FILE);
+    this.now = opts.now ?? (() => new Date());
+    this.stepDelayMs = Math.max(0, Math.min(5000, Math.trunc(opts.stepDelayMs ?? DEFAULT_STEP_DELAY_MS)));
+    this.store = readStore(this.storePath);
+  }
+
+  listProposals(filter: { status?: ProposalStatus; limit?: number } = {}): WorkProposal[] {
+    const limit = Math.max(1, Math.min(500, Math.trunc(filter.limit ?? 200)));
+    const status = sanitizeText(filter.status);
+    const proposals = this.store.proposals
+      .slice()
+      .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))
+      .filter((proposal) => !status || proposal.status === status);
+    return deepClone(proposals.slice(0, limit));
+  }
+
+  getProposal(proposalId: string): WorkProposal | null {
+    const found = this.store.proposals.find((proposal) => proposal.proposalId === proposalId);
+    return found ? deepClone(found) : null;
+  }
+
+  submitProposal(input: SubmitProposalInput): WorkProposal {
+    const title = sanitizeText(input.title);
+    const goal = sanitizeText(input.goal);
+    const submittedByAgentId = sanitizeId(input.submittedByAgentId, 'agent');
+    if (!title) throw new Error('Proposal title is required');
+    if (!goal) throw new Error('Proposal goal is required');
+
+    const ts = nowIso(this.now);
+    const proposal: WorkProposal = {
+      proposalId: `proposal-${crypto.randomUUID().slice(0, 8)}`,
+      title,
+      goal,
+      submittedByAgentId,
+      estimatedCostUsd: clampNonNegativeNumber(input.estimatedCostUsd, 0),
+      requiredSkills: uniqueStrings(Array.isArray(input.requiredSkills) ? input.requiredSkills : []),
+      riskAssessment: normalizeRiskAssessment(input.riskAssessment),
+      steps: normalizeSteps(input.steps),
+      status: 'pending',
+      createdAt: ts,
+      updatedAt: ts,
+    };
+
+    this.store.proposals.push(proposal);
+    this.pushEvent({
+      type: 'proposal.submitted',
+      ts,
+      proposalId: proposal.proposalId,
+      payload: {
+        title: proposal.title,
+        submittedByAgentId: proposal.submittedByAgentId,
+        estimatedCostUsd: proposal.estimatedCostUsd,
+      },
+    });
+    this.persist();
+    return deepClone(proposal);
+  }
+
+  reviewProposal(proposalId: string, review: ReviewProposalInput): {
+    proposal: WorkProposal;
+    mission?: ProposalMission;
+  } {
+    const proposal = this.store.proposals.find((item) => item.proposalId === proposalId);
+    if (!proposal) throw new Error(`Proposal not found: ${proposalId}`);
+    if (proposal.status === 'approved' || proposal.status === 'rejected') {
+      throw new Error(`Proposal already finalized with status: ${proposal.status}`);
+    }
+
+    const action = sanitizeText(review.action).toLowerCase();
+    if (action !== 'approve' && action !== 'reject' && action !== 'modify') {
+      throw new Error(`Unsupported review action: ${review.action}`);
+    }
+    const reviewerId = sanitizeId(review.reviewerId, 'human');
+    const notes = sanitizeText(review.notes) || undefined;
+
+    if (review.modifications) {
+      this.applyProposalPatch(proposal, review.modifications);
+    }
+
+    const ts = nowIso(this.now);
+    proposal.status = action === 'approve'
+      ? 'approved'
+      : action === 'reject'
+        ? 'rejected'
+        : 'needs_changes';
+    proposal.updatedAt = ts;
+    proposal.review = {
+      action,
+      reviewerId,
+      notes,
+      reviewedAt: ts,
+    };
+
+    this.pushEvent({
+      type: 'proposal.reviewed',
+      ts,
+      proposalId: proposal.proposalId,
+      payload: {
+        action,
+        reviewerId,
+        notes,
+      },
+    });
+
+    let mission: ProposalMission | undefined;
+    if (proposal.status === 'approved') {
+      mission = proposalToMission(proposal, ts);
+      proposal.missionId = mission.missionId;
+      this.store.missions.push(mission);
+      this.pushEvent({
+        type: 'mission.created',
+        ts,
+        proposalId: proposal.proposalId,
+        missionId: mission.missionId,
+        payload: {
+          title: mission.title,
+          stepCount: mission.steps.length,
+        },
+      });
+
+      const autoStart = review.autoStart !== false;
+      if (autoStart) {
+        mission = this.startMission({ missionId: mission.missionId });
+      }
+    }
+
+    this.persist();
+    return {
+      proposal: deepClone(proposal),
+      mission: mission ? deepClone(mission) : undefined,
+    };
+  }
+
+  listMissions(filter: { status?: MissionStatus; limit?: number } = {}): ProposalMission[] {
+    const limit = Math.max(1, Math.min(500, Math.trunc(filter.limit ?? 200)));
+    const status = sanitizeText(filter.status);
+    const missions = this.store.missions
+      .slice()
+      .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))
+      .filter((mission) => !status || mission.status === status);
+    return deepClone(missions.slice(0, limit));
+  }
+
+  getMission(missionId: string): ProposalMission | null {
+    const mission = this.store.missions.find((item) => item.missionId === missionId);
+    return mission ? deepClone(mission) : null;
+  }
+
+  startMission(input: StartMissionInput): ProposalMission {
+    const mission = this.store.missions.find((item) => item.missionId === input.missionId);
+    if (!mission) throw new Error(`Mission not found: ${input.missionId}`);
+    if (mission.status === 'running' || mission.status === 'completed') return deepClone(mission);
+    if (mission.status === 'failed') throw new Error(`Mission already failed: ${input.missionId}`);
+
+    const proposal = this.store.proposals.find((item) => item.proposalId === mission.proposalId);
+    if (!proposal || proposal.status !== 'approved') {
+      throw new Error('Mission cannot start before proposal approval');
+    }
+
+    const ts = nowIso(this.now);
+    mission.status = 'running';
+    mission.startedAt = mission.startedAt ?? ts;
+    mission.updatedAt = ts;
+    mission.currentStepId = mission.currentStepId ?? mission.steps.find((step) => step.status === 'pending')?.stepId;
+
+    this.pushEvent({
+      type: 'mission.started',
+      ts,
+      proposalId: mission.proposalId,
+      missionId: mission.missionId,
+      payload: {
+        title: mission.title,
+      },
+    });
+    this.persist();
+    this.scheduleMissionExecution(mission.missionId);
+    return deepClone(mission);
+  }
+
+  listEvents(filter: { missionId?: string; proposalId?: string; limit?: number } = {}): ProposalLifecycleEvent[] {
+    const limit = Math.max(1, Math.min(1000, Math.trunc(filter.limit ?? 200)));
+    const missionId = sanitizeText(filter.missionId);
+    const proposalId = sanitizeText(filter.proposalId);
+    const events = this.store.events
+      .slice()
+      .sort((a, b) => Date.parse(b.ts) - Date.parse(a.ts))
+      .filter((event) => (!missionId || event.missionId === missionId) && (!proposalId || event.proposalId === proposalId));
+    return deepClone(events.slice(0, limit));
+  }
+
+  getSummary(): ProposalLifecycleSummary {
+    const pendingProposals = this.store.proposals
+      .filter((proposal) => proposal.status === 'pending' || proposal.status === 'needs_changes')
+      .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))
+      .slice(0, 25);
+    const activeMissions = this.store.missions
+      .filter((mission) => mission.status === 'running' || mission.status === 'pending' || mission.status === 'blocked')
+      .sort((a, b) => Date.parse(b.updatedAt) - Date.parse(a.updatedAt))
+      .slice(0, 20);
+    const recentEvents = this.store.events
+      .slice()
+      .sort((a, b) => Date.parse(b.ts) - Date.parse(a.ts))
+      .slice(0, 80);
+
+    return deepClone({
+      pendingProposals,
+      activeMissions,
+      recentEvents,
+      stats: {
+        totalProposals: this.store.proposals.length,
+        totalMissions: this.store.missions.length,
+        pendingApprovals: this.store.proposals.filter((proposal) => proposal.status === 'pending').length,
+        runningMissions: this.store.missions.filter((mission) => mission.status === 'running').length,
+      },
+    });
+  }
+
+  subscribe(listener: (event: ProposalLifecycleEvent) => void): () => void {
+    this.on('event', listener);
+    return () => {
+      this.off('event', listener);
+    };
+  }
+
+  private applyProposalPatch(proposal: WorkProposal, patch: ProposalPatchInput): void {
+    const nextTitle = sanitizeText(patch.title);
+    if (nextTitle) proposal.title = nextTitle;
+
+    const nextGoal = sanitizeText(patch.goal);
+    if (nextGoal) proposal.goal = nextGoal;
+
+    if (patch.estimatedCostUsd != null) {
+      proposal.estimatedCostUsd = clampNonNegativeNumber(patch.estimatedCostUsd, proposal.estimatedCostUsd);
+    }
+
+    if (Array.isArray(patch.requiredSkills)) {
+      proposal.requiredSkills = uniqueStrings(patch.requiredSkills);
+    }
+
+    if (patch.riskAssessment) {
+      proposal.riskAssessment = normalizeRiskAssessment({
+        ...proposal.riskAssessment,
+        ...patch.riskAssessment,
+      });
+    }
+
+    if (Array.isArray(patch.steps) && patch.steps.length > 0) {
+      proposal.steps = normalizeSteps(patch.steps);
+    }
+  }
+
+  private scheduleMissionExecution(missionId: string): void {
+    if (this.runningMissions.has(missionId)) return;
+    this.runningMissions.add(missionId);
+
+    void this.runMission(missionId).finally(() => {
+      this.runningMissions.delete(missionId);
+    });
+  }
+
+  private async runMission(missionId: string): Promise<void> {
+    while (true) {
+      const mission = this.store.missions.find((item) => item.missionId === missionId);
+      if (!mission) return;
+      if (mission.status !== 'running') return;
+
+      const completedStepIds = new Set(
+        mission.steps.filter((step) => step.status === 'completed').map((step) => step.stepId),
+      );
+
+      const pendingSteps = mission.steps.filter((step) => step.status === 'pending');
+      if (pendingSteps.length === 0) {
+        const ts = nowIso(this.now);
+        mission.status = 'completed';
+        mission.finishedAt = ts;
+        mission.updatedAt = ts;
+        mission.currentStepId = undefined;
+        this.pushEvent({
+          type: 'mission.completed',
+          ts,
+          missionId: mission.missionId,
+          proposalId: mission.proposalId,
+          payload: {
+            stepCount: mission.steps.length,
+          },
+        });
+        this.persist();
+        return;
+      }
+
+      const readySteps = pendingSteps
+        .filter((step) => dependenciesSatisfied(step, completedStepIds))
+        .sort((a, b) => a.order - b.order);
+
+      if (readySteps.length === 0) {
+        const ts = nowIso(this.now);
+        mission.status = 'blocked';
+        mission.updatedAt = ts;
+        this.pushEvent({
+          type: 'mission.failed',
+          ts,
+          missionId: mission.missionId,
+          proposalId: mission.proposalId,
+          payload: {
+            reason: 'No runnable steps found. Check dependencies.',
+          },
+        });
+        this.persist();
+        return;
+      }
+
+      const step = readySteps[0];
+      const startedAt = nowIso(this.now);
+      mission.currentStepId = step.stepId;
+      mission.updatedAt = startedAt;
+      step.status = 'running';
+      step.startedAt = startedAt;
+
+      this.pushEvent({
+        type: 'step.assigned',
+        ts: startedAt,
+        missionId: mission.missionId,
+        proposalId: mission.proposalId,
+        stepId: step.stepId,
+        agentId: step.agentId,
+        payload: {
+          order: step.order,
+          title: step.title,
+        },
+      });
+      this.pushEvent({
+        type: 'step.started',
+        ts: startedAt,
+        missionId: mission.missionId,
+        proposalId: mission.proposalId,
+        stepId: step.stepId,
+        agentId: step.agentId,
+      });
+      this.persist();
+
+      await delay(this.stepDelayMs);
+
+      const ts = nowIso(this.now);
+      mission.updatedAt = ts;
+      if (step.simulateFailure) {
+        step.status = 'failed';
+        step.finishedAt = ts;
+        step.error = 'Simulated step failure';
+        mission.status = 'failed';
+        mission.finishedAt = ts;
+        mission.currentStepId = step.stepId;
+        this.pushEvent({
+          type: 'step.failed',
+          ts,
+          missionId: mission.missionId,
+          proposalId: mission.proposalId,
+          stepId: step.stepId,
+          agentId: step.agentId,
+          payload: {
+            error: step.error,
+          },
+        });
+        this.pushEvent({
+          type: 'mission.failed',
+          ts,
+          missionId: mission.missionId,
+          proposalId: mission.proposalId,
+          payload: {
+            failedStepId: step.stepId,
+            failedAgentId: step.agentId,
+          },
+        });
+        this.persist();
+        return;
+      }
+
+      step.status = 'completed';
+      step.finishedAt = ts;
+      step.summary = step.expectedOutcome || `Completed by ${step.agentId}`;
+      this.pushEvent({
+        type: 'step.completed',
+        ts,
+        missionId: mission.missionId,
+        proposalId: mission.proposalId,
+        stepId: step.stepId,
+        agentId: step.agentId,
+        payload: {
+          summary: step.summary,
+        },
+      });
+
+      const completedAfterStep = new Set(
+        mission.steps.filter((item) => item.status === 'completed').map((item) => item.stepId),
+      );
+      const newlyReady = mission.steps
+        .filter((item) => item.status === 'pending')
+        .filter((item) => dependenciesSatisfied(item, completedAfterStep))
+        .sort((a, b) => a.order - b.order);
+
+      for (const nextStep of newlyReady) {
+        if (nextStep.agentId !== step.agentId) {
+          this.pushEvent({
+            type: 'step.handoff',
+            ts,
+            missionId: mission.missionId,
+            proposalId: mission.proposalId,
+            stepId: nextStep.stepId,
+            agentId: step.agentId,
+            toAgentId: nextStep.agentId,
+            payload: {
+              fromStepId: step.stepId,
+              toStepId: nextStep.stepId,
+            },
+          });
+        }
+      }
+
+      this.persist();
+    }
+  }
+
+  private pushEvent(event: Omit<ProposalLifecycleEvent, 'eventId'>): void {
+    const next: ProposalLifecycleEvent = {
+      ...event,
+      eventId: `evt-${crypto.randomUUID().slice(0, 10)}`,
+    };
+    this.store.events.push(next);
+    if (this.store.events.length > MAX_EVENTS) {
+      this.store.events.splice(0, this.store.events.length - MAX_EVENTS);
+    }
+    this.emit('event', deepClone(next));
+  }
+
+  private persist(): void {
+    fs.mkdirSync(path.dirname(this.storePath), { recursive: true });
+    fs.writeFileSync(this.storePath, JSON.stringify(this.store, null, 2), 'utf8');
+  }
+}
+
+const engineCache = new Map<string, ProposalLifecycleEngine>();
+
+export function getProposalLifecycleEngine(
+  dataDir: string,
+  opts: ProposalLifecycleEngineOptions = {},
+): ProposalLifecycleEngine {
+  const key = path.resolve(dataDir);
+  const cached = engineCache.get(key);
+  if (cached) return cached;
+  const engine = new ProposalLifecycleEngine(key, opts);
+  engineCache.set(key, engine);
+  return engine;
+}
+
+export function resetProposalLifecycleEngine(dataDir?: string): void {
+  if (!dataDir) {
+    engineCache.clear();
+    return;
+  }
+  engineCache.delete(path.resolve(dataDir));
+}

--- a/dashboard/server/routes/index.ts
+++ b/dashboard/server/routes/index.ts
@@ -42,6 +42,7 @@ export {
 } from '../task-board-events.js';
 export type { SseSubscriptionFilter } from '../task-board-events.js';
 export { handleMemoryState } from './memory-state.js';
+export { handleProposalLifecycle, handleProposalLifecycleUpgrade } from './proposal-lifecycle.js';
 export { handleSharedContext } from './shared-context.js';
 export {
   readAlertConfig,

--- a/dashboard/server/routes/proposal-lifecycle.ts
+++ b/dashboard/server/routes/proposal-lifecycle.ts
@@ -1,0 +1,403 @@
+/**
+ * Proposal → Mission → Step lifecycle API routes (Issue #227).
+ */
+
+import crypto from 'node:crypto';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import type { Socket } from 'node:net';
+
+import {
+  getProposalLifecycleEngine,
+  type MissionStatus,
+  type ProposalStatus,
+} from '../proposal-lifecycle.js';
+
+export interface ProposalLifecycleRouteDeps {
+  dataDir: string;
+  sendJson: (res: ServerResponse, data: unknown, status?: number) => void;
+  readRequestBody: (req: IncomingMessage, opts?: { maxBytes?: number }) => Promise<string>;
+  isAuthenticated?: (req: IncomingMessage) => boolean;
+}
+
+function parseUrl(req: IncomingMessage): URL | null {
+  try {
+    return new URL(req.url ?? '', 'http://localhost');
+  } catch {
+    return null;
+  }
+}
+
+function parseJson<T>(raw: string): T | null {
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+function sanitize(input: unknown): string {
+  return typeof input === 'string' ? input.trim() : '';
+}
+
+function parseLimit(raw: string | null, fallback: number, min: number, max: number): number {
+  const n = Number.parseInt(String(raw ?? ''), 10);
+  if (Number.isNaN(n)) return fallback;
+  return Math.max(min, Math.min(max, n));
+}
+
+function asProposalStatus(raw: string | null): ProposalStatus | undefined {
+  const value = sanitize(raw).toLowerCase();
+  if (value === 'pending' || value === 'approved' || value === 'rejected' || value === 'needs_changes') {
+    return value;
+  }
+  return undefined;
+}
+
+function asMissionStatus(raw: string | null): MissionStatus | undefined {
+  const value = sanitize(raw).toLowerCase();
+  if (value === 'pending' || value === 'running' || value === 'completed' || value === 'failed' || value === 'blocked') {
+    return value;
+  }
+  return undefined;
+}
+
+function wsFrameFromJson(payload: unknown): Buffer {
+  const data = Buffer.from(JSON.stringify(payload), 'utf8');
+  const len = data.length;
+
+  if (len < 126) {
+    const out = Buffer.allocUnsafe(2 + len);
+    out[0] = 0x81;
+    out[1] = len;
+    data.copy(out, 2);
+    return out;
+  }
+
+  if (len < 65536) {
+    const out = Buffer.allocUnsafe(4 + len);
+    out[0] = 0x81;
+    out[1] = 126;
+    out.writeUInt16BE(len, 2);
+    data.copy(out, 4);
+    return out;
+  }
+
+  const out = Buffer.allocUnsafe(10 + len);
+  out[0] = 0x81;
+  out[1] = 127;
+  out.writeUInt32BE(0, 2);
+  out.writeUInt32BE(len, 6);
+  data.copy(out, 10);
+  return out;
+}
+
+function writeUpgradeError(socket: Socket, status: number, message: string): void {
+  const body = JSON.stringify({ ok: false, error: message });
+  socket.write(
+    `HTTP/1.1 ${status} Error\r\n` +
+      'Content-Type: application/json\r\n' +
+      `Content-Length: ${Buffer.byteLength(body)}\r\n` +
+      'Connection: close\r\n' +
+      '\r\n' +
+      body,
+  );
+  socket.destroy();
+}
+
+export async function handleProposalLifecycle(
+  req: IncomingMessage,
+  res: ServerResponse,
+  deps: ProposalLifecycleRouteDeps,
+): Promise<boolean> {
+  if (!req.url || !req.url.startsWith('/api/proposal-lifecycle')) return false;
+  const url = parseUrl(req);
+  if (!url) {
+    deps.sendJson(res, { ok: false, error: 'Bad request URL' }, 400);
+    return true;
+  }
+  const engine = getProposalLifecycleEngine(deps.dataDir);
+  const method = req.method ?? 'GET';
+  const pathname = url.pathname;
+
+  if (method === 'GET' && pathname === '/api/proposal-lifecycle/summary') {
+    deps.sendJson(res, { ok: true, summary: engine.getSummary() });
+    return true;
+  }
+
+  if (method === 'GET' && pathname === '/api/proposal-lifecycle/proposals') {
+    const status = asProposalStatus(url.searchParams.get('status'));
+    const limit = parseLimit(url.searchParams.get('limit'), 50, 1, 500);
+    deps.sendJson(res, { ok: true, proposals: engine.listProposals({ status, limit }) });
+    return true;
+  }
+
+  if (method === 'POST' && pathname === '/api/proposal-lifecycle/proposals') {
+    const payload = parseJson<{
+      title?: string;
+      goal?: string;
+      submittedByAgentId?: string;
+      estimatedCostUsd?: number;
+      requiredSkills?: string[];
+      riskAssessment?: {
+        level?: string;
+        summary?: string;
+        mitigations?: string[];
+      };
+      steps?: Array<{
+        stepId?: string;
+        title?: string;
+        description?: string;
+        agentId?: string;
+        dependsOnStepIds?: string[];
+        expectedOutcome?: string;
+        simulateFailure?: boolean;
+      }>;
+    }>(await deps.readRequestBody(req, { maxBytes: 262_144 })) ?? {};
+
+    try {
+      const proposal = engine.submitProposal({
+        title: sanitize(payload.title),
+        goal: sanitize(payload.goal),
+        submittedByAgentId: sanitize(payload.submittedByAgentId) || 'agent',
+        estimatedCostUsd: Number(payload.estimatedCostUsd ?? 0),
+        requiredSkills: Array.isArray(payload.requiredSkills) ? payload.requiredSkills : [],
+        riskAssessment: {
+          level: sanitize(payload.riskAssessment?.level) as 'low' | 'medium' | 'high' | 'critical',
+          summary: sanitize(payload.riskAssessment?.summary),
+          mitigations: Array.isArray(payload.riskAssessment?.mitigations) ? payload.riskAssessment.mitigations : [],
+        },
+        steps: Array.isArray(payload.steps)
+          ? payload.steps.map((step) => ({
+            stepId: sanitize(step.stepId) || undefined,
+            title: sanitize(step.title),
+            description: sanitize(step.description),
+            agentId: sanitize(step.agentId) || 'agent',
+            dependsOnStepIds: Array.isArray(step.dependsOnStepIds) ? step.dependsOnStepIds : [],
+            expectedOutcome: sanitize(step.expectedOutcome) || undefined,
+            simulateFailure: step.simulateFailure === true,
+          }))
+          : [],
+      });
+      deps.sendJson(res, { ok: true, proposal }, 201);
+      return true;
+    } catch (err: unknown) {
+      deps.sendJson(res, { ok: false, error: err instanceof Error ? err.message : 'Failed to submit proposal' }, 400);
+      return true;
+    }
+  }
+
+  if (method === 'POST' && pathname.startsWith('/api/proposal-lifecycle/proposals/') && pathname.endsWith('/review')) {
+    const proposalId = sanitize(pathname.split('/api/proposal-lifecycle/proposals/')[1]?.replace('/review', ''));
+    if (!proposalId) {
+      deps.sendJson(res, { ok: false, error: 'proposalId is required' }, 400);
+      return true;
+    }
+    const payload = parseJson<{
+      action?: 'approve' | 'reject' | 'modify';
+      reviewerId?: string;
+      notes?: string;
+      autoStart?: boolean;
+      modifications?: {
+        title?: string;
+        goal?: string;
+        estimatedCostUsd?: number;
+        requiredSkills?: string[];
+        riskAssessment?: {
+          level?: string;
+          summary?: string;
+          mitigations?: string[];
+        };
+        steps?: Array<{
+          stepId?: string;
+          title?: string;
+          description?: string;
+          agentId?: string;
+          dependsOnStepIds?: string[];
+          expectedOutcome?: string;
+          simulateFailure?: boolean;
+        }>;
+      };
+    }>(await deps.readRequestBody(req, { maxBytes: 262_144 })) ?? {};
+    try {
+      const result = engine.reviewProposal(proposalId, {
+        action: (sanitize(payload.action) || 'modify') as 'approve' | 'reject' | 'modify',
+        reviewerId: sanitize(payload.reviewerId) || 'human',
+        notes: sanitize(payload.notes) || undefined,
+        autoStart: payload.autoStart !== false,
+        modifications: payload.modifications
+          ? {
+            title: sanitize(payload.modifications.title) || undefined,
+            goal: sanitize(payload.modifications.goal) || undefined,
+            estimatedCostUsd: payload.modifications.estimatedCostUsd,
+            requiredSkills: Array.isArray(payload.modifications.requiredSkills)
+              ? payload.modifications.requiredSkills
+              : undefined,
+            riskAssessment: payload.modifications.riskAssessment
+              ? {
+                level: sanitize(payload.modifications.riskAssessment.level) as 'low' | 'medium' | 'high' | 'critical',
+                summary: sanitize(payload.modifications.riskAssessment.summary) || undefined,
+                mitigations: Array.isArray(payload.modifications.riskAssessment.mitigations)
+                  ? payload.modifications.riskAssessment.mitigations
+                  : undefined,
+              }
+              : undefined,
+            steps: Array.isArray(payload.modifications.steps)
+              ? payload.modifications.steps.map((step) => ({
+                stepId: sanitize(step.stepId) || undefined,
+                title: sanitize(step.title),
+                description: sanitize(step.description),
+                agentId: sanitize(step.agentId) || 'agent',
+                dependsOnStepIds: Array.isArray(step.dependsOnStepIds) ? step.dependsOnStepIds : [],
+                expectedOutcome: sanitize(step.expectedOutcome) || undefined,
+                simulateFailure: step.simulateFailure === true,
+              }))
+              : undefined,
+          }
+          : undefined,
+      });
+      deps.sendJson(res, { ok: true, proposal: result.proposal, mission: result.mission });
+      return true;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to review proposal';
+      const status = /not found/i.test(message) ? 404 : 400;
+      deps.sendJson(res, { ok: false, error: message }, status);
+      return true;
+    }
+  }
+
+  if (method === 'GET' && pathname === '/api/proposal-lifecycle/missions') {
+    const status = asMissionStatus(url.searchParams.get('status'));
+    const limit = parseLimit(url.searchParams.get('limit'), 50, 1, 500);
+    deps.sendJson(res, { ok: true, missions: engine.listMissions({ status, limit }) });
+    return true;
+  }
+
+  if (method === 'GET' && pathname.startsWith('/api/proposal-lifecycle/missions/')) {
+    const missionId = sanitize(pathname.split('/api/proposal-lifecycle/missions/')[1]);
+    if (!missionId) {
+      deps.sendJson(res, { ok: false, error: 'missionId is required' }, 400);
+      return true;
+    }
+    const mission = engine.getMission(missionId);
+    if (!mission) {
+      deps.sendJson(res, { ok: false, error: 'Mission not found' }, 404);
+      return true;
+    }
+    deps.sendJson(res, { ok: true, mission });
+    return true;
+  }
+
+  if (method === 'POST' && pathname.startsWith('/api/proposal-lifecycle/missions/') && pathname.endsWith('/start')) {
+    const missionId = sanitize(pathname.split('/api/proposal-lifecycle/missions/')[1]?.replace('/start', ''));
+    if (!missionId) {
+      deps.sendJson(res, { ok: false, error: 'missionId is required' }, 400);
+      return true;
+    }
+
+    try {
+      const mission = engine.startMission({ missionId });
+      deps.sendJson(res, { ok: true, mission });
+      return true;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to start mission';
+      const status = /not found/i.test(message) ? 404 : 400;
+      deps.sendJson(res, { ok: false, error: message }, status);
+      return true;
+    }
+  }
+
+  if (method === 'GET' && pathname === '/api/proposal-lifecycle/events') {
+    const missionId = sanitize(url.searchParams.get('missionId'));
+    const proposalId = sanitize(url.searchParams.get('proposalId'));
+    const limit = parseLimit(url.searchParams.get('limit'), 100, 1, 1000);
+    deps.sendJson(res, {
+      ok: true,
+      events: engine.listEvents({
+        missionId: missionId || undefined,
+        proposalId: proposalId || undefined,
+        limit,
+      }),
+    });
+    return true;
+  }
+
+  if (method === 'GET' && pathname === '/api/proposal-lifecycle/events/stream') {
+    deps.sendJson(res, { ok: false, error: 'WebSocket upgrade required for stream endpoint' }, 426);
+    return true;
+  }
+
+  deps.sendJson(res, { ok: false, error: 'Not found' }, 404);
+  return true;
+}
+
+export function handleProposalLifecycleUpgrade(
+  req: IncomingMessage,
+  socket: Socket,
+  _head: Buffer,
+  deps: ProposalLifecycleRouteDeps,
+): boolean {
+  if (!req.url) return false;
+  const url = new URL(req.url, 'http://localhost');
+  if (url.pathname !== '/api/proposal-lifecycle/events/stream') return false;
+
+  if (deps.isAuthenticated && !deps.isAuthenticated(req)) {
+    writeUpgradeError(socket, 401, 'Unauthorized');
+    return true;
+  }
+
+  const upgrade = String(req.headers.upgrade ?? '').toLowerCase();
+  const wsKey = String(req.headers['sec-websocket-key'] ?? '');
+  if (upgrade !== 'websocket' || !wsKey) {
+    writeUpgradeError(socket, 400, 'Invalid WebSocket upgrade request');
+    return true;
+  }
+
+  const accept = crypto
+    .createHash('sha1')
+    .update(`${wsKey}258EAFA5-E914-47DA-95CA-C5AB0DC85B11`)
+    .digest('base64');
+
+  socket.write(
+    'HTTP/1.1 101 Switching Protocols\r\n' +
+      'Upgrade: websocket\r\n' +
+      'Connection: Upgrade\r\n' +
+      `Sec-WebSocket-Accept: ${accept}\r\n` +
+      '\r\n',
+  );
+
+  const engine = getProposalLifecycleEngine(deps.dataDir);
+  const send = (payload: unknown): void => {
+    try {
+      socket.write(wsFrameFromJson(payload));
+    } catch {
+      // socket closed
+    }
+  };
+
+  send({ type: 'snapshot', summary: engine.getSummary() });
+  const unsubscribe = engine.subscribe((event) => {
+    send({ type: 'event', event });
+  });
+  const heartbeat = setInterval(() => send({ type: 'heartbeat', ts: Date.now() }), 15_000);
+
+  let closed = false;
+  const cleanup = () => {
+    if (closed) return;
+    closed = true;
+    clearInterval(heartbeat);
+    unsubscribe();
+    try {
+      socket.end();
+    } catch {
+      // ignore
+    }
+  };
+
+  socket.on('data', (buf: Buffer) => {
+    if (buf.length > 0 && (buf[0] & 0x0f) === 0x08) cleanup();
+  });
+  socket.on('close', cleanup);
+  socket.on('end', cleanup);
+  socket.on('error', cleanup);
+  return true;
+}

--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -122,6 +122,7 @@ import { handleSelfImprovement } from './routes/self-improvement.js';
 import { handleCodeFactory } from './routes/code-factory.js';
 import { handleWebMcp } from './routes/webmcp.js';
 import { handleVisualExplainer } from './routes/visual-explainer.js';
+import { handleProposalLifecycle, handleProposalLifecycleUpgrade } from './routes/proposal-lifecycle.js';
 import { getSchedulerJobs } from './scheduler-jobs.js';
 
 // ─── Configuration ───────────────────────────────────────────────────────────
@@ -3227,6 +3228,18 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
     return;
   }
 
+  try {
+    if (await handleProposalLifecycle(req, res, {
+      dataDir,
+      sendJson,
+      readRequestBody,
+      isAuthenticated,
+    })) return;
+  } catch {
+    sendJson(res, { ok: false, error: 'Failed to process proposal lifecycle request' }, 500);
+    return;
+  }
+
   // VentureOS API aliases
   if (req.url === '/api/ventureos-mission-control') {
     if (
@@ -4146,6 +4159,17 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
 export { server };
 
 server.on('upgrade', (req: IncomingMessage, socket: import('node:net').Socket, head: Buffer) => {
+  if (
+    handleProposalLifecycleUpgrade(req, socket, head, {
+      dataDir,
+      sendJson,
+      readRequestBody,
+      isAuthenticated,
+    })
+  ) {
+    return;
+  }
+
   if (
     handleTacticalMapLiveUpgrade(req, socket, head, {
       openclawDir: OPENCLAW_DIR,

--- a/dashboard/tests/unit/proposal-lifecycle.test.ts
+++ b/dashboard/tests/unit/proposal-lifecycle.test.ts
@@ -1,0 +1,126 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  getProposalLifecycleEngine,
+  resetProposalLifecycleEngine,
+} from '../../server/proposal-lifecycle.js';
+
+const testRoot = path.join('/tmp', `ventureos-proposal-lifecycle-${process.pid}`);
+const dataDir = path.join(testRoot, 'data');
+
+async function waitForMissionTerminal(missionId: string, timeoutMs = 1500): Promise<void> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    const engine = getProposalLifecycleEngine(dataDir);
+    const mission = engine.getMission(missionId);
+    if (!mission) throw new Error(`mission missing: ${missionId}`);
+    if (mission.status === 'completed' || mission.status === 'failed' || mission.status === 'blocked') return;
+    await new Promise((resolve) => setTimeout(resolve, 10));
+  }
+  throw new Error(`mission did not complete within ${timeoutMs}ms`);
+}
+
+beforeEach(() => {
+  fs.rmSync(testRoot, { recursive: true, force: true });
+  fs.mkdirSync(dataDir, { recursive: true });
+  resetProposalLifecycleEngine(dataDir);
+});
+
+afterEach(() => {
+  resetProposalLifecycleEngine(dataDir);
+  fs.rmSync(testRoot, { recursive: true, force: true });
+});
+
+describe('proposal lifecycle engine', () => {
+  it('stores proposals in pending queue until reviewed', () => {
+    const engine = getProposalLifecycleEngine(dataDir, { stepDelayMs: 0 });
+    const proposal = engine.submitProposal({
+      title: 'Ship rollout report',
+      goal: 'Generate a weekly rollout report with release health summary',
+      submittedByAgentId: 'echo',
+      estimatedCostUsd: 2.5,
+      requiredSkills: ['reporting', 'analysis'],
+      riskAssessment: {
+        level: 'low',
+        summary: 'Low operational risk',
+        mitigations: ['Verify data freshness'],
+      },
+      steps: [
+        {
+          title: 'Collect release metrics',
+          description: 'Gather last 7 days of release metrics',
+          agentId: 'oracle',
+        },
+      ],
+    });
+
+    expect(proposal.status).toBe('pending');
+    expect(engine.listProposals({ status: 'pending' })).toHaveLength(1);
+    expect(engine.listMissions()).toHaveLength(0);
+    const summary = engine.getSummary();
+    expect(summary.stats.pendingApprovals).toBe(1);
+    expect(summary.activeMissions).toHaveLength(0);
+  });
+
+  it('creates mission only after approval and executes ordered cross-agent handoffs', async () => {
+    const engine = getProposalLifecycleEngine(dataDir, { stepDelayMs: 0 });
+    const proposal = engine.submitProposal({
+      title: 'Publish integration release',
+      goal: 'Prepare, validate, and publish integration release artifacts',
+      submittedByAgentId: 'echo',
+      estimatedCostUsd: 6.25,
+      requiredSkills: ['build', 'qa', 'docs'],
+      riskAssessment: {
+        level: 'medium',
+        summary: 'Requires QA gate before publish',
+        mitigations: ['Add smoke tests', 'manual checklist'],
+      },
+      steps: [
+        {
+          stepId: 'prep',
+          title: 'Prepare build',
+          description: 'Build and package artifacts',
+          agentId: 'atlas',
+        },
+        {
+          stepId: 'qa',
+          title: 'Validate release',
+          description: 'Run smoke + regression checks',
+          agentId: 'verifier',
+          dependsOnStepIds: ['prep'],
+        },
+        {
+          stepId: 'docs',
+          title: 'Publish notes',
+          description: 'Update changelog and release notes',
+          agentId: 'archivist',
+          dependsOnStepIds: ['qa'],
+        },
+      ],
+    });
+
+    expect(engine.listMissions()).toHaveLength(0);
+
+    const reviewed = engine.reviewProposal(proposal.proposalId, {
+      action: 'approve',
+      reviewerId: 'human-operator',
+      notes: 'Looks good, proceed',
+      autoStart: true,
+    });
+
+    expect(reviewed.proposal.status).toBe('approved');
+    expect(reviewed.mission).toBeTruthy();
+
+    await waitForMissionTerminal(reviewed.mission!.missionId);
+    const mission = engine.getMission(reviewed.mission!.missionId);
+    expect(mission?.status).toBe('completed');
+    expect(mission?.steps.map((step) => step.status)).toEqual(['completed', 'completed', 'completed']);
+
+    const events = engine.listEvents({ missionId: reviewed.mission!.missionId, limit: 200 });
+    expect(events.some((event) => event.type === 'step.handoff' && event.toAgentId === 'verifier')).toBe(true);
+    expect(events.some((event) => event.type === 'step.handoff' && event.toAgentId === 'archivist')).toBe(true);
+    expect(events.some((event) => event.type === 'mission.completed')).toBe(true);
+  });
+});

--- a/dashboard/tests/unit/routes/proposal-lifecycle.test.ts
+++ b/dashboard/tests/unit/routes/proposal-lifecycle.test.ts
@@ -1,0 +1,203 @@
+import { EventEmitter } from 'node:events';
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { mockRequest, mockResponse, parseJsonBody } from '../../helpers.js';
+import {
+  handleProposalLifecycle,
+  handleProposalLifecycleUpgrade,
+} from '../../../server/routes/proposal-lifecycle.js';
+import { resetProposalLifecycleEngine } from '../../../server/proposal-lifecycle.js';
+
+const testRoot = path.join('/tmp', `ventureos-proposal-lifecycle-routes-${process.pid}`);
+const dataDir = path.join(testRoot, 'data');
+
+function sendJson(res: ReturnType<typeof mockResponse>, data: unknown, status = 200): void {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(data));
+}
+
+class MockSocket extends EventEmitter {
+  public chunks: Array<string | Buffer> = [];
+  public ended = false;
+  public destroyed = false;
+
+  write(chunk: string | Buffer): boolean {
+    this.chunks.push(chunk);
+    return true;
+  }
+
+  end(): this {
+    this.ended = true;
+    return this;
+  }
+
+  destroy(): this {
+    this.destroyed = true;
+    return this;
+  }
+}
+
+beforeEach(() => {
+  fs.rmSync(testRoot, { recursive: true, force: true });
+  fs.mkdirSync(dataDir, { recursive: true });
+  resetProposalLifecycleEngine(dataDir);
+});
+
+afterEach(() => {
+  resetProposalLifecycleEngine(dataDir);
+  fs.rmSync(testRoot, { recursive: true, force: true });
+});
+
+describe('proposal lifecycle routes', () => {
+  it('submits proposal and exposes it in summary', async () => {
+    const submitReq = mockRequest({ method: 'POST', url: '/api/proposal-lifecycle/proposals' });
+    const submitRes = mockResponse();
+    const handled = await handleProposalLifecycle(submitReq, submitRes, {
+      dataDir,
+      sendJson: sendJson as any,
+      readRequestBody: async () => JSON.stringify({
+        title: 'Launch campaign',
+        goal: 'Ship campaign assets with QA',
+        submittedByAgentId: 'echo',
+        estimatedCostUsd: 4.2,
+        requiredSkills: ['creative', 'qa'],
+        riskAssessment: { level: 'medium', summary: 'coordination risk', mitigations: ['handoff checklist'] },
+        steps: [
+          { title: 'Draft assets', description: 'Create campaign assets', agentId: 'synth' },
+          { title: 'Run QA', description: 'Validate assets', agentId: 'verifier' },
+        ],
+      }),
+    });
+    expect(handled).toBe(true);
+    expect(submitRes._statusCode).toBe(201);
+    const submitBody = parseJsonBody<{ proposal: { proposalId: string } }>(submitRes);
+    expect(submitBody.proposal.proposalId).toContain('proposal-');
+
+    const summaryReq = mockRequest({ method: 'GET', url: '/api/proposal-lifecycle/summary' });
+    const summaryRes = mockResponse();
+    await handleProposalLifecycle(summaryReq, summaryRes, {
+      dataDir,
+      sendJson: sendJson as any,
+      readRequestBody: async () => '',
+    });
+    const summaryBody = parseJsonBody<{ ok: boolean; summary: { pendingProposals: unknown[] } }>(summaryRes);
+    expect(summaryBody.ok).toBe(true);
+    expect(summaryBody.summary.pendingProposals.length).toBe(1);
+  });
+
+  it('approves proposal then starts mission', async () => {
+    const submitReq = mockRequest({ method: 'POST', url: '/api/proposal-lifecycle/proposals' });
+    const submitRes = mockResponse();
+    await handleProposalLifecycle(submitReq, submitRes, {
+      dataDir,
+      sendJson: sendJson as any,
+      readRequestBody: async () => JSON.stringify({
+        title: 'Feature release',
+        goal: 'Release feature bundle',
+        submittedByAgentId: 'echo',
+        estimatedCostUsd: 5,
+        requiredSkills: ['delivery'],
+        riskAssessment: { level: 'low', summary: 'standard release', mitigations: [] },
+        steps: [
+          { stepId: 'one', title: 'Build', description: 'Build package', agentId: 'atlas' },
+          { stepId: 'two', title: 'Verify', description: 'Verify package', agentId: 'verifier', dependsOnStepIds: ['one'] },
+        ],
+      }),
+    });
+    const proposalId = parseJsonBody<{ proposal: { proposalId: string } }>(submitRes).proposal.proposalId;
+
+    const reviewReq = mockRequest({
+      method: 'POST',
+      url: `/api/proposal-lifecycle/proposals/${proposalId}/review`,
+    });
+    const reviewRes = mockResponse();
+    await handleProposalLifecycle(reviewReq, reviewRes, {
+      dataDir,
+      sendJson: sendJson as any,
+      readRequestBody: async () => JSON.stringify({
+        action: 'approve',
+        reviewerId: 'human',
+        autoStart: false,
+      }),
+    });
+    expect(reviewRes._statusCode).toBe(200);
+    const reviewBody = parseJsonBody<{ mission: { missionId: string; status: string } }>(reviewRes);
+    expect(reviewBody.mission.status).toBe('pending');
+
+    const startReq = mockRequest({
+      method: 'POST',
+      url: `/api/proposal-lifecycle/missions/${reviewBody.mission.missionId}/start`,
+    });
+    const startRes = mockResponse();
+    await handleProposalLifecycle(startReq, startRes, {
+      dataDir,
+      sendJson: sendJson as any,
+      readRequestBody: async () => '',
+    });
+    expect(startRes._statusCode).toBe(200);
+    const startBody = parseJsonBody<{ mission: { missionId: string; status: string } }>(startRes);
+    expect(startBody.mission.missionId).toBe(reviewBody.mission.missionId);
+    expect(startBody.mission.status).toBe('running');
+  });
+
+  it('returns 426 for stream endpoint without websocket upgrade', async () => {
+    const req = mockRequest({ method: 'GET', url: '/api/proposal-lifecycle/events/stream' });
+    const res = mockResponse();
+    const handled = await handleProposalLifecycle(req, res, {
+      dataDir,
+      sendJson: sendJson as any,
+      readRequestBody: async () => '',
+    });
+    expect(handled).toBe(true);
+    expect(res._statusCode).toBe(426);
+  });
+});
+
+describe('proposal lifecycle websocket upgrades', () => {
+  it('rejects unauthorized upgrades', () => {
+    const req = mockRequest({
+      method: 'GET',
+      url: '/api/proposal-lifecycle/events/stream',
+      headers: {
+        upgrade: 'websocket',
+        'sec-websocket-key': 'dGhlIHNhbXBsZSBub25jZQ==',
+      },
+    }) as any;
+    const socket = new MockSocket();
+    const handled = handleProposalLifecycleUpgrade(req, socket as any, Buffer.alloc(0), {
+      dataDir,
+      sendJson: sendJson as any,
+      readRequestBody: async () => '',
+      isAuthenticated: () => false,
+    });
+    expect(handled).toBe(true);
+    expect(String(socket.chunks[0] ?? '')).toContain('401');
+    expect(socket.destroyed).toBe(true);
+  });
+
+  it('accepts authenticated upgrades and sends snapshot payload', () => {
+    const req = mockRequest({
+      method: 'GET',
+      url: '/api/proposal-lifecycle/events/stream',
+      headers: {
+        connection: 'Upgrade',
+        upgrade: 'websocket',
+        'sec-websocket-key': 'dGhlIHNhbXBsZSBub25jZQ==',
+        'sec-websocket-version': '13',
+      },
+    }) as any;
+    const socket = new MockSocket();
+    const handled = handleProposalLifecycleUpgrade(req, socket as any, Buffer.alloc(0), {
+      dataDir,
+      sendJson: sendJson as any,
+      readRequestBody: async () => '',
+      isAuthenticated: () => true,
+    });
+    expect(handled).toBe(true);
+    expect(String(socket.chunks[0] ?? '')).toContain('101 Switching Protocols');
+    expect(String(socket.chunks[1] ?? '')).toContain('"snapshot"');
+    socket.emit('close');
+  });
+});

--- a/docs/DOC_INDEX.md
+++ b/docs/DOC_INDEX.md
@@ -31,6 +31,7 @@
 - **docs/CODE_FACTORY_PIPELINE.md** – risk-tiered CI policy, SHA-discipline, auto-remediation, and harness-gap tracker (#220)
 - **docs/WEBMCP_INTEGRATION.md** – structured website tool discovery/invocation with cache + browser fallback (#225)
 - **docs/VISUAL_EXPLAINER_CANVAS.md** – slash-command visual explainer skill with 5 interactive HTML patterns (#226)
+- **docs/PROPOSAL_MISSION_STEP_LIFECYCLE.md** – proposal approval gate, step execution engine, cross-agent handoffs, and event streaming (#227)
 
 ## VentureOS / Multi-Agent Orchestration
 - **docs/roles/VENTURE_OS.md** – venture studio OS overview (system vs persona)

--- a/docs/PROPOSAL_MISSION_STEP_LIFECYCLE.md
+++ b/docs/PROPOSAL_MISSION_STEP_LIFECYCLE.md
@@ -1,0 +1,38 @@
+# Proposal → Mission → Step Lifecycle
+
+Issue: #227
+
+## Delivered
+
+- structured proposal intake with explicit metadata:
+  - goal
+  - estimated cost
+  - required skills
+  - risk assessment
+  - ordered step plan with agent ownership
+- mandatory human review workflow before mission execution:
+  - `approve`
+  - `reject`
+  - `modify`
+- mission execution engine:
+  - dependency-aware step scheduler
+  - automatic cross-agent handoff events
+  - persisted mission/step status
+- event stream:
+  - persisted event log (`proposal.submitted`, `proposal.reviewed`, `mission.started`, `step.*`, `mission.completed|failed`)
+  - WebSocket stream endpoint for live dashboard updates
+- dashboard mission page enhancements:
+  - proposal queue panel
+  - active proposal mission progress panel
+
+## API Surface
+
+- `POST /api/proposal-lifecycle/proposals`
+- `GET /api/proposal-lifecycle/proposals`
+- `POST /api/proposal-lifecycle/proposals/:proposalId/review`
+- `GET /api/proposal-lifecycle/missions`
+- `GET /api/proposal-lifecycle/missions/:missionId`
+- `POST /api/proposal-lifecycle/missions/:missionId/start`
+- `GET /api/proposal-lifecycle/events`
+- `GET /api/proposal-lifecycle/summary`
+- `GET /api/proposal-lifecycle/events/stream` (WebSocket upgrade)


### PR DESCRIPTION
## Summary
- implement a persisted proposal lifecycle engine with an explicit human review gate before mission execution
- add dependency-aware mission step execution with automatic cross-agent handoff events
- add proposal lifecycle API + websocket stream routes and wire them into dashboard server + rate limits
- add Mission Control UI cards for proposal queue and active proposal mission progress
- add tests and docs for the new lifecycle feature

## API
- POST /api/proposal-lifecycle/proposals
- GET /api/proposal-lifecycle/proposals
- POST /api/proposal-lifecycle/proposals/:proposalId/review
- GET /api/proposal-lifecycle/missions
- GET /api/proposal-lifecycle/missions/:missionId
- POST /api/proposal-lifecycle/missions/:missionId/start
- GET /api/proposal-lifecycle/events
- GET /api/proposal-lifecycle/summary
- GET /api/proposal-lifecycle/events/stream (WebSocket)

## Validation
- npm run build --workspace=dashboard
- npm run test --workspace=dashboard
- npm test

Closes #227
