### PR TITLE
fix(tactical-map): clip KPI ticker text to HUD strip (issue #393)

### DIFF
--- a/tactical-map/src/renderer/hud.ts
+++ b/tactical-map/src/renderer/hud.ts
@@ -62,6 +62,13 @@ export function createHud(): Hud {
   const tickerBg = new Graphics();
   tickerContainer.addChild(tickerBg);
 
+  // Keep ticker text constrained to the strip bounds.
+  const tickerViewport = new Container();
+  tickerContainer.addChild(tickerViewport);
+  const tickerMask = new Graphics();
+  tickerContainer.addChild(tickerMask);
+  tickerViewport.mask = tickerMask;
+
   const tickerText = new Text({
     text: 'Loading KPIs…',
     style: {
@@ -71,7 +78,7 @@ export function createHud(): Hud {
     }
   });
   tickerText.anchor.set(0, 0.5);
-  tickerContainer.addChild(tickerText);
+  tickerViewport.addChild(tickerText);
 
   let width = 1920;
   let height = 1080;
@@ -101,6 +108,8 @@ export function createHud(): Hud {
     tickerContainer.position.set(width - pad - tickerW, 0);
     tickerBg.clear();
     tickerBg.rect(0, 0, tickerW, barH).fill({ color: 0x000000, alpha: 0.66 });
+    tickerMask.clear();
+    tickerMask.rect(0, 0, tickerW, barH).fill({ color: 0xffffff, alpha: 1 });
 
     tickerText.position.set(12, barH / 2);
     scrollX = tickerW; // reset scroll

--- a/tactical-map/tests/unit/renderer-foundation.test.ts
+++ b/tactical-map/tests/unit/renderer-foundation.test.ts
@@ -154,11 +154,28 @@ describe('renderer foundation', () => {
     hud.setSize(1920, 1080);
     hud.setKpiText('Oracle WIS: 85 | Atlas SPD: 72');
     hud.update(16);
+    hud.setSize(1366, 768);
+    hud.update(16);
 
     // Sanity: should have at least one Text child somewhere.
     const hasText =
       hud.container.children.some((c) => c instanceof Text) ||
       hud.container.children.some((c) => (c as Container).children?.some((cc) => cc instanceof Text));
     expect(hasText).toBe(true);
+
+    // Regression guard: ticker scroll layer must be clipped to the strip bounds.
+    const hasMask = findDescendant(hud.container, (node) => Boolean((node as { mask?: unknown }).mask));
+    expect(hasMask).toBe(true);
   });
 });
+
+function findDescendant(node: unknown, predicate: (node: unknown) => boolean): boolean {
+  if (!node || typeof node !== 'object') return false;
+  if (predicate(node)) return true;
+  const children = (node as { children?: unknown[] }).children;
+  if (!Array.isArray(children)) return false;
+  for (const child of children) {
+    if (findDescendant(child, predicate)) return true;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary
- fixes #393 by clipping the KPI ticker scroll layer to the HUD ticker strip bounds
- keeps ticker background and scrolling behavior unchanged while preventing bleed over nav tabs
- adds a regression assertion in renderer foundation tests to ensure HUD ticker masking remains in place after resize

## Changes
- `tactical-map/src/renderer/hud.ts`
  - added `tickerViewport` + `tickerMask`
  - applied mask to ticker text layer
  - redraws mask on resize with the current ticker dimensions
- `tactical-map/tests/unit/renderer-foundation.test.ts`
  - added resize pass in HUD test
  - added recursive descendant helper + assertion that a masked node exists

## Verification
- `cd tactical-map && npm test`
- `npm run build`
- `npm run build:tactical-map`
