### PR TITLE
feat: add living-files self-maintaining docs system

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -176,6 +176,8 @@ See **[docs/API.md](docs/API.md)** for the complete API reference covering all e
 | `POST /api/proposal-lifecycle/proposals` | Submit structured proposal for human review before mission execution |
 | `POST /api/proposal-lifecycle/proposals/:proposalId/review` | Approve/reject/modify proposal and create mission on approval |
 | `GET /api/proposal-lifecycle/summary` | Read proposal queue + active mission progress for Mission Control |
+| `GET /api/living-files/dashboard` | Freshness counts + stale/missing file status for living docs registry |
+| `POST /api/living-files/check-run` | Run staleness detection and auto-trigger responsible owner tasks |
 | `GET /api/live` | SSE real-time feed |
 
 ## Architecture

--- a/dashboard/client/index.html
+++ b/dashboard/client/index.html
@@ -4795,6 +4795,11 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
       </div>
 
       <div class="card mb-24">
+        <h3 class="card-title">Living Files Freshness</h3>
+        <div id="mcLivingFiles"></div>
+      </div>
+
+      <div class="card mb-24">
         <h3 class="card-title">Team Status</h3>
         <div id="mcTeamGrid" style="display:grid;grid-template-columns:repeat(3,1fr);gap:12px;"></div>
       </div>
@@ -6478,6 +6483,7 @@ let workflowPatterns = null;
 let ventureosAgents = null;
 let missionControl = null;
 let proposalLifecycleSummary = null;
+let livingFilesSummary = null;
 let schedulerJobs = [];
 let ventureFeatureFlags = { officeViewEnabled: false, updatedAt: 0 };
 let missionOfficeTasks = [];
@@ -8169,19 +8175,21 @@ function renderBarChart(el, items, opts = {}) {
 
 async function fetchMissionControlNow() {
   try {
-    const [mc, kpis, agents, scheduler, flags, lifecycle] = await Promise.all([
+    const [mc, kpis, agents, scheduler, flags, lifecycle, living] = await Promise.all([
       fetchJson('/api/ventureos-mission-control'),
       fetchJson('/api/ventureos-kpis?days=7'),
       fetchJson('/api/ventureos-agents'),
       fetchJson('/api/scheduler-jobs'),
       fetchJson('/api/ventureos-feature-flags').catch(() => null),
       fetchJson('/api/proposal-lifecycle/summary').catch(() => null),
+      fetchJson('/api/living-files/dashboard').catch(() => null),
     ]);
     missionControl = mc;
     ventureosKpis = kpis;
     ventureosAgents = agents;
     schedulerJobs = Array.isArray(scheduler) ? scheduler : [];
     proposalLifecycleSummary = lifecycle?.summary || null;
+    livingFilesSummary = living?.summary || null;
     if (flags && typeof flags === 'object') {
       ventureFeatureFlags = {
         officeViewEnabled: !!flags.officeViewEnabled,
@@ -8219,10 +8227,11 @@ async function fetchVentureosNow() {
 
 async function fetchAgentsNow() {
   try {
-    const [agents, mc, lifecycle] = await Promise.all([
+    const [agents, mc, lifecycle, living] = await Promise.all([
       fetchJson('/api/ventureos-agents'),
       fetchJson('/api/ventureos-mission-control').catch(() => null),
       fetchJson('/api/proposal-lifecycle/summary').catch(() => null),
+      fetchJson('/api/living-files/dashboard').catch(() => null),
     ]);
     ventureosAgents = agents;
     if (mc && typeof mc === 'object' && !mc.error) {
@@ -8230,6 +8239,9 @@ async function fetchAgentsNow() {
     }
     if (lifecycle && lifecycle.summary) {
       proposalLifecycleSummary = lifecycle.summary;
+    }
+    if (living && living.summary) {
+      livingFilesSummary = living.summary;
     }
     updateDashboard();
   } catch (e) {
@@ -8683,6 +8695,43 @@ function updateMissionControl() {
       </div>`;
     }).join('');
     lifecycleEl.innerHTML = cards || '<div class="empty-state-text">No active proposal missions</div>';
+  }
+
+  const livingEl = document.getElementById('mcLivingFiles');
+  if (livingEl) {
+    const summary = livingFilesSummary || {};
+    const counts = summary.counts || {};
+    const countRow = `<div style="display:flex;gap:8px;flex-wrap:wrap;margin-bottom:10px;">
+      <span class="tb-badge" style="background:rgba(34,197,94,0.18);color:var(--green);">🟢 ${counts.fresh ?? 0} fresh</span>
+      <span class="tb-badge" style="background:rgba(250,204,21,0.18);color:var(--yellow);">🟡 ${counts.warning ?? 0} warning</span>
+      <span class="tb-badge" style="background:rgba(239,68,68,0.18);color:var(--red);">🔴 ${(counts.stale ?? 0) + (counts.missing ?? 0)} stale/missing</span>
+      <span class="tb-badge" style="background:rgba(148,163,184,0.18);color:var(--text-muted);">⚪ ${counts.static ?? 0} static</span>
+      <span class="tb-badge" style="background:rgba(99,102,241,0.18);color:var(--accent);">🚨 ${counts.openTriggers ?? 0} open triggers</span>
+    </div>`;
+
+    const files = (summary.files || []).slice(0, 12);
+    const rows = files.map((row) => {
+      const status = (row.status || '').toLowerCase();
+      const badge = status === 'fresh'
+        ? { emoji: '🟢', color: 'var(--green)' }
+        : status === 'warning'
+          ? { emoji: '🟡', color: 'var(--yellow)' }
+          : status === 'static'
+            ? { emoji: '⚪', color: 'var(--text-muted)' }
+            : { emoji: '🔴', color: 'var(--red)' };
+      const ageText = typeof row.ageHours === 'number' ? `${row.ageHours.toFixed(1)}h` : '—';
+      const owner = row.entry?.ownerAgentId || 'agent';
+      const pathText = row.entry?.filePath || '';
+      const cadence = row.expectedUpdateHours != null ? `${row.expectedUpdateHours}h` : '--';
+      return `<div style="display:grid;grid-template-columns:120px 1fr 120px 120px;gap:8px;padding:8px 0;border-bottom:1px solid var(--border);font-size:12px;">
+        <div class="mono" style="color:${badge.color};font-weight:800;">${badge.emoji} ${escapeHtml(status.toUpperCase() || '--')}</div>
+        <div class="mono" style="overflow:hidden;text-overflow:ellipsis;white-space:nowrap;" title="${escapeHtml(pathText)}">${escapeHtml(pathText)}</div>
+        <div style="color:var(--text-muted);">owner ${escapeHtml(owner)}</div>
+        <div style="color:var(--text-muted);">age ${escapeHtml(ageText)} / ${escapeHtml(cadence)}</div>
+      </div>`;
+    }).join('');
+
+    livingEl.innerHTML = countRow + (rows || '<div class="empty-state-text">No living files registered</div>');
   }
 
   const schedulerEl = document.getElementById('mcSchedulerJobs');

--- a/dashboard/docs/API.md
+++ b/dashboard/docs/API.md
@@ -22,6 +22,7 @@ Complete reference for all OpenClaw Dashboard HTTP endpoints.
 - [WebMCP Endpoints](#webmcp-endpoints)
 - [Visual Explainer Endpoints](#visual-explainer-endpoints)
 - [Proposal Lifecycle Endpoints](#proposal-lifecycle-endpoints)
+- [Living Files Endpoints](#living-files-endpoints)
 - [Schemas](#schemas)
 
 ---
@@ -1288,6 +1289,70 @@ If requested over plain HTTP, returns `426 Upgrade Required`.
 
 ---
 
+## Living Files Endpoints
+
+Self-maintaining documentation ownership, freshness checks, and stale-file triggers (Issue #228).
+
+### `GET /api/living-files/dashboard`
+
+Returns freshness counts, per-file status snapshots, recent checks, and open triggers for Mission Control UI.
+
+### `GET /api/living-files/files`
+
+List registered file ownership records (`?ownerAgentId=archivist` optional filter).
+
+### `POST /api/living-files/files`
+
+Register (or upsert) a managed file.
+
+**Request:**
+```json
+{
+  "filePath": "docs/API.md",
+  "ownerAgentId": "archivist",
+  "expectedUpdateHours": 24,
+  "intentionallyStatic": false,
+  "notes": "API docs should be refreshed on endpoint changes"
+}
+```
+
+### `PATCH /api/living-files/files/:fileId`
+
+Update owner/cadence/notes, including manual static override:
+```json
+{ "intentionallyStatic": true }
+```
+
+### `DELETE /api/living-files/files/:fileId`
+
+Unregister a managed file.
+
+### `POST /api/living-files/check-run`
+
+Run staleness detection now.
+
+**Request (optional):**
+```json
+{
+  "source": "manual",
+  "autoTrigger": true
+}
+```
+
+### `GET /api/living-files/triggers`
+
+List stale-file trigger records (`?status=queued|acknowledged|resolved`).
+
+### `POST /api/living-files/triggers/:triggerId/acknowledge`
+
+Mark trigger in-progress.
+
+### `POST /api/living-files/triggers/:triggerId/resolve`
+
+Resolve trigger with optional note.
+
+---
+
 ## Rate Limiting
 
 Per-IP, per-endpoint sliding window rate limits:
@@ -1304,6 +1369,7 @@ Per-IP, per-endpoint sliding window rate limits:
 | `/api/webmcp*` | 30 req | 60s |
 | `/api/visual-explainer*` | 30 req | 60s |
 | `/api/proposal-lifecycle*` | 30 req | 60s |
+| `/api/living-files*` | 30 req | 60s |
 | `/api/ventureos-agents` | 30 req | 60s |
 | `/api/ventureos-kpis` | 30 req | 60s |
 | `/api/rpg/*` | 20 req | 60s |

--- a/dashboard/server/living-files.ts
+++ b/dashboard/server/living-files.ts
@@ -1,0 +1,588 @@
+/**
+ * Living Files engine (Issue #228).
+ *
+ * Tracks file ownership + freshness and auto-triggers remediation tasks
+ * when registered files become stale.
+ */
+
+import crypto from 'node:crypto';
+import fs from 'node:fs';
+import path from 'node:path';
+
+import type { TaskCard } from './types.js';
+
+export type LivingFileStatus = 'fresh' | 'warning' | 'stale' | 'missing' | 'static';
+export type LivingFileTriggerStatus = 'queued' | 'acknowledged' | 'resolved';
+
+export interface LivingFileEntry {
+  fileId: string;
+  filePath: string;
+  ownerAgentId: string;
+  expectedUpdateHours: number;
+  intentionallyStatic: boolean;
+  notes?: string;
+  createdAt: string;
+  updatedAt: string;
+  lastCheckedAt?: string;
+  lastStatus?: LivingFileStatus;
+  lastKnownMtimeMs?: number;
+  lastAgeHours?: number | null;
+  lastTriggeredAt?: string;
+}
+
+export interface LivingFileTrigger {
+  triggerId: string;
+  fileId: string;
+  filePath: string;
+  ownerAgentId: string;
+  status: LivingFileTriggerStatus;
+  reason: string;
+  source: string;
+  createdAt: string;
+  updatedAt: string;
+  taskId?: string;
+  resolvedAt?: string;
+  resolutionNote?: string;
+}
+
+export interface LivingFileCheckRun {
+  runId: string;
+  source: string;
+  startedAt: string;
+  finishedAt: string;
+  counts: {
+    fresh: number;
+    warning: number;
+    stale: number;
+    missing: number;
+    static: number;
+    triggered: number;
+  };
+}
+
+export interface LivingFileSnapshot {
+  entry: LivingFileEntry;
+  status: LivingFileStatus;
+  ageHours: number | null;
+  mtimeMs: number | null;
+  overdueByHours: number | null;
+  expectedUpdateHours: number;
+}
+
+interface LivingFileStore {
+  version: 1;
+  files: LivingFileEntry[];
+  triggers: LivingFileTrigger[];
+  checks: LivingFileCheckRun[];
+}
+
+export interface RegisterLivingFileInput {
+  filePath: string;
+  ownerAgentId: string;
+  expectedUpdateHours: number;
+  intentionallyStatic?: boolean;
+  notes?: string;
+}
+
+export interface UpdateLivingFileInput {
+  ownerAgentId?: string;
+  expectedUpdateHours?: number;
+  intentionallyStatic?: boolean;
+  notes?: string;
+}
+
+export interface LivingFileEngineOptions {
+  now?: () => Date;
+  checkIntervalMs?: number;
+}
+
+export interface LivingFileDashboardSummary {
+  updatedAt: string;
+  counts: {
+    total: number;
+    fresh: number;
+    warning: number;
+    stale: number;
+    missing: number;
+    static: number;
+    openTriggers: number;
+  };
+  files: LivingFileSnapshot[];
+  triggers: LivingFileTrigger[];
+  checks: LivingFileCheckRun[];
+}
+
+const STORE_FILE = 'living-files.json';
+const TASK_BOARD_FILE = 'task-board.json';
+const DEFAULT_CHECK_INTERVAL_MS = 60 * 60 * 1000;
+const MAX_CHECK_HISTORY = 120;
+const MAX_TRIGGER_HISTORY = 1000;
+
+function sanitizeText(input: unknown): string {
+  return typeof input === 'string' ? input.trim() : '';
+}
+
+function sanitizeAgentId(input: unknown): string {
+  const cleaned = sanitizeText(input).toLowerCase().replace(/[^a-z0-9._-]+/g, '-').replace(/^-+|-+$/g, '');
+  return cleaned || 'agent';
+}
+
+function normalizeExpectedUpdateHours(input: unknown, fallback = 24): number {
+  const parsed = Number(input);
+  if (!Number.isFinite(parsed)) return fallback;
+  return Math.max(1, Math.min(24 * 90, Math.round(parsed)));
+}
+
+function nowIso(now: () => Date): string {
+  return now().toISOString();
+}
+
+function deepClone<T>(value: T): T {
+  return JSON.parse(JSON.stringify(value)) as T;
+}
+
+function safeReadStore(storePath: string): LivingFileStore {
+  try {
+    if (!fs.existsSync(storePath)) return { version: 1, files: [], triggers: [], checks: [] };
+    const parsed = JSON.parse(fs.readFileSync(storePath, 'utf8')) as Partial<LivingFileStore>;
+    return {
+      version: 1,
+      files: Array.isArray(parsed.files) ? parsed.files : [],
+      triggers: Array.isArray(parsed.triggers) ? parsed.triggers : [],
+      checks: Array.isArray(parsed.checks) ? parsed.checks : [],
+    };
+  } catch {
+    return { version: 1, files: [], triggers: [], checks: [] };
+  }
+}
+
+function normalizeRelativeFilePath(workspaceDir: string, rawPath: string): string {
+  const cleaned = sanitizeText(rawPath).replace(/\\/g, '/').replace(/^\/+/, '');
+  if (!cleaned) throw new Error('filePath is required');
+  const resolved = path.resolve(workspaceDir, cleaned);
+  const root = path.resolve(workspaceDir);
+  if (!resolved.startsWith(root)) throw new Error('filePath must stay inside workspace');
+  return path.relative(root, resolved).replace(/\\/g, '/');
+}
+
+function evaluateSnapshot(
+  entry: LivingFileEntry,
+  workspaceDir: string,
+  nowMs: number,
+): { status: LivingFileStatus; ageHours: number | null; mtimeMs: number | null; overdueByHours: number | null } {
+  if (entry.intentionallyStatic) {
+    return { status: 'static', ageHours: null, mtimeMs: null, overdueByHours: null };
+  }
+
+  const absPath = path.resolve(workspaceDir, entry.filePath);
+  if (!absPath.startsWith(path.resolve(workspaceDir)) || !fs.existsSync(absPath)) {
+    return {
+      status: 'missing',
+      ageHours: null,
+      mtimeMs: null,
+      overdueByHours: null,
+    };
+  }
+
+  const stat = fs.statSync(absPath);
+  const mtimeMs = stat.mtimeMs;
+  const ageHours = Math.max(0, (nowMs - mtimeMs) / (1000 * 60 * 60));
+  const overdueByHours = Math.max(0, ageHours - entry.expectedUpdateHours);
+
+  if (ageHours <= entry.expectedUpdateHours) {
+    return { status: 'fresh', ageHours, mtimeMs, overdueByHours: null };
+  }
+  if (ageHours <= entry.expectedUpdateHours * 1.25) {
+    return { status: 'warning', ageHours, mtimeMs, overdueByHours };
+  }
+  return { status: 'stale', ageHours, mtimeMs, overdueByHours };
+}
+
+function readTaskBoardCards(dataDir: string): TaskCard[] {
+  try {
+    const filePath = path.join(dataDir, TASK_BOARD_FILE);
+    if (!fs.existsSync(filePath)) return [];
+    const parsed = JSON.parse(fs.readFileSync(filePath, 'utf8')) as { tasks?: TaskCard[] };
+    return Array.isArray(parsed.tasks) ? parsed.tasks : [];
+  } catch {
+    return [];
+  }
+}
+
+function saveTaskBoardCards(dataDir: string, tasks: TaskCard[]): void {
+  fs.mkdirSync(dataDir, { recursive: true });
+  const filePath = path.join(dataDir, TASK_BOARD_FILE);
+  fs.writeFileSync(filePath, JSON.stringify({ tasks }, null, 2), 'utf8');
+}
+
+function isOpenTriggerStatus(status: LivingFileTriggerStatus): boolean {
+  return status === 'queued' || status === 'acknowledged';
+}
+
+export class LivingFileEngine {
+  private readonly dataDir: string;
+  private readonly workspaceDir: string;
+  private readonly storePath: string;
+  private readonly now: () => Date;
+  private readonly checkIntervalMs: number;
+  private readonly timer: NodeJS.Timeout | null;
+  private store: LivingFileStore;
+
+  constructor(dataDir: string, workspaceDir: string, opts: LivingFileEngineOptions = {}) {
+    this.dataDir = path.resolve(dataDir);
+    this.workspaceDir = path.resolve(workspaceDir);
+    this.storePath = path.join(this.dataDir, STORE_FILE);
+    this.now = opts.now ?? (() => new Date());
+    this.checkIntervalMs = opts.checkIntervalMs == null
+      ? DEFAULT_CHECK_INTERVAL_MS
+      : Math.max(0, Math.trunc(opts.checkIntervalMs));
+    this.store = safeReadStore(this.storePath);
+
+    if (this.checkIntervalMs > 0) {
+      this.timer = setInterval(() => {
+        try {
+          this.runStalenessCheck({ source: 'scheduler', autoTrigger: true });
+        } catch {
+          // Scheduler should never crash the server.
+        }
+      }, this.checkIntervalMs);
+      this.timer.unref();
+    } else {
+      this.timer = null;
+    }
+  }
+
+  listFiles(filter: { ownerAgentId?: string } = {}): LivingFileEntry[] {
+    const owner = sanitizeAgentId(filter.ownerAgentId);
+    const rows = this.store.files
+      .slice()
+      .sort((a, b) => a.filePath.localeCompare(b.filePath))
+      .filter((entry) => !filter.ownerAgentId || entry.ownerAgentId === owner);
+    return deepClone(rows);
+  }
+
+  getFile(fileId: string): LivingFileEntry | null {
+    const row = this.store.files.find((entry) => entry.fileId === fileId);
+    return row ? deepClone(row) : null;
+  }
+
+  registerFile(input: RegisterLivingFileInput): LivingFileEntry {
+    const filePath = normalizeRelativeFilePath(this.workspaceDir, input.filePath);
+    const ownerAgentId = sanitizeAgentId(input.ownerAgentId);
+    const expectedUpdateHours = normalizeExpectedUpdateHours(input.expectedUpdateHours, 24);
+    const intentionallyStatic = input.intentionallyStatic === true;
+    const notes = sanitizeText(input.notes) || undefined;
+    const ts = nowIso(this.now);
+
+    const existing = this.store.files.find((entry) => entry.filePath === filePath);
+    if (existing) {
+      existing.ownerAgentId = ownerAgentId;
+      existing.expectedUpdateHours = expectedUpdateHours;
+      existing.intentionallyStatic = intentionallyStatic;
+      existing.notes = notes;
+      existing.updatedAt = ts;
+      this.persist();
+      return deepClone(existing);
+    }
+
+    const created: LivingFileEntry = {
+      fileId: `lf-${crypto.randomUUID().slice(0, 10)}`,
+      filePath,
+      ownerAgentId,
+      expectedUpdateHours,
+      intentionallyStatic,
+      notes,
+      createdAt: ts,
+      updatedAt: ts,
+    };
+    this.store.files.push(created);
+    this.persist();
+    return deepClone(created);
+  }
+
+  updateFile(fileId: string, patch: UpdateLivingFileInput): LivingFileEntry {
+    const entry = this.store.files.find((row) => row.fileId === fileId);
+    if (!entry) throw new Error(`Living file not found: ${fileId}`);
+
+    if (patch.ownerAgentId != null) entry.ownerAgentId = sanitizeAgentId(patch.ownerAgentId);
+    if (patch.expectedUpdateHours != null) {
+      entry.expectedUpdateHours = normalizeExpectedUpdateHours(patch.expectedUpdateHours, entry.expectedUpdateHours);
+    }
+    if (patch.intentionallyStatic != null) entry.intentionallyStatic = patch.intentionallyStatic === true;
+    if (patch.notes != null) entry.notes = sanitizeText(patch.notes) || undefined;
+    entry.updatedAt = nowIso(this.now);
+
+    this.persist();
+    return deepClone(entry);
+  }
+
+  unregisterFile(fileId: string): boolean {
+    const before = this.store.files.length;
+    this.store.files = this.store.files.filter((entry) => entry.fileId !== fileId);
+    if (this.store.files.length === before) return false;
+    this.persist();
+    return true;
+  }
+
+  listTriggers(filter: { status?: LivingFileTriggerStatus; fileId?: string; limit?: number } = {}): LivingFileTrigger[] {
+    const limit = Math.max(1, Math.min(500, Math.trunc(filter.limit ?? 200)));
+    const rows = this.store.triggers
+      .slice()
+      .sort((a, b) => Date.parse(b.createdAt) - Date.parse(a.createdAt))
+      .filter((trigger) => (!filter.status || trigger.status === filter.status) && (!filter.fileId || trigger.fileId === filter.fileId));
+    return deepClone(rows.slice(0, limit));
+  }
+
+  acknowledgeTrigger(triggerId: string): LivingFileTrigger {
+    const trigger = this.store.triggers.find((row) => row.triggerId === triggerId);
+    if (!trigger) throw new Error(`Trigger not found: ${triggerId}`);
+    if (trigger.status !== 'queued') return deepClone(trigger);
+    trigger.status = 'acknowledged';
+    trigger.updatedAt = nowIso(this.now);
+    this.persist();
+    return deepClone(trigger);
+  }
+
+  resolveTrigger(triggerId: string, note?: string): LivingFileTrigger {
+    const trigger = this.store.triggers.find((row) => row.triggerId === triggerId);
+    if (!trigger) throw new Error(`Trigger not found: ${triggerId}`);
+    if (trigger.status === 'resolved') return deepClone(trigger);
+    const ts = nowIso(this.now);
+    trigger.status = 'resolved';
+    trigger.resolvedAt = ts;
+    trigger.updatedAt = ts;
+    trigger.resolutionNote = sanitizeText(note) || undefined;
+    this.persist();
+    return deepClone(trigger);
+  }
+
+  runStalenessCheck(input: { source?: string; autoTrigger?: boolean } = {}): {
+    run: LivingFileCheckRun;
+    snapshots: LivingFileSnapshot[];
+    triggered: LivingFileTrigger[];
+  } {
+    const source = sanitizeText(input.source) || 'manual';
+    const autoTrigger = input.autoTrigger !== false;
+    const startedAt = nowIso(this.now);
+    const nowMs = this.now().getTime();
+    const counts = { fresh: 0, warning: 0, stale: 0, missing: 0, static: 0, triggered: 0 };
+    const triggered: LivingFileTrigger[] = [];
+    const snapshots: LivingFileSnapshot[] = [];
+
+    for (const entry of this.store.files) {
+      const evaluation = evaluateSnapshot(entry, this.workspaceDir, nowMs);
+      counts[evaluation.status] += 1;
+      entry.lastCheckedAt = startedAt;
+      entry.lastStatus = evaluation.status;
+      entry.lastKnownMtimeMs = evaluation.mtimeMs ?? undefined;
+      entry.lastAgeHours = evaluation.ageHours;
+
+      snapshots.push({
+        entry: deepClone(entry),
+        status: evaluation.status,
+        ageHours: evaluation.ageHours,
+        mtimeMs: evaluation.mtimeMs,
+        overdueByHours: evaluation.overdueByHours,
+        expectedUpdateHours: entry.expectedUpdateHours,
+      });
+
+      if (!autoTrigger) continue;
+      if (evaluation.status !== 'stale' && evaluation.status !== 'missing') {
+        this.resolveOpenTriggersForFile(entry.fileId, 'File returned to healthy state');
+        continue;
+      }
+
+      const open = this.store.triggers.find(
+        (row) => row.fileId === entry.fileId && isOpenTriggerStatus(row.status),
+      );
+      if (open) continue;
+
+      const trigger = this.createTrigger(entry, source, evaluation.status);
+      triggered.push(trigger);
+      counts.triggered += 1;
+    }
+
+    const finishedAt = nowIso(this.now);
+    const run: LivingFileCheckRun = {
+      runId: `lf-run-${crypto.randomUUID().slice(0, 10)}`,
+      source,
+      startedAt,
+      finishedAt,
+      counts,
+    };
+    this.store.checks.push(run);
+    if (this.store.checks.length > MAX_CHECK_HISTORY) {
+      this.store.checks.splice(0, this.store.checks.length - MAX_CHECK_HISTORY);
+    }
+    this.persist();
+
+    return {
+      run: deepClone(run),
+      snapshots: deepClone(snapshots),
+      triggered: deepClone(triggered),
+    };
+  }
+
+  getDashboardSummary(limit = 200): LivingFileDashboardSummary {
+    const nowMs = this.now().getTime();
+    const snapshots: LivingFileSnapshot[] = this.store.files
+      .map((entry) => {
+        const evaluation = evaluateSnapshot(entry, this.workspaceDir, nowMs);
+        return {
+          entry: deepClone(entry),
+          status: evaluation.status,
+          ageHours: evaluation.ageHours,
+          mtimeMs: evaluation.mtimeMs,
+          overdueByHours: evaluation.overdueByHours,
+          expectedUpdateHours: entry.expectedUpdateHours,
+        };
+      })
+      .sort((a, b) => a.entry.filePath.localeCompare(b.entry.filePath))
+      .slice(0, Math.max(1, Math.min(1000, Math.trunc(limit))));
+
+    const counts = {
+      total: snapshots.length,
+      fresh: snapshots.filter((row) => row.status === 'fresh').length,
+      warning: snapshots.filter((row) => row.status === 'warning').length,
+      stale: snapshots.filter((row) => row.status === 'stale').length,
+      missing: snapshots.filter((row) => row.status === 'missing').length,
+      static: snapshots.filter((row) => row.status === 'static').length,
+      openTriggers: this.store.triggers.filter((row) => isOpenTriggerStatus(row.status)).length,
+    };
+
+    return deepClone({
+      updatedAt: nowIso(this.now),
+      counts,
+      files: snapshots,
+      triggers: this.listTriggers({ limit: 80 }),
+      checks: this.store.checks.slice().sort((a, b) => Date.parse(b.startedAt) - Date.parse(a.startedAt)).slice(0, 30),
+    });
+  }
+
+  dispose(): void {
+    if (this.timer) {
+      clearInterval(this.timer);
+    }
+  }
+
+  private resolveOpenTriggersForFile(fileId: string, note: string): void {
+    const ts = nowIso(this.now);
+    for (const trigger of this.store.triggers) {
+      if (trigger.fileId !== fileId || !isOpenTriggerStatus(trigger.status)) continue;
+      trigger.status = 'resolved';
+      trigger.resolvedAt = ts;
+      trigger.updatedAt = ts;
+      trigger.resolutionNote = note;
+    }
+  }
+
+  private createTrigger(entry: LivingFileEntry, source: string, status: LivingFileStatus): LivingFileTrigger {
+    const ts = nowIso(this.now);
+    const trigger: LivingFileTrigger = {
+      triggerId: `lf-trg-${crypto.randomUUID().slice(0, 10)}`,
+      fileId: entry.fileId,
+      filePath: entry.filePath,
+      ownerAgentId: entry.ownerAgentId,
+      status: 'queued',
+      reason: status === 'missing'
+        ? `Registered file is missing: ${entry.filePath}`
+        : `File is stale beyond ${entry.expectedUpdateHours}h window`,
+      source,
+      createdAt: ts,
+      updatedAt: ts,
+    };
+    trigger.taskId = this.enqueueTaskForTrigger(entry, trigger);
+    this.store.triggers.push(trigger);
+    if (this.store.triggers.length > MAX_TRIGGER_HISTORY) {
+      this.store.triggers.splice(0, this.store.triggers.length - MAX_TRIGGER_HISTORY);
+    }
+    entry.lastTriggeredAt = ts;
+    entry.updatedAt = ts;
+    return trigger;
+  }
+
+  private enqueueTaskForTrigger(entry: LivingFileEntry, trigger: LivingFileTrigger): string | undefined {
+    const tasks = readTaskBoardCards(this.dataDir);
+    const openExisting = tasks.find((task) =>
+      task.status !== 'done' &&
+      task.status !== 'failed' &&
+      task.title === `Living File Refresh: ${entry.filePath}` &&
+      task.assigneeId === entry.ownerAgentId,
+    );
+    if (openExisting) return openExisting.id;
+
+    const nowMs = this.now().getTime();
+    const id = `task-${crypto.randomUUID().slice(0, 10)}`;
+    const card: TaskCard = {
+      id,
+      agentId: entry.ownerAgentId,
+      title: `Living File Refresh: ${entry.filePath}`,
+      description: `${trigger.reason}\n\nOwner: ${entry.ownerAgentId}\nExpected cadence: ${entry.expectedUpdateHours}h`,
+      priority: 'medium',
+      status: 'queued',
+      createdAt: nowMs,
+      queuedAt: nowMs,
+      startedAt: null,
+      completedAt: null,
+      resultSummary: null,
+      tokensUsed: null,
+      error: null,
+      costEstimate: null,
+      runtimeMs: null,
+      missionId: `living-files-${new Date(nowMs).toISOString().slice(0, 10)}`,
+      missionBrief: 'Living files staleness remediation',
+      assigneeType: 'agent',
+      assigneeId: entry.ownerAgentId,
+      dependencies: [],
+      artifactLinks: [entry.filePath],
+      replaySessionId: null,
+      statusHistory: [
+        {
+          status: 'queued',
+          at: nowMs,
+          by: 'living-files',
+          note: trigger.triggerId,
+        },
+      ],
+    };
+    tasks.push(card);
+    saveTaskBoardCards(this.dataDir, tasks);
+    return id;
+  }
+
+  private persist(): void {
+    fs.mkdirSync(path.dirname(this.storePath), { recursive: true });
+    fs.writeFileSync(this.storePath, JSON.stringify(this.store, null, 2), 'utf8');
+  }
+}
+
+const engineCache = new Map<string, LivingFileEngine>();
+
+function engineKey(dataDir: string, workspaceDir: string): string {
+  return `${path.resolve(dataDir)}::${path.resolve(workspaceDir)}`;
+}
+
+export function getLivingFileEngine(
+  dataDir: string,
+  workspaceDir: string,
+  opts: LivingFileEngineOptions = {},
+): LivingFileEngine {
+  const key = engineKey(dataDir, workspaceDir);
+  const cached = engineCache.get(key);
+  if (cached) return cached;
+  const created = new LivingFileEngine(dataDir, workspaceDir, opts);
+  engineCache.set(key, created);
+  return created;
+}
+
+export function resetLivingFileEngine(dataDir?: string, workspaceDir?: string): void {
+  if (!dataDir || !workspaceDir) {
+    for (const engine of engineCache.values()) engine.dispose();
+    engineCache.clear();
+    return;
+  }
+  const key = engineKey(dataDir, workspaceDir);
+  const engine = engineCache.get(key);
+  if (engine) engine.dispose();
+  engineCache.delete(key);
+}

--- a/dashboard/server/middleware/rate-limit.ts
+++ b/dashboard/server/middleware/rate-limit.ts
@@ -100,6 +100,7 @@ export const LIMITS: Record<string, RateLimitConfig> = {
   '/api/webmcp':              { limit: 30, windowMs: 60000 },
   '/api/visual-explainer':    { limit: 30, windowMs: 60000 },
   '/api/proposal-lifecycle':  { limit: 30, windowMs: 60000 },
+  '/api/living-files':        { limit: 30, windowMs: 60000 },
   '/api/replay':              { limit: 10, windowMs: 60000 },
   '/api/live':                { limit: 10, windowMs: 60000 },
   '/api/conversation':        { limit: 30, windowMs: 60000 },

--- a/dashboard/server/routes/index.ts
+++ b/dashboard/server/routes/index.ts
@@ -42,6 +42,7 @@ export {
 } from '../task-board-events.js';
 export type { SseSubscriptionFilter } from '../task-board-events.js';
 export { handleMemoryState } from './memory-state.js';
+export { handleLivingFiles } from './living-files.js';
 export { handleProposalLifecycle, handleProposalLifecycleUpgrade } from './proposal-lifecycle.js';
 export { handleSharedContext } from './shared-context.js';
 export {

--- a/dashboard/server/routes/living-files.ts
+++ b/dashboard/server/routes/living-files.ts
@@ -1,0 +1,207 @@
+/**
+ * Living Files API routes (Issue #228).
+ */
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+import {
+  getLivingFileEngine,
+  type LivingFileTriggerStatus,
+} from '../living-files.js';
+
+export interface LivingFilesRouteDeps {
+  dataDir: string;
+  workspaceDir: string;
+  sendJson: (res: ServerResponse, data: unknown, status?: number) => void;
+  readRequestBody: (req: IncomingMessage, opts?: { maxBytes?: number }) => Promise<string>;
+}
+
+function parseUrl(req: IncomingMessage): URL | null {
+  try {
+    return new URL(req.url ?? '', 'http://localhost');
+  } catch {
+    return null;
+  }
+}
+
+function parseJson<T>(raw: string): T | null {
+  try {
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+function sanitize(input: unknown): string {
+  return typeof input === 'string' ? input.trim() : '';
+}
+
+function parseBool(input: unknown): boolean | undefined {
+  if (input == null) return undefined;
+  if (input === true || input === false) return input;
+  const text = sanitize(input).toLowerCase();
+  if (text === 'true' || text === '1' || text === 'yes') return true;
+  if (text === 'false' || text === '0' || text === 'no') return false;
+  return undefined;
+}
+
+function parseNumber(input: unknown, fallback: number): number {
+  const n = Number(input);
+  if (!Number.isFinite(n)) return fallback;
+  return n;
+}
+
+function asTriggerStatus(value: string | null): LivingFileTriggerStatus | undefined {
+  const status = sanitize(value).toLowerCase();
+  if (status === 'queued' || status === 'acknowledged' || status === 'resolved') return status;
+  return undefined;
+}
+
+export async function handleLivingFiles(
+  req: IncomingMessage,
+  res: ServerResponse,
+  deps: LivingFilesRouteDeps,
+): Promise<boolean> {
+  if (!req.url || !req.url.startsWith('/api/living-files')) return false;
+
+  const url = parseUrl(req);
+  if (!url) {
+    deps.sendJson(res, { ok: false, error: 'Bad request URL' }, 400);
+    return true;
+  }
+  const method = req.method ?? 'GET';
+  const pathname = url.pathname;
+  const engine = getLivingFileEngine(deps.dataDir, deps.workspaceDir);
+
+  if (method === 'GET' && pathname === '/api/living-files/dashboard') {
+    const limit = Math.max(1, Math.min(1000, Math.trunc(parseNumber(url.searchParams.get('limit'), 200))));
+    deps.sendJson(res, { ok: true, summary: engine.getDashboardSummary(limit) });
+    return true;
+  }
+
+  if (method === 'GET' && pathname === '/api/living-files/files') {
+    const ownerAgentId = sanitize(url.searchParams.get('ownerAgentId')) || undefined;
+    deps.sendJson(res, { ok: true, files: engine.listFiles({ ownerAgentId }) });
+    return true;
+  }
+
+  if (method === 'POST' && pathname === '/api/living-files/files') {
+    const payload = parseJson<{
+      filePath?: string;
+      ownerAgentId?: string;
+      expectedUpdateHours?: number;
+      intentionallyStatic?: boolean;
+      notes?: string;
+    }>(await deps.readRequestBody(req, { maxBytes: 131_072 })) ?? {};
+
+    try {
+      const file = engine.registerFile({
+        filePath: sanitize(payload.filePath),
+        ownerAgentId: sanitize(payload.ownerAgentId) || 'agent',
+        expectedUpdateHours: parseNumber(payload.expectedUpdateHours, 24),
+        intentionallyStatic: parseBool(payload.intentionallyStatic),
+        notes: sanitize(payload.notes) || undefined,
+      });
+      deps.sendJson(res, { ok: true, file }, 201);
+      return true;
+    } catch (err: unknown) {
+      deps.sendJson(res, { ok: false, error: err instanceof Error ? err.message : 'Failed to register file' }, 400);
+      return true;
+    }
+  }
+
+  if (method === 'PATCH' && pathname.startsWith('/api/living-files/files/')) {
+    const fileId = sanitize(pathname.split('/api/living-files/files/')[1]);
+    if (!fileId) {
+      deps.sendJson(res, { ok: false, error: 'fileId is required' }, 400);
+      return true;
+    }
+
+    const payload = parseJson<{
+      ownerAgentId?: string;
+      expectedUpdateHours?: number;
+      intentionallyStatic?: boolean;
+      notes?: string;
+    }>(await deps.readRequestBody(req, { maxBytes: 131_072 })) ?? {};
+
+    try {
+      const file = engine.updateFile(fileId, {
+        ownerAgentId: payload.ownerAgentId == null ? undefined : sanitize(payload.ownerAgentId),
+        expectedUpdateHours: payload.expectedUpdateHours,
+        intentionallyStatic: parseBool(payload.intentionallyStatic),
+        notes: payload.notes == null ? undefined : sanitize(payload.notes),
+      });
+      deps.sendJson(res, { ok: true, file });
+      return true;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to update file';
+      deps.sendJson(res, { ok: false, error: message }, /not found/i.test(message) ? 404 : 400);
+      return true;
+    }
+  }
+
+  if (method === 'DELETE' && pathname.startsWith('/api/living-files/files/')) {
+    const fileId = sanitize(pathname.split('/api/living-files/files/')[1]);
+    if (!fileId) {
+      deps.sendJson(res, { ok: false, error: 'fileId is required' }, 400);
+      return true;
+    }
+    const deleted = engine.unregisterFile(fileId);
+    if (!deleted) {
+      deps.sendJson(res, { ok: false, error: 'File not found' }, 404);
+      return true;
+    }
+    deps.sendJson(res, { ok: true, deletedId: fileId });
+    return true;
+  }
+
+  if (method === 'POST' && pathname === '/api/living-files/check-run') {
+    const payload = parseJson<{ source?: string; autoTrigger?: boolean }>(
+      await deps.readRequestBody(req, { maxBytes: 65_536 }),
+    ) ?? {};
+    const result = engine.runStalenessCheck({
+      source: sanitize(payload.source) || 'manual',
+      autoTrigger: parseBool(payload.autoTrigger),
+    });
+    deps.sendJson(res, { ok: true, ...result });
+    return true;
+  }
+
+  if (method === 'GET' && pathname === '/api/living-files/triggers') {
+    const status = asTriggerStatus(url.searchParams.get('status'));
+    const fileId = sanitize(url.searchParams.get('fileId')) || undefined;
+    const limit = Math.max(1, Math.min(1000, Math.trunc(parseNumber(url.searchParams.get('limit'), 200))));
+    deps.sendJson(res, { ok: true, triggers: engine.listTriggers({ status, fileId, limit }) });
+    return true;
+  }
+
+  if (method === 'POST' && pathname.startsWith('/api/living-files/triggers/')) {
+    const suffix = pathname.split('/api/living-files/triggers/')[1] ?? '';
+    const parts = suffix.split('/').filter(Boolean);
+    const triggerId = sanitize(parts[0]);
+    const action = sanitize(parts[1]).toLowerCase();
+    if (!triggerId || (action !== 'acknowledge' && action !== 'resolve')) {
+      deps.sendJson(res, { ok: false, error: 'Invalid trigger action route' }, 400);
+      return true;
+    }
+
+    try {
+      if (action === 'acknowledge') {
+        const trigger = engine.acknowledgeTrigger(triggerId);
+        deps.sendJson(res, { ok: true, trigger });
+        return true;
+      }
+      const payload = parseJson<{ note?: string }>(await deps.readRequestBody(req, { maxBytes: 65_536 })) ?? {};
+      const trigger = engine.resolveTrigger(triggerId, sanitize(payload.note));
+      deps.sendJson(res, { ok: true, trigger });
+      return true;
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Failed to update trigger';
+      deps.sendJson(res, { ok: false, error: message }, /not found/i.test(message) ? 404 : 400);
+      return true;
+    }
+  }
+
+  deps.sendJson(res, { ok: false, error: 'Not found' }, 404);
+  return true;
+}

--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -123,6 +123,7 @@ import { handleCodeFactory } from './routes/code-factory.js';
 import { handleWebMcp } from './routes/webmcp.js';
 import { handleVisualExplainer } from './routes/visual-explainer.js';
 import { handleProposalLifecycle, handleProposalLifecycleUpgrade } from './routes/proposal-lifecycle.js';
+import { handleLivingFiles } from './routes/living-files.js';
 import { getSchedulerJobs } from './scheduler-jobs.js';
 
 // ─── Configuration ───────────────────────────────────────────────────────────
@@ -3237,6 +3238,18 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
     })) return;
   } catch {
     sendJson(res, { ok: false, error: 'Failed to process proposal lifecycle request' }, 500);
+    return;
+  }
+
+  try {
+    if (await handleLivingFiles(req, res, {
+      dataDir,
+      workspaceDir: WORKSPACE_DIR,
+      sendJson,
+      readRequestBody,
+    })) return;
+  } catch {
+    sendJson(res, { ok: false, error: 'Failed to process living-files request' }, 500);
     return;
   }
 

--- a/dashboard/tests/unit/living-files.test.ts
+++ b/dashboard/tests/unit/living-files.test.ts
@@ -1,0 +1,99 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  getLivingFileEngine,
+  resetLivingFileEngine,
+} from '../../server/living-files.js';
+
+const testRoot = path.join('/tmp', `ventureos-living-files-${process.pid}`);
+const dataDir = path.join(testRoot, 'data');
+const workspaceDir = path.join(testRoot, 'workspace');
+
+function fixedNow(): Date {
+  return new Date('2026-02-21T20:00:00.000Z');
+}
+
+beforeEach(() => {
+  fs.rmSync(testRoot, { recursive: true, force: true });
+  fs.mkdirSync(dataDir, { recursive: true });
+  fs.mkdirSync(workspaceDir, { recursive: true });
+  resetLivingFileEngine(dataDir, workspaceDir);
+});
+
+afterEach(() => {
+  resetLivingFileEngine(dataDir, workspaceDir);
+  fs.rmSync(testRoot, { recursive: true, force: true });
+});
+
+describe('living-files engine', () => {
+  it('supports register, update, and unregister', () => {
+    const engine = getLivingFileEngine(dataDir, workspaceDir, { now: fixedNow, checkIntervalMs: 0 });
+
+    const created = engine.registerFile({
+      filePath: 'README.md',
+      ownerAgentId: 'archivist',
+      expectedUpdateHours: 24,
+    });
+    expect(created.fileId).toContain('lf-');
+    expect(engine.listFiles()).toHaveLength(1);
+
+    const updated = engine.updateFile(created.fileId, {
+      expectedUpdateHours: 12,
+      intentionallyStatic: true,
+      notes: 'Core static contract file',
+    });
+    expect(updated.expectedUpdateHours).toBe(12);
+    expect(updated.intentionallyStatic).toBe(true);
+    expect(updated.notes).toContain('static');
+
+    const removed = engine.unregisterFile(created.fileId);
+    expect(removed).toBe(true);
+    expect(engine.listFiles()).toHaveLength(0);
+  });
+
+  it('detects stale files and auto-triggers owner task', () => {
+    const filePath = path.join(workspaceDir, 'docs', 'API.md');
+    fs.mkdirSync(path.dirname(filePath), { recursive: true });
+    fs.writeFileSync(filePath, '# API\n');
+    fs.utimesSync(filePath, new Date('2026-02-18T10:00:00.000Z'), new Date('2026-02-18T10:00:00.000Z'));
+
+    const engine = getLivingFileEngine(dataDir, workspaceDir, { now: fixedNow, checkIntervalMs: 0 });
+    const file = engine.registerFile({
+      filePath: 'docs/API.md',
+      ownerAgentId: 'archivist',
+      expectedUpdateHours: 24,
+    });
+
+    const run1 = engine.runStalenessCheck({ source: 'test', autoTrigger: true });
+    const snapshot = run1.snapshots.find((row) => row.entry.fileId === file.fileId);
+    expect(snapshot?.status).toBe('stale');
+    expect(run1.triggered).toHaveLength(1);
+    expect(run1.triggered[0].ownerAgentId).toBe('archivist');
+
+    const taskBoardPath = path.join(dataDir, 'task-board.json');
+    expect(fs.existsSync(taskBoardPath)).toBe(true);
+    const taskBoard = JSON.parse(fs.readFileSync(taskBoardPath, 'utf8')) as { tasks: Array<{ title: string; assigneeId: string }> };
+    expect(taskBoard.tasks.some((task) => task.title.includes('docs/API.md') && task.assigneeId === 'archivist')).toBe(true);
+
+    const run2 = engine.runStalenessCheck({ source: 'test', autoTrigger: true });
+    expect(run2.triggered).toHaveLength(0);
+    expect(engine.listTriggers({ status: 'queued' })).toHaveLength(1);
+  });
+
+  it('supports intentionally static override to suppress triggers', () => {
+    const engine = getLivingFileEngine(dataDir, workspaceDir, { now: fixedNow, checkIntervalMs: 0 });
+    engine.registerFile({
+      filePath: 'docs/CONTRACT.md',
+      ownerAgentId: 'archivist',
+      expectedUpdateHours: 12,
+      intentionallyStatic: true,
+    });
+
+    const result = engine.runStalenessCheck({ source: 'test', autoTrigger: true });
+    expect(result.run.counts.static).toBe(1);
+    expect(result.triggered).toHaveLength(0);
+    expect(engine.listTriggers()).toHaveLength(0);
+  });
+});

--- a/dashboard/tests/unit/routes/living-files.test.ts
+++ b/dashboard/tests/unit/routes/living-files.test.ts
@@ -1,0 +1,154 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { mockRequest, mockResponse, parseJsonBody } from '../../helpers.js';
+import { handleLivingFiles } from '../../../server/routes/living-files.js';
+import { resetLivingFileEngine } from '../../../server/living-files.js';
+
+const testRoot = path.join('/tmp', `ventureos-living-files-routes-${process.pid}`);
+const dataDir = path.join(testRoot, 'data');
+const workspaceDir = path.join(testRoot, 'workspace');
+
+function sendJson(res: ReturnType<typeof mockResponse>, data: unknown, status = 200): void {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(data));
+}
+
+beforeEach(() => {
+  fs.rmSync(testRoot, { recursive: true, force: true });
+  fs.mkdirSync(dataDir, { recursive: true });
+  fs.mkdirSync(workspaceDir, { recursive: true });
+  resetLivingFileEngine(dataDir, workspaceDir);
+});
+
+afterEach(() => {
+  resetLivingFileEngine(dataDir, workspaceDir);
+  fs.rmSync(testRoot, { recursive: true, force: true });
+});
+
+describe('living-files routes', () => {
+  it('registers and lists living files', async () => {
+    const createReq = mockRequest({ method: 'POST', url: '/api/living-files/files' });
+    const createRes = mockResponse();
+    const handled = await handleLivingFiles(createReq, createRes, {
+      dataDir,
+      workspaceDir,
+      sendJson: sendJson as any,
+      readRequestBody: async () => JSON.stringify({
+        filePath: 'README.md',
+        ownerAgentId: 'archivist',
+        expectedUpdateHours: 24,
+      }),
+    });
+    expect(handled).toBe(true);
+    expect(createRes._statusCode).toBe(201);
+    const created = parseJsonBody<{ file: { fileId: string } }>(createRes);
+    expect(created.file.fileId).toContain('lf-');
+
+    const listReq = mockRequest({ method: 'GET', url: '/api/living-files/files' });
+    const listRes = mockResponse();
+    await handleLivingFiles(listReq, listRes, {
+      dataDir,
+      workspaceDir,
+      sendJson: sendJson as any,
+      readRequestBody: async () => '',
+    });
+    const listBody = parseJsonBody<{ files: unknown[] }>(listRes);
+    expect(listBody.files).toHaveLength(1);
+  });
+
+  it('runs staleness check and returns dashboard summary', async () => {
+    const createReq = mockRequest({ method: 'POST', url: '/api/living-files/files' });
+    const createRes = mockResponse();
+    await handleLivingFiles(createReq, createRes, {
+      dataDir,
+      workspaceDir,
+      sendJson: sendJson as any,
+      readRequestBody: async () => JSON.stringify({
+        filePath: 'docs/MISSING.md',
+        ownerAgentId: 'oracle',
+        expectedUpdateHours: 12,
+      }),
+    });
+
+    const runReq = mockRequest({ method: 'POST', url: '/api/living-files/check-run' });
+    const runRes = mockResponse();
+    await handleLivingFiles(runReq, runRes, {
+      dataDir,
+      workspaceDir,
+      sendJson: sendJson as any,
+      readRequestBody: async () => JSON.stringify({ source: 'unit-test', autoTrigger: true }),
+    });
+    const runBody = parseJsonBody<{ run: { counts: { missing: number; triggered: number } }; triggered: unknown[] }>(runRes);
+    expect(runBody.run.counts.missing).toBe(1);
+    expect(runBody.run.counts.triggered).toBe(1);
+    expect(runBody.triggered).toHaveLength(1);
+
+    const dashboardReq = mockRequest({ method: 'GET', url: '/api/living-files/dashboard' });
+    const dashboardRes = mockResponse();
+    await handleLivingFiles(dashboardReq, dashboardRes, {
+      dataDir,
+      workspaceDir,
+      sendJson: sendJson as any,
+      readRequestBody: async () => '',
+    });
+    const dashboard = parseJsonBody<{ summary: { counts: { openTriggers: number; missing: number } } }>(dashboardRes);
+    expect(dashboard.summary.counts.openTriggers).toBeGreaterThanOrEqual(1);
+    expect(dashboard.summary.counts.missing).toBe(1);
+  });
+
+  it('supports trigger acknowledge and resolve actions', async () => {
+    const createReq = mockRequest({ method: 'POST', url: '/api/living-files/files' });
+    await handleLivingFiles(createReq, mockResponse(), {
+      dataDir,
+      workspaceDir,
+      sendJson: sendJson as any,
+      readRequestBody: async () => JSON.stringify({
+        filePath: 'docs/MISSING.md',
+        ownerAgentId: 'oracle',
+        expectedUpdateHours: 12,
+      }),
+    });
+
+    await handleLivingFiles(mockRequest({ method: 'POST', url: '/api/living-files/check-run' }), mockResponse(), {
+      dataDir,
+      workspaceDir,
+      sendJson: sendJson as any,
+      readRequestBody: async () => JSON.stringify({ autoTrigger: true }),
+    });
+
+    const triggersReq = mockRequest({ method: 'GET', url: '/api/living-files/triggers?status=queued' });
+    const triggersRes = mockResponse();
+    await handleLivingFiles(triggersReq, triggersRes, {
+      dataDir,
+      workspaceDir,
+      sendJson: sendJson as any,
+      readRequestBody: async () => '',
+    });
+    const triggerId = parseJsonBody<{ triggers: Array<{ triggerId: string }> }>(triggersRes).triggers[0].triggerId;
+
+    const ackReq = mockRequest({ method: 'POST', url: `/api/living-files/triggers/${triggerId}/acknowledge` });
+    const ackRes = mockResponse();
+    await handleLivingFiles(ackReq, ackRes, {
+      dataDir,
+      workspaceDir,
+      sendJson: sendJson as any,
+      readRequestBody: async () => '',
+    });
+    const ackBody = parseJsonBody<{ trigger: { status: string } }>(ackRes);
+    expect(ackBody.trigger.status).toBe('acknowledged');
+
+    const resolveReq = mockRequest({ method: 'POST', url: `/api/living-files/triggers/${triggerId}/resolve` });
+    const resolveRes = mockResponse();
+    await handleLivingFiles(resolveReq, resolveRes, {
+      dataDir,
+      workspaceDir,
+      sendJson: sendJson as any,
+      readRequestBody: async () => JSON.stringify({ note: 'Handled manually' }),
+    });
+    const resolveBody = parseJsonBody<{ trigger: { status: string; resolutionNote: string } }>(resolveRes);
+    expect(resolveBody.trigger.status).toBe('resolved');
+    expect(resolveBody.trigger.resolutionNote).toContain('Handled');
+  });
+});

--- a/docs/DOC_INDEX.md
+++ b/docs/DOC_INDEX.md
@@ -32,6 +32,7 @@
 - **docs/WEBMCP_INTEGRATION.md** – structured website tool discovery/invocation with cache + browser fallback (#225)
 - **docs/VISUAL_EXPLAINER_CANVAS.md** – slash-command visual explainer skill with 5 interactive HTML patterns (#226)
 - **docs/PROPOSAL_MISSION_STEP_LIFECYCLE.md** – proposal approval gate, step execution engine, cross-agent handoffs, and event streaming (#227)
+- **docs/LIVING_FILES.md** – file ownership registry, stale detection scheduler, auto-triggered remediation, and freshness dashboard (#228)
 
 ## VentureOS / Multi-Agent Orchestration
 - **docs/roles/VENTURE_OS.md** – venture studio OS overview (system vs persona)

--- a/docs/LIVING_FILES.md
+++ b/docs/LIVING_FILES.md
@@ -1,0 +1,33 @@
+# Living Files — Self-Maintaining Documentation
+
+Issue: #228
+
+## Delivered
+
+- file ownership registry with CRUD:
+  - register file path → owner agent + expected update cadence
+  - update owner/cadence/notes
+  - unregister file
+- staleness detection engine:
+  - freshness states: `fresh`, `warning`, `stale`, `missing`, `static`
+  - periodic scheduler checks (cron-like interval) plus on-demand check endpoint
+- auto-trigger workflow:
+  - stale/missing files emit trigger records
+  - owner-assigned remediation tasks are queued in task board automatically
+  - trigger lifecycle: `queued` → `acknowledged` → `resolved`
+- manual override:
+  - `intentionallyStatic=true` suppresses stale triggers for files intentionally not updated
+- dashboard surface:
+  - Mission Control panel for living-files freshness counts and per-file status list
+
+## API Surface
+
+- `GET /api/living-files/dashboard`
+- `GET /api/living-files/files`
+- `POST /api/living-files/files`
+- `PATCH /api/living-files/files/:fileId`
+- `DELETE /api/living-files/files/:fileId`
+- `POST /api/living-files/check-run`
+- `GET /api/living-files/triggers`
+- `POST /api/living-files/triggers/:triggerId/acknowledge`
+- `POST /api/living-files/triggers/:triggerId/resolve`


### PR DESCRIPTION
## Summary
- add a living-files engine with file ownership registry CRUD and persistent staleness state
- implement freshness detection (`fresh`, `warning`, `stale`, `missing`, `static`) with periodic scheduler checks + on-demand check runs
- auto-trigger owner remediation when files go stale/missing by creating trigger records and queueing task-board tasks
- add manual override for intentionally static files to suppress stale triggers
- add dashboard Mission Control freshness panel and living-files API routes/docs/tests

## API
- GET /api/living-files/dashboard
- GET /api/living-files/files
- POST /api/living-files/files
- PATCH /api/living-files/files/:fileId
- DELETE /api/living-files/files/:fileId
- POST /api/living-files/check-run
- GET /api/living-files/triggers
- POST /api/living-files/triggers/:triggerId/acknowledge
- POST /api/living-files/triggers/:triggerId/resolve

## Validation
- npm run build --workspace=dashboard
- npm run test --workspace=dashboard -- tests/unit/living-files.test.ts tests/unit/routes/living-files.test.ts
- npm run test --workspace=dashboard

Closes #228
