### PR TITLE
docs: reconcile README/ROADMAP with live GitHub tracker (#364)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ VentureOS is a Protoss-themed RPG system overlay for multi-agent coordination, m
 
 - **Master Plan:** [docs/RPG_SYSTEM.md](docs/RPG_SYSTEM.md) — Full spec, phases, KPIs, formulas
 - **Dashboard:** [dashboard/](dashboard/) — Operational monitoring, KPI tracking, agent health ([API docs](dashboard/docs/API.md))
-- **GitLab Integration:** [docs/GITLAB_PROCESS.md](docs/GITLAB_PROCESS.md) — MR workflow for P0/P1 fixes
+- **Roadmap Tracker:** [#138](https://github.com/zachyzissou/ventureos/issues/138) — Living delivery plan (source of truth)
 - **Phase 5 Tactical Map:** [tactical-map/](tactical-map/) — Real-time 2D StarCraft-style command center
 
 ## Project Structure
@@ -58,6 +58,7 @@ ventureos/
 - ✅ **Phase 5.5:** Mission Tracking — Mission timeline, dependency arrows, completion animations, task queue (#16)
 - ✅ **Phase 5.6:** Health & Diagnostics — Health indicators, alert overlays, metrics dashboard (#18)
 - ✅ **Phase 5.7:** Interactive Controls — Agent detail panel, command palette, mission spawn, budget slider, undo/redo (#19)
+- ✅ **Phase 5.8:** Replay & History — replay engine + session create/delete APIs shipped (#17)
 - ✅ **P0 Remediation:** All security (VULN-002/003, XSS, auth bypass), QA (phantom tests, XSS coverage), and performance (N+1 query) issues resolved (#2–#6, #142–#149)
 - ✅ **Dashboard Merge:** Monorepo consolidation — TypeScript migration, shared libraries, deployment procedures (epic #84)
 - ✅ **Security Hardening:** Auth bypass fix, query-token removal, XSS sanitization, RPG static auth gating, action endpoint defense-in-depth, DoS body-read bounding (#142–#149)
@@ -66,15 +67,15 @@ ventureos/
 
 ### In Progress
 
-- 🔄 **Phase 5.8:** Replay & History — client engine + storage complete; server mutating endpoints pending (read-only live, create/delete sessions return 501) (#17)
-- 🔄 **Live Data:** Conversation wiring + Pylon auto-refresh polling (PR#180 merged, integration ongoing — #181–#184)
-- 🔄 **Hybrid Deployment:** Containerized dashboard + bridge API — architecture designed, Dockerfile ready, not yet running in production (#140)
+- 🔄 **Tracker Hygiene + Docs Accuracy:** status/docs parity and roadmap cleanup (#364)
+- 🔄 **Docs Tooling Improvements:** reduce docs-lint false positives in instructional prose (#365)
+- 🔄 **Server Maintainability:** decompose oversized dashboard server modules (#366)
 
 ### Next Up
 
-- **Phase 4.5:** Deep Progression System — extended levels, skill trees, XP diversification (design complete, implementation not started)
-- **Polish & Sound:** Audio atmosphere, voice lines, onboarding tour, help overlay (not started)
-- **Production Containerization:** Execute hybrid deployment plan with Docker Compose
+- **Roadmap execution from #138:** convert living-plan items into tracked implementation issues/PRs
+- **Phase 4.5:** Deep Progression System — extended levels, skill trees, XP diversification
+- **Polish & Sound:** Audio atmosphere, voice lines, onboarding tour, help overlay
 
 ## Roadmap
 
@@ -99,19 +100,20 @@ Implementation milestones (visible incremental rollout):
 
 | Milestone | Scope | Issue | Status |
 |---|---|---|---|
-| M1 | Contract Foundation | [#284](https://github.com/zachyzissou/ventureos/issues/284) | Open |
-| M2 | Nexus Authority Plane | [#285](https://github.com/zachyzissou/ventureos/issues/285) | Open |
-| M3 | Competition Engine | [#286](https://github.com/zachyzissou/ventureos/issues/286) | Open |
-| M4 | Observability + Replay Authority | [#287](https://github.com/zachyzissou/ventureos/issues/287) | Open |
-| M5 | Deployment Safety | [#288](https://github.com/zachyzissou/ventureos/issues/288) | Open |
-| M6 | Production Readiness Report | [#289](https://github.com/zachyzissou/ventureos/issues/289) | Open |
+| M1 | Contract Foundation | [#284](https://github.com/zachyzissou/ventureos/issues/284) | Closed (2026-02-19) |
+| M2 | Nexus Authority Plane | [#285](https://github.com/zachyzissou/ventureos/issues/285) | Closed (2026-02-21) |
+| M3 | Competition Engine | [#286](https://github.com/zachyzissou/ventureos/issues/286) | Closed (2026-02-20) |
+| M4 | Observability + Replay Authority | [#287](https://github.com/zachyzissou/ventureos/issues/287) | Closed (2026-02-21) |
+| M5 | Deployment Safety | [#288](https://github.com/zachyzissou/ventureos/issues/288) | Closed (2026-02-21) |
+| M6 | Production Readiness Report | [#289](https://github.com/zachyzissou/ventureos/issues/289) | Closed (2026-02-21) |
 
 
 ### Now (active)
 
-- Phase 5.8 server-side replay endpoints — promote 501 stubs to real implementations (#17)
-- Live data integration — wire real conversation ingest + interaction logging (#181–#184)
-- Hybrid deployment execution — Docker Compose + production cutover (#140)
+- Docs/status reconciliation and roadmap archival cleanup (#364)
+- Docs-lint signal quality improvements for instructional content (#365)
+- Dashboard server module decomposition and maintainability cleanup (#366)
+- Living roadmap stewardship in issue #138
 
 ### Next
 
@@ -134,7 +136,6 @@ Now items map to currently open issues; see #138 and linked issues for live stat
 ### Prerequisites
 - Node.js 25+ (for tactical-map)
 - SQLite 3.x (for ventureos-rpg)
-- GitLab access (http://slurpnet:9080)
 
 ### Running the Tactical Map (Dev)
 ```bash
@@ -156,17 +157,17 @@ Tactical map integrates with the VentureOS dashboard on port 8001:
 http://192.168.225.149:8001/map
 ```
 
-## GitLab Workflow
+## GitHub Workflow
 
-All P0 and P1 fixes **MUST** go through GitLab MRs with verification:
+All implementation work is tracked and merged via GitHub issues + PRs:
 
 1. **Issue created** (acceptance criteria + verification steps)
-2. **MR opened** (use `.gitlab/merge_request_templates/Fix.md`)
+2. **PR opened** (link issue, include verification commands)
 3. **Verification** (actual testing, not just code review)
-4. **Merge** (only after verification passes)
-5. **Announce** (only after merge)
+4. **Copilot review addressed** (if comments are generated)
+5. **Merge** (only after checks pass)
 
-See [docs/GITLAB_PROCESS.md](docs/GITLAB_PROCESS.md) for full workflow.
+Legacy GitLab process notes remain in [docs/GITLAB_PROCESS.md](docs/GITLAB_PROCESS.md).
 
 ## Architecture
 
@@ -198,12 +199,12 @@ See [docs/RPG_SYSTEM.md](docs/RPG_SYSTEM.md) for formulas.
 
 ## Contributing
 
-1. Create issue in GitLab (use templates)
+1. Create issue in GitHub (use templates where available)
 2. Create branch (`git checkout -b fix/your-fix-name`)
 3. Make changes + tests
-4. Open MR (fill verification checklist)
-5. Wait for Mission Control verification
-6. Merge after verification passes
+4. Open PR (fill verification checklist in PR body)
+5. Request/handle Copilot review
+6. Merge after checks pass
 
 ## License
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,127 +1,18 @@
-# VentureOS – Roadmap
+# VentureOS Roadmap (Archived)
 
-## Phase 0 – Foundation (Week 1)
-**Objective:** get the core project organized and measurable.
-- ✅ Project plan and backlog created
-- ✅ Basic workflow definition
-- ✅ Metrics defined (tracking pending)
+This document is retained for historical context only.
 
-## Phase 0.5 – Policy & Ops (Week 1)
-**Objective:** set guardrails, proactive rules, and ops baselines.
-- ✅ Goals + constraints brief (deep onboarding)
-- ✅ Guardrails + proactive mode rules
-- ✅ Model strategy + quota caps
-- ✅ Monitoring + backup + update cadence defined
-- ✅ Restore workflow + task‑run retention + archive job spec
-- ✅ Templates + docs‑lint CI
+## Source Of Truth
 
-## Phase 1 – Reliability (Weeks 2–3)
-**Objective:** reduce failures, increase consistency.
-**Status:** 🟡 In Progress
+Roadmap planning and delivery status are tracked in GitHub issue:
+- [#138 — Roadmap: VentureOS delivery plan (living)](https://github.com/zachyzissou/ventureos/issues/138)
 
-### Completed
-- ✅ Reliability playbook (retry/backoff, timeouts, taxonomy, graceful degradation)
-- ✅ Helper scripts: `retry.sh`, `with-timeout.sh`, `guarded-run.sh`
-- ✅ Payload hardening applied to Bloom PR Monitor
+## Why Archived
 
-### In Progress
-- 🔄 **Issue #48 [P0]**: Complete Phase 1 Reliability Implementation
-  - Apply guarded execution pattern to all cron jobs
-  - Standardize network timeouts and retries
-  - Complete degradation matrix documentation
+This file still referenced legacy GitLab-era phases/issues that no longer match current repository state.
+As of 2026-02-21, active planning and prioritization happen in GitHub issues/PRs.
 
-## Phase 2 – Proactive Engine + Mission Control (Weeks 4–5)
-**Objective:** agent anticipates work and runs VentureOS missions.
-**Status:** 🟡 Planning Complete, Implementation Starting
+## Related
 
-### Completed
-- ✅ Proactive Engine design (SLA tiers, scheduler rules)
-- ✅ VentureOS/Mission Control docs integrated (roles, squads, business units, templates)
-- ✅ Task queue schema designed with mission metadata support
-- ✅ 20-role roster defined
-
-### Next Steps
-- 🔄 **Issue #49 [P0]**: Seed Business Unit Registry
-  - Create `~/clawd/runtime/business-units.json`
-  - Link initial portfolio units to Obsidian
-- 🔄 **Issue #50 [P0]**: Create Core Role Cards
-  - 10 role cards for Echo, Sentinel, Verifier, Archivist, etc.
-  - Define squad composition patterns
-- 🔄 **Issue #51 [P1]**: Implement Mission Runner Workflow
-  - Mission brief → squad execution → gates → artifacts
-- 🔄 **Issue #52 [P1]**: Phase 2 Queue Integration - Mission Metadata
-  - Extend task queue with businessUnit, missionType, role fields
-  - Portfolio-aware routing and logging
-
-## Phase 3 – Quality Upgrades (Weeks 6–7)
-**Objective:** raise output quality in all core workflows.
-**Status:** 🔵 Planned
-
-### Defined Work
-- 🔄 **Issue #53 [P1]**: Output QA Framework
-  - Format validators (markdown, JSON schema)
-  - Completeness checks (required sections, metadata)
-  - Quality scoring rubric
-  - Integration with Verifier role
-
-### Additional Goals
-- Style guides for summaries and responses
-- User feedback loop (thumbs up/down)
-- Quality scoring + continuous improvement
-
-## Phase 4 – Workflow Acceleration (Weeks 8–9)
-**Objective:** reduce manual steps for common tasks.
-**Status:** 🔵 Planned
-
-### Defined Work
-- 🔄 **Issue #54 [P2]**: Workflow Acceleration - 1-Command Workflows
-  - NewCo Sprint, Content Batch, Deploy Check, Weekly Review, Incident Response
-  - Reusable macro system
-  - Batch processing support
-
-### Additional Goals
-- Shortcut command library
-- Common task templates
-- Multi-step workflow recorder
-
-## Phase 5 – Autonomy Optimization (Weeks 10–12)
-**Objective:** make automation more durable and intelligent.
-**Status:** 🔵 Planned
-
-### Defined Work
-- 🔄 **Issue #55 [P2]**: Enhanced Model Routing - Smart Selection
-  - Multi-factor scoring (complexity, quota, priority, time)
-  - Quota-aware routing (90% threshold → cheap model)
-  - Fallback chain implementation
-  - Business unit priority overrides
-
-### Additional Goals
-- Self‑healing patterns
-- Dependency health checks
-- Adaptive learning from failures
-
----
-
-## Current Sprint Focus (Feb 2026)
-**Priority**: Complete Phase 1 Reliability, Begin Phase 2 Foundation
-
-### This Week
-1. **[P0] Issue #48**: Complete reliability rollout to all workflows
-2. **[P0] Issue #49**: Seed business unit registry
-3. **[P0] Issue #50**: Create core role cards
-
-### Next Week
-4. **[P1] Issue #52**: Queue integration with mission metadata
-5. **[P1] Issue #51**: Mission runner workflow implementation
-
----
-
-## Issue Tracking
-All implementation work tracked in GitLab issues:
-- **P0 (Critical)**: Issues #48, #49, #50
-- **P1 (High Priority)**: Issues #51, #52, #53
-- **P2 (Medium Priority)**: Issues #54, #55
-
----
-
-**Security work is intentionally deferred** to a later phase.
+- Current project snapshot: [`README.md`](../README.md)
+- Hybrid deployment guide: [`docs/HYBRID_DEPLOYMENT.md`](./HYBRID_DEPLOYMENT.md)


### PR DESCRIPTION
## Summary
- update README status sections to remove stale replay/501 messaging and align with current issue state
- mark all Nexus 2.0 milestone rows as closed with concrete close dates
- update "Now (active)" focus to match currently open tracker issues
- align workflow language to GitHub issues/PRs as source of truth
- convert `docs/ROADMAP.md` into an archival pointer to GitHub roadmap issue #138

## Verification
- `python3 scripts/docs-lint.py` *(currently fails on pre-existing placeholder detection noise tracked in #365)*
- Manual issue/status sanity check via `gh issue list` and `gh issue view` for #17, #284-#289

Closes #364
