### PR TITLE
test: stabilize shared-context watcher update-event race (issue #398)

### DIFF
--- a/lib/__tests__/shared-context-watcher.test.ts
+++ b/lib/__tests__/shared-context-watcher.test.ts
@@ -338,6 +338,8 @@ describe('SharedContextWatcher — File Events', () => {
 
     watcher.on('change', (evt: SharedContextEvent) => events.push(evt));
     watcher.watchTeam(TEAM_ID, TEAM_NAME);
+    // Ensure FS watcher has attached before update write (avoids attach race).
+    await waitForEvent(100);
 
     // Update the file
     fs.writeFileSync(path.join(teamDir, 'priorities.md'), 'Updated priorities\n\n1. Ship feature X');


### PR DESCRIPTION
## Summary
- fixes #398 by removing an attach-race in the shared-context watcher update test
- aligns the update test with existing file-event tests by waiting briefly after `watchTeam(...)` before writing

## Changes
- `lib/__tests__/shared-context-watcher.test.ts`
  - added `await waitForEvent(100)` before the update write in `emits "change" event on file update`

## Verification
- `npx jest lib/__tests__/shared-context-watcher.test.ts --runInBand --testNamePattern "emits \"change\" event on file update"` (10 repeated runs)
- `npm test`
- `npm run build`
