### PR TITLE
fix(routing): support home-relative webhook map paths (issue #406)

### DIFF
--- a/config/alert-routing.json
+++ b/config/alert-routing.json
@@ -9,6 +9,6 @@
     "archivist": "1470210653154185298",
     "synth": "1470210654819451024"
   },
-  "webhookMapPath": "/Users/zachgonser/.openclaw/credentials/discord/webhooks.json",
+  "webhookMapPath": "~/.openclaw/credentials/discord/webhooks.json",
   "suppressSeconds": 14400
 }

--- a/scripts/routing-healthcheck.sh
+++ b/scripts/routing-healthcheck.sh
@@ -109,14 +109,15 @@ fi
 alerts_channel_id=$(jq -r '.alertsChannelId' "$CFG")
 webhook_map_path=$(jq -r '.webhookMapPath' "$CFG")
 suppress_seconds=$(jq -r '.suppressSeconds' "$CFG")
+resolved_webhook_map_path="$(agent_env_resolve_path "$webhook_map_path")"
 
 if [[ -z "$alerts_channel_id" || "$alerts_channel_id" == "null" ]]; then
   fail "invalid_config:alertsChannelId"
   exit 1
 fi
 
-if [[ ! -f "$webhook_map_path" ]]; then
-  fail "missing_webhook_map:$webhook_map_path"
+if [[ ! -f "$resolved_webhook_map_path" ]]; then
+  fail "missing_webhook_map:$resolved_webhook_map_path"
   exit 1
 fi
 
@@ -127,13 +128,13 @@ missing_roles=()
 for cid in $role_ids; do
   # webhook map is expected to be an object keyed by channelId
   # (we treat presence of any value at that key as "configured")
-  present=$(jq -r --arg cid "$cid" 'has($cid)' "$webhook_map_path")
+  present=$(jq -r --arg cid "$cid" 'has($cid)' "$resolved_webhook_map_path")
   if [[ "$present" != "true" ]]; then
     missing_roles+=("$cid")
   fi
 done
 
-has_alerts_webhook=$(jq -r --arg cid "$alerts_channel_id" 'has($cid)' "$webhook_map_path")
+has_alerts_webhook=$(jq -r --arg cid "$alerts_channel_id" 'has($cid)' "$resolved_webhook_map_path")
 
 status="ok"
 reason=""
@@ -172,8 +173,9 @@ P1 Routing Healthcheck FAILED ($(now_iso_utc))
 - workspace: ${WORKSPACE_ROOT}
 - reason: ${reason}
 - cfg: ${CFG}
+- webhookMapPath: ${resolved_webhook_map_path}
 - expected webhook map keys for alerts + role channels
-- remediation: create/add webhooks for missing channel ids in ${webhook_map_path}
+- remediation: create/add webhooks for missing channel ids in ${resolved_webhook_map_path}
 EOF
   )
 

--- a/scripts/tests/test-routing-healthcheck-path-resolution.sh
+++ b/scripts/tests/test-routing-healthcheck-path-resolution.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT/scripts/routing-healthcheck.sh"
+TMP_DIR="$(mktemp -d)"
+trap 'rm -rf "$TMP_DIR"' EXIT
+
+HOME_DIR="$TMP_DIR/home"
+WS="$TMP_DIR/workspace-atlas"
+mkdir -p "$HOME_DIR/.openclaw/credentials/discord" "$WS/config"
+
+cat > "$HOME_DIR/.openclaw/credentials/discord/webhooks.json" <<'JSON'
+{
+  "alerts": "https://example.invalid/alerts",
+  "role-1": "https://example.invalid/role1"
+}
+JSON
+
+cat > "$WS/config/alert-routing.json" <<'JSON'
+{
+  "alertsChannelId": "alerts",
+  "roleChannels": {
+    "mission-control": "role-1"
+  },
+  "webhookMapPath": "~/.openclaw/credentials/discord/webhooks.json",
+  "suppressSeconds": 3600
+}
+JSON
+
+HOME="$HOME_DIR" AGENT_ID=atlas OPENCLAW_WORKSPACE="$WS" "$SCRIPT" > "$TMP_DIR/out.txt"
+
+python3 - <<PY
+import json
+from pathlib import Path
+
+out = Path("$TMP_DIR/out.txt").read_text()
+assert "HEARTBEAT_OK" in out, out
+
+state = Path("$WS/runtime/monitor/atlas/routing-healthcheck.json")
+assert state.exists(), state
+payload = json.loads(state.read_text())
+assert payload.get("lastStatus") == "ok", payload
+assert payload.get("agentId") == "atlas", payload
+print("ROUTING_HEALTHCHECK_PATH_RESOLUTION_OK")
+PY


### PR DESCRIPTION
## Summary
- fixes #406 by resolving `webhookMapPath` before healthcheck file existence + key checks
- makes routing healthcheck support home-relative (`~`) webhook map config paths
- updates default config to use home-relative webhook map path for portability
- adds script test coverage for path expansion behavior

## Changes
- `scripts/routing-healthcheck.sh`
  - resolves config `webhookMapPath` via `agent_env_resolve_path`
  - uses resolved path for file checks, key checks, and alert payload diagnostics
- `config/alert-routing.json`
  - switched `webhookMapPath` from absolute user path to `~/.openclaw/credentials/discord/webhooks.json`
- `scripts/tests/test-routing-healthcheck-path-resolution.sh`
  - new regression test proving `~` path resolution works under a temporary HOME

## Validation
- `bash scripts/tests/test-routing-healthcheck-path-resolution.sh`
- `bash scripts/tests/test-routing-healthcheck-isolation.sh`
- `npm run build`
