### PR TITLE
fix(scripts): make OpenClaw allowlist defaults home-relative (issue #404)

### DIFF
--- a/scripts/routing-healthcheck.sh
+++ b/scripts/routing-healthcheck.sh
@@ -16,7 +16,7 @@ STATE_FILE="$STATE_DIR/routing-healthcheck.json"
 
 # Shared sender allowlist: workspace copy first, then shared canonical path(s).
 DEFAULT_WEBHOOK_SEND_WORKSPACE="$WORKSPACE_ROOT/scripts/discord-webhook-send.mjs"
-DEFAULT_WEBHOOK_SEND_SHARED="/Users/zachgonser/clawd/scripts/discord-webhook-send.mjs"
+DEFAULT_WEBHOOK_SEND_SHARED="$HOME/clawd/scripts/discord-webhook-send.mjs"
 WEBHOOK_SEND="${DISCORD_WEBHOOK_SEND:-}"
 if [[ -z "$WEBHOOK_SEND" ]]; then
   if [[ -f "$DEFAULT_WEBHOOK_SEND_WORKSPACE" ]]; then
@@ -29,8 +29,8 @@ fi
 DEFAULT_SHARED_ALLOWLIST=(
   "$DEFAULT_WEBHOOK_SEND_WORKSPACE"
   "$DEFAULT_WEBHOOK_SEND_SHARED"
-  "/Users/zachgonser/clawd/projects/openclaw-upgrade/scripts/retry.sh"
-  "/Users/zachgonser/clawd/projects/openclaw-upgrade/scripts/with-timeout.sh"
+  "$HOME/clawd/projects/openclaw-upgrade/scripts/retry.sh"
+  "$HOME/clawd/projects/openclaw-upgrade/scripts/with-timeout.sh"
 )
 
 IFS=':' read -r -a EXTRA_SHARED_ALLOWLIST <<< "${SHARED_SCRIPT_ALLOWLIST:-}"

--- a/scripts/spawn-with-retry.mjs
+++ b/scripts/spawn-with-retry.mjs
@@ -22,12 +22,13 @@ const REPO_ROOT = path.resolve(__dirname, "..");
 const BACKOFF_SECONDS = [2, 4, 8, 16];
 const DEFAULT_MAX_RETRIES = 3;
 const DEFAULT_SPAWN_CMD = process.env.SESSIONS_SPAWN_CMD || "sessions_spawn";
+const HOME_DIR = os.homedir();
 
 const DEFAULT_SHARED_ALLOWLIST = [
   path.resolve(REPO_ROOT, "scripts/discord-webhook-send.mjs"),
-  "/Users/zachgonser/clawd/scripts/discord-webhook-send.mjs",
-  "/Users/zachgonser/clawd/projects/openclaw-upgrade/scripts/retry.sh",
-  "/Users/zachgonser/clawd/projects/openclaw-upgrade/scripts/with-timeout.sh",
+  path.join(HOME_DIR, "clawd", "scripts", "discord-webhook-send.mjs"),
+  path.join(HOME_DIR, "clawd", "projects", "openclaw-upgrade", "scripts", "retry.sh"),
+  path.join(HOME_DIR, "clawd", "projects", "openclaw-upgrade", "scripts", "with-timeout.sh"),
 ].map((p) => path.resolve(p));
 
 function getAgentId() {

--- a/scripts/spawn-with-verification.mjs
+++ b/scripts/spawn-with-verification.mjs
@@ -25,13 +25,14 @@ const DEFAULT_BACKOFF_SECONDS = [2, 4, 8, 16];
 const DEFAULT_MAX_SPAWN_RETRIES = 3;
 const DEFAULT_MAX_VERIFY_CYCLES = 2;
 const DEFAULT_SPAWN_CMD = process.env.SESSIONS_SPAWN_CMD || "sessions_spawn";
+const HOME_DIR = os.homedir();
 
 const DEFAULT_SHARED_ALLOWLIST = [
   path.resolve(REPO_ROOT, "scripts/spawn-with-retry.mjs"),
   path.resolve(REPO_ROOT, "scripts/discord-webhook-send.mjs"),
-  "/Users/zachgonser/clawd/scripts/discord-webhook-send.mjs",
-  "/Users/zachgonser/clawd/projects/openclaw-upgrade/scripts/retry.sh",
-  "/Users/zachgonser/clawd/projects/openclaw-upgrade/scripts/with-timeout.sh",
+  path.join(HOME_DIR, "clawd", "scripts", "discord-webhook-send.mjs"),
+  path.join(HOME_DIR, "clawd", "projects", "openclaw-upgrade", "scripts", "retry.sh"),
+  path.join(HOME_DIR, "clawd", "projects", "openclaw-upgrade", "scripts", "with-timeout.sh"),
 ].map((p) => path.resolve(p));
 
 function getAgentId() {


### PR DESCRIPTION
## Summary
- fixes #404 by removing user-specific absolute paths from script allowlist defaults
- preserves workspace-first behavior and existing path-isolation guarantees
- makes local OpenClaw script wrappers portable across different user home directories

## Changes
- `scripts/spawn-with-retry.mjs`
  - replaced hardcoded `/Users/zachgonser/...` allowlist entries with `os.homedir()` derived paths
- `scripts/spawn-with-verification.mjs`
  - replaced hardcoded `/Users/zachgonser/...` allowlist entries with `os.homedir()` derived paths
- `scripts/routing-healthcheck.sh`
  - replaced hardcoded fallback sender + shared allowlist entries with `$HOME/...` derived paths

## Validation
- `bash scripts/tests/test-spawn-with-retry.sh`
- `bash scripts/tests/test-spawn-with-verification.sh`
- `bash scripts/tests/test-routing-healthcheck-isolation.sh`
- `npm run build`
