### PR TITLE
fix: close living-files workspace containment bypass (#360)

### DIFF
--- a/dashboard/server/living-files.ts
+++ b/dashboard/server/living-files.ts
@@ -137,6 +137,11 @@ function nowIso(now: () => Date): string {
   return now().toISOString();
 }
 
+/**
+ * Security-critical containment check for workspace-bound file operations.
+ * Uses canonical `path.relative(...)` semantics to prevent traversal,
+ * including sibling-prefix escapes that bypass naive string prefix checks.
+ */
 function isPathInsideRoot(rootDir: string, candidatePath: string): boolean {
   const relative = path.relative(rootDir, candidatePath);
   if (relative === '') return true;
@@ -164,7 +169,11 @@ function safeReadStore(storePath: string): LivingFileStore {
 }
 
 function normalizeRelativeFilePath(workspaceDir: string, rawPath: string): string {
-  const cleaned = sanitizeText(rawPath).replace(/\\/g, '/').replace(/^\/+/, '');
+  const normalizedInput = sanitizeText(rawPath).replace(/\\/g, '/');
+  if (path.posix.isAbsolute(normalizedInput) || /^[A-Za-z]:\//.test(normalizedInput)) {
+    throw new Error('filePath must stay inside workspace');
+  }
+  const cleaned = normalizedInput.replace(/^\/+/, '');
   if (!cleaned) throw new Error('filePath is required');
   const resolved = path.resolve(workspaceDir, cleaned);
   const root = path.resolve(workspaceDir);

--- a/dashboard/tests/unit/living-files.test.ts
+++ b/dashboard/tests/unit/living-files.test.ts
@@ -111,4 +111,25 @@ describe('living-files engine', () => {
       }),
     ).toThrow('filePath must stay inside workspace');
   });
+
+  it('rejects absolute file paths outside the workspace', () => {
+    const engine = getLivingFileEngine(dataDir, workspaceDir, { now: fixedNow, checkIntervalMs: 0 });
+    const absoluteOutside = path.join(path.parse(workspaceDir).root, 'ventureos-outside', 'secret.txt');
+
+    expect(() =>
+      engine.registerFile({
+        filePath: absoluteOutside,
+        ownerAgentId: 'archivist',
+        expectedUpdateHours: 24,
+      }),
+    ).toThrow('filePath must stay inside workspace');
+
+    expect(() =>
+      engine.registerFile({
+        filePath: 'C:/Windows/System32/config/SAM',
+        ownerAgentId: 'archivist',
+        expectedUpdateHours: 24,
+      }),
+    ).toThrow('filePath must stay inside workspace');
+  });
 });

--- a/dashboard/tests/unit/routes/living-files.test.ts
+++ b/dashboard/tests/unit/routes/living-files.test.ts
@@ -175,4 +175,25 @@ describe('living-files routes', () => {
     expect(body.ok).toBe(false);
     expect(body.error).toContain('filePath must stay inside workspace');
   });
+
+  it('rejects registration paths that escape workspace via absolute path', async () => {
+    const absoluteOutside = path.join(path.parse(workspaceDir).root, 'ventureos-outside', 'secret.txt');
+    const createReq = mockRequest({ method: 'POST', url: '/api/living-files/files' });
+    const createRes = mockResponse();
+    const handled = await handleLivingFiles(createReq, createRes, {
+      dataDir,
+      workspaceDir,
+      sendJson: sendJson as any,
+      readRequestBody: async () => JSON.stringify({
+        filePath: absoluteOutside,
+        ownerAgentId: 'archivist',
+        expectedUpdateHours: 24,
+      }),
+    });
+    expect(handled).toBe(true);
+    expect(createRes._statusCode).toBe(400);
+    const body = parseJsonBody<{ ok: boolean; error: string }>(createRes);
+    expect(body.ok).toBe(false);
+    expect(body.error).toContain('filePath must stay inside workspace');
+  });
 });


### PR DESCRIPTION
## Summary
- fixes the living-files workspace boundary check to use canonical containment semantics instead of string prefix matching
- blocks sibling-prefix escapes such as `../workspace2/secret.txt`
- adds regression coverage at engine and route levels

## Related
- Closes #360

## Changes
- `dashboard/server/living-files.ts`
  - added `isPathInsideRoot(...)` helper based on `path.relative(...)`
  - replaced vulnerable `startsWith(root)` checks in registration and snapshot evaluation
- `dashboard/tests/unit/living-files.test.ts`
  - added engine-level regression for sibling-prefix escape
- `dashboard/tests/unit/routes/living-files.test.ts`
  - added route-level regression asserting `400` on escaped path payloads

## Verification
- `npm run test --workspace=dashboard -- tests/unit/living-files.test.ts tests/unit/routes/living-files.test.ts`
- `npm run test --workspace=dashboard`
