### PR TITLE
fix(dashboard): platform-aware ops actions + service status (issue #401)

### DIFF
--- a/dashboard/docs/API.md
+++ b/dashboard/docs/API.md
@@ -542,7 +542,9 @@ Returns recent git commits (last 7 days) from tracked repositories.
 
 ### `GET /api/services`
 
-Returns systemd service status for `openclaw`, `agent-dashboard`, `tailscaled`.
+Returns service status for `openclaw`, `agent-dashboard`, `tailscaled` using platform-aware checks:
+- Linux: `systemctl is-active`
+- macOS: `openclaw gateway status`, `launchctl list`, `tailscale status`
 
 ### `GET /api/memory`
 
@@ -646,7 +648,7 @@ Security guardrails:
 | Endpoint | Description |
 |----------|-------------|
 | `POST /api/action/restart-openclaw` | Restart OpenClaw service |
-| `POST /api/action/restart-dashboard` | Restart dashboard (2s delay) |
+| `POST /api/action/restart-dashboard` | Restart dashboard service |
 | `POST /api/action/clear-cache` | Clear all in-memory caches |
 | `POST /api/action/restart-tailscale` | Restart Tailscale daemon |
 | `POST /api/action/update-openclaw` | Run `npm update -g openclaw` |

--- a/dashboard/server/bridge-aggregation-helpers.ts
+++ b/dashboard/server/bridge-aggregation-helpers.ts
@@ -1,6 +1,7 @@
 import fs from 'node:fs';
 import path from 'node:path';
 import { execSync } from 'node:child_process';
+import { getPlatformServiceStatuses } from './platform-ops.js';
 
 interface BridgeAgentSessionEntry {
   sessionId: string;
@@ -225,18 +226,7 @@ function getGitActivity(workspaceDir: string): Array<{ repo: string; hash: strin
 }
 
 function getServicesStatus(): Array<{ name: string; active: boolean }> {
-  const services = ['openclaw', 'agent-dashboard', 'tailscaled'];
-  return services.map((name) => {
-    try {
-      const status = execSync(`systemctl is-active ${name} 2>/dev/null`, {
-        encoding: 'utf8',
-        timeout: 3000,
-      }).trim();
-      return { name, active: status === 'active' };
-    } catch {
-      return { name, active: false };
-    }
-  });
+  return getPlatformServiceStatuses();
 }
 
 function getMemoryFiles(

--- a/dashboard/server/platform-ops.ts
+++ b/dashboard/server/platform-ops.ts
@@ -1,0 +1,116 @@
+import { execSync } from 'node:child_process';
+
+export type ServiceStatus = { name: string; active: boolean };
+
+export type RestartAction = 'restart-openclaw' | 'restart-dashboard' | 'restart-tailscale';
+
+type CommandProbe = (command: string, timeoutMs: number) => boolean;
+
+export interface PlatformOpsOptions {
+  platform?: NodeJS.Platform;
+  uid?: number | null;
+  probe?: CommandProbe;
+}
+
+export interface RestartCommandPlan {
+  command: string;
+  timeoutMs: number;
+  unsupportedReason?: string;
+}
+
+const DASHBOARD_LAUNCHD_LABELS = ['com.openclaw.dashboard.monorepo', 'com.openclaw.dashboard'];
+
+function defaultProbe(command: string, timeoutMs: number): boolean {
+  try {
+    execSync(command, { stdio: 'ignore', timeout: timeoutMs });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function resolveUid(candidate?: number | null): number | null {
+  if (typeof candidate === 'number' && Number.isFinite(candidate) && candidate >= 0) {
+    return Math.floor(candidate);
+  }
+  if (typeof process.getuid === 'function') {
+    return process.getuid();
+  }
+  return null;
+}
+
+export function getPlatformServiceStatuses(options: PlatformOpsOptions = {}): ServiceStatus[] {
+  const platform = options.platform ?? process.platform;
+  const probe = options.probe ?? defaultProbe;
+
+  if (platform === 'linux') {
+    return [
+      { name: 'openclaw', active: probe('systemctl is-active --quiet openclaw', 3000) },
+      { name: 'agent-dashboard', active: probe('systemctl is-active --quiet agent-dashboard', 3000) },
+      { name: 'tailscaled', active: probe('systemctl is-active --quiet tailscaled', 3000) },
+    ];
+  }
+
+  if (platform === 'darwin') {
+    const dashboardActive = DASHBOARD_LAUNCHD_LABELS.some((label) =>
+      probe(`launchctl list ${label} >/dev/null 2>&1`, 3000),
+    );
+    return [
+      { name: 'openclaw', active: probe('openclaw gateway status >/dev/null 2>&1', 5000) },
+      { name: 'agent-dashboard', active: dashboardActive },
+      { name: 'tailscaled', active: probe('tailscale status >/dev/null 2>&1', 5000) },
+    ];
+  }
+
+  return [
+    { name: 'openclaw', active: probe('openclaw gateway status >/dev/null 2>&1', 5000) },
+    { name: 'agent-dashboard', active: false },
+    { name: 'tailscaled', active: probe('tailscale status >/dev/null 2>&1', 5000) },
+  ];
+}
+
+export function resolveRestartActionCommand(
+  action: RestartAction,
+  options: PlatformOpsOptions = {},
+): RestartCommandPlan {
+  const platform = options.platform ?? process.platform;
+  const uid = resolveUid(options.uid);
+
+  switch (action) {
+    case 'restart-openclaw':
+      return { command: 'openclaw gateway restart', timeoutMs: 60000 };
+    case 'restart-dashboard':
+      if (platform === 'linux') {
+        return { command: 'systemctl restart agent-dashboard', timeoutMs: 60000 };
+      }
+      if (platform === 'darwin' && uid != null) {
+        const primary = `launchctl kickstart -k gui/${uid}/com.openclaw.dashboard.monorepo`;
+        const legacy = `launchctl kickstart -k gui/${uid}/com.openclaw.dashboard`;
+        return { command: `${primary} || ${legacy}`, timeoutMs: 60000 };
+      }
+      return {
+        command: '',
+        timeoutMs: 0,
+        unsupportedReason: `restart-dashboard is not supported on platform '${platform}'`,
+      };
+    case 'restart-tailscale':
+      if (platform === 'linux') {
+        return { command: 'systemctl restart tailscaled', timeoutMs: 60000 };
+      }
+      if (platform === 'darwin') {
+        // Requires elevated privileges on many macOS installs; caller surfaces failures.
+        const primary = 'launchctl kickstart -k system/com.tailscaled';
+        const fallback = 'launchctl kickstart -k system/com.tailscale.tailscaled';
+        return { command: `${primary} || ${fallback}`, timeoutMs: 60000 };
+      }
+      return {
+        command: '',
+        timeoutMs: 0,
+        unsupportedReason: `restart-tailscale is not supported on platform '${platform}'`,
+      };
+    default: {
+      const exhaustive: never = action;
+      throw new Error(`Unknown restart action: ${exhaustive as string}`);
+    }
+  }
+}

--- a/dashboard/server/server-ops-helpers.ts
+++ b/dashboard/server/server-ops-helpers.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { execSync } from 'node:child_process';
 
 import type { CronJobInfo, GitCommit, GitRepo } from './types.js';
+import { getPlatformServiceStatuses } from './platform-ops.js';
 
 interface CronJobRaw {
   id: string;
@@ -109,18 +110,7 @@ export function getGitActivity(workspaceDir: string): GitCommit[] {
 }
 
 export function getServicesStatus(): Array<{ name: string; active: boolean }> {
-  const services: string[] = ['openclaw', 'agent-dashboard', 'tailscaled'];
-  return services.map((name) => {
-    try {
-      const status: string = execSync(`systemctl is-active ${name} 2>/dev/null`, {
-        encoding: 'utf8',
-        timeout: 3000,
-      }).trim();
-      return { name, active: status === 'active' };
-    } catch {
-      return { name, active: false };
-    }
-  });
+  return getPlatformServiceStatuses();
 }
 
 export function getMemoryFiles(

--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -10,6 +10,7 @@ import http from 'node:http';
 import fs from 'node:fs';
 import path from 'node:path';
 import { exec, execSync } from 'node:child_process';
+import { promisify } from 'node:util';
 
 import type { IncomingMessage, ServerResponse, Server } from 'node:http';
 
@@ -157,6 +158,7 @@ import {
   getMemoryFiles as getMemoryFilesInternal,
   getServicesStatus as getServicesStatusInternal,
 } from './server-ops-helpers.js';
+import { resolveRestartActionCommand } from './platform-ops.js';
 
 // ─── Configuration ───────────────────────────────────────────────────────────
 // All VentureOS data paths flow through lib/paths.ts (no os.homedir() needed).
@@ -196,6 +198,27 @@ const bridgeProxyDeps = {
   bridgeUrl: BRIDGE_URL,
   bridgeToken: BRIDGE_TOKEN,
 };
+
+const execAsync = promisify(exec);
+
+async function runShellCommand(
+  command: string,
+  timeoutMs: number,
+): Promise<{ ok: boolean; output: string; error?: string }> {
+  try {
+    const { stdout, stderr } = await execAsync(command, {
+      timeout: timeoutMs,
+      maxBuffer: 1024 * 1024,
+      encoding: 'utf8',
+    });
+    const output = [stdout, stderr].map((s) => s.trim()).filter(Boolean).join('\n');
+    return { ok: true, output };
+  } catch (error: unknown) {
+    const e = error as { message?: string; stdout?: string; stderr?: string };
+    const output = [e.stdout, e.stderr].map((s) => (s ?? '').trim()).filter(Boolean).join('\n');
+    return { ok: false, output, error: e.message ?? 'Command execution failed' };
+  }
+}
 
 // Ensure data directory exists
 try {
@@ -2478,8 +2501,17 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
   if (req.url === '/api/action/restart-openclaw' && req.method === 'POST') {
     try {
       logInfo('dashboard', 'action_invoked', 'restart-openclaw requested', { action: 'restart-openclaw' });
-      exec('systemctl restart openclaw', () => {});
-      sendJson(res, { success: true });
+      const plan = resolveRestartActionCommand('restart-openclaw');
+      if (plan.unsupportedReason) {
+        sendJson(res, { success: false, error: plan.unsupportedReason }, 400);
+        return;
+      }
+      const result = await runShellCommand(plan.command, plan.timeoutMs);
+      if (!result.ok) {
+        sendJson(res, { success: false, error: result.error, output: result.output }, 502);
+        return;
+      }
+      sendJson(res, { success: true, output: result.output });
     } catch (e: unknown) {
       const safe = toSafeError(e, { action: 'restart-openclaw' });
       slogError('dashboard', 'action_failed', 'restart-openclaw failed', { action: 'restart-openclaw', errorRef: safe.errorRef });
@@ -2489,10 +2521,17 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
   }
   if (req.url === '/api/action/restart-dashboard' && req.method === 'POST') {
     try {
-      setTimeout(() => {
-        exec('systemctl restart agent-dashboard', () => {});
-      }, 2000);
-      sendJson(res, { success: true, message: 'Restarting in 2 seconds...' });
+      const plan = resolveRestartActionCommand('restart-dashboard');
+      if (plan.unsupportedReason) {
+        sendJson(res, { success: false, error: plan.unsupportedReason }, 400);
+        return;
+      }
+      const result = await runShellCommand(plan.command, plan.timeoutMs);
+      if (!result.ok) {
+        sendJson(res, { success: false, error: result.error, output: result.output }, 502);
+        return;
+      }
+      sendJson(res, { success: true, message: 'Dashboard restart command completed.', output: result.output });
     } catch (e: unknown) {
       const safe = toSafeError(e, { action: 'restart-dashboard' });
       sendJson(res, { ok: false, error: safe.error, errorRef: safe.errorRef }, safe.status);
@@ -2513,9 +2552,13 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
     return;
   }
   if (req.url === '/api/action/restart-tailscale' && req.method === 'POST') {
-    exec('systemctl restart tailscaled', (err) => {
-      sendJson(res, { success: !err, error: err?.message });
-    });
+    const plan = resolveRestartActionCommand('restart-tailscale');
+    if (plan.unsupportedReason) {
+      sendJson(res, { success: false, error: plan.unsupportedReason }, 400);
+      return;
+    }
+    const result = await runShellCommand(plan.command, plan.timeoutMs);
+    sendJson(res, { success: result.ok, output: result.output, error: result.error });
     return;
   }
   if (req.url === '/api/action/update-openclaw' && req.method === 'POST') {

--- a/dashboard/tests/unit/platform-ops.test.ts
+++ b/dashboard/tests/unit/platform-ops.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import { getPlatformServiceStatuses, resolveRestartActionCommand } from '../../server/platform-ops.js';
+
+describe('platform ops service status', () => {
+  it('uses systemd probes on linux', () => {
+    const commands: string[] = [];
+    const statuses = getPlatformServiceStatuses({
+      platform: 'linux',
+      probe: (command) => {
+        commands.push(command);
+        return command.includes('openclaw') || command.includes('agent-dashboard');
+      },
+    });
+
+    expect(commands).toEqual([
+      'systemctl is-active --quiet openclaw',
+      'systemctl is-active --quiet agent-dashboard',
+      'systemctl is-active --quiet tailscaled',
+    ]);
+    expect(statuses).toEqual([
+      { name: 'openclaw', active: true },
+      { name: 'agent-dashboard', active: true },
+      { name: 'tailscaled', active: false },
+    ]);
+  });
+
+  it('uses launchd/openclaw/tailscale probes on macOS', () => {
+    const commands: string[] = [];
+    const statuses = getPlatformServiceStatuses({
+      platform: 'darwin',
+      probe: (command) => {
+        commands.push(command);
+        return command.includes('dashboard.monorepo') || command.includes('openclaw gateway status');
+      },
+    });
+
+    expect(commands[0]).toContain('launchctl list com.openclaw.dashboard.monorepo');
+    expect(commands[1]).toContain('openclaw gateway status');
+    expect(commands[2]).toContain('tailscale status');
+    expect(statuses).toEqual([
+      { name: 'openclaw', active: true },
+      { name: 'agent-dashboard', active: true },
+      { name: 'tailscaled', active: false },
+    ]);
+  });
+});
+
+describe('platform ops restart commands', () => {
+  it('resolves linux restart commands', () => {
+    expect(resolveRestartActionCommand('restart-openclaw', { platform: 'linux' })).toEqual({
+      command: 'openclaw gateway restart',
+      timeoutMs: 60000,
+    });
+    expect(resolveRestartActionCommand('restart-dashboard', { platform: 'linux' })).toEqual({
+      command: 'systemctl restart agent-dashboard',
+      timeoutMs: 60000,
+    });
+    expect(resolveRestartActionCommand('restart-tailscale', { platform: 'linux' })).toEqual({
+      command: 'systemctl restart tailscaled',
+      timeoutMs: 60000,
+    });
+  });
+
+  it('resolves macOS restart commands with launchd labels', () => {
+    const dashboard = resolveRestartActionCommand('restart-dashboard', { platform: 'darwin', uid: 501 });
+    expect(dashboard.timeoutMs).toBe(60000);
+    expect(dashboard.command).toContain('launchctl kickstart -k gui/501/com.openclaw.dashboard.monorepo');
+    expect(dashboard.command).toContain('com.openclaw.dashboard');
+
+    const tailscale = resolveRestartActionCommand('restart-tailscale', { platform: 'darwin' });
+    expect(tailscale.timeoutMs).toBe(60000);
+    expect(tailscale.command).toContain('launchctl kickstart -k system/com.tailscaled');
+  });
+
+  it('returns unsupported command plans on unknown platforms', () => {
+    const dashboard = resolveRestartActionCommand('restart-dashboard', { platform: 'win32', uid: null });
+    expect(dashboard.command).toBe('');
+    expect(dashboard.unsupportedReason).toContain('not supported');
+
+    const tailscale = resolveRestartActionCommand('restart-tailscale', { platform: 'win32' });
+    expect(tailscale.command).toBe('');
+    expect(tailscale.unsupportedReason).toContain('not supported');
+  });
+});


### PR DESCRIPTION
## Summary
- fixes #401 by making dashboard ops controls and service status checks platform-aware for Linux and macOS
- removes false-positive success responses for restart actions by awaiting command completion and surfacing execution errors
- updates API docs to reflect platform-aware behavior

## What changed
- added `dashboard/server/platform-ops.ts`
  - `getPlatformServiceStatuses()` for Linux/systemd + macOS launchd/OpenClaw/Tailscale probes
  - `resolveRestartActionCommand()` for platform-specific restart commands
- wired service status callers to shared helper:
  - `dashboard/server/server-ops-helpers.ts`
  - `dashboard/server/bridge-aggregation-helpers.ts`
- updated action endpoints in `dashboard/server/server.ts`
  - `POST /api/action/restart-openclaw`
  - `POST /api/action/restart-dashboard`
  - `POST /api/action/restart-tailscale`
  now execute commands via awaited shell runner and return `502` on command failures
- added unit coverage:
  - `dashboard/tests/unit/platform-ops.test.ts`
- updated docs:
  - `dashboard/docs/API.md`

## Verification
- `cd dashboard && npx vitest run --config vitest.config.ts tests/unit/platform-ops.test.ts`
- `npm run test --workspace=dashboard`
- `npm run build`
- `npm test`
- `python3 scripts/docs-lint.py`
