### PR TITLE
OpenClaw readiness: add --prune-keep retention control

### DIFF
--- a/docs/OPENCLAW_LOCAL_INTEGRATION_SMOKE.md
+++ b/docs/OPENCLAW_LOCAL_INTEGRATION_SMOKE.md
@@ -72,6 +72,7 @@ The JSON report includes machine-readable check metadata and readiness summary f
 - Per-check metadata: `group`, `severity`, `likelyCause`, `nextCommand`
 
 `scripts/refresh-local-integration-ready.sh` now enforces strict latest JSON/MD/SVG timestamp pairing and schema validation before regenerating `docs/LOCAL_INTEGRATION_READY.md`.
+Use `--prune-keep <n>` if you want refresh to keep only the newest `n` timestamp groups of smoke artifacts after regeneration.
 
 ## Regression Test
 Run the mock-server regression test:

--- a/docs/SCRIPT_SPECS.md
+++ b/docs/SCRIPT_SPECS.md
@@ -260,6 +260,7 @@ bash scripts/refresh-local-integration-ready.sh \
 - Enforces strict latest JSON/MD/SVG timestamp pairing.
 - Validates required smoke JSON schema before rendering readiness markdown.
 - Supports `--history-limit <n>` to control trend rows in the output.
+- Supports `--prune-keep <n>` to retain only newest `n` timestamp groups after refresh.
 - Rewrites readiness summary markdown with:
   - mission control card (`GO/HOLD/BLOCKED`, score, confidence)
   - top blockers and next commands

--- a/scripts/refresh-local-integration-ready.sh
+++ b/scripts/refresh-local-integration-ready.sh
@@ -7,6 +7,7 @@ SMOKE_SCRIPT="$REPO_ROOT/scripts/openclaw-local-smoke.sh"
 REPORT_DIR="${SMOKE_REPORT_DIR:-$REPO_ROOT/runtime/reports/openclaw-local-smoke}"
 OUTPUT_DOC="$REPO_ROOT/docs/LOCAL_INTEGRATION_READY.md"
 HISTORY_LIMIT=7
+PRUNE_KEEP=0
 RUN_SMOKE=1
 SMOKE_ARGS=()
 
@@ -21,6 +22,7 @@ Options:
   --output-doc <path>          Output markdown path (default: docs/LOCAL_INTEGRATION_READY.md)
   --report-dir <path>          Smoke report directory (default: runtime/reports/openclaw-local-smoke)
   --history-limit <n>          Number of historical runs in trend table (default: 7)
+  --prune-keep <n>             Keep only newest N timestamped artifact sets after refresh (default: 0=disabled)
   --skip-smoke                 Do not run smoke; refresh doc from existing artifacts
 
   Forwarded smoke options:
@@ -62,6 +64,11 @@ while [[ $# -gt 0 ]]; do
       HISTORY_LIMIT="$2"
       shift 2
       ;;
+    --prune-keep)
+      need_value "$@"
+      PRUNE_KEEP="$2"
+      shift 2
+      ;;
     --skip-smoke)
       RUN_SMOKE=0
       shift
@@ -91,6 +98,10 @@ if ! [[ "$HISTORY_LIMIT" =~ ^[0-9]+$ ]] || [[ "$HISTORY_LIMIT" -lt 1 ]]; then
   echo "Invalid --history-limit: $HISTORY_LIMIT" >&2
   exit 2
 fi
+if ! [[ "$PRUNE_KEEP" =~ ^[0-9]+$ ]]; then
+  echo "Invalid --prune-keep: $PRUNE_KEEP" >&2
+  exit 2
+fi
 
 if [[ "${#SMOKE_ARGS[@]}" -gt 0 ]]; then
   SMOKE_ARGS=(--report-dir "$REPORT_DIR" "${SMOKE_ARGS[@]}")
@@ -106,7 +117,7 @@ if [[ "$RUN_SMOKE" == "1" ]]; then
   set -e
 fi
 
-python3 - "$REPORT_DIR" "$OUTPUT_DOC" "$REPO_ROOT" "$smoke_rc" "$HISTORY_LIMIT" <<'PY'
+python3 - "$REPORT_DIR" "$OUTPUT_DOC" "$REPO_ROOT" "$smoke_rc" "$HISTORY_LIMIT" "$PRUNE_KEEP" <<'PY'
 from __future__ import annotations
 
 import json
@@ -120,6 +131,7 @@ output_path = pathlib.Path(sys.argv[2]).resolve()
 repo_root = pathlib.Path(sys.argv[3]).resolve()
 smoke_rc = int(sys.argv[4])
 history_limit = int(sys.argv[5])
+prune_keep = int(sys.argv[6])
 
 if not report_dir.exists() or not report_dir.is_dir():
     raise SystemExit(f"No report directory found: {report_dir}")
@@ -391,10 +403,25 @@ if smoke_rc != 0:
 
 output_path.parent.mkdir(parents=True, exist_ok=True)
 output_path.write_text("\n".join(out) + "\n", encoding="utf-8")
+
+pruned_files = 0
+if prune_keep > 0:
+    all_timestamps = sorted(set(json_by_ts.keys()) | set(md_by_ts.keys()) | set(svg_by_ts.keys()))
+    keep_timestamps = set(all_timestamps[-prune_keep:])
+    for mapping in (json_by_ts, md_by_ts, svg_by_ts):
+        for ts, artifact_path in list(mapping.items()):
+            if ts in keep_timestamps:
+                continue
+            if artifact_path.exists():
+                artifact_path.unlink()
+                pruned_files += 1
+
 print(f"REFRESH_SOURCE_JSON={latest_json}")
 print(f"REFRESH_SOURCE_MD={latest_md}")
 if latest_svg:
     print(f"REFRESH_SOURCE_SVG={latest_svg}")
+if prune_keep > 0:
+    print(f"REFRESH_PRUNED_FILES={pruned_files}")
 PY
 
 echo "Local integration readiness refreshed:"

--- a/scripts/tests/test-refresh-local-integration-ready.sh
+++ b/scripts/tests/test-refresh-local-integration-ready.sh
@@ -232,6 +232,42 @@ assert "Top 3 Blockers" in text, text
 print("REFRESH_LOCAL_INTEGRATION_READY_GO_SCENARIO_OK")
 PY
 
+# Retention check: prune to latest single timestamp group.
+bash "$REFRESH_SCRIPT" \
+  --skip-smoke \
+  --history-limit 1 \
+  --prune-keep 1 \
+  --report-dir "$REPORT_DIR" \
+  --output-doc "$OUT_DOC" >/tmp/refresh-local-prune.out
+
+python3 - "$REPORT_DIR" <<'PY'
+from pathlib import Path
+import sys
+
+report_dir = Path(sys.argv[1])
+assert len(list(report_dir.glob("openclaw-local-smoke-*.json"))) == 1
+assert len(list(report_dir.glob("openclaw-local-smoke-*.md"))) == 1
+assert len(list(report_dir.glob("openclaw-local-smoke-*.svg"))) == 1
+print("REFRESH_LOCAL_INTEGRATION_READY_PRUNE_CHECK_OK")
+PY
+
+# Input validation: prune-keep must be numeric.
+set +e
+bash "$REFRESH_SCRIPT" --skip-smoke --prune-keep nope --report-dir "$REPORT_DIR" --output-doc "$OUT_DOC" >/tmp/refresh-local-prune-invalid.out 2>&1
+rc=$?
+set -e
+if [[ "$rc" -eq 0 ]]; then
+  echo "expected invalid prune-keep failure" >&2
+  exit 1
+fi
+if ! has_pattern "Invalid --prune-keep" /tmp/refresh-local-prune-invalid.out; then
+  echo "expected prune-keep validation message" >&2
+  cat /tmp/refresh-local-prune-invalid.out >&2
+  exit 1
+fi
+
+echo "REFRESH_LOCAL_INTEGRATION_READY_PRUNE_VALIDATION_OK"
+
 # Mismatch check: create a newer JSON without matching markdown.
 sleep 1
 cp "$(ls -1 "$REPORT_DIR"/openclaw-local-smoke-*.json | tail -n 1)" "$REPORT_DIR/openclaw-local-smoke-20990101T000000Z.json"


### PR DESCRIPTION
## Summary
Adds operator-controlled artifact retention to readiness refresh so local smoke evidence does not grow unbounded.

## Changes
- `scripts/refresh-local-integration-ready.sh`
  - adds `--prune-keep <n>` (default `0`, disabled).
  - validates prune input.
  - after refresh, keeps only newest `n` timestamp groups across `.json/.md/.svg` and emits `REFRESH_PRUNED_FILES=<count>`.
- `scripts/tests/test-refresh-local-integration-ready.sh`
  - adds deterministic prune behavior check (`--prune-keep 1`).
  - adds invalid input validation check for `--prune-keep`.
  - retains existing mismatch/schema/svg checks.
- docs
  - updates `docs/OPENCLAW_LOCAL_INTEGRATION_SMOKE.md` and `docs/SCRIPT_SPECS.md` with prune option contract.

## Validation
- `npm run test:openclaw:local-ready`
- `npm run test:openclaw:local-smoke`

Closes #423.
