### PR TITLE
docs: migrate process tracking guidance to GitHub-first (#374)

### DIFF
--- a/docs/DOC_INDEX.md
+++ b/docs/DOC_INDEX.md
@@ -15,9 +15,9 @@
 ## Core
 - **README.md** – project overview
 - **docs/roles/REPO_CHARTER.md** – VentureOS charter + scope boundaries
-- **docs/process/OPERATING_CONTRACT_GITLAB.md** – GitLab-first work contract (Issue → Evidence → MR/commit → Verify → Close)
+- **docs/process/OPERATING_CONTRACT_GITLAB.md** – GitHub-first work contract (legacy filename kept for compatibility)
 - **docs/process/LABEL_PROTOCOL.md** – how workflow labels are applied/removed
-- **docs/process/GITLAB_PROJECT_RESOLVER.md** – how Mission Control chooses which GitLab project to create issues in
+- **docs/process/GITLAB_PROJECT_RESOLVER.md** – how Mission Control resolves the target GitHub repository for issues/PRs (legacy filename kept for compatibility)
 - **docs/process/STATUS.md** – current implementation status
 - **docs/process/ROADMAP.md** – phased roadmap
 - **docs/process/PROJECT_PLAN.md** – milestones + success metrics
@@ -68,7 +68,7 @@
 - **docs/roles/foley.md** – audio director
 
 ## Policy Docs (repo copies; to be placed in workspace root)
-- **docs/ops/WORK_TRACKING.md** – GitLab issues/MRs as canonical tracker + evidence standards
+- **docs/WORK_TRACKING.md** – GitHub issues/PRs as canonical tracker + evidence standards
 - **docs/ops/GOALS_CONSTRAINTS.md** – goals, constraints, comms preferences
 - **docs/ops/GUARDRAILS.md** – explicit prohibitions + allowed actions
 - **docs/ops/PROACTIVE_MODE.md** – proactive window + escalation rules
@@ -93,8 +93,10 @@
 - **docs/templates/mission-runner.md** – mission runner workflow template
 - **docs/templates/role-card.md** – role card template
 - **docs/templates/business-unit-registry.json** – business unit registry template
-- **docs/templates/gitlab-issue-template.md** – issue template (Goal/AC/Evidence/Close-out)
-- **docs/templates/gitlab-mr-template.md** – MR template (Issue link/verification)
+- **docs/templates/github-issue-template.md** – issue template (Goal/AC/Evidence/Close-out)
+- **docs/templates/github-pr-template.md** – PR template (Issue link/verification)
+- **docs/templates/gitlab-issue-template.md** – legacy alias pointing to GitHub issue template
+- **docs/templates/gitlab-mr-template.md** – legacy alias pointing to GitHub PR template
 
 ## Implementation Design
 - **docs/process/REQUIREMENTS.md** – detailed functional + non‑functional requirements

--- a/docs/WORK_TRACKING.md
+++ b/docs/WORK_TRACKING.md
@@ -1,19 +1,19 @@
-# Work Tracking (GitLab = Source of Truth)
+# Work Tracking (GitHub = Source of Truth)
 
 This repository is the **canonical tracker + implementation repo** for VentureOS (built on OpenClaw).
 
 ## Source of Truth
-- **GitLab Issues** in this repo are the source of truth for:
+- **GitHub Issues** in this repo are the source of truth for:
   - scope, acceptance criteria, and priority
-  - progress state (Todo / Doing / Blocked / Done)
+  - progress state (open / in progress / blocked / done)
   - decisions + tradeoffs
   - verification evidence
-- **GitLab Merge Requests** are the source of truth for the actual code/doc change.
+- **GitHub Pull Requests** are the source of truth for code and doc changes.
 
-## Rules (Non‑Negotiable)
+## Rules (Non-Negotiable)
 1. **No non-trivial work without an issue.**
-   - If it takes **>10 minutes**, touches infra, changes behavior, or adds a new workflow → create/link an issue.
-2. **Every MR must link an issue** and include verification evidence.
+   - If it takes **>10 minutes**, touches infra, changes behavior, or adds a new workflow -> create/link an issue.
+2. **Every PR must link an issue** and include verification evidence.
 3. **Definitions beat vibes.** Every issue needs:
    - Why / context
    - Definition of Done
@@ -23,17 +23,16 @@ This repository is the **canonical tracker + implementation repo** for VentureOS
 ## Local Agent Memory (secondary)
 The agent maintains local work logs under `~/clawd/memory/work-items/` for continuity across sessions.
 
-**Policy:** Local work items are helpful, but they must link back to the GitLab Issue URL (GitLab is canonical).
+**Policy:** Local work items are helpful, but they must link back to the GitHub issue URL (GitHub is canonical).
 
 ## Suggested Labels
-- `type::bug`, `type::feature`, `type::docs`, `type::ops`
-- `prio::p0`, `prio::p1`, `prio::p2`, `prio::p3`
-- `area::ventureos`, `area::quality`, `area::workflow`, `area::model-orchestration`
-- `bu::<name>` (optional, business‑unit scoped)
+- `bug`, `enhancement`, `documentation`, `security`
+- `P0`, `P1`, `P2` (priority)
+- `architecture`, `backend`, `dashboard`, `qa`
 
 ## Templates
-- Issues: `.gitlab/issue_templates/`
-- Merge requests: `.gitlab/merge_request_templates/`
+- Issue template: `docs/templates/github-issue-template.md`
+- PR template: `docs/templates/github-pr-template.md`
 
 ## Note: Huly
 We attempted a Huly-based tracker workflow, but Huly Desktop on this machine is not exposing a local server for automated import. If/when a self-hosted Huly backend is available, we can revisit.

--- a/docs/process/GITLAB_PROJECT_RESOLVER.md
+++ b/docs/process/GITLAB_PROJECT_RESOLVER.md
@@ -1,24 +1,26 @@
-# GitLab Project Resolver (Mission Control)
+# GitHub Project Resolver (Mission Control)
 
-Mission Control must be able to target the correct GitLab project when creating Issues/MRs.
+> Legacy filename retained for compatibility with existing links.
+
+Mission Control must target the correct GitHub repository when creating issues/PRs.
 
 ## Core rule (no default)
-1) If the user specifies a project alias/name/link → use that.
-2) If there is an active thread already tied to a GitLab issue/MR → use that project.
-3) Otherwise ask exactly one question: **“Which GitLab project should this live in?”**
+1) If the user specifies a repo alias/name/link -> use that.
+2) If there is an active thread already tied to a GitHub issue/PR -> use that repo.
+3) Otherwise ask exactly one question: **"Which GitHub repo should this live in?"**
 
 ## Canonical aliases (fast path)
-- `ventureos` → `zachgonser/ventureos`
-- `stanton` → `zachgonser/stanton-times`
-- `clawd` → `zachgonser/clawd`
+- `ventureos` -> `zachyzissou/ventureos`
+- `stanton` -> `zachgonser/stanton-times`
+- `clawd` -> `zachgonser/clawd`
 
-## Discovering other projects (smart lookup)
-When the user references an unfamiliar project name:
-- Use GitLab search (`list_projects search=<query>`) to resolve candidates.
-- Present **top 3 matches** as `path_with_namespace` + link.
+## Discovering other repos (smart lookup)
+When the user references an unfamiliar repo name:
+- Use GitHub repo search (`gh repo list` / `gh search repos`) to resolve candidates.
+- Present top matches as `owner/name` + link.
 - If ambiguous, ask the user to pick one.
 
 ## Examples
-- “ventureos: add routing health check” → create issue in `zachgonser/ventureos`.
-- “in zachgonser/stanton-times: fix approvals flow” → create issue there.
-- “work on the bloom repo” → search for `bloom` and ask to confirm the intended project.
+- "ventureos: add routing health check" -> create issue in `zachyzissou/ventureos`.
+- "in zachgonser/stanton-times: fix approvals flow" -> create issue there.
+- "work on the bloom repo" -> search for `bloom` and ask to confirm the intended repo.

--- a/docs/process/LABEL_PROTOCOL.md
+++ b/docs/process/LABEL_PROTOCOL.md
@@ -1,17 +1,17 @@
-# Label Protocol (GitLab-First)
+# Label Protocol (GitHub-First)
 
 These labels make workflow state explicit and enforce the Operating Contract.
 
 ## Canonical labels
 - `needs-evidence` — default for any issue without close-out evidence block filled + links attached.
-- `needs-review` — work is implemented; ready for MR review / second set of eyes.
+- `needs-review` — work is implemented; ready for PR review / second set of eyes.
 - `needs-verification` — ready for QA verification against acceptance criteria.
 - `blocked` — cannot proceed; comment must state blocker + next step.
-- `no-code-change` — explicit exception when closing without MR/commit (must explain why).
+- `no-code-change` — explicit exception when closing without PR/commit (must explain why).
 
 ## How labels should flow
 1) **New issue** → apply `needs-evidence`.
-2) **Implementation ready** → open MR; apply `needs-review`.
+2) **Implementation ready** -> open PR; apply `needs-review`.
 3) **Post-merge / deployed** → apply `needs-verification` (if applicable).
 4) **Verified** → remove `needs-*` labels; issue can be closed once close-out block is complete.
 

--- a/docs/process/OPERATING_CONTRACT_GITLAB.md
+++ b/docs/process/OPERATING_CONTRACT_GITLAB.md
@@ -1,72 +1,74 @@
-# VentureOS Operating Contract (GitLab-First)
+# VentureOS Operating Contract (GitHub-First)
 
-**Status:** Draft
+> Legacy filename retained for compatibility with existing links.
+
+**Status:** Active
 
 ## 0) Principle
-**GitLab is the system of record.** If it isn’t in GitLab (issue/MR/notes), it doesn’t exist.
+**GitHub is the system of record.** If it is not in GitHub (issue/PR/comments), it does not exist.
 - Obsidian = supporting notes only.
-- Discord = coordination + status pings only.
+- Chat/Discord = coordination only.
 
 ## 1) The Unit of Work
-Every non-trivial piece of work MUST have a **GitLab Issue**.
+Every non-trivial piece of work MUST have a **GitHub Issue**.
 
 **Issue contains:**
-- **Goal** (what outcome exists when we’re done)
+- **Goal** (what outcome exists when done)
 - **Acceptance Criteria** (observable checks)
 - **Owner / Squad** (who is accountable)
-- **Evidence plan** (what we will link or attach)
+- **Evidence plan** (what to link when closing)
 
 ## 2) Definition of Done (DoD)
-An issue is only “Done” when it has:
+An issue is only "Done" when it has:
 1) **Evidence** (links, screenshots, logs, or artifacts)
 2) **Change record**
-   - either an **MR**, or
+   - a **PR link**, or
    - a **commit link**, or
-   - an explicit note: “no code change” + why
+   - explicit note: "no code change" + why
 3) **Verification**
    - who verified + what they checked
 4) **Close-out note**
-   - short summary + any follow-ups spawned as new issues
+   - summary + follow-up issues if needed
 
-### 2.1 Evidence types (pick what fits)
-- MR link (preferred)
+### 2.1 Evidence types
+- PR link (preferred)
 - commit hash link
-- job run logs (OpenClaw cron runs, CI logs)
+- CI/job run logs
 - before/after screenshots
 - config diffs
-- reproducible commands (copy/paste)
+- reproducible commands
 
-## 3) Execution Loop (How work moves)
+## 3) Execution Loop
 **State machine:**
-- Backlog → Ready → In Progress → In Review → Verified → Done
+- Backlog -> Ready -> In Progress -> In Review -> Verified -> Done
 
 **Rules:**
 - **One accountable owner** per issue.
-- Keep issue description stable; post progress as **issue notes**.
-- For risky/ambiguous work, post a short **Plan** comment before execution.
+- Keep issue description stable; post progress as issue comments.
+- For risky/ambiguous work, post a short plan comment before execution.
 
-## 4) Agent Responsibilities (Minimum)
-When an agent is asked to do something non-trivial, it must:
-1) Ask: **“What’s the GitLab issue link?”**
-2) If none exists: create one (or request user to create if permissions/process require).
+## 4) Agent Responsibilities
+When an agent is asked to do non-trivial work:
+1) Ask: **"What is the GitHub issue link?"**
+2) If none exists: create one (or request creation if permissions require).
 3) Work against acceptance criteria.
 4) Post evidence + close-out note.
 
 ## 5) Reviews & QA
-### 5.1 When an MR is required
-Default: **If it changes code/config, open an MR.**
+### 5.1 When a PR is required
+Default: **If it changes code/config/docs, open a PR.**
 Exceptions allowed only with explicit note.
 
-### 5.2 Verifier (QA) responsibilities
-- Confirm acceptance criteria
-- Confirm evidence links resolve
-- Confirm no missing secrets / obvious security footguns
+### 5.2 Verifier responsibilities
+- Confirm acceptance criteria.
+- Confirm evidence links resolve.
+- Confirm no secrets or obvious security footguns.
 
 ## 6) Communication Discipline
-- Discord is for coordination and quick status, not canonical decisions.
-- Any decision that affects scope/architecture must be copied into the GitLab issue as a note.
+- Chat is for coordination, not canonical decisions.
+- Decisions that affect scope/architecture must be copied into the GitHub issue.
 
-## 7) Templates (Copy/Paste)
+## 7) Templates
 ### 7.1 Issue template (minimum)
 **Goal:**
 
@@ -94,23 +96,10 @@ Exceptions allowed only with explicit note.
 - 
 
 ## 8) Escalation / Exceptions
-If a task cannot be represented as an issue/MR (e.g., urgent outage):
-- Create a “Hotfix / Incident” issue ASAP and backfill evidence.
-
----
+If a task cannot be represented as an issue/PR (for example, urgent outage):
+- Create a "Hotfix / Incident" issue as soon as possible and backfill evidence.
 
 ## Decisions (locked)
-- **Enforcement via labels:** YES (see below).
-- **MR required for code/config changes:** YES by default.
-- **Mission Control issue creation:** allowed to **auto-create** issues (with sane defaults).
-
-## Labels (standard set)
-Use these to keep flow honest and searchable:
-- `needs-evidence`
-- `needs-review`
-- `needs-verification`
-- `blocked`
-- `no-code-change` (explicit exception flag)
-
-## Open Questions (later)
-1) One shared issue template across all projects, or per-project variants?
+- **Enforcement via labels:** YES (see `docs/process/LABEL_PROTOCOL.md`).
+- **PR required for code/config changes:** YES by default.
+- **Mission Control issue creation:** allowed to auto-create issues with sane defaults.

--- a/docs/templates/github-issue-template.md
+++ b/docs/templates/github-issue-template.md
@@ -1,0 +1,38 @@
+# GitHub Issue Template — VentureOS
+
+## Goal
+(Outcome that exists when done)
+
+## Acceptance Criteria
+- [ ]
+- [ ]
+- [ ]
+
+## Owner / Squad
+- Owner: @
+- Squad: (oracle/atlas/sentinel/verifier/archivist/synth/etc)
+
+## Evidence Plan
+(What you will link when closing)
+- 
+
+## Plan (if risky / ambiguous)
+- 
+
+## Progress Updates
+(Post short updates as comments; keep this description stable.)
+
+## Close-out (when done)
+**Result:**
+
+**Evidence:**
+- 
+
+**PR / Commit:**
+- 
+
+**Verification:**
+- 
+
+**Follow-ups (new issues):**
+- 

--- a/docs/templates/github-pr-template.md
+++ b/docs/templates/github-pr-template.md
@@ -1,0 +1,17 @@
+# GitHub PR Template — VentureOS
+
+## What / Why
+
+## Linked Issue
+Closes: #
+
+## Changes
+- 
+
+## Verification
+- [ ] Acceptance criteria met
+- [ ] Evidence linked in issue
+- [ ] No secrets in diffs/logs
+- [ ] Rollback plan noted if risky
+
+## Notes / Risks

--- a/docs/templates/gitlab-issue-template.md
+++ b/docs/templates/gitlab-issue-template.md
@@ -1,38 +1,5 @@
-# GitLab Issue Template — VentureOS (GitLab-First)
+# Legacy Alias: GitHub Issue Template
 
-## Goal
-(Outcome that exists when done)
+This file name is retained for backward compatibility.
 
-## Acceptance Criteria
-- [ ]
-- [ ]
-- [ ]
-
-## Owner / Squad
-- Owner: @
-- Squad: (oracle/atlas/sentinel/verifier/archivist/synth/etc)
-
-## Evidence Plan
-(What you will link/attach when closing)
-- 
-
-## Plan (if risky / ambiguous)
-- 
-
-## Progress Updates
-(Post short updates as comments; keep this description stable.)
-
-## Close-out (when done)
-**Result:**
-
-**Evidence:**
-- 
-
-**MR / Commit:**
-- 
-
-**Verification:**
-- 
-
-**Follow-ups (new issues):**
-- 
+Use `docs/templates/github-issue-template.md` for active GitHub issue tracking.

--- a/docs/templates/gitlab-mr-template.md
+++ b/docs/templates/gitlab-mr-template.md
@@ -1,18 +1,5 @@
-# GitLab MR Template — VentureOS
+# Legacy Alias: GitHub PR Template
 
-## What / Why
+This file name is retained for backward compatibility.
 
-## Linked Issue
-Closes: #
-
-## Changes
-- 
-
-## Verification
-- [ ] Acceptance criteria met
-- [ ] Evidence attached/linked in issue
-- [ ] No secrets in diffs/logs
-- [ ] Rollback plan noted if risky
-
-## Notes / Risks
-
+Use `docs/templates/github-pr-template.md` for active GitHub pull request tracking.


### PR DESCRIPTION
## Summary\n- migrate active process docs from GitLab-first language to GitHub-first workflow\n- keep legacy filenames for compatibility but clarify active behavior\n- add GitHub-native issue/PR templates and convert old GitLab template files to legacy aliases\n- update documentation index entries to match the new process guidance\n\n## Verification\n- DOCS_LINT_OK\n\nCloses #374