### PR TITLE
OpenClaw readiness: require latest JSON/MD/SVG evidence triplet

### DIFF
--- a/docs/OPENCLAW_LOCAL_INTEGRATION_SMOKE.md
+++ b/docs/OPENCLAW_LOCAL_INTEGRATION_SMOKE.md
@@ -71,7 +71,7 @@ The JSON report includes machine-readable check metadata and readiness summary f
 - `summary.confidence`: `high|medium|low`
 - Per-check metadata: `group`, `severity`, `likelyCause`, `nextCommand`
 
-`scripts/refresh-local-integration-ready.sh` now enforces strict JSON/MD pairing and schema validation before regenerating `docs/LOCAL_INTEGRATION_READY.md`.
+`scripts/refresh-local-integration-ready.sh` now enforces strict latest JSON/MD/SVG timestamp pairing and schema validation before regenerating `docs/LOCAL_INTEGRATION_READY.md`.
 
 ## Regression Test
 Run the mock-server regression test:

--- a/docs/SCRIPT_SPECS.md
+++ b/docs/SCRIPT_SPECS.md
@@ -257,7 +257,7 @@ bash scripts/refresh-local-integration-ready.sh \
 
 **Behavior:**
 - Runs `scripts/openclaw-local-smoke.sh` (unless `--skip-smoke` is set).
-- Enforces strict latest JSON/MD timestamp pairing.
+- Enforces strict latest JSON/MD/SVG timestamp pairing.
 - Validates required smoke JSON schema before rendering readiness markdown.
 - Supports `--history-limit <n>` to control trend rows in the output.
 - Rewrites readiness summary markdown with:

--- a/scripts/refresh-local-integration-ready.sh
+++ b/scripts/refresh-local-integration-ready.sh
@@ -145,13 +145,19 @@ for path in report_dir.iterdir():
 
 if not json_by_ts or not md_by_ts:
     raise SystemExit(f"No smoke artifacts found in {report_dir}")
+if not svg_by_ts:
+    raise SystemExit(
+        f"No smoke SVG artifacts found in {report_dir}. "
+        "Run smoke again to generate a complete evidence set."
+    )
 
 latest_json_ts = max(json_by_ts.keys())
 latest_md_ts = max(md_by_ts.keys())
-if latest_json_ts != latest_md_ts:
+latest_svg_ts = max(svg_by_ts.keys())
+if latest_json_ts != latest_md_ts or latest_json_ts != latest_svg_ts:
     raise SystemExit(
         "Latest smoke artifacts are mismatched "
-        f"(latest json={latest_json_ts}, latest md={latest_md_ts}). "
+        f"(latest json={latest_json_ts}, latest md={latest_md_ts}, latest svg={latest_svg_ts}). "
         "Run smoke again to produce a paired set."
     )
 
@@ -162,7 +168,7 @@ if not paired_timestamps:
 latest_ts = paired_timestamps[-1]
 latest_json = json_by_ts[latest_ts]
 latest_md = md_by_ts[latest_ts]
-latest_svg = svg_by_ts.get(latest_ts)
+latest_svg = svg_by_ts[latest_ts]
 
 payload = json.loads(latest_json.read_text(encoding="utf-8"))
 
@@ -263,7 +269,7 @@ def rel(path: pathlib.Path) -> str:
 now_utc = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 verdict = str(summary["verdict"]).upper()
 
-status_strip_rel = rel(latest_svg) if latest_svg else "(not generated)"
+status_strip_rel = rel(latest_svg)
 
 out = [
     "# Local Integration Ready Checklist",

--- a/scripts/tests/test-refresh-local-integration-ready.sh
+++ b/scripts/tests/test-refresh-local-integration-ready.sh
@@ -260,6 +260,9 @@ JSON
 cat > "$BAD_DIR/openclaw-local-smoke-20990101T010101Z.md" <<'MD'
 # bad
 MD
+cat > "$BAD_DIR/openclaw-local-smoke-20990101T010101Z.svg" <<'SVG'
+<svg xmlns="http://www.w3.org/2000/svg" width="10" height="10"></svg>
+SVG
 set +e
 bash "$REFRESH_SCRIPT" --skip-smoke --report-dir "$BAD_DIR" --output-doc "$OUT_DOC" >/tmp/refresh-local-schema.out 2>&1
 rc=$?
@@ -275,3 +278,24 @@ if ! has_pattern "schema" /tmp/refresh-local-schema.out; then
 fi
 
 echo "REFRESH_LOCAL_INTEGRATION_READY_SCHEMA_CHECK_OK"
+
+# SVG completeness check: latest paired JSON/MD without SVG must fail.
+BAD_SVG_DIR="$TMP_DIR/reports-no-svg"
+mkdir -p "$BAD_SVG_DIR"
+cp "$(ls -1 "$REPORT_DIR"/openclaw-local-smoke-*.json | tail -n 1)" "$BAD_SVG_DIR/openclaw-local-smoke-20990101T020202Z.json"
+cp "$(ls -1 "$REPORT_DIR"/openclaw-local-smoke-*.md | tail -n 1)" "$BAD_SVG_DIR/openclaw-local-smoke-20990101T020202Z.md"
+set +e
+bash "$REFRESH_SCRIPT" --skip-smoke --report-dir "$BAD_SVG_DIR" --output-doc "$OUT_DOC" >/tmp/refresh-local-svg.out 2>&1
+rc=$?
+set -e
+if [[ "$rc" -eq 0 ]]; then
+  echo "expected missing svg failure" >&2
+  exit 1
+fi
+if ! has_pattern "SVG" /tmp/refresh-local-svg.out; then
+  echo "expected svg error message" >&2
+  cat /tmp/refresh-local-svg.out >&2
+  exit 1
+fi
+
+echo "REFRESH_LOCAL_INTEGRATION_READY_SVG_CHECK_OK"


### PR DESCRIPTION
## Summary
Hardens local readiness evidence by requiring a complete latest artifact triplet (`.json`, `.md`, `.svg`) before regenerating `docs/LOCAL_INTEGRATION_READY.md`.

## What changed
- `scripts/refresh-local-integration-ready.sh`
  - now fails when no SVG artifacts are present.
  - now enforces latest timestamp alignment across JSON/MD/SVG.
  - keeps trend generation compatible with older JSON/MD historical runs while requiring latest run completeness.
- `scripts/tests/test-refresh-local-integration-ready.sh`
  - keeps existing mismatch and schema checks.
  - adds deterministic failure check for missing latest SVG evidence.
  - updates schema fixture to include SVG so schema assertion remains targeted.
- docs
  - updates contract wording in `docs/OPENCLAW_LOCAL_INTEGRATION_SMOKE.md` and `docs/SCRIPT_SPECS.md`.

## Validation
- `npm run test:openclaw:local-ready`
- `npm run test:openclaw:local-smoke`

Closes #420.
