### PR TITLE
refactor: extract dashboard server utility helpers

### DIFF
--- a/dashboard/server/server-utils.ts
+++ b/dashboard/server/server-utils.ts
@@ -1,0 +1,115 @@
+import fs from 'node:fs';
+import crypto from 'node:crypto';
+
+import type { IncomingMessage, ServerResponse } from 'node:http';
+import { COOKIE_NAME } from './middleware/auth.js';
+
+export function safeReadJson(filePath: string, fallback: null): Record<string, unknown> | null;
+export function safeReadJson(filePath: string, fallback: Record<string, unknown>): Record<string, unknown>;
+export function safeReadJson(
+  filePath: string,
+  fallback: Record<string, unknown> | null,
+): Record<string, unknown> | null {
+  try {
+    if (!fs.existsSync(filePath)) return fallback;
+    return JSON.parse(fs.readFileSync(filePath, 'utf8')) as Record<string, unknown>;
+  } catch {
+    return fallback;
+  }
+}
+
+export function safeReadText(filePath: string, fallback: string): string {
+  try {
+    if (!fs.existsSync(filePath)) return fallback;
+    return fs.readFileSync(filePath, 'utf8');
+  } catch {
+    return fallback;
+  }
+}
+
+export function sendJson(res: ServerResponse, data: unknown, status: number = 200): void {
+  res.writeHead(status, { 'Content-Type': 'application/json' });
+  res.end(JSON.stringify(data));
+}
+
+export function clampInt(n: string | number | null, lo: number, hi: number, dflt: number): number {
+  const v: number = parseInt(String(n));
+  if (Number.isNaN(v)) return dflt;
+  return Math.max(lo, Math.min(hi, v));
+}
+
+export function readEnvFlag(name: string, fallback = false): boolean {
+  const raw = (process.env[name] ?? '').trim().toLowerCase();
+  if (!raw) return fallback;
+  if (raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on') return true;
+  if (raw === '0' || raw === 'false' || raw === 'no' || raw === 'off') return false;
+  return fallback;
+}
+
+export async function readRequestBody(
+  req: IncomingMessage,
+  opts: { maxBytes?: number } = {},
+): Promise<string> {
+  const maxBytes: number = opts.maxBytes ?? 1024 * 1024;
+  return await new Promise<string>((resolve, reject) => {
+    let data: string = '';
+    let bytes: number = 0;
+    req.on('data', (chunk: Buffer) => {
+      bytes += chunk.length;
+      if (bytes > maxBytes) {
+        try {
+          req.destroy();
+        } catch {
+          // ignore
+        }
+        reject(new Error('Request body too large'));
+        return;
+      }
+      data += chunk.toString('utf8');
+    });
+    req.on('end', () => resolve(data));
+    req.on('error', reject);
+  });
+}
+
+export function isHttpsRequest(req: IncomingMessage): boolean {
+  const xfProto: string = ((req?.headers?.['x-forwarded-proto'] as string | undefined) ?? '').toLowerCase();
+  return xfProto === 'https' || !!(req?.socket as { encrypted?: boolean })?.encrypted;
+}
+
+export function buildAuthCookie(
+  req: IncomingMessage,
+  token: string,
+  opts: { maxAgeSeconds?: number } = {},
+): string {
+  const maxAgeSeconds: number = opts.maxAgeSeconds ?? 60 * 60 * 24 * 30;
+  const parts: string[] = [];
+  parts.push(`${COOKIE_NAME}=${encodeURIComponent(token)}`);
+  parts.push('Path=/');
+  parts.push('HttpOnly');
+  parts.push('SameSite=Strict');
+  parts.push(`Max-Age=${maxAgeSeconds}`);
+  if (isHttpsRequest(req)) parts.push('Secure');
+  return parts.join('; ');
+}
+
+export function buildClearAuthCookie(
+  req: IncomingMessage,
+): string {
+  const parts: string[] = [];
+  parts.push(`${COOKIE_NAME}=`);
+  parts.push('Path=/');
+  parts.push('HttpOnly');
+  parts.push('SameSite=Strict');
+  parts.push('Max-Age=0');
+  if (isHttpsRequest(req)) parts.push('Secure');
+  return parts.join('; ');
+}
+
+export function timingSafeStringEqual(a: string, b: string): boolean {
+  if (typeof a !== 'string' || typeof b !== 'string') return false;
+  const aa: Buffer = Buffer.from(a);
+  const bb: Buffer = Buffer.from(b);
+  if (aa.length !== bb.length) return false;
+  return crypto.timingSafeEqual(aa, bb);
+}

--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -8,7 +8,6 @@
 
 import http from 'node:http';
 import fs from 'node:fs';
-import crypto from 'node:crypto';
 import path from 'node:path';
 import os from 'node:os';
 import { exec, execSync } from 'node:child_process';
@@ -93,6 +92,17 @@ import { authorizeActionRequest } from './middleware/action-guard.js';
 import { withCorrelationId, CORRELATION_HEADER } from './middleware/correlation-id.js';
 import { proxyBridgeJson, proxyBridgeSse } from './bridge-proxy.js';
 import { tryServeStatic } from './static-serve.js';
+import {
+  safeReadJson,
+  safeReadText,
+  sendJson,
+  clampInt,
+  readEnvFlag,
+  readRequestBody,
+  buildAuthCookie,
+  buildClearAuthCookie,
+  timingSafeStringEqual,
+} from './server-utils.js';
 
 // Structured logging (Issue #195 — Observability)
 import structuredLogger from '../../lib/structured-logger.js';
@@ -187,114 +197,6 @@ try {
 }
 
 // ─── Utility Functions ───────────────────────────────────────────────────────
-
-function safeReadJson(filePath: string, fallback: null): Record<string, unknown> | null;
-function safeReadJson(filePath: string, fallback: Record<string, unknown>): Record<string, unknown>;
-function safeReadJson(
-  filePath: string,
-  fallback: Record<string, unknown> | null,
-): Record<string, unknown> | null {
-  try {
-    if (!fs.existsSync(filePath)) return fallback;
-    return JSON.parse(fs.readFileSync(filePath, 'utf8')) as Record<string, unknown>;
-  } catch {
-    return fallback;
-  }
-}
-
-function safeReadText(filePath: string, fallback: string): string {
-  try {
-    if (!fs.existsSync(filePath)) return fallback;
-    return fs.readFileSync(filePath, 'utf8');
-  } catch {
-    return fallback;
-  }
-}
-
-function sendJson(res: ServerResponse, data: unknown, status: number = 200): void {
-  res.writeHead(status, { 'Content-Type': 'application/json' });
-  res.end(JSON.stringify(data));
-}
-
-function clampInt(n: string | number | null, lo: number, hi: number, dflt: number): number {
-  const v: number = parseInt(String(n));
-  if (Number.isNaN(v)) return dflt;
-  return Math.max(lo, Math.min(hi, v));
-}
-
-function readEnvFlag(name: string, fallback = false): boolean {
-  const raw = (process.env[name] ?? '').trim().toLowerCase();
-  if (!raw) return fallback;
-  if (raw === '1' || raw === 'true' || raw === 'yes' || raw === 'on') return true;
-  if (raw === '0' || raw === 'false' || raw === 'no' || raw === 'off') return false;
-  return fallback;
-}
-
-async function readRequestBody(
-  req: IncomingMessage,
-  opts: { maxBytes?: number } = {},
-): Promise<string> {
-  const maxBytes: number = opts.maxBytes ?? 1024 * 1024;
-  return await new Promise<string>((resolve, reject) => {
-    let data: string = '';
-    let bytes: number = 0;
-    req.on('data', (chunk: Buffer) => {
-      bytes += chunk.length;
-      if (bytes > maxBytes) {
-        try {
-          req.destroy();
-        } catch {
-          // ignore
-        }
-        reject(new Error('Request body too large'));
-        return;
-      }
-      data += chunk.toString('utf8');
-    });
-    req.on('end', () => resolve(data));
-    req.on('error', reject);
-  });
-}
-
-function isHttpsRequest(req: IncomingMessage): boolean {
-  const xfProto: string = ((req?.headers?.['x-forwarded-proto'] as string | undefined) ?? '').toLowerCase();
-  return xfProto === 'https' || !!(req?.socket as { encrypted?: boolean })?.encrypted;
-}
-
-function buildAuthCookie(
-  req: IncomingMessage,
-  token: string,
-  opts: { maxAgeSeconds?: number } = {},
-): string {
-  const maxAgeSeconds: number = opts.maxAgeSeconds ?? 60 * 60 * 24 * 30;
-  const parts: string[] = [];
-  parts.push(`${COOKIE_NAME}=${encodeURIComponent(token)}`);
-  parts.push('Path=/');
-  parts.push('HttpOnly');
-  parts.push('SameSite=Strict');
-  parts.push(`Max-Age=${maxAgeSeconds}`);
-  if (isHttpsRequest(req)) parts.push('Secure');
-  return parts.join('; ');
-}
-
-function buildClearAuthCookie(req: IncomingMessage): string {
-  const parts: string[] = [];
-  parts.push(`${COOKIE_NAME}=`);
-  parts.push('Path=/');
-  parts.push('HttpOnly');
-  parts.push('SameSite=Strict');
-  parts.push('Max-Age=0');
-  if (isHttpsRequest(req)) parts.push('Secure');
-  return parts.join('; ');
-}
-
-function timingSafeStringEqual(a: string, b: string): boolean {
-  if (typeof a !== 'string' || typeof b !== 'string') return false;
-  const aa: Buffer = Buffer.from(a);
-  const bb: Buffer = Buffer.from(b);
-  if (aa.length !== bb.length) return false;
-  return crypto.timingSafeEqual(aa, bb);
-}
 
 // ─── VentureOS helpers + cache ───────────────────────────────────────────────
 

--- a/docs/SERVER_DECOMPOSITION_PLAN.md
+++ b/docs/SERVER_DECOMPOSITION_PLAN.md
@@ -1,11 +1,11 @@
-# Server Decomposition Plan (Issue #366)
+# Server Decomposition Plan (Issues #366, #384)
 
 ## Goal
 Reduce regression blast-radius from oversized dashboard server modules while preserving behavior parity.
 
 ## Baseline (2026-02-21)
-- `dashboard/server/server.ts`: 4231 LOC
-- `dashboard/server/routes/task-board.ts`: 2650 LOC
+- `dashboard/server/server.ts`: 4231 LOC (142282 bytes)
+- `dashboard/server/routes/task-board.ts`: 2650 LOC (86570 bytes)
 
 ## Staged Plan
 1. Stage 1 (completed)
@@ -13,11 +13,15 @@ Reduce regression blast-radius from oversized dashboard server modules while pre
 - Extract task-board metrics/stuck-task logic from `task-board.ts` into `dashboard/server/routes/task-board-metrics.ts`.
 - Add file-size guardrails in `dashboard/tests/unit/maintainability/file-size-guard.test.ts`.
 
-2. Stage 2 (next)
+2. Stage 1.1 (in progress, Issue #384)
+- Extract shared request/file/auth utility helpers from `server.ts` into `dashboard/server/server-utils.ts`.
+- Keep routing and response semantics unchanged while shrinking entrypoint responsibilities.
+
+3. Stage 2 (next)
 - Split task-board API surface by concern (metrics/history/webhooks/escalations) into route-local modules.
 - Keep `handleTaskBoard` as a thin dispatcher/composer.
 
-3. Stage 3 (next)
+4. Stage 3 (next)
 - Group high-volume route wiring in `server.ts` into route registrars by domain.
 - Preserve middleware ordering, auth boundaries, and existing response semantics.
 


### PR DESCRIPTION
## Summary
- extract shared request, file, and auth utility helpers out of dashboard/server/server.ts into dashboard/server/server-utils.ts
- keep server route behavior unchanged while reducing entrypoint coupling
- update docs/SERVER_DECOMPOSITION_PLAN.md with stage progress for issue #384

## Verification
- npm run build --workspace=dashboard
- npm run test --workspace=dashboard
- python3 scripts/docs-lint.py

Refs #384
