### PR TITLE
fix: align rate-limit IP trust model with auth policy (#362)

### DIFF
--- a/dashboard/server/middleware/rate-limit.ts
+++ b/dashboard/server/middleware/rate-limit.ts
@@ -25,6 +25,29 @@
 import type { IncomingMessage, ServerResponse } from 'node:http';
 import type { RateLimitResult, RateLimitConfig } from '../types.js';
 
+const TRUST_PROXY: boolean =
+  ((process.env.DASHBOARD_TRUST_PROXY ?? 'false').toLowerCase() === 'true');
+const TRUSTED_PROXY_IPS: Set<string> = new Set(
+  (process.env.DASHBOARD_TRUSTED_PROXY_IPS ?? '127.0.0.1,::1,::ffff:127.0.0.1')
+    .split(',')
+    .map((ip) => ip.trim())
+    .filter(Boolean),
+);
+
+function normalizeIp(ip: string): string {
+  if (!ip) return ip;
+  return ip.replace(/^::ffff:/, '');
+}
+
+function getPeerIp(req: IncomingMessage): string {
+  return req.socket?.remoteAddress ?? '0.0.0.0';
+}
+
+function isTrustedProxyPeer(ip: string): boolean {
+  const cleaned: string = normalizeIp(ip);
+  return TRUSTED_PROXY_IPS.has(ip) || TRUSTED_PROXY_IPS.has(cleaned);
+}
+
 export class RateLimiter {
   private windows: Map<string, number[]> = new Map();
 
@@ -108,16 +131,24 @@ export const LIMITS: Record<string, RateLimitConfig> = {
 };
 
 /**
- * Extract the client IP from a request, handling proxies.
+ * Extract the client IP using the same trust-proxy policy as auth middleware:
+ * only honor X-Forwarded-For when proxy trust is enabled and the direct peer
+ * is in DASHBOARD_TRUSTED_PROXY_IPS.
  */
 function getClientIP(req: IncomingMessage): string {
-  // Trust X-Forwarded-For on LAN (single-hop reverse proxy at most)
-  const xff: string | undefined = req.headers['x-forwarded-for'] as string | undefined;
-  if (xff) {
+  const peerIp: string = getPeerIp(req);
+  if (!TRUST_PROXY || !isTrustedProxyPeer(peerIp)) {
+    return peerIp;
+  }
+
+  const xffRaw: string | string[] | undefined = req.headers['x-forwarded-for'];
+  const xff: string = Array.isArray(xffRaw) ? xffRaw[0] : (xffRaw ?? '');
+  if (typeof xff === 'string' && xff.trim()) {
     const first: string = xff.split(',')[0].trim();
     if (first) return first;
   }
-  return req.socket?.remoteAddress ?? '0.0.0.0';
+
+  return peerIp;
 }
 
 /**

--- a/dashboard/tests/unit/middleware/rate-limit.test.ts
+++ b/dashboard/tests/unit/middleware/rate-limit.test.ts
@@ -2,11 +2,23 @@
  * Rate limit middleware tests.
  */
 
-import { describe, it, expect, beforeEach } from 'vitest';
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { mockRequest, mockResponse, parseJsonBody } from '../../helpers.js';
 import { RateLimiter, rateLimit, LIMITS } from '../../../server/middleware/rate-limit.js';
 
+async function importRateLimitWithEnv(env: Record<string, string>): Promise<typeof import('../../../server/middleware/rate-limit.js')> {
+  for (const [key, value] of Object.entries(env)) {
+    vi.stubEnv(key, value);
+  }
+  vi.resetModules();
+  return import('../../../server/middleware/rate-limit.js');
+}
+
 describe('Rate Limit Middleware', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   describe('RateLimiter class', () => {
     let rl: InstanceType<typeof RateLimiter>;
 
@@ -141,6 +153,101 @@ describe('Rate Limit Middleware', () => {
           res,
         ),
       ).toBe(true);
+    });
+
+    it('ignores spoofed X-Forwarded-For by default for keying', () => {
+      const limit = LIMITS['/api/replay']?.limit ?? 10;
+      for (let i = 0; i < limit; i++) {
+        rateLimit(
+          mockRequest({
+            url: '/api/replay',
+            headers: { 'x-forwarded-for': `198.51.100.${i + 1}` },
+            socket: { remoteAddress: '203.0.113.150' },
+          }),
+          mockResponse(),
+        );
+      }
+
+      const res = mockResponse();
+      expect(rateLimit(
+        mockRequest({
+          url: '/api/replay',
+          headers: { 'x-forwarded-for': '198.51.100.250' },
+          socket: { remoteAddress: '203.0.113.150' },
+        }),
+        res,
+      )).toBe(false);
+      expect(res._statusCode).toBe(429);
+    });
+
+    it('uses X-Forwarded-For when trusted proxy conditions are met', async () => {
+      const { rateLimit: trustedRateLimit, LIMITS: trustedLimits } = await importRateLimitWithEnv({
+        DASHBOARD_TRUST_PROXY: 'true',
+        DASHBOARD_TRUSTED_PROXY_IPS: '198.51.100.10',
+      });
+
+      const limit = trustedLimits['/api/replay']?.limit ?? 10;
+      for (let i = 0; i < limit; i++) {
+        trustedRateLimit(
+          mockRequest({
+            url: '/api/replay',
+            headers: { 'x-forwarded-for': '203.0.113.10' },
+            socket: { remoteAddress: '198.51.100.10' },
+          }),
+          mockResponse(),
+        );
+      }
+
+      const sameClientRes = mockResponse();
+      expect(trustedRateLimit(
+        mockRequest({
+          url: '/api/replay',
+          headers: { 'x-forwarded-for': '203.0.113.10' },
+          socket: { remoteAddress: '198.51.100.10' },
+        }),
+        sameClientRes,
+      )).toBe(false);
+      expect(sameClientRes._statusCode).toBe(429);
+
+      const differentClientRes = mockResponse();
+      expect(trustedRateLimit(
+        mockRequest({
+          url: '/api/replay',
+          headers: { 'x-forwarded-for': '203.0.113.11' },
+          socket: { remoteAddress: '198.51.100.10' },
+        }),
+        differentClientRes,
+      )).toBe(true);
+    });
+
+    it('ignores X-Forwarded-For from untrusted peers even when trust proxy is enabled', async () => {
+      const { rateLimit: trustedRateLimit, LIMITS: trustedLimits } = await importRateLimitWithEnv({
+        DASHBOARD_TRUST_PROXY: 'true',
+        DASHBOARD_TRUSTED_PROXY_IPS: '198.51.100.10',
+      });
+
+      const limit = trustedLimits['/api/replay']?.limit ?? 10;
+      for (let i = 0; i < limit; i++) {
+        trustedRateLimit(
+          mockRequest({
+            url: '/api/replay',
+            headers: { 'x-forwarded-for': `203.0.113.${i + 1}` },
+            socket: { remoteAddress: '198.51.100.11' },
+          }),
+          mockResponse(),
+        );
+      }
+
+      const res = mockResponse();
+      expect(trustedRateLimit(
+        mockRequest({
+          url: '/api/replay',
+          headers: { 'x-forwarded-for': '203.0.113.200' },
+          socket: { remoteAddress: '198.51.100.11' },
+        }),
+        res,
+      )).toBe(false);
+      expect(res._statusCode).toBe(429);
     });
   });
 });


### PR DESCRIPTION
## Summary
- align rate-limit client IP derivation with auth middleware trust-proxy policy
- only honor `X-Forwarded-For` when `DASHBOARD_TRUST_PROXY=true` and peer IP is in `DASHBOARD_TRUSTED_PROXY_IPS`
- keep direct-connection behavior safe by default (no proxy trust)
- add regression tests proving spoofed `X-Forwarded-For` cannot bypass limits unless trusted-proxy conditions are met

## Verification
- `npm run test --workspace=dashboard -- tests/unit/middleware/rate-limit.test.ts`
- `npm run test --workspace=dashboard`
- `npm run build --workspace=dashboard`

Closes #362
