### PR TITLE
feat: decompose model routing engine module

### DIFF
--- a/docs/DOC_INDEX.md
+++ b/docs/DOC_INDEX.md
@@ -32,6 +32,7 @@
 - **docs/SERVER_DECOMPOSITION_PLAN.md** – stage plan + guardrails for large dashboard server modules (#366)
 - **docs/BRIDGE_DECOMPOSITION_PLAN.md** – stage plan + guardrails for bridge server decomposition (#375)
 - **docs/WORKFLOW_MACROS_DECOMPOSITION_PLAN.md** – stage plan + guardrails for workflow macro module decomposition (#376)
+- **docs/MODEL_ROUTER_DECOMPOSITION_PLAN.md** – stage plan + guardrails for model router decomposition (#377)
 - **docs/WEBMCP_INTEGRATION.md** – structured website tool discovery/invocation with cache + browser fallback (#225)
 - **docs/VISUAL_EXPLAINER_CANVAS.md** – slash-command visual explainer skill with 5 interactive HTML patterns (#226)
 - **docs/PROPOSAL_MISSION_STEP_LIFECYCLE.md** – proposal approval gate, step execution engine, cross-agent handoffs, and event streaming (#227)

--- a/docs/MODEL_ROUTER_DECOMPOSITION_PLAN.md
+++ b/docs/MODEL_ROUTER_DECOMPOSITION_PLAN.md
@@ -1,0 +1,35 @@
+# Model Router Decomposition Plan
+
+Issue: #377  
+Status: Stage 1 complete (interface-compatible extraction)
+
+## Why
+`lib/model-router.ts` combined policy evaluation, scoring, fallback resolution, and security telemetry in one module. This increased regression risk for routing behavior and made policy updates harder to review.
+
+## Stage 1 (Completed)
+- Extracted static config/constants into `lib/model-router-constants.ts`.
+- Extracted stateful trackers into `lib/model-router-trackers.ts`:
+  - `QuotaTracker`
+  - `PerformanceTracker`
+- Extracted policy evaluation into `lib/model-router-policy.ts`:
+  - tier bound resolution
+  - quota restriction evaluation
+  - candidate filtering
+- Extracted scoring into `lib/model-router-scoring.ts`:
+  - per-candidate score breakdown
+  - sorted candidate ranking
+- Extracted fallback resolution into `lib/model-router-fallback.ts`.
+- Extracted security/cost telemetry helpers into `lib/model-router-security.ts`.
+- Preserved public API surface of `lib/model-router.ts` (backward-compatible imports/exports).
+
+## Guardrails
+- Line budget guard added in `lib/__tests__/maintainability-file-size-guard.test.ts`:
+  - `lib/model-router.ts` must remain <= 750 lines.
+- Expanded regression coverage in `lib/__tests__/model-router.test.ts` for:
+  - policy precedence (`forceModel` vs BU forced model)
+  - high-risk routing overriding restrictive max-tier policy
+  - fallback behavior when quotas filter all available models
+
+## Verification
+- `npx jest --runInBand lib/__tests__/model-router.test.ts`
+- `npm run build`

--- a/lib/__tests__/maintainability-file-size-guard.test.ts
+++ b/lib/__tests__/maintainability-file-size-guard.test.ts
@@ -8,6 +8,10 @@ const FILE_SIZE_BUDGETS = [
     relativePath: 'lib/workflow-macros.ts',
     maxLines: 1300,
   },
+  {
+    relativePath: 'lib/model-router.ts',
+    maxLines: 750,
+  },
 ] as const;
 
 function lineCount(filePath: string): number {

--- a/lib/__tests__/model-router.test.ts
+++ b/lib/__tests__/model-router.test.ts
@@ -265,6 +265,27 @@ describe('ModelRouter', () => {
       expect(decision.security.forcedByRequest).toBe(true);
     });
 
+    it('high-risk routing overrides restrictive maxTier policy', () => {
+      const router = makeRouter({
+        businessUnitOverrides: [
+          {
+            businessUnit: 'budget-locked',
+            priority: 'low',
+            maxTier: 1,
+          },
+        ],
+      });
+      const decision = router.selectModel(makeRequest({
+        businessUnit: 'budget-locked',
+        complexity: 'simple',
+        timeSensitivity: 'batch',
+        containsExternalContent: true,
+      }));
+
+      expect(decision.security.riskLevel).toBe('high');
+      expect(decision.tier).toBe(3);
+    });
+
     it('records injection detections from routing decisions', () => {
       const router = makeRouter();
       router.clearSecurityTelemetry();
@@ -499,6 +520,26 @@ describe('ModelRouter', () => {
       expect(decision.reason).toContain('Forced by business unit override');
     });
 
+    it('request forceModel takes precedence over BU forcedModel', () => {
+      const router = makeRouter({
+        businessUnitOverrides: [
+          {
+            businessUnit: 'ventureos',
+            priority: 'high',
+            forcedModel: 'claude-opus',
+          },
+        ],
+      });
+
+      const decision = router.selectModel(makeRequest({
+        businessUnit: 'ventureos',
+        forceModel: 'gpt-4o-mini',
+      }));
+
+      expect(decision.model.id).toBe('gpt-4o-mini');
+      expect(decision.security.forcedByRequest).toBe(true);
+    });
+
     it('falls back when forced model is unavailable', () => {
       const models = makeModels([{ id: 'claude-opus', status: 'unavailable' }]);
       const router = makeRouter({
@@ -700,6 +741,24 @@ describe('ModelRouter', () => {
         ])
       );
       expect(logger.error).toHaveBeenCalled();
+    });
+
+    it('surfaces critical warning when quotas filter all available models', () => {
+      const router = makeRouter();
+      router.quota.setQuota('openai', { total: 1000, used: 1000, resetsAt: '2026-03-01' });
+      router.quota.setQuota('anthropic', { total: 1000, used: 1000, resetsAt: '2026-03-01' });
+
+      const decision = router.selectModel(makeRequest({
+        complexity: 'complex',
+        timeSensitivity: 'urgent',
+      }));
+
+      expect(decision.fallbackUsed).toBe(true);
+      expect(decision.warnings).toEqual(
+        expect.arrayContaining([
+          expect.stringContaining('No models available after quota filtering'),
+        ]),
+      );
     });
 
     it('excludes unavailable models from fallback chain', () => {

--- a/lib/model-router-constants.ts
+++ b/lib/model-router-constants.ts
@@ -1,0 +1,153 @@
+import type {
+  ModelDefinition,
+  ModelTier,
+  RoutingPriority,
+  TaskComplexity,
+  TimeSensitivity,
+} from './model-router';
+
+/** Default models available in the system. */
+export const DEFAULT_MODELS: ModelDefinition[] = [
+  // Tier 1 — Cheap
+  {
+    id: 'gpt-4o-mini',
+    name: 'GPT-4o Mini',
+    provider: 'openai',
+    tier: 1,
+    costPer1kInput: 0.00015,
+    costPer1kOutput: 0.0006,
+    maxContextTokens: 128_000,
+    status: 'available',
+    capabilities: ['chat', 'code', 'summarization', 'classification'],
+  },
+  {
+    id: 'claude-haiku',
+    name: 'Claude Haiku',
+    provider: 'anthropic',
+    tier: 1,
+    costPer1kInput: 0.00025,
+    costPer1kOutput: 0.00125,
+    maxContextTokens: 200_000,
+    status: 'available',
+    capabilities: ['chat', 'code', 'summarization', 'classification'],
+  },
+  // Tier 2 — Balanced
+  {
+    id: 'gpt-4o',
+    name: 'GPT-4o',
+    provider: 'openai',
+    tier: 2,
+    costPer1kInput: 0.0025,
+    costPer1kOutput: 0.01,
+    maxContextTokens: 128_000,
+    status: 'available',
+    capabilities: ['chat', 'code', 'reasoning', 'summarization', 'classification', 'vision'],
+  },
+  {
+    id: 'claude-sonnet',
+    name: 'Claude Sonnet',
+    provider: 'anthropic',
+    tier: 2,
+    costPer1kInput: 0.003,
+    costPer1kOutput: 0.015,
+    maxContextTokens: 200_000,
+    status: 'available',
+    capabilities: ['chat', 'code', 'reasoning', 'summarization', 'classification', 'vision'],
+  },
+  // Tier 3 — Premium
+  {
+    id: 'o1',
+    name: 'o1',
+    provider: 'openai',
+    tier: 3,
+    costPer1kInput: 0.015,
+    costPer1kOutput: 0.06,
+    maxContextTokens: 200_000,
+    status: 'available',
+    capabilities: ['chat', 'code', 'reasoning', 'planning', 'complex-analysis'],
+  },
+  {
+    id: 'claude-opus',
+    name: 'Claude Opus',
+    provider: 'anthropic',
+    tier: 3,
+    costPer1kInput: 0.015,
+    costPer1kOutput: 0.075,
+    maxContextTokens: 200_000,
+    status: 'available',
+    capabilities: ['chat', 'code', 'reasoning', 'planning', 'complex-analysis', 'vision'],
+  },
+];
+
+/** Complexity → base tier mapping. */
+export const COMPLEXITY_TIER_MAP: Record<TaskComplexity, ModelTier> = {
+  simple: 1,
+  medium: 2,
+  complex: 3,
+};
+
+/** Complexity scoring weights. */
+export const COMPLEXITY_SCORES: Record<TaskComplexity, number> = {
+  simple: 10,
+  medium: 50,
+  complex: 100,
+};
+
+/** Time sensitivity scoring weights. */
+export const TIME_SENSITIVITY_SCORES: Record<TimeSensitivity, number> = {
+  urgent: 80,
+  normal: 40,
+  batch: 10,
+};
+
+/** Priority scoring weights. */
+export const PRIORITY_SCORES: Record<RoutingPriority, number> = {
+  high: 100,
+  medium: 50,
+  low: 20,
+};
+
+/** Priority → ideal tier mapping (used to differentiate model ranking). */
+export const PRIORITY_TIER_MAP: Record<RoutingPriority, ModelTier> = {
+  high: 3,
+  medium: 2,
+  low: 1,
+};
+
+/** Time sensitivity → ideal tier mapping (used to differentiate model ranking). */
+export const TIME_SENSITIVITY_TIER_MAP: Record<TimeSensitivity, ModelTier> = {
+  urgent: 3,
+  normal: 2,
+  batch: 1,
+};
+
+/** Tier mismatch penalties for priority/time sensitivity alignment. */
+export const PRIORITY_TIER_MISMATCH_PENALTY = 20;
+export const TIME_SENSITIVITY_TIER_MISMATCH_PENALTY = 15;
+
+/** Default quota threshold (90%). */
+export const DEFAULT_QUOTA_THRESHOLD = 0.9;
+
+/** Provider preference bonus. */
+export const PROVIDER_PREFERENCE_BONUS = 15;
+
+/** Capability match bonus per matched capability. */
+export const CAPABILITY_MATCH_BONUS = 10;
+
+/** Maximum performance bonus. */
+export const MAX_PERFORMANCE_BONUS = 30;
+
+/** Security routing defaults. */
+export const DEFAULT_INJECTION_ALERT_THRESHOLD = 0.6;
+export const DEFAULT_ROUTING_HISTORY_LIMIT = 500;
+export const DEFAULT_ESTIMATED_INPUT_TOKENS = 1000;
+export const DEFAULT_ESTIMATED_OUTPUT_TOKENS = 500;
+export const EXTERNAL_CONTENT_SOURCES = new Set([
+  'external',
+  'web',
+  'email',
+  'social',
+  'url',
+  'user_url',
+  'browser',
+]);

--- a/lib/model-router-fallback.ts
+++ b/lib/model-router-fallback.ts
@@ -1,0 +1,65 @@
+import type {
+  ModelDefinition,
+  ModelTier,
+  QuotaTracker,
+  RoutingRequest,
+} from './model-router';
+
+export interface FallbackCandidatesResult {
+  candidates: ModelDefinition[];
+  warnings: string[];
+  hasAvailableByStatus: boolean;
+}
+
+/**
+ * Build a fallback chain for a requested tier.
+ * Returns models in fallback order (same tier first, then higher-quality tiers before lower tiers).
+ */
+export function getFallbackChain(models: ModelDefinition[], tier: ModelTier): ModelDefinition[] {
+  const available = models.filter((model) => model.status !== 'unavailable');
+  return available
+    .sort((a, b) => {
+      // Same tier as requested comes first
+      if (a.tier === tier && b.tier !== tier) return -1;
+      if (b.tier === tier && a.tier !== tier) return 1;
+      // Then sort by tier (higher tier = better quality = tried first in fallback)
+      if (a.tier !== b.tier) return b.tier - a.tier;
+      // Within same tier, prefer cheaper
+      return a.costPer1kInput - b.costPer1kInput;
+    });
+}
+
+export function resolveFallbackCandidates(
+  models: ModelDefinition[],
+  request: RoutingRequest,
+  enforceQuota: boolean,
+  quotaExempt: boolean,
+  quota: QuotaTracker,
+): FallbackCandidatesResult {
+  // Try all models in fallback order (any tier, any provider)
+  const allAvailable = models
+    .filter((model) => {
+      if (model.status === 'unavailable') return false;
+      if (enforceQuota && !quotaExempt && quota.isExhausted(model.provider)) return false;
+      return true;
+    })
+    .sort((a, b) => a.costPer1kInput - b.costPer1kInput); // Cheapest first in emergency
+
+  const warnings: string[] = [];
+  const hasAvailableByStatus = models.some((model) => model.status !== 'unavailable');
+
+  // Filter by required capabilities if possible
+  if (!request.requiredCapabilities?.length) {
+    return { candidates: allAvailable, warnings, hasAvailableByStatus };
+  }
+
+  const withCapabilities = allAvailable.filter((model) =>
+    request.requiredCapabilities!.every((capability) => model.capabilities.includes(capability)),
+  );
+  if (withCapabilities.length > 0) {
+    return { candidates: withCapabilities, warnings, hasAvailableByStatus };
+  }
+
+  warnings.push('No models match all required capabilities — selecting best available');
+  return { candidates: allAvailable, warnings, hasAvailableByStatus };
+}

--- a/lib/model-router-policy.ts
+++ b/lib/model-router-policy.ts
@@ -1,0 +1,112 @@
+import type {
+  BusinessUnitOverride,
+  ModelDefinition,
+  ModelTier,
+  QuotaTracker,
+  RoutingRequest,
+} from './model-router';
+
+export interface QuotaRestrictionResult {
+  maxTier: ModelTier;
+  downgraded: boolean;
+  warning?: string;
+}
+
+export function resolveEffectiveTiers(
+  request: RoutingRequest,
+  override?: BusinessUnitOverride,
+): { minTier: ModelTier; maxTier: ModelTier } {
+  let minTier: ModelTier = request.minTier ?? 1;
+  let maxTier: ModelTier = request.maxTier ?? 3;
+
+  // Override from business unit
+  if (override?.minTier) minTier = Math.max(minTier, override.minTier) as ModelTier;
+  if (override?.maxTier) maxTier = Math.min(maxTier, override.maxTier) as ModelTier;
+
+  // Urgent tasks get at least tier 2
+  if (request.timeSensitivity === 'urgent' && minTier < 2) {
+    minTier = 2;
+  }
+
+  // Complex tasks get at least tier 2
+  if (request.complexity === 'complex' && minTier < 2) {
+    minTier = 2;
+  }
+
+  // Batch tasks can go to tier 1 (only if no explicit minTier was requested)
+  if (request.timeSensitivity === 'batch' && !override?.minTier && !request.minTier) {
+    minTier = 1;
+  }
+
+  return { minTier, maxTier };
+}
+
+export function applyQuotaRestrictions(
+  request: RoutingRequest,
+  currentMaxTier: ModelTier,
+  quotaExempt: boolean,
+  quotaThreshold: number,
+  quota: QuotaTracker,
+): QuotaRestrictionResult {
+  // Check global quota first
+  const globalUsage = quota.getUsagePercent('global');
+  if (globalUsage >= quotaThreshold) {
+    if (quotaExempt) {
+      return {
+        maxTier: currentMaxTier,
+        downgraded: false,
+        warning: `Quota at ${(globalUsage * 100).toFixed(0)}% but security/safety critical task — no downgrade`,
+      };
+    }
+    return {
+      maxTier: 1,
+      downgraded: currentMaxTier > 1,
+      warning: `Quota at ${(globalUsage * 100).toFixed(0)}% (threshold: ${(quotaThreshold * 100).toFixed(0)}%) — restricted to tier 1`,
+    };
+  }
+
+  // Check provider-specific quota
+  if (request.preferredProvider) {
+    const providerUsage = quota.getUsagePercent(request.preferredProvider);
+    if (providerUsage >= quotaThreshold) {
+      return {
+        maxTier: currentMaxTier, // Don't downgrade tier, just warn
+        downgraded: false,
+        warning: `${request.preferredProvider} quota at ${(providerUsage * 100).toFixed(0)}% — may prefer other provider`,
+      };
+    }
+  }
+
+  return { maxTier: currentMaxTier, downgraded: false };
+}
+
+export function filterCandidates(
+  models: ModelDefinition[],
+  request: RoutingRequest,
+  minTier: ModelTier,
+  maxTier: ModelTier,
+  quotaExempt: boolean,
+  enforceQuota: boolean,
+  quota: QuotaTracker,
+): ModelDefinition[] {
+  return models.filter((model) => {
+    // Must be available
+    if (model.status === 'unavailable') return false;
+
+    // Tier bounds
+    if (model.tier < minTier || model.tier > maxTier) return false;
+
+    // Required capabilities
+    if (request.requiredCapabilities?.length) {
+      const hasAll = request.requiredCapabilities.every((capability) => model.capabilities.includes(capability));
+      if (!hasAll) return false;
+    }
+
+    // Provider quota exhausted — skip (except safety-critical requests)
+    if (enforceQuota && !quotaExempt && quota.isExhausted(model.provider)) {
+      return false;
+    }
+
+    return true;
+  });
+}

--- a/lib/model-router-scoring.ts
+++ b/lib/model-router-scoring.ts
@@ -1,0 +1,113 @@
+import {
+  CAPABILITY_MATCH_BONUS,
+  COMPLEXITY_SCORES,
+  COMPLEXITY_TIER_MAP,
+  MAX_PERFORMANCE_BONUS,
+  PRIORITY_SCORES,
+  PRIORITY_TIER_MAP,
+  PRIORITY_TIER_MISMATCH_PENALTY,
+  PROVIDER_PREFERENCE_BONUS,
+  TIME_SENSITIVITY_SCORES,
+  TIME_SENSITIVITY_TIER_MAP,
+  TIME_SENSITIVITY_TIER_MISMATCH_PENALTY,
+} from './model-router-constants';
+import type {
+  BusinessUnitOverride,
+  ModelDefinition,
+  PerformanceTracker,
+  QuotaTracker,
+  RoutingPriority,
+  RoutingRequest,
+  ScoreBreakdown,
+} from './model-router';
+
+export interface ScoredCandidate {
+  model: ModelDefinition;
+  score: number;
+  breakdown: ScoreBreakdown;
+}
+
+export function scoreCandidates(
+  candidates: ModelDefinition[],
+  request: RoutingRequest,
+  priority: RoutingPriority,
+  override: BusinessUnitOverride | undefined,
+  quota: QuotaTracker,
+  performance: PerformanceTracker,
+): ScoredCandidate[] {
+  const scored = candidates.map((model) => {
+    const breakdown = computeBreakdown(model, request, priority, override, quota, performance);
+    const score = Object.values(breakdown).reduce((sum, value) => sum + value, 0);
+    return { model, score, breakdown };
+  });
+
+  scored.sort((a, b) => b.score - a.score);
+  return scored;
+}
+
+export function computeBreakdown(
+  model: ModelDefinition,
+  request: RoutingRequest,
+  priority: RoutingPriority,
+  override: BusinessUnitOverride | undefined,
+  quota: QuotaTracker,
+  performance: PerformanceTracker,
+): ScoreBreakdown {
+  // Complexity: reward tier match to complexity
+  const idealTier = COMPLEXITY_TIER_MAP[request.complexity];
+  const tierDiff = Math.abs(model.tier - idealTier);
+  const complexityScore = COMPLEXITY_SCORES[request.complexity] - tierDiff * 20;
+
+  // Quota: penalize expensive models when quota is high
+  const globalUsage = quota.getUsagePercent('global');
+  const providerUsage = quota.getUsagePercent(model.provider);
+  const usagePressure = Math.max(globalUsage, providerUsage);
+  // Higher tier = more penalty when quota is high
+  const quotaScore = model.tier === 1
+    ? usagePressure * 30 // Cheap models get bonus when quota is tight
+    : -usagePressure * model.tier * 15;
+
+  // Priority: align tier preference to business importance so this factor affects ranking
+  const priorityIdealTier = PRIORITY_TIER_MAP[priority];
+  const priorityTierDiff = Math.abs(model.tier - priorityIdealTier);
+  const priorityScore = PRIORITY_SCORES[priority] - priorityTierDiff * PRIORITY_TIER_MISMATCH_PENALTY;
+
+  // Time sensitivity: urgent prefers higher tiers, batch prefers lower tiers
+  const timeIdealTier = TIME_SENSITIVITY_TIER_MAP[request.timeSensitivity];
+  const timeTierDiff = Math.abs(model.tier - timeIdealTier);
+  const timeSensitivityScore =
+    TIME_SENSITIVITY_SCORES[request.timeSensitivity]
+    - timeTierDiff * TIME_SENSITIVITY_TIER_MISMATCH_PENALTY;
+
+  // Performance: use historical data if available
+  let performanceScore = 0;
+  if (request.taskType) {
+    const perfScore = performance.getPerformanceScore(model.id, request.taskType);
+    performanceScore = (perfScore - 0.5) * MAX_PERFORMANCE_BONUS * 2; // Normalize around 0
+  }
+
+  // Provider preference
+  const providerPreferenceScore =
+    (request.preferredProvider && model.provider === request.preferredProvider)
+      ? PROVIDER_PREFERENCE_BONUS
+      : (override?.preferredProvider && model.provider === override.preferredProvider)
+        ? PROVIDER_PREFERENCE_BONUS
+        : 0;
+
+  // Capability match: bonus per required capability matched (defensive; filterCandidates enforces all)
+  let capabilityMatchScore = 0;
+  if (request.requiredCapabilities?.length) {
+    const matched = request.requiredCapabilities.filter((capability) => model.capabilities.includes(capability));
+    capabilityMatchScore = matched.length * CAPABILITY_MATCH_BONUS;
+  }
+
+  return {
+    complexityScore,
+    quotaScore,
+    priorityScore,
+    timeSensitivityScore,
+    performanceScore,
+    providerPreferenceScore,
+    capabilityMatchScore,
+  };
+}

--- a/lib/model-router-security.ts
+++ b/lib/model-router-security.ts
@@ -1,0 +1,167 @@
+import {
+  DEFAULT_ESTIMATED_INPUT_TOKENS,
+  DEFAULT_ESTIMATED_OUTPUT_TOKENS,
+  DEFAULT_MODELS,
+  EXTERNAL_CONTENT_SOURCES,
+} from './model-router-constants';
+import type {
+  InjectionDetectionEvent,
+  ModelDefinition,
+  RoutingDecision,
+  RoutingRequest,
+  RoutingRiskLevel,
+  RoutingSecurityMetadata,
+  SecurityRoutingSummary,
+} from './model-router';
+
+export interface RoutingTelemetryEntry {
+  decidedAt: string;
+  riskLevel: RoutingRiskLevel;
+  modelId: string;
+  tier: 1 | 2 | 3;
+  estimatedCostUsd: number;
+  baselineCostUsd: number;
+  injectionDetected: boolean;
+}
+
+export function classifySecurityRisk(
+  request: RoutingRequest,
+  injectionAlertThreshold: number,
+): RoutingSecurityMetadata {
+  const signals: string[] = [];
+  let riskLevel: RoutingRiskLevel = request.riskLevel ?? 'low';
+
+  const escalateTo = (target: RoutingRiskLevel, signal: string): void => {
+    signals.push(signal);
+    if (target === 'high') {
+      riskLevel = 'high';
+    } else if (target === 'medium' && riskLevel === 'low') {
+      riskLevel = 'medium';
+    }
+  };
+
+  if (request.containsExternalContent) {
+    escalateTo('high', 'containsExternalContent');
+  }
+
+  for (const source of request.contentSources ?? []) {
+    if (EXTERNAL_CONTENT_SOURCES.has(source.toLowerCase())) {
+      escalateTo('high', `contentSource:${source}`);
+    }
+  }
+
+  const injectionScore = typeof request.injectionScore === 'number' ? request.injectionScore : 0;
+  if (injectionScore >= injectionAlertThreshold) {
+    escalateTo('high', `injectionScore:${injectionScore.toFixed(2)}`);
+  } else if (injectionScore >= 0.3) {
+    escalateTo('medium', `injectionScoreElevated:${injectionScore.toFixed(2)}`);
+  }
+
+  const taskType = (request.taskType ?? '').toLowerCase();
+  if (taskType.includes('code') || taskType.includes('review') || taskType.includes('generation')) {
+    escalateTo('medium', `taskType:${request.taskType}`);
+  }
+
+  if (request.requiredCapabilities?.some((capability) => ['browser', 'vision'].includes(capability))) {
+    escalateTo('high', 'untrusted-capability');
+  }
+
+  return {
+    riskLevel,
+    signals,
+    injectionDetected: injectionScore >= injectionAlertThreshold,
+    forcedByRequest: false,
+  };
+}
+
+export function estimateRoutingCostUsd(
+  model: ModelDefinition,
+  inputTokens: number,
+  outputTokens: number,
+): number {
+  return (inputTokens / 1000) * model.costPer1kInput + (outputTokens / 1000) * model.costPer1kOutput;
+}
+
+export function getBaselineModel(models: ModelDefinition[]): ModelDefinition {
+  const available = models.filter((model) => model.status !== 'unavailable');
+  if (available.length === 0) return models[0] ?? DEFAULT_MODELS[0];
+  return [...available].sort(
+    (a, b) => (b.costPer1kInput + b.costPer1kOutput) - (a.costPer1kInput + a.costPer1kOutput),
+  )[0];
+}
+
+export function buildRoutingTelemetryEntry(
+  request: RoutingRequest,
+  decision: RoutingDecision,
+  baselineModel: ModelDefinition,
+): RoutingTelemetryEntry {
+  const inputTokens = request.estimatedInputTokens ?? DEFAULT_ESTIMATED_INPUT_TOKENS;
+  const outputTokens = request.estimatedOutputTokens ?? DEFAULT_ESTIMATED_OUTPUT_TOKENS;
+  return {
+    decidedAt: decision.decidedAt,
+    riskLevel: decision.security.riskLevel,
+    modelId: decision.model.id,
+    tier: decision.tier,
+    estimatedCostUsd: estimateRoutingCostUsd(decision.model, inputTokens, outputTokens),
+    baselineCostUsd: estimateRoutingCostUsd(baselineModel, inputTokens, outputTokens),
+    injectionDetected: decision.security.injectionDetected,
+  };
+}
+
+export function buildInjectionDetectionEvent(
+  request: RoutingRequest,
+  decision: RoutingDecision,
+): InjectionDetectionEvent {
+  return {
+    detectedAt: decision.decidedAt,
+    riskLevel: decision.security.riskLevel,
+    modelId: decision.model.id,
+    injectionScore: request.injectionScore ?? 0,
+    signals: [...decision.security.signals],
+  };
+}
+
+export function getSecurityRoutingSummary(
+  telemetry: RoutingTelemetryEntry[],
+  now: () => Date,
+  routingHistoryLimit: number,
+  limit?: number,
+): SecurityRoutingSummary {
+  const effectiveLimit = limit && Number.isFinite(limit)
+    ? Math.max(1, Math.min(Math.trunc(limit), routingHistoryLimit))
+    : routingHistoryLimit;
+  const slice = telemetry.slice(-effectiveLimit);
+  const riskCounts: Record<RoutingRiskLevel, number> = { low: 0, medium: 0, high: 0 };
+  const tierCounts: Record<'tier1' | 'tier2' | 'tier3', number> = { tier1: 0, tier2: 0, tier3: 0 };
+  const modelUsage: Record<string, number> = {};
+  let estimatedCostUsd = 0;
+  let baselineCostUsd = 0;
+  let injectionDetections = 0;
+
+  for (const entry of slice) {
+    riskCounts[entry.riskLevel] += 1;
+    tierCounts[`tier${entry.tier}`] += 1;
+    modelUsage[entry.modelId] = (modelUsage[entry.modelId] ?? 0) + 1;
+    estimatedCostUsd += entry.estimatedCostUsd;
+    baselineCostUsd += entry.baselineCostUsd;
+    if (entry.injectionDetected) injectionDetections += 1;
+  }
+
+  const estimatedSavingsUsd = baselineCostUsd - estimatedCostUsd;
+  const estimatedSavingsPct = baselineCostUsd > 0
+    ? Number(((estimatedSavingsUsd / baselineCostUsd) * 100).toFixed(2))
+    : 0;
+
+  return {
+    updatedAt: now().toISOString(),
+    windowSize: slice.length,
+    riskCounts,
+    tierCounts,
+    modelUsage,
+    injectionDetections,
+    estimatedCostUsd: Number(estimatedCostUsd.toFixed(6)),
+    baselineCostUsd: Number(baselineCostUsd.toFixed(6)),
+    estimatedSavingsUsd: Number(estimatedSavingsUsd.toFixed(6)),
+    estimatedSavingsPct,
+  };
+}

--- a/lib/model-router-trackers.ts
+++ b/lib/model-router-trackers.ts
@@ -1,0 +1,173 @@
+import type { PerformanceRecord, QuotaState } from './model-router';
+
+export class QuotaTracker {
+  private quotas: Map<string, QuotaState> = new Map();
+
+  /** Set quota state for a key (e.g., 'global', 'openai', 'anthropic'). */
+  setQuota(key: string, quota: QuotaState): void {
+    this.quotas.set(key, { ...quota });
+  }
+
+  /** Get current quota state. */
+  getQuota(key: string): QuotaState | undefined {
+    const quota = this.quotas.get(key);
+    return quota ? { ...quota } : undefined;
+  }
+
+  /** Get usage percentage (0-1). Returns 0 if no quota is set. */
+  getUsagePercent(key: string): number {
+    const q = this.quotas.get(key);
+    if (!q || q.total <= 0) return 0;
+    return Math.min(1, q.used / q.total);
+  }
+
+  /** Check if quota exceeds threshold. */
+  isOverThreshold(key: string, threshold: number): boolean {
+    return this.getUsagePercent(key) >= threshold;
+  }
+
+  /** Record usage. */
+  recordUsage(key: string, amount: number): void {
+    const q = this.quotas.get(key);
+    if (q) {
+      q.used = Math.min(q.total, q.used + amount);
+    }
+  }
+
+  /** Check if quota is exhausted (100%). */
+  isExhausted(key: string): boolean {
+    const q = this.quotas.get(key);
+    if (!q) return false;
+    return q.used >= q.total;
+  }
+
+  /** Reset usage for a key. */
+  resetUsage(key: string): void {
+    const q = this.quotas.get(key);
+    if (q) q.used = 0;
+  }
+
+  /** Get all quota keys. */
+  getKeys(): string[] {
+    return Array.from(this.quotas.keys());
+  }
+
+  /** Export all quota states. */
+  export(): Record<string, QuotaState> {
+    const result: Record<string, QuotaState> = {};
+    for (const [k, v] of this.quotas) result[k] = { ...v };
+    return result;
+  }
+
+  /** Import quota states. */
+  import(data: Record<string, QuotaState>): void {
+    this.quotas.clear();
+    for (const [k, v] of Object.entries(data)) {
+      this.quotas.set(k, { ...v });
+    }
+  }
+}
+
+export class PerformanceTracker {
+  private records: Map<string, PerformanceRecord> = new Map();
+  private readonly now: () => Date;
+
+  constructor(now?: () => Date) {
+    this.now = now ?? (() => new Date());
+  }
+
+  /** Generate composite key. */
+  private key(modelId: string, taskType: string): string {
+    return `${modelId}::${taskType}`;
+  }
+
+  /** Record a completion. Updates running averages. */
+  recordCompletion(
+    modelId: string,
+    taskType: string,
+    latencyMs: number,
+    success: boolean,
+    qualityScore: number
+  ): void {
+    const k = this.key(modelId, taskType);
+    const existing = this.records.get(k);
+
+    if (!existing) {
+      this.records.set(k, {
+        modelId,
+        taskType,
+        sampleCount: 1,
+        avgLatencyMs: latencyMs,
+        successRate: success ? 1 : 0,
+        avgQualityScore: qualityScore,
+        updatedAt: this.now().toISOString(),
+      });
+      return;
+    }
+
+    // Exponential moving average with α = 2/(n+2), capped at n=100
+    // The +2 ensures α < 1 even for the first update, providing smooth blending
+    const n = Math.min(existing.sampleCount, 100);
+    const alpha = 2 / (n + 2);
+
+    existing.avgLatencyMs = existing.avgLatencyMs * (1 - alpha) + latencyMs * alpha;
+    existing.successRate = existing.successRate * (1 - alpha) + (success ? 1 : 0) * alpha;
+    existing.avgQualityScore = existing.avgQualityScore * (1 - alpha) + qualityScore * alpha;
+    existing.sampleCount += 1;
+    existing.updatedAt = this.now().toISOString();
+  }
+
+  /** Get performance record. */
+  getRecord(modelId: string, taskType: string): PerformanceRecord | undefined {
+    return this.records.get(this.key(modelId, taskType));
+  }
+
+  /** Compute a performance score (0-1) for a model+taskType. */
+  getPerformanceScore(modelId: string, taskType: string): number {
+    const record = this.records.get(this.key(modelId, taskType));
+    if (!record || record.sampleCount < 3) return 0.5; // Neutral score for insufficient data
+
+    // Weighted combination: quality 50%, success 35%, latency 15%
+    const latencyScore = Math.max(0, 1 - record.avgLatencyMs / 30_000); // 30s = 0 score
+    return record.avgQualityScore * 0.5 + record.successRate * 0.35 + latencyScore * 0.15;
+  }
+
+  /** Get all records. */
+  getAll(): PerformanceRecord[] {
+    return Array.from(this.records.values());
+  }
+
+  /** Get best model for a task type. */
+  getBestModel(taskType: string, candidates: string[]): string | undefined {
+    let bestId: string | undefined;
+    let bestScore = -1;
+
+    for (const id of candidates) {
+      const score = this.getPerformanceScore(id, taskType);
+      if (score > bestScore) {
+        bestScore = score;
+        bestId = id;
+      }
+    }
+
+    return bestId;
+  }
+
+  /** Export all records. */
+  export(): PerformanceRecord[] {
+    return this.getAll();
+  }
+
+  /** Import records. */
+  import(records: PerformanceRecord[]): void {
+    this.records.clear();
+    for (const r of records) {
+      this.records.set(this.key(r.modelId, r.taskType), { ...r });
+    }
+  }
+
+  /** Clear all records. */
+  clear(): void {
+    this.records.clear();
+  }
+}

--- a/lib/model-router.ts
+++ b/lib/model-router.ts
@@ -25,6 +25,28 @@
  * @see docs/MODEL_FALLBACK_CHAIN.md
  */
 
+import {
+  DEFAULT_INJECTION_ALERT_THRESHOLD,
+  DEFAULT_MODELS,
+  DEFAULT_QUOTA_THRESHOLD,
+  DEFAULT_ROUTING_HISTORY_LIMIT,
+} from './model-router-constants';
+import { getFallbackChain, resolveFallbackCandidates } from './model-router-fallback';
+import { applyQuotaRestrictions, filterCandidates, resolveEffectiveTiers } from './model-router-policy';
+import { scoreCandidates } from './model-router-scoring';
+import {
+  buildInjectionDetectionEvent,
+  buildRoutingTelemetryEntry,
+  classifySecurityRisk,
+  getBaselineModel,
+  getSecurityRoutingSummary as summarizeSecurityRoutingTelemetry,
+  type RoutingTelemetryEntry,
+} from './model-router-security';
+import { PerformanceTracker, QuotaTracker } from './model-router-trackers';
+
+export { DEFAULT_MODELS };
+export { PerformanceTracker, QuotaTracker };
+
 // ============================================================================
 // Types
 // ============================================================================
@@ -250,336 +272,6 @@ export interface SecurityRoutingSummary {
 }
 
 // ============================================================================
-// Constants
-// ============================================================================
-
-/** Default models available in the system. */
-export const DEFAULT_MODELS: ModelDefinition[] = [
-  // Tier 1 — Cheap
-  {
-    id: 'gpt-4o-mini',
-    name: 'GPT-4o Mini',
-    provider: 'openai',
-    tier: 1,
-    costPer1kInput: 0.00015,
-    costPer1kOutput: 0.0006,
-    maxContextTokens: 128_000,
-    status: 'available',
-    capabilities: ['chat', 'code', 'summarization', 'classification'],
-  },
-  {
-    id: 'claude-haiku',
-    name: 'Claude Haiku',
-    provider: 'anthropic',
-    tier: 1,
-    costPer1kInput: 0.00025,
-    costPer1kOutput: 0.00125,
-    maxContextTokens: 200_000,
-    status: 'available',
-    capabilities: ['chat', 'code', 'summarization', 'classification'],
-  },
-  // Tier 2 — Balanced
-  {
-    id: 'gpt-4o',
-    name: 'GPT-4o',
-    provider: 'openai',
-    tier: 2,
-    costPer1kInput: 0.0025,
-    costPer1kOutput: 0.01,
-    maxContextTokens: 128_000,
-    status: 'available',
-    capabilities: ['chat', 'code', 'reasoning', 'summarization', 'classification', 'vision'],
-  },
-  {
-    id: 'claude-sonnet',
-    name: 'Claude Sonnet',
-    provider: 'anthropic',
-    tier: 2,
-    costPer1kInput: 0.003,
-    costPer1kOutput: 0.015,
-    maxContextTokens: 200_000,
-    status: 'available',
-    capabilities: ['chat', 'code', 'reasoning', 'summarization', 'classification', 'vision'],
-  },
-  // Tier 3 — Premium
-  {
-    id: 'o1',
-    name: 'o1',
-    provider: 'openai',
-    tier: 3,
-    costPer1kInput: 0.015,
-    costPer1kOutput: 0.06,
-    maxContextTokens: 200_000,
-    status: 'available',
-    capabilities: ['chat', 'code', 'reasoning', 'planning', 'complex-analysis'],
-  },
-  {
-    id: 'claude-opus',
-    name: 'Claude Opus',
-    provider: 'anthropic',
-    tier: 3,
-    costPer1kInput: 0.015,
-    costPer1kOutput: 0.075,
-    maxContextTokens: 200_000,
-    status: 'available',
-    capabilities: ['chat', 'code', 'reasoning', 'planning', 'complex-analysis', 'vision'],
-  },
-];
-
-/** Complexity → base tier mapping. */
-const COMPLEXITY_TIER_MAP: Record<TaskComplexity, ModelTier> = {
-  simple: 1,
-  medium: 2,
-  complex: 3,
-};
-
-/** Complexity scoring weights. */
-const COMPLEXITY_SCORES: Record<TaskComplexity, number> = {
-  simple: 10,
-  medium: 50,
-  complex: 100,
-};
-
-/** Time sensitivity scoring weights. */
-const TIME_SENSITIVITY_SCORES: Record<TimeSensitivity, number> = {
-  urgent: 80,
-  normal: 40,
-  batch: 10,
-};
-
-/** Priority scoring weights. */
-const PRIORITY_SCORES: Record<RoutingPriority, number> = {
-  high: 100,
-  medium: 50,
-  low: 20,
-};
-
-/** Priority → ideal tier mapping (used to differentiate model ranking). */
-const PRIORITY_TIER_MAP: Record<RoutingPriority, ModelTier> = {
-  high: 3,
-  medium: 2,
-  low: 1,
-};
-
-/** Time sensitivity → ideal tier mapping (used to differentiate model ranking). */
-const TIME_SENSITIVITY_TIER_MAP: Record<TimeSensitivity, ModelTier> = {
-  urgent: 3,
-  normal: 2,
-  batch: 1,
-};
-
-/** Tier mismatch penalties for priority/time sensitivity alignment. */
-const PRIORITY_TIER_MISMATCH_PENALTY = 20;
-const TIME_SENSITIVITY_TIER_MISMATCH_PENALTY = 15;
-
-/** Default quota threshold (90%). */
-const DEFAULT_QUOTA_THRESHOLD = 0.9;
-
-/** Provider preference bonus. */
-const PROVIDER_PREFERENCE_BONUS = 15;
-
-/** Capability match bonus per matched capability. */
-const CAPABILITY_MATCH_BONUS = 10;
-
-/** Maximum performance bonus. */
-const MAX_PERFORMANCE_BONUS = 30;
-
-/** Security routing defaults. */
-const DEFAULT_INJECTION_ALERT_THRESHOLD = 0.6;
-const DEFAULT_ROUTING_HISTORY_LIMIT = 500;
-const DEFAULT_ESTIMATED_INPUT_TOKENS = 1000;
-const DEFAULT_ESTIMATED_OUTPUT_TOKENS = 500;
-const EXTERNAL_CONTENT_SOURCES = new Set([
-  'external',
-  'web',
-  'email',
-  'social',
-  'url',
-  'user_url',
-  'browser',
-]);
-
-// ============================================================================
-// Quota Tracker
-// ============================================================================
-
-export class QuotaTracker {
-  private quotas: Map<string, QuotaState> = new Map();
-
-  /** Set quota state for a key (e.g., 'global', 'openai', 'anthropic'). */
-  setQuota(key: string, quota: QuotaState): void {
-    this.quotas.set(key, { ...quota });
-  }
-
-  /** Get current quota state. */
-  getQuota(key: string): QuotaState | undefined {
-    const quota = this.quotas.get(key);
-    return quota ? { ...quota } : undefined;
-  }
-
-  /** Get usage percentage (0-1). Returns 0 if no quota is set. */
-  getUsagePercent(key: string): number {
-    const q = this.quotas.get(key);
-    if (!q || q.total <= 0) return 0;
-    return Math.min(1, q.used / q.total);
-  }
-
-  /** Check if quota exceeds threshold. */
-  isOverThreshold(key: string, threshold: number): boolean {
-    return this.getUsagePercent(key) >= threshold;
-  }
-
-  /** Record usage. */
-  recordUsage(key: string, amount: number): void {
-    const q = this.quotas.get(key);
-    if (q) {
-      q.used = Math.min(q.total, q.used + amount);
-    }
-  }
-
-  /** Check if quota is exhausted (100%). */
-  isExhausted(key: string): boolean {
-    const q = this.quotas.get(key);
-    if (!q) return false;
-    return q.used >= q.total;
-  }
-
-  /** Reset usage for a key. */
-  resetUsage(key: string): void {
-    const q = this.quotas.get(key);
-    if (q) q.used = 0;
-  }
-
-  /** Get all quota keys. */
-  getKeys(): string[] {
-    return Array.from(this.quotas.keys());
-  }
-
-  /** Export all quota states. */
-  export(): Record<string, QuotaState> {
-    const result: Record<string, QuotaState> = {};
-    for (const [k, v] of this.quotas) result[k] = { ...v };
-    return result;
-  }
-
-  /** Import quota states. */
-  import(data: Record<string, QuotaState>): void {
-    this.quotas.clear();
-    for (const [k, v] of Object.entries(data)) {
-      this.quotas.set(k, { ...v });
-    }
-  }
-}
-
-// ============================================================================
-// Performance Tracker
-// ============================================================================
-
-export class PerformanceTracker {
-  private records: Map<string, PerformanceRecord> = new Map();
-  private readonly now: () => Date;
-
-  constructor(now?: () => Date) {
-    this.now = now ?? (() => new Date());
-  }
-
-  /** Generate composite key. */
-  private key(modelId: string, taskType: string): string {
-    return `${modelId}::${taskType}`;
-  }
-
-  /** Record a completion. Updates running averages. */
-  recordCompletion(
-    modelId: string,
-    taskType: string,
-    latencyMs: number,
-    success: boolean,
-    qualityScore: number
-  ): void {
-    const k = this.key(modelId, taskType);
-    const existing = this.records.get(k);
-
-    if (!existing) {
-      this.records.set(k, {
-        modelId,
-        taskType,
-        sampleCount: 1,
-        avgLatencyMs: latencyMs,
-        successRate: success ? 1 : 0,
-        avgQualityScore: qualityScore,
-        updatedAt: this.now().toISOString(),
-      });
-      return;
-    }
-
-    // Exponential moving average with α = 2/(n+2), capped at n=100
-    // The +2 ensures α < 1 even for the first update, providing smooth blending
-    const n = Math.min(existing.sampleCount, 100);
-    const alpha = 2 / (n + 2);
-
-    existing.avgLatencyMs = existing.avgLatencyMs * (1 - alpha) + latencyMs * alpha;
-    existing.successRate = existing.successRate * (1 - alpha) + (success ? 1 : 0) * alpha;
-    existing.avgQualityScore = existing.avgQualityScore * (1 - alpha) + qualityScore * alpha;
-    existing.sampleCount += 1;
-    existing.updatedAt = this.now().toISOString();
-  }
-
-  /** Get performance record. */
-  getRecord(modelId: string, taskType: string): PerformanceRecord | undefined {
-    return this.records.get(this.key(modelId, taskType));
-  }
-
-  /** Compute a performance score (0-1) for a model+taskType. */
-  getPerformanceScore(modelId: string, taskType: string): number {
-    const record = this.records.get(this.key(modelId, taskType));
-    if (!record || record.sampleCount < 3) return 0.5; // Neutral score for insufficient data
-
-    // Weighted combination: quality 50%, success 35%, latency 15%
-    const latencyScore = Math.max(0, 1 - record.avgLatencyMs / 30_000); // 30s = 0 score
-    return record.avgQualityScore * 0.5 + record.successRate * 0.35 + latencyScore * 0.15;
-  }
-
-  /** Get all records. */
-  getAll(): PerformanceRecord[] {
-    return Array.from(this.records.values());
-  }
-
-  /** Get best model for a task type. */
-  getBestModel(taskType: string, candidates: string[]): string | undefined {
-    let bestId: string | undefined;
-    let bestScore = -1;
-
-    for (const id of candidates) {
-      const score = this.getPerformanceScore(id, taskType);
-      if (score > bestScore) {
-        bestScore = score;
-        bestId = id;
-      }
-    }
-
-    return bestId;
-  }
-
-  /** Export all records. */
-  export(): PerformanceRecord[] {
-    return this.getAll();
-  }
-
-  /** Import records. */
-  import(records: PerformanceRecord[]): void {
-    this.records.clear();
-    for (const r of records) {
-      this.records.set(this.key(r.modelId, r.taskType), { ...r });
-    }
-  }
-
-  /** Clear all records. */
-  clear(): void {
-    this.records.clear();
-  }
-}
-
-// ============================================================================
 // Model Router
 // ============================================================================
 
@@ -591,16 +283,6 @@ const defaultLogger: ModelRouterLogger = {
   warn: (msg, meta) => console.warn(`[model-router] ${msg}`, meta ?? ''),
   error: (msg, meta) => console.error(`[model-router] ${msg}`, meta ?? ''),
 };
-
-interface RoutingTelemetryEntry {
-  decidedAt: string;
-  riskLevel: RoutingRiskLevel;
-  modelId: string;
-  tier: ModelTier;
-  estimatedCostUsd: number;
-  baselineCostUsd: number;
-  injectionDetected: boolean;
-}
 
 export class ModelRouter {
   private readonly models: ModelDefinition[];
@@ -687,14 +369,20 @@ export class ModelRouter {
     }
 
     // 3. Determine effective tier bounds
-    let { minTier, maxTier } = this.resolveEffectiveTiers(request, override);
+    let { minTier, maxTier } = resolveEffectiveTiers(request, override);
     // Security-aware tier floors
     if (security.riskLevel === 'high') minTier = Math.max(minTier, 3) as ModelTier;
     if (security.riskLevel === 'medium') minTier = Math.max(minTier, 2) as ModelTier;
 
     // 4. Apply quota restrictions
     if (this.enforceQuota) {
-      const quotaResult = this.applyQuotaRestrictions(request, maxTier, quotaExempt);
+      const quotaResult = applyQuotaRestrictions(
+        request,
+        maxTier,
+        quotaExempt,
+        this.quotaThreshold,
+        this.quota,
+      );
       maxTier = quotaResult.maxTier;
       quotaDowngraded = quotaResult.downgraded;
       if (quotaResult.warning) warnings.push(quotaResult.warning);
@@ -713,7 +401,15 @@ export class ModelRouter {
     }
 
     // 5. Filter candidate models
-    const candidates = this.filterCandidates(request, minTier, maxTier, override, quotaExempt);
+    const candidates = filterCandidates(
+      this.models,
+      request,
+      minTier,
+      maxTier,
+      quotaExempt,
+      this.enforceQuota,
+      this.quota,
+    );
 
     if (candidates.length === 0) {
       // No candidates at all — try fallback chain
@@ -721,7 +417,8 @@ export class ModelRouter {
     }
 
     // 6. Score candidates
-    const scored = this.scoreCandidates(candidates, request, override);
+    const priority = request.priorityOverride ?? override?.priority ?? 'medium';
+    const scored = scoreCandidates(candidates, request, priority, override, this.quota, this.performance);
 
     // 7. Select best
     const best = scored[0];
@@ -742,20 +439,7 @@ export class ModelRouter {
    * Returns models in fallback order (same tier first, then higher-quality tiers before lower tiers).
    */
   getFallbackChain(tier: ModelTier): ModelDefinition[] {
-    const available = this.models.filter(m => m.status !== 'unavailable');
-
-    // Sort: same tier first, then descending by tier (prefer higher quality fallbacks)
-    // Within same tier, prefer lower cost
-    return available
-      .sort((a, b) => {
-        // Same tier as requested comes first
-        if (a.tier === tier && b.tier !== tier) return -1;
-        if (b.tier === tier && a.tier !== tier) return 1;
-        // Then sort by tier (higher tier = better quality = tried first in fallback)
-        if (a.tier !== b.tier) return b.tier - a.tier;
-        // Within same tier, prefer cheaper
-        return a.costPer1kInput - b.costPer1kInput;
-      });
+    return getFallbackChain(this.models, tier);
   }
 
   // ────────────────────────────────────────────────────────────────────
@@ -802,201 +486,8 @@ export class ModelRouter {
   }
 
   // ────────────────────────────────────────────────────────────────────
-  // Internal Scoring
+  // Internal Routing Helpers
   // ────────────────────────────────────────────────────────────────────
-
-  /** Resolve effective tier bounds from request + overrides. */
-  private resolveEffectiveTiers(
-    request: RoutingRequest,
-    override?: BusinessUnitOverride
-  ): { minTier: ModelTier; maxTier: ModelTier } {
-    let minTier: ModelTier = request.minTier ?? 1;
-    let maxTier: ModelTier = request.maxTier ?? 3;
-
-    // Override from business unit
-    if (override?.minTier) minTier = Math.max(minTier, override.minTier) as ModelTier;
-    if (override?.maxTier) maxTier = Math.min(maxTier, override.maxTier) as ModelTier;
-
-    // Urgent tasks get at least tier 2
-    if (request.timeSensitivity === 'urgent' && minTier < 2) {
-      minTier = 2;
-    }
-
-    // Complex tasks get at least tier 2
-    if (request.complexity === 'complex' && minTier < 2) {
-      minTier = 2;
-    }
-
-    // Batch tasks can go to tier 1 (only if no explicit minTier was requested)
-    if (request.timeSensitivity === 'batch' && !override?.minTier && !request.minTier) {
-      minTier = 1;
-    }
-
-    return { minTier, maxTier };
-  }
-
-  /** Apply quota restrictions and potentially downgrade maxTier. */
-  private applyQuotaRestrictions(
-    request: RoutingRequest,
-    currentMaxTier: ModelTier,
-    quotaExempt: boolean,
-  ): { maxTier: ModelTier; downgraded: boolean; warning?: string } {
-    // Check global quota first
-    const globalUsage = this.quota.getUsagePercent('global');
-    if (globalUsage >= this.quotaThreshold) {
-      if (quotaExempt) {
-        return {
-          maxTier: currentMaxTier,
-          downgraded: false,
-          warning: `Quota at ${(globalUsage * 100).toFixed(0)}% but security/safety critical task — no downgrade`,
-        };
-      }
-      return {
-        maxTier: 1,
-        downgraded: currentMaxTier > 1,
-        warning: `Quota at ${(globalUsage * 100).toFixed(0)}% (threshold: ${(this.quotaThreshold * 100).toFixed(0)}%) — restricted to tier 1`,
-      };
-    }
-
-    // Check provider-specific quota
-    if (request.preferredProvider) {
-      const providerUsage = this.quota.getUsagePercent(request.preferredProvider);
-      if (providerUsage >= this.quotaThreshold) {
-        return {
-          maxTier: currentMaxTier, // Don't downgrade tier, just warn
-          downgraded: false,
-          warning: `${request.preferredProvider} quota at ${(providerUsage * 100).toFixed(0)}% — may prefer other provider`,
-        };
-      }
-    }
-
-    return { maxTier: currentMaxTier, downgraded: false };
-  }
-
-  /** Filter models to candidates matching constraints. */
-  private filterCandidates(
-    request: RoutingRequest,
-    minTier: ModelTier,
-    maxTier: ModelTier,
-    override?: BusinessUnitOverride,
-    quotaExempt: boolean = false,
-  ): ModelDefinition[] {
-    return this.models.filter(m => {
-      // Must be available
-      if (m.status === 'unavailable') return false;
-
-      // Tier bounds
-      if (m.tier < minTier || m.tier > maxTier) return false;
-
-      // Required capabilities
-      if (request.requiredCapabilities?.length) {
-        const hasAll = request.requiredCapabilities.every(c => m.capabilities.includes(c));
-        if (!hasAll) return false;
-      }
-
-      // Provider quota exhausted — skip (except safety-critical requests)
-      if (this.enforceQuota && !quotaExempt && this.quota.isExhausted(m.provider)) {
-        return false;
-      }
-
-      return true;
-    });
-  }
-
-  /** Score all candidates and return sorted (best first). */
-  private scoreCandidates(
-    candidates: ModelDefinition[],
-    request: RoutingRequest,
-    override?: BusinessUnitOverride
-  ): Array<{ model: ModelDefinition; score: number; breakdown: ScoreBreakdown }> {
-    const priority = request.priorityOverride
-      ?? override?.priority
-      ?? 'medium';
-
-    const scored = candidates.map(model => {
-      const breakdown = this.computeBreakdown(model, request, priority, override);
-      const score =
-        breakdown.complexityScore +
-        breakdown.quotaScore +
-        breakdown.priorityScore +
-        breakdown.timeSensitivityScore +
-        breakdown.performanceScore +
-        breakdown.providerPreferenceScore +
-        breakdown.capabilityMatchScore;
-
-      return { model, score, breakdown };
-    });
-
-    // Sort descending by score
-    scored.sort((a, b) => b.score - a.score);
-    return scored;
-  }
-
-  /** Compute individual score breakdown for a model. */
-  private computeBreakdown(
-    model: ModelDefinition,
-    request: RoutingRequest,
-    priority: RoutingPriority,
-    override?: BusinessUnitOverride
-  ): ScoreBreakdown {
-    // Complexity: reward tier match to complexity
-    const idealTier = COMPLEXITY_TIER_MAP[request.complexity];
-    const tierDiff = Math.abs(model.tier - idealTier);
-    const complexityScore = COMPLEXITY_SCORES[request.complexity] - tierDiff * 20;
-
-    // Quota: penalize expensive models when quota is high
-    const globalUsage = this.quota.getUsagePercent('global');
-    const providerUsage = this.quota.getUsagePercent(model.provider);
-    const usagePressure = Math.max(globalUsage, providerUsage);
-    // Higher tier = more penalty when quota is high
-    const quotaScore = model.tier === 1
-      ? usagePressure * 30  // Cheap models get bonus when quota is tight
-      : -usagePressure * model.tier * 15;
-
-    // Priority: align tier preference to business importance so this factor affects ranking
-    const priorityIdealTier = PRIORITY_TIER_MAP[priority];
-    const priorityTierDiff = Math.abs(model.tier - priorityIdealTier);
-    const priorityScore = PRIORITY_SCORES[priority] - priorityTierDiff * PRIORITY_TIER_MISMATCH_PENALTY;
-
-    // Time sensitivity: urgent prefers higher tiers, batch prefers lower tiers
-    const timeIdealTier = TIME_SENSITIVITY_TIER_MAP[request.timeSensitivity];
-    const timeTierDiff = Math.abs(model.tier - timeIdealTier);
-    const timeSensitivityScore =
-      TIME_SENSITIVITY_SCORES[request.timeSensitivity]
-      - timeTierDiff * TIME_SENSITIVITY_TIER_MISMATCH_PENALTY;
-
-    // Performance: use historical data if available
-    let performanceScore = 0;
-    if (request.taskType) {
-      const perfScore = this.performance.getPerformanceScore(model.id, request.taskType);
-      performanceScore = (perfScore - 0.5) * MAX_PERFORMANCE_BONUS * 2; // Normalize around 0
-    }
-
-    // Provider preference
-    const providerPreferenceScore =
-      (request.preferredProvider && model.provider === request.preferredProvider)
-        ? PROVIDER_PREFERENCE_BONUS
-        : (override?.preferredProvider && model.provider === override.preferredProvider)
-          ? PROVIDER_PREFERENCE_BONUS
-          : 0;
-
-    // Capability match: bonus per required capability matched (defensive; filterCandidates enforces all)
-    let capabilityMatchScore = 0;
-    if (request.requiredCapabilities?.length) {
-      const matched = request.requiredCapabilities.filter(c => model.capabilities.includes(c));
-      capabilityMatchScore = matched.length * CAPABILITY_MATCH_BONUS;
-    }
-
-    return {
-      complexityScore,
-      quotaScore,
-      priorityScore,
-      timeSensitivityScore,
-      performanceScore,
-      providerPreferenceScore,
-      capabilityMatchScore,
-    };
-  }
 
   /** Execute fallback chain when no primary candidates are available. */
   private fallback(
@@ -1005,36 +496,17 @@ export class ModelRouter {
     security: RoutingSecurityMetadata,
     quotaExempt: boolean,
   ): RoutingDecision {
-    const warnings = [...existingWarnings];
+    const fallbackResolution = resolveFallbackCandidates(
+      this.models,
+      request,
+      this.enforceQuota,
+      quotaExempt,
+      this.quota,
+    );
+    const warnings = [...existingWarnings, ...fallbackResolution.warnings];
 
-    // Try all models in fallback order (any tier, any provider)
-    const allAvailable = this.models
-      .filter(m => {
-        if (m.status === 'unavailable') return false;
-        if (this.enforceQuota && !quotaExempt && this.quota.isExhausted(m.provider)) {
-          return false;
-        }
-        return true;
-      })
-      .sort((a, b) => a.costPer1kInput - b.costPer1kInput); // Cheapest first in emergency
-
-    // Filter by required capabilities if possible
-    let fallbacks = allAvailable;
-    if (request.requiredCapabilities?.length) {
-      const withCaps = allAvailable.filter(m =>
-        request.requiredCapabilities!.every(c => m.capabilities.includes(c))
-      );
-      if (withCaps.length > 0) {
-        fallbacks = withCaps;
-      } else {
-        warnings.push('No models match all required capabilities — selecting best available');
-      }
-    }
-
-    if (fallbacks.length === 0) {
-      // All models are unavailable or filtered out by quota — catastrophic scenario
-      const hasAvailableByStatus = this.models.some(m => m.status !== 'unavailable');
-      const failureReason = hasAvailableByStatus
+    if (fallbackResolution.candidates.length === 0) {
+      const failureReason = fallbackResolution.hasAvailableByStatus
         ? 'No models available after quota filtering — cannot route request'
         : 'All models unavailable — cannot route request';
       this.logger.error(failureReason, { request });
@@ -1052,12 +524,12 @@ export class ModelRouter {
         capabilities: [],
       };
       warnings.push(
-        hasAvailableByStatus
+        fallbackResolution.hasAvailableByStatus
           ? 'CRITICAL: No models available after quota filtering'
           : 'CRITICAL: All models unavailable'
       );
       return this.buildDecision(marker, request, {
-        reason: hasAvailableByStatus
+        reason: fallbackResolution.hasAvailableByStatus
           ? 'No models available after quota filtering — no routing possible'
           : 'All models unavailable — no routing possible',
         fallbackUsed: true,
@@ -1068,7 +540,7 @@ export class ModelRouter {
       });
     }
 
-    const selected = fallbacks[0];
+    const selected = fallbackResolution.candidates[0];
     warnings.push(`Fallback selected: ${selected.id} (no candidates in requested tier range)`);
 
     return this.buildDecision(selected, request, {
@@ -1145,97 +617,18 @@ export class ModelRouter {
 
   /** Classify routing threat level from request metadata. */
   private classifySecurityRisk(request: RoutingRequest): RoutingSecurityMetadata {
-    const signals: string[] = [];
-    let riskLevel: RoutingRiskLevel = request.riskLevel ?? 'low';
-
-    const escalateTo = (target: RoutingRiskLevel, signal: string): void => {
-      signals.push(signal);
-      if (target === 'high') {
-        riskLevel = 'high';
-      } else if (target === 'medium' && riskLevel === 'low') {
-        riskLevel = 'medium';
-      }
-    };
-
-    if (request.containsExternalContent) {
-      escalateTo('high', 'containsExternalContent');
-    }
-
-    for (const source of request.contentSources ?? []) {
-      if (EXTERNAL_CONTENT_SOURCES.has(source.toLowerCase())) {
-        escalateTo('high', `contentSource:${source}`);
-      }
-    }
-
-    const injectionScore = typeof request.injectionScore === 'number' ? request.injectionScore : 0;
-    if (injectionScore >= this.injectionAlertThreshold) {
-      escalateTo('high', `injectionScore:${injectionScore.toFixed(2)}`);
-    } else if (injectionScore >= 0.3) {
-      escalateTo('medium', `injectionScoreElevated:${injectionScore.toFixed(2)}`);
-    }
-
-    const taskType = (request.taskType ?? '').toLowerCase();
-    if (taskType.includes('code') || taskType.includes('review') || taskType.includes('generation')) {
-      escalateTo('medium', `taskType:${request.taskType}`);
-    }
-
-    if (request.requiredCapabilities?.some((cap) => ['browser', 'vision'].includes(cap))) {
-      escalateTo('high', 'untrusted-capability');
-    }
-
-    return {
-      riskLevel,
-      signals,
-      injectionDetected: injectionScore >= this.injectionAlertThreshold,
-      forcedByRequest: false,
-    };
-  }
-
-  private estimateCostUsd(
-    model: ModelDefinition,
-    inputTokens: number,
-    outputTokens: number,
-  ): number {
-    return (inputTokens / 1000) * model.costPer1kInput + (outputTokens / 1000) * model.costPer1kOutput;
-  }
-
-  private getBaselineModel(): ModelDefinition {
-    const available = this.models.filter((m) => m.status !== 'unavailable');
-    if (available.length === 0) return this.models[0] ?? DEFAULT_MODELS[0];
-    return [...available].sort(
-      (a, b) => (b.costPer1kInput + b.costPer1kOutput) - (a.costPer1kInput + a.costPer1kOutput),
-    )[0];
+    return classifySecurityRisk(request, this.injectionAlertThreshold);
   }
 
   private recordTelemetry(request: RoutingRequest, decision: RoutingDecision): void {
-    const inputTokens = request.estimatedInputTokens ?? DEFAULT_ESTIMATED_INPUT_TOKENS;
-    const outputTokens = request.estimatedOutputTokens ?? DEFAULT_ESTIMATED_OUTPUT_TOKENS;
-    const baselineModel = this.getBaselineModel();
-
-    const estimatedCostUsd = this.estimateCostUsd(decision.model, inputTokens, outputTokens);
-    const baselineCostUsd = this.estimateCostUsd(baselineModel, inputTokens, outputTokens);
-
-    this.routingTelemetry.push({
-      decidedAt: decision.decidedAt,
-      riskLevel: decision.security.riskLevel,
-      modelId: decision.model.id,
-      tier: decision.tier,
-      estimatedCostUsd,
-      baselineCostUsd,
-      injectionDetected: decision.security.injectionDetected,
-    });
+    const baselineModel = getBaselineModel(this.models);
+    this.routingTelemetry.push(buildRoutingTelemetryEntry(request, decision, baselineModel));
     if (this.routingTelemetry.length > this.routingHistoryLimit) {
       this.routingTelemetry.splice(0, this.routingTelemetry.length - this.routingHistoryLimit);
     }
 
     if (decision.security.injectionDetected) {
-      const event: InjectionDetectionEvent = {
-        detectedAt: decision.decidedAt,
-        riskLevel: decision.security.riskLevel,
-        modelId: decision.model.id,
-        injectionScore: request.injectionScore ?? 0,
-        signals: [...decision.security.signals],
-      };
+      const event = buildInjectionDetectionEvent(request, decision);
       this.injectionEvents.push(event);
       if (this.injectionEvents.length > this.routingHistoryLimit) {
         this.injectionEvents.splice(0, this.injectionEvents.length - this.routingHistoryLimit);
@@ -1246,42 +639,7 @@ export class ModelRouter {
 
   /** Return security-routing telemetry for dashboard/API surfaces. */
   getSecurityRoutingSummary(limit?: number): SecurityRoutingSummary {
-    const effectiveLimit = limit && Number.isFinite(limit)
-      ? Math.max(1, Math.min(Math.trunc(limit), this.routingHistoryLimit))
-      : this.routingHistoryLimit;
-    const slice = this.routingTelemetry.slice(-effectiveLimit);
-    const riskCounts: Record<RoutingRiskLevel, number> = { low: 0, medium: 0, high: 0 };
-    const tierCounts: Record<'tier1' | 'tier2' | 'tier3', number> = { tier1: 0, tier2: 0, tier3: 0 };
-    const modelUsage: Record<string, number> = {};
-    let estimatedCostUsd = 0;
-    let baselineCostUsd = 0;
-    let injectionDetections = 0;
-
-    for (const entry of slice) {
-      riskCounts[entry.riskLevel] += 1;
-      tierCounts[`tier${entry.tier}` as 'tier1' | 'tier2' | 'tier3'] += 1;
-      modelUsage[entry.modelId] = (modelUsage[entry.modelId] ?? 0) + 1;
-      estimatedCostUsd += entry.estimatedCostUsd;
-      baselineCostUsd += entry.baselineCostUsd;
-      if (entry.injectionDetected) injectionDetections += 1;
-    }
-    const estimatedSavingsUsd = baselineCostUsd - estimatedCostUsd;
-    const estimatedSavingsPct = baselineCostUsd > 0
-      ? Number(((estimatedSavingsUsd / baselineCostUsd) * 100).toFixed(2))
-      : 0;
-
-    return {
-      updatedAt: this.now().toISOString(),
-      windowSize: slice.length,
-      riskCounts,
-      tierCounts,
-      modelUsage,
-      injectionDetections,
-      estimatedCostUsd: Number(estimatedCostUsd.toFixed(6)),
-      baselineCostUsd: Number(baselineCostUsd.toFixed(6)),
-      estimatedSavingsUsd: Number(estimatedSavingsUsd.toFixed(6)),
-      estimatedSavingsPct,
-    };
+    return summarizeSecurityRoutingTelemetry(this.routingTelemetry, this.now, this.routingHistoryLimit, limit);
   }
 
   /** Return recent injection-detection events. */


### PR DESCRIPTION
## Summary
- decompose `lib/model-router.ts` into focused modules for policy evaluation, scoring, fallback resolution, and security telemetry
- preserve public router/tracker interfaces while moving constants and tracker implementations out of the orchestration module
- add decomposition documentation and maintainability guardrails, plus additional precedence/fallback regression tests

## Files
- `lib/model-router.ts`
- `lib/model-router-constants.ts`
- `lib/model-router-trackers.ts`
- `lib/model-router-policy.ts`
- `lib/model-router-scoring.ts`
- `lib/model-router-fallback.ts`
- `lib/model-router-security.ts`
- `lib/__tests__/model-router.test.ts`
- `lib/__tests__/maintainability-file-size-guard.test.ts`
- `docs/MODEL_ROUTER_DECOMPOSITION_PLAN.md`
- `docs/DOC_INDEX.md`

## Verification
- `npx jest --runInBand lib/__tests__/model-router.test.ts lib/__tests__/maintainability-file-size-guard.test.ts`
- `npm run build`
- `npm test -- --runInBand` (one intermittent unrelated failure observed once in `lib/__tests__/shared-context-watcher.test.ts`; immediate rerun of that suite passed)
- `python3 scripts/docs-lint.py`

Closes #377
