### PR TITLE
fix: add bounded bridge proxy request timeouts (#363)

### DIFF
--- a/.env.hybrid.example
+++ b/.env.hybrid.example
@@ -25,5 +25,7 @@ BRIDGE_TOKEN=change-me
 # ── Optional Overrides ───────────────────────────────────────────────────────
 # DATABASE_URL=postgres://ventureos:change-me@db:5432/ventureos
 # DASHBOARD_DATA_MODE=bridge
+# DASHBOARD_BRIDGE_JSON_TIMEOUT_MS=10000
+# DASHBOARD_BRIDGE_SSE_CONNECT_TIMEOUT_MS=10000
 # DASHBOARD_ALLOW_LAN_BYPASS=false
 # DASHBOARD_ENABLE_ACTIONS=false

--- a/dashboard/server/bridge-proxy.ts
+++ b/dashboard/server/bridge-proxy.ts
@@ -9,6 +9,8 @@ export interface BridgeProxyDeps {
   bridgeUrl?: string;
   bridgeToken?: string;
   fetchImpl?: typeof fetch;
+  jsonTimeoutMs?: number;
+  sseConnectTimeoutMs?: number;
 }
 
 export interface BridgeProxyRequest {
@@ -22,6 +24,11 @@ export interface BridgeSseRequest {
   forwardQuery?: boolean;
 }
 
+const DEFAULT_JSON_TIMEOUT_MS = 10_000;
+const DEFAULT_SSE_CONNECT_TIMEOUT_MS = 10_000;
+const MIN_TIMEOUT_MS = 100;
+const MAX_TIMEOUT_MS = 120_000;
+
 function sendJson(res: ServerResponse, body: unknown, status = 200): void {
   res.writeHead(status, {
     'Content-Type': 'application/json',
@@ -32,6 +39,26 @@ function sendJson(res: ServerResponse, body: unknown, status = 200): void {
 
 function isBridgeMode(mode: string | undefined): boolean {
   return (mode ?? '').toLowerCase() === 'bridge';
+}
+
+function normalizeTimeoutMs(value: unknown, fallbackMs: number): number {
+  const parsed = Number(value);
+  if (!Number.isFinite(parsed)) return fallbackMs;
+  return Math.min(MAX_TIMEOUT_MS, Math.max(MIN_TIMEOUT_MS, Math.round(parsed)));
+}
+
+function resolveJsonTimeoutMs(deps: BridgeProxyDeps): number {
+  return normalizeTimeoutMs(
+    deps.jsonTimeoutMs ?? process.env.DASHBOARD_BRIDGE_JSON_TIMEOUT_MS,
+    DEFAULT_JSON_TIMEOUT_MS,
+  );
+}
+
+function resolveSseConnectTimeoutMs(deps: BridgeProxyDeps): number {
+  return normalizeTimeoutMs(
+    deps.sseConnectTimeoutMs ?? process.env.DASHBOARD_BRIDGE_SSE_CONNECT_TIMEOUT_MS,
+    DEFAULT_SSE_CONNECT_TIMEOUT_MS,
+  );
 }
 
 function buildBridgeTarget(
@@ -76,20 +103,52 @@ export async function proxyBridgeJson(
   const target = buildBridgeTarget(req, bridgeUrl, request);
 
   const fetchImpl = deps.fetchImpl ?? fetch;
+  const timeoutMs = resolveJsonTimeoutMs(deps);
+  const abortController = new AbortController();
+  let timedOut = false;
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    try {
+      abortController.abort();
+    } catch {
+      // ignore
+    }
+  }, timeoutMs);
+  timeout.unref();
+
   let bridgeResponse: Response;
   try {
     bridgeResponse = await fetchImpl(target.toString(), {
       headers: {
         Authorization: `Bearer ${bridgeToken}`,
       },
+      signal: abortController.signal,
     });
   } catch {
+    clearTimeout(timeout);
+    if (timedOut) {
+      sendJson(res, { ok: false, error: 'Bridge timeout' }, 504);
+      return true;
+    }
     sendJson(res, { ok: false, error: 'Bridge unavailable' }, 502);
     return true;
   }
 
+  let bodyText: string;
+  try {
+    bodyText = await bridgeResponse.text();
+  } catch {
+    clearTimeout(timeout);
+    if (timedOut) {
+      sendJson(res, { ok: false, error: 'Bridge timeout' }, 504);
+      return true;
+    }
+    sendJson(res, { ok: false, error: 'Bridge unavailable' }, 502);
+    return true;
+  }
+  clearTimeout(timeout);
+
   const contentType = bridgeResponse.headers.get('content-type') ?? 'application/json';
-  const bodyText = await bridgeResponse.text();
   res.writeHead(bridgeResponse.status, {
     'Content-Type': contentType,
     'Cache-Control': 'no-store',
@@ -121,8 +180,12 @@ export async function proxyBridgeSse(
 
   const target = buildBridgeTarget(req, bridgeUrl, request);
   const fetchImpl = deps.fetchImpl ?? fetch;
+  const timeoutMs = resolveSseConnectTimeoutMs(deps);
   const abortController = new AbortController();
+  let timedOut = false;
+  let clientDisconnected = false;
   const abort = () => {
+    clientDisconnected = true;
     try {
       abortController.abort();
     } catch {
@@ -130,6 +193,15 @@ export async function proxyBridgeSse(
     }
   };
   req.on('close', abort);
+  const timeout = setTimeout(() => {
+    timedOut = true;
+    try {
+      abortController.abort();
+    } catch {
+      // ignore
+    }
+  }, timeoutMs);
+  timeout.unref();
 
   let bridgeResponse: Response;
   try {
@@ -140,9 +212,19 @@ export async function proxyBridgeSse(
       signal: abortController.signal,
     });
   } catch {
+    clearTimeout(timeout);
+    req.off('close', abort);
+    if (timedOut) {
+      sendJson(res, { ok: false, error: 'Bridge timeout' }, 504);
+      return true;
+    }
+    if (clientDisconnected || res.writableEnded) {
+      return true;
+    }
     sendJson(res, { ok: false, error: 'Bridge unavailable' }, 502);
     return true;
   }
+  clearTimeout(timeout);
 
   if (!bridgeResponse.ok) {
     const bodyText = await bridgeResponse.text();
@@ -151,6 +233,7 @@ export async function proxyBridgeSse(
       'Cache-Control': 'no-store',
     });
     res.end(bodyText);
+    req.off('close', abort);
     return true;
   }
 
@@ -163,6 +246,7 @@ export async function proxyBridgeSse(
   const body = bridgeResponse.body;
   if (!body) {
     res.end();
+    req.off('close', abort);
     return true;
   }
 
@@ -179,6 +263,7 @@ export async function proxyBridgeSse(
   } catch {
     // stream aborted/disconnected
   } finally {
+    req.off('close', abort);
     try {
       reader.releaseLock();
     } catch {

--- a/dashboard/tests/unit/bridge-proxy.test.ts
+++ b/dashboard/tests/unit/bridge-proxy.test.ts
@@ -61,12 +61,47 @@ describe('bridge proxy', () => {
     expect(fetchMock).toHaveBeenCalledTimes(1);
     expect(fetchMock).toHaveBeenCalledWith('http://bridge.local:18790/api/bridge/costs?window=7d', {
       headers: { Authorization: 'Bearer bridge-token-123' },
+      signal: expect.any(AbortSignal),
     });
 
     expect(res._statusCode).toBe(200);
     const body = parseJsonBody<{ ok: boolean; url: string }>(res);
     expect(body.ok).toBe(true);
     expect(body.url).toContain('/api/bridge/costs');
+  });
+
+  it('returns 504 when bridge JSON request times out', async () => {
+    const req = mockRequest({ url: '/api/costs' });
+    const res = mockResponse();
+
+    const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (!signal) {
+          reject(new Error('missing abort signal'));
+          return;
+        }
+        signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+      });
+    });
+
+    const handled = await proxyBridgeJson(
+      req,
+      res,
+      {
+        dataMode: 'bridge',
+        bridgeUrl: 'http://bridge.local:18790',
+        bridgeToken: 'bridge-token-123',
+        fetchImpl: fetchMock,
+        jsonTimeoutMs: 5,
+      },
+      { targetPath: '/api/bridge/costs' },
+    );
+
+    expect(handled).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(res._statusCode).toBe(504);
+    expect(parseJsonBody(res).error).toBe('Bridge timeout');
   });
 
   it('returns false for SSE proxy when not in bridge mode', async () => {
@@ -130,5 +165,39 @@ describe('bridge proxy', () => {
     expect(res._body).toContain('status');
     expect(res._body).toContain('telemetry');
     expect(res._ended).toBe(true);
+  });
+
+  it('returns 504 when SSE bridge connect times out', async () => {
+    const req = mockRequest({ url: '/api/live-telemetry' });
+    const res = mockResponse();
+
+    const fetchMock = vi.fn((_url: string, init?: RequestInit) => {
+      return new Promise<Response>((_resolve, reject) => {
+        const signal = init?.signal;
+        if (!signal) {
+          reject(new Error('missing abort signal'));
+          return;
+        }
+        signal.addEventListener('abort', () => reject(new Error('aborted')), { once: true });
+      });
+    });
+
+    const handled = await proxyBridgeSse(
+      req,
+      res,
+      {
+        dataMode: 'bridge',
+        bridgeUrl: 'http://bridge.local:18790',
+        bridgeToken: 'bridge-token-123',
+        fetchImpl: fetchMock,
+        sseConnectTimeoutMs: 5,
+      },
+      { targetPath: '/api/bridge/live-telemetry' },
+    );
+
+    expect(handled).toBe(true);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(res._statusCode).toBe(504);
+    expect(parseJsonBody(res).error).toBe('Bridge timeout');
   });
 });

--- a/docs/HYBRID_DEPLOYMENT.md
+++ b/docs/HYBRID_DEPLOYMENT.md
@@ -169,6 +169,8 @@ Template: [`.env.hybrid.example`](../.env.hybrid.example)
 | `DASHBOARD_API_TOKEN` | **Yes** | — | Token to access dashboard UI/API |
 | `BRIDGE_TOKEN` | **Yes** | — | Token for dashboard → bridge communication |
 | `BRIDGE_URL` | No | `http://host.docker.internal:18790` | Bridge API base URL |
+| `DASHBOARD_BRIDGE_JSON_TIMEOUT_MS` | No | `10000` | JSON bridge request timeout (ms) before 504 |
+| `DASHBOARD_BRIDGE_SSE_CONNECT_TIMEOUT_MS` | No | `10000` | SSE bridge connect timeout (ms) before 504 |
 | `DASHBOARD_PORT` | No | `8001` | Dashboard port |
 | `POSTGRES_PORT` | No | `5433` | Host-exposed Postgres port |
 | `DASHBOARD_DATA_MODE` | No | `bridge` | Data source (`bridge` or `filesystem`) |


### PR DESCRIPTION
## Summary
- add bounded timeout handling to bridge JSON proxy calls with safe defaults and env overrides
- make SSE bridge connect timeout explicit while keeping stream cancellation behavior intact
- return deterministic `504` responses on bridge timeout and retain `502` for non-timeout bridge failures
- document new timeout env vars in hybrid deployment docs and `.env.hybrid.example`
- add unit coverage for JSON and SSE timeout paths

## Configuration
- `DASHBOARD_BRIDGE_JSON_TIMEOUT_MS` (default: `10000`)
- `DASHBOARD_BRIDGE_SSE_CONNECT_TIMEOUT_MS` (default: `10000`)

## Verification
- `npm run test --workspace=dashboard -- tests/unit/bridge-proxy.test.ts`
- `npm run test --workspace=dashboard`
- `npm run build --workspace=dashboard`

Closes #363
