### PR TITLE
refactor: decompose oversized dashboard modules (stage 1) (#366)

### DIFF
--- a/dashboard/server/routes/task-board-metrics.ts
+++ b/dashboard/server/routes/task-board-metrics.ts
@@ -1,0 +1,235 @@
+import type {
+  TaskCard,
+  TaskPriority,
+  TaskStatus,
+} from '../types.js';
+import type { AlertEvaluation } from '../alert-rules.js';
+
+/** Default stuck-task timeout: 30 minutes. */
+export const DEFAULT_STUCK_TIMEOUT_MS = 30 * 60 * 1000;
+
+/** A running task that exceeds the configured timeout threshold. */
+export interface StuckTask {
+  id: string;
+  title: string;
+  agentId: string | null;
+  priority: TaskPriority;
+  startedAt: number;
+  runningMs: number;
+  thresholdMs: number;
+  /** How far past the threshold (runningMs / thresholdMs). */
+  overshootRatio: number;
+}
+
+/** Computed task board metrics — derived from existing data, no schema changes. */
+export interface TaskBoardMetrics {
+  updatedAt: number;
+  /** Counts by status. */
+  statusCounts: Record<TaskStatus, number>;
+  total: number;
+  /** Throughput: tasks that reached done/failed in the given windows. */
+  throughput: {
+    last24h: number;
+    last7d: number;
+    last30d: number;
+  };
+  /** Average runtime of completed tasks (done/failed with runtimeMs). */
+  avgRuntimeMs: number | null;
+  /** Median runtime of completed tasks. */
+  medianRuntimeMs: number | null;
+  /** Success rate: done / (done + failed), null if no terminal tasks. */
+  successRate: number | null;
+  /** Per-day completion counts for the last 7 days (ISO date → count). */
+  completionTrend7d: Array<{ date: string; done: number; failed: number }>;
+  /** Per-agent breakdown of completed/running tasks. */
+  agentBreakdown: Array<{
+    agentId: string;
+    running: number;
+    done: number;
+    failed: number;
+    avgRuntimeMs: number | null;
+  }>;
+  /** Stuck tasks — running tasks exceeding the timeout threshold. */
+  stuckTasks: StuckTask[];
+  stuckCount: number;
+  stuckTimeoutMs: number;
+  /** Alert evaluation results (Phase 9). */
+  alerts?: AlertEvaluation;
+}
+
+/**
+ * Identify running tasks that exceed the given timeout threshold.
+ * Pure function — no side effects, bounded to the input array.
+ */
+export function computeStuckTasks(
+  tasks: TaskCard[],
+  timeoutMs: number = DEFAULT_STUCK_TIMEOUT_MS,
+  now: number = Date.now(),
+): StuckTask[] {
+  const stuck: StuckTask[] = [];
+  for (const t of tasks) {
+    if (t.status !== 'running' || !t.startedAt) continue;
+    const runningMs = now - t.startedAt;
+    if (runningMs > timeoutMs) {
+      stuck.push({
+        id: t.id,
+        title: t.title,
+        agentId: t.agentId,
+        priority: t.priority,
+        startedAt: t.startedAt,
+        runningMs,
+        thresholdMs: timeoutMs,
+        overshootRatio: runningMs / timeoutMs,
+      });
+    }
+  }
+  // Sort by overshoot descending (most stuck first)
+  stuck.sort((a, b) => b.overshootRatio - a.overshootRatio);
+  return stuck;
+}
+
+/**
+ * Compute comprehensive task board metrics from existing task data.
+ * All calculations are bounded (single pass + lightweight aggregations).
+ */
+export function computeMetrics(
+  tasks: TaskCard[],
+  opts: { stuckTimeoutMs?: number; now?: number } = {},
+): TaskBoardMetrics {
+  const now = opts.now ?? Date.now();
+  const stuckTimeoutMs = opts.stuckTimeoutMs ?? DEFAULT_STUCK_TIMEOUT_MS;
+
+  // Status counts
+  const statusCounts: Record<TaskStatus, number> = {
+    backlog: 0,
+    queued: 0,
+    running: 0,
+    blocked: 0,
+    review: 0,
+    done: 0,
+    failed: 0,
+  };
+  for (const t of tasks) {
+    statusCounts[t.status] = (statusCounts[t.status] ?? 0) + 1;
+  }
+
+  // Throughput windows
+  const ms24h = 24 * 60 * 60 * 1000;
+  const ms7d = 7 * ms24h;
+  const ms30d = 30 * ms24h;
+  let tp24h = 0, tp7d = 0, tp30d = 0;
+
+  // Runtime stats for completed tasks
+  const runtimes: number[] = [];
+
+  // Success rate
+  let doneCount = 0, failedCount = 0;
+
+  // Per-day completion trend (last 7 days)
+  const trendMap = new Map<string, { done: number; failed: number }>();
+  // Pre-fill 7 days
+  for (let i = 6; i >= 0; i--) {
+    const d = new Date(now - i * ms24h);
+    const key = d.toISOString().slice(0, 10);
+    trendMap.set(key, { done: 0, failed: 0 });
+  }
+
+  // Per-agent breakdown
+  const agentMap = new Map<string, { running: number; done: number; failed: number; runtimes: number[] }>();
+
+  for (const t of tasks) {
+    const aid = t.agentId ?? '_unassigned';
+    if (!agentMap.has(aid)) {
+      agentMap.set(aid, { running: 0, done: 0, failed: 0, runtimes: [] });
+    }
+    const ag = agentMap.get(aid)!;
+
+    if (t.status === 'running') ag.running++;
+
+    // Terminal tasks
+    if (t.status === 'done' || t.status === 'failed') {
+      if (t.status === 'done') { doneCount++; ag.done++; }
+      if (t.status === 'failed') { failedCount++; ag.failed++; }
+
+      // Throughput: use completedAt
+      if (t.completedAt) {
+        const age = now - t.completedAt;
+        if (age <= ms24h) tp24h++;
+        if (age <= ms7d) tp7d++;
+        if (age <= ms30d) tp30d++;
+
+        // Trend
+        const dateKey = new Date(t.completedAt).toISOString().slice(0, 10);
+        if (trendMap.has(dateKey)) {
+          const entry = trendMap.get(dateKey)!;
+          if (t.status === 'done') entry.done++;
+          else entry.failed++;
+        }
+      }
+
+      // Runtime
+      const rt = t.runtimeMs ?? (t.startedAt && t.completedAt ? t.completedAt - t.startedAt : null);
+      if (rt != null && rt >= 0) {
+        runtimes.push(rt);
+        ag.runtimes.push(rt);
+      }
+    }
+  }
+
+  // Average & median runtime
+  const avgRuntimeMs = runtimes.length > 0
+    ? Math.round(runtimes.reduce((s, v) => s + v, 0) / runtimes.length)
+    : null;
+  const medianRuntimeMs = runtimes.length > 0
+    ? (() => {
+        const sorted = [...runtimes].sort((a, b) => a - b);
+        const mid = Math.floor(sorted.length / 2);
+        return sorted.length % 2 !== 0
+          ? sorted[mid]
+          : Math.round((sorted[mid - 1] + sorted[mid]) / 2);
+      })()
+    : null;
+
+  // Success rate
+  const totalTerminal = doneCount + failedCount;
+  const successRate = totalTerminal > 0 ? Math.round((doneCount / totalTerminal) * 10000) / 10000 : null;
+
+  // Completion trend array
+  const completionTrend7d = [...trendMap.entries()].map(([date, v]) => ({
+    date,
+    done: v.done,
+    failed: v.failed,
+  }));
+
+  // Agent breakdown
+  const agentBreakdown = [...agentMap.entries()]
+    .filter(([id]) => id !== '_unassigned' || agentMap.size === 1) // include unassigned only if it's the only bucket
+    .map(([agentId, data]) => ({
+      agentId,
+      running: data.running,
+      done: data.done,
+      failed: data.failed,
+      avgRuntimeMs: data.runtimes.length > 0
+        ? Math.round(data.runtimes.reduce((s, v) => s + v, 0) / data.runtimes.length)
+        : null,
+    }))
+    .sort((a, b) => (b.done + b.failed + b.running) - (a.done + a.failed + a.running));
+
+  // Stuck tasks
+  const stuckTasks = computeStuckTasks(tasks, stuckTimeoutMs, now);
+
+  return {
+    updatedAt: now,
+    statusCounts,
+    total: tasks.length,
+    throughput: { last24h: tp24h, last7d: tp7d, last30d: tp30d },
+    avgRuntimeMs,
+    medianRuntimeMs,
+    successRate,
+    completionTrend7d,
+    agentBreakdown,
+    stuckTasks,
+    stuckCount: stuckTasks.length,
+    stuckTimeoutMs,
+  };
+}

--- a/dashboard/server/routes/task-board.ts
+++ b/dashboard/server/routes/task-board.ts
@@ -58,8 +58,21 @@ import {
 
 import type {
   AlertRulesConfig,
-  AlertEvaluation,
 } from '../alert-rules.js';
+import {
+  DEFAULT_STUCK_TIMEOUT_MS,
+  computeMetrics,
+  computeStuckTasks,
+} from './task-board-metrics.js';
+export {
+  DEFAULT_STUCK_TIMEOUT_MS,
+  computeMetrics,
+  computeStuckTasks,
+};
+export type {
+  StuckTask,
+  TaskBoardMetrics,
+} from './task-board-metrics.js';
 
 import {
   maybeAppendAlertEvent,
@@ -763,237 +776,6 @@ function instantiatePipelineFromTemplate(
     templateId: template.id,
     created: created.length,
     cards: created,
-  };
-}
-
-// ─── Metrics & Stuck-Task Detection (Issue #219 — Task Metrics Dashboard) ────
-
-/** Default stuck-task timeout: 30 minutes. */
-const DEFAULT_STUCK_TIMEOUT_MS = 30 * 60 * 1000;
-
-/** A running task that exceeds the configured timeout threshold. */
-export interface StuckTask {
-  id: string;
-  title: string;
-  agentId: string | null;
-  priority: TaskPriority;
-  startedAt: number;
-  runningMs: number;
-  thresholdMs: number;
-  /** How far past the threshold (runningMs / thresholdMs). */
-  overshootRatio: number;
-}
-
-/** Computed task board metrics — derived from existing data, no schema changes. */
-export interface TaskBoardMetrics {
-  updatedAt: number;
-  /** Counts by status. */
-  statusCounts: Record<TaskStatus, number>;
-  total: number;
-  /** Throughput: tasks that reached done/failed in the given windows. */
-  throughput: {
-    last24h: number;
-    last7d: number;
-    last30d: number;
-  };
-  /** Average runtime of completed tasks (done/failed with runtimeMs). */
-  avgRuntimeMs: number | null;
-  /** Median runtime of completed tasks. */
-  medianRuntimeMs: number | null;
-  /** Success rate: done / (done + failed), null if no terminal tasks. */
-  successRate: number | null;
-  /** Per-day completion counts for the last 7 days (ISO date → count). */
-  completionTrend7d: Array<{ date: string; done: number; failed: number }>;
-  /** Per-agent breakdown of completed/running tasks. */
-  agentBreakdown: Array<{
-    agentId: string;
-    running: number;
-    done: number;
-    failed: number;
-    avgRuntimeMs: number | null;
-  }>;
-  /** Stuck tasks — running tasks exceeding the timeout threshold. */
-  stuckTasks: StuckTask[];
-  stuckCount: number;
-  stuckTimeoutMs: number;
-  /** Alert evaluation results (Phase 9). */
-  alerts?: AlertEvaluation;
-}
-
-/**
- * Identify running tasks that exceed the given timeout threshold.
- * Pure function — no side effects, bounded to the input array.
- */
-export function computeStuckTasks(
-  tasks: TaskCard[],
-  timeoutMs: number = DEFAULT_STUCK_TIMEOUT_MS,
-  now: number = Date.now(),
-): StuckTask[] {
-  const stuck: StuckTask[] = [];
-  for (const t of tasks) {
-    if (t.status !== 'running' || !t.startedAt) continue;
-    const runningMs = now - t.startedAt;
-    if (runningMs > timeoutMs) {
-      stuck.push({
-        id: t.id,
-        title: t.title,
-        agentId: t.agentId,
-        priority: t.priority,
-        startedAt: t.startedAt,
-        runningMs,
-        thresholdMs: timeoutMs,
-        overshootRatio: runningMs / timeoutMs,
-      });
-    }
-  }
-  // Sort by overshoot descending (most stuck first)
-  stuck.sort((a, b) => b.overshootRatio - a.overshootRatio);
-  return stuck;
-}
-
-/**
- * Compute comprehensive task board metrics from existing task data.
- * All calculations are bounded (single pass + lightweight aggregations).
- */
-export function computeMetrics(
-  tasks: TaskCard[],
-  opts: { stuckTimeoutMs?: number; now?: number } = {},
-): TaskBoardMetrics {
-  const now = opts.now ?? Date.now();
-  const stuckTimeoutMs = opts.stuckTimeoutMs ?? DEFAULT_STUCK_TIMEOUT_MS;
-
-  // Status counts
-  const statusCounts: Record<TaskStatus, number> = {
-    backlog: 0,
-    queued: 0,
-    running: 0,
-    blocked: 0,
-    review: 0,
-    done: 0,
-    failed: 0,
-  };
-  for (const t of tasks) {
-    statusCounts[t.status] = (statusCounts[t.status] ?? 0) + 1;
-  }
-
-  // Throughput windows
-  const ms24h = 24 * 60 * 60 * 1000;
-  const ms7d = 7 * ms24h;
-  const ms30d = 30 * ms24h;
-  let tp24h = 0, tp7d = 0, tp30d = 0;
-
-  // Runtime stats for completed tasks
-  const runtimes: number[] = [];
-
-  // Success rate
-  let doneCount = 0, failedCount = 0;
-
-  // Per-day completion trend (last 7 days)
-  const trendMap = new Map<string, { done: number; failed: number }>();
-  // Pre-fill 7 days
-  for (let i = 6; i >= 0; i--) {
-    const d = new Date(now - i * ms24h);
-    const key = d.toISOString().slice(0, 10);
-    trendMap.set(key, { done: 0, failed: 0 });
-  }
-
-  // Per-agent breakdown
-  const agentMap = new Map<string, { running: number; done: number; failed: number; runtimes: number[] }>();
-
-  for (const t of tasks) {
-    const aid = t.agentId ?? '_unassigned';
-    if (!agentMap.has(aid)) {
-      agentMap.set(aid, { running: 0, done: 0, failed: 0, runtimes: [] });
-    }
-    const ag = agentMap.get(aid)!;
-
-    if (t.status === 'running') ag.running++;
-
-    // Terminal tasks
-    if (t.status === 'done' || t.status === 'failed') {
-      if (t.status === 'done') { doneCount++; ag.done++; }
-      if (t.status === 'failed') { failedCount++; ag.failed++; }
-
-      // Throughput: use completedAt
-      if (t.completedAt) {
-        const age = now - t.completedAt;
-        if (age <= ms24h) tp24h++;
-        if (age <= ms7d) tp7d++;
-        if (age <= ms30d) tp30d++;
-
-        // Trend
-        const dateKey = new Date(t.completedAt).toISOString().slice(0, 10);
-        if (trendMap.has(dateKey)) {
-          const entry = trendMap.get(dateKey)!;
-          if (t.status === 'done') entry.done++;
-          else entry.failed++;
-        }
-      }
-
-      // Runtime
-      const rt = t.runtimeMs ?? (t.startedAt && t.completedAt ? t.completedAt - t.startedAt : null);
-      if (rt != null && rt >= 0) {
-        runtimes.push(rt);
-        ag.runtimes.push(rt);
-      }
-    }
-  }
-
-  // Average & median runtime
-  const avgRuntimeMs = runtimes.length > 0
-    ? Math.round(runtimes.reduce((s, v) => s + v, 0) / runtimes.length)
-    : null;
-  const medianRuntimeMs = runtimes.length > 0
-    ? (() => {
-        const sorted = [...runtimes].sort((a, b) => a - b);
-        const mid = Math.floor(sorted.length / 2);
-        return sorted.length % 2 !== 0
-          ? sorted[mid]
-          : Math.round((sorted[mid - 1] + sorted[mid]) / 2);
-      })()
-    : null;
-
-  // Success rate
-  const totalTerminal = doneCount + failedCount;
-  const successRate = totalTerminal > 0 ? Math.round((doneCount / totalTerminal) * 10000) / 10000 : null;
-
-  // Completion trend array
-  const completionTrend7d = [...trendMap.entries()].map(([date, v]) => ({
-    date,
-    done: v.done,
-    failed: v.failed,
-  }));
-
-  // Agent breakdown
-  const agentBreakdown = [...agentMap.entries()]
-    .filter(([id]) => id !== '_unassigned' || agentMap.size === 1) // include unassigned only if it's the only bucket
-    .map(([agentId, data]) => ({
-      agentId,
-      running: data.running,
-      done: data.done,
-      failed: data.failed,
-      avgRuntimeMs: data.runtimes.length > 0
-        ? Math.round(data.runtimes.reduce((s, v) => s + v, 0) / data.runtimes.length)
-        : null,
-    }))
-    .sort((a, b) => (b.done + b.failed + b.running) - (a.done + a.failed + a.running));
-
-  // Stuck tasks
-  const stuckTasks = computeStuckTasks(tasks, stuckTimeoutMs, now);
-
-  return {
-    updatedAt: now,
-    statusCounts,
-    total: tasks.length,
-    throughput: { last24h: tp24h, last7d: tp7d, last30d: tp30d },
-    avgRuntimeMs,
-    medianRuntimeMs,
-    successRate,
-    completionTrend7d,
-    agentBreakdown,
-    stuckTasks,
-    stuckCount: stuckTasks.length,
-    stuckTimeoutMs,
   };
 }
 

--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -92,7 +92,7 @@ import { auditLog } from './middleware/audit-log.js';
 import { authorizeActionRequest } from './middleware/action-guard.js';
 import { withCorrelationId, CORRELATION_HEADER } from './middleware/correlation-id.js';
 import { proxyBridgeJson, proxyBridgeSse } from './bridge-proxy.js';
-import { isPathInsideRoot } from './path-containment.js';
+import { tryServeStatic } from './static-serve.js';
 
 // Structured logging (Issue #195 — Observability)
 import structuredLogger from '../../lib/structured-logger.js';
@@ -228,62 +228,6 @@ function readEnvFlag(name: string, fallback = false): boolean {
   if (raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on') return true;
   if (raw === '0' || raw === 'false' || raw === 'no' || raw === 'off') return false;
   return fallback;
-}
-
-function contentTypeFor(filePath: string): string {
-  const ext: string = path.extname(filePath).toLowerCase();
-  if (ext === '.js' || ext === '.mjs') return 'text/javascript; charset=utf-8';
-  if (ext === '.css') return 'text/css; charset=utf-8';
-  if (ext === '.json') return 'application/json; charset=utf-8';
-  if (ext === '.svg') return 'image/svg+xml';
-  if (ext === '.png') return 'image/png';
-  if (ext === '.jpg' || ext === '.jpeg') return 'image/jpeg';
-  if (ext === '.gif') return 'image/gif';
-  if (ext === '.webp') return 'image/webp';
-  return 'application/octet-stream';
-}
-
-function tryServeStatic(
-  req: IncomingMessage,
-  res: ServerResponse,
-  opts: { urlPrefix: string; rootDir: string },
-): boolean {
-  try {
-    if (!req.url || req.method !== 'GET') return false;
-    if (!req.url.startsWith(opts.urlPrefix)) return false;
-
-    const rel: string = decodeURIComponent(req.url.slice(opts.urlPrefix.length)).replace(/^\/+/, '');
-    const root: string = path.resolve(opts.rootDir);
-    let fpath: string = path.resolve(path.join(root, rel));
-
-    if (!isPathInsideRoot(root, fpath)) {
-      res.writeHead(403);
-      res.end('Forbidden');
-      return true;
-    }
-
-    // Auto-serve index.html for directory requests
-    if (fs.existsSync(fpath) && fs.statSync(fpath).isDirectory()) {
-      fpath = path.join(fpath, 'index.html');
-    }
-
-    if (!fs.existsSync(fpath) || !fs.statSync(fpath).isFile()) {
-      res.writeHead(404);
-      res.end('Not found');
-      return true;
-    }
-
-    res.writeHead(200, {
-      'Content-Type': contentTypeFor(fpath),
-      'Cache-Control': 'no-cache',
-    });
-    res.end(fs.readFileSync(fpath));
-    return true;
-  } catch {
-    res.writeHead(500);
-    res.end('Static file error');
-    return true;
-  }
 }
 
 async function readRequestBody(

--- a/dashboard/server/static-serve.ts
+++ b/dashboard/server/static-serve.ts
@@ -1,0 +1,61 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import type { IncomingMessage, ServerResponse } from 'node:http';
+
+import { isPathInsideRoot } from './path-containment.js';
+
+function contentTypeFor(filePath: string): string {
+  const ext: string = path.extname(filePath).toLowerCase();
+  if (ext === '.js' || ext === '.mjs') return 'text/javascript; charset=utf-8';
+  if (ext === '.css') return 'text/css; charset=utf-8';
+  if (ext === '.json') return 'application/json; charset=utf-8';
+  if (ext === '.svg') return 'image/svg+xml';
+  if (ext === '.png') return 'image/png';
+  if (ext === '.jpg' || ext === '.jpeg') return 'image/jpeg';
+  if (ext === '.gif') return 'image/gif';
+  if (ext === '.webp') return 'image/webp';
+  return 'application/octet-stream';
+}
+
+export function tryServeStatic(
+  req: IncomingMessage,
+  res: ServerResponse,
+  opts: { urlPrefix: string; rootDir: string },
+): boolean {
+  try {
+    if (!req.url || req.method !== 'GET') return false;
+    if (!req.url.startsWith(opts.urlPrefix)) return false;
+
+    const rel: string = decodeURIComponent(req.url.slice(opts.urlPrefix.length)).replace(/^\/+/, '');
+    const root: string = path.resolve(opts.rootDir);
+    let fpath: string = path.resolve(path.join(root, rel));
+
+    if (!isPathInsideRoot(root, fpath)) {
+      res.writeHead(403);
+      res.end('Forbidden');
+      return true;
+    }
+
+    // Auto-serve index.html for directory requests.
+    if (fs.existsSync(fpath) && fs.statSync(fpath).isDirectory()) {
+      fpath = path.join(fpath, 'index.html');
+    }
+
+    if (!fs.existsSync(fpath) || !fs.statSync(fpath).isFile()) {
+      res.writeHead(404);
+      res.end('Not found');
+      return true;
+    }
+
+    res.writeHead(200, {
+      'Content-Type': contentTypeFor(fpath),
+      'Cache-Control': 'no-cache',
+    });
+    res.end(fs.readFileSync(fpath));
+    return true;
+  } catch {
+    res.writeHead(500);
+    res.end('Static file error');
+    return true;
+  }
+}

--- a/dashboard/tests/unit/maintainability/file-size-guard.test.ts
+++ b/dashboard/tests/unit/maintainability/file-size-guard.test.ts
@@ -1,0 +1,31 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { describe, it, expect } from 'vitest';
+
+const DASHBOARD_ROOT = path.resolve(import.meta.dirname, '..', '..', '..');
+
+const FILE_SIZE_BUDGETS = [
+  {
+    relativePath: 'server/server.ts',
+    maxLines: 4200,
+  },
+  {
+    relativePath: 'server/routes/task-board.ts',
+    maxLines: 2500,
+  },
+] as const;
+
+function lineCount(filePath: string): number {
+  return fs.readFileSync(filePath, 'utf8').split(/\r?\n/).length;
+}
+
+describe('Maintainability Guardrails', () => {
+  for (const budget of FILE_SIZE_BUDGETS) {
+    it(`${budget.relativePath} stays within ${budget.maxLines} lines`, () => {
+      const fullPath = path.join(DASHBOARD_ROOT, budget.relativePath);
+      const count = lineCount(fullPath);
+      expect(count).toBeLessThanOrEqual(budget.maxLines);
+    });
+  }
+});

--- a/docs/SERVER_DECOMPOSITION_PLAN.md
+++ b/docs/SERVER_DECOMPOSITION_PLAN.md
@@ -1,0 +1,27 @@
+# Server Decomposition Plan (Issue #366)
+
+## Goal
+Reduce regression blast-radius from oversized dashboard server modules while preserving behavior parity.
+
+## Baseline (2026-02-21)
+- `dashboard/server/server.ts`: 4231 LOC
+- `dashboard/server/routes/task-board.ts`: 2650 LOC
+
+## Staged Plan
+1. Stage 1 (completed)
+- Extract static-file serving helpers from `server.ts` into `dashboard/server/static-serve.ts`.
+- Extract task-board metrics/stuck-task logic from `task-board.ts` into `dashboard/server/routes/task-board-metrics.ts`.
+- Add file-size guardrails in `dashboard/tests/unit/maintainability/file-size-guard.test.ts`.
+
+2. Stage 2 (next)
+- Split task-board API surface by concern (metrics/history/webhooks/escalations) into route-local modules.
+- Keep `handleTaskBoard` as a thin dispatcher/composer.
+
+3. Stage 3 (next)
+- Group high-volume route wiring in `server.ts` into route registrars by domain.
+- Preserve middleware ordering, auth boundaries, and existing response semantics.
+
+## Guardrails
+- `server.ts` budget: <= 4200 LOC
+- `task-board.ts` budget: <= 2500 LOC
+- Budgets enforced in dashboard unit tests to prevent re-monolithing.


### PR DESCRIPTION
## Summary
Stage 1 of decomposition for oversized dashboard modules.

### Extractions
- extracted static file serving helpers from `dashboard/server/server.ts` into `dashboard/server/static-serve.ts`
- extracted task-board metrics/stuck-task logic from `dashboard/server/routes/task-board.ts` into `dashboard/server/routes/task-board-metrics.ts`
- preserved public exports from `task-board.ts` for behavior parity (`computeMetrics`, `computeStuckTasks`, related types)

### Guardrails
- added file-size budgets enforced by tests in `dashboard/tests/unit/maintainability/file-size-guard.test.ts`
  - `dashboard/server/server.ts <= 4200`
  - `dashboard/server/routes/task-board.ts <= 2500`

### Plan Tracking
- added staged extraction plan doc: `docs/SERVER_DECOMPOSITION_PLAN.md`

## Verification
- `npm run test --workspace=dashboard -- tests/unit/routes/task-board-metrics.test.ts tests/unit/routes/task-board.test.ts tests/unit/dist-client-assets.test.ts tests/unit/maintainability/file-size-guard.test.ts`
- `npm run test --workspace=dashboard`
- `npm run build --workspace=dashboard`

Closes #366
