### PR TITLE
Docs: reset roadmap/status pointers to living issue tracker

### DIFF
--- a/docs/DOC_INDEX.md
+++ b/docs/DOC_INDEX.md
@@ -18,10 +18,10 @@
 - **docs/process/OPERATING_CONTRACT_GITLAB.md** – GitHub-first work contract (legacy filename kept for compatibility)
 - **docs/process/LABEL_PROTOCOL.md** – how workflow labels are applied/removed
 - **docs/process/GITLAB_PROJECT_RESOLVER.md** – how Mission Control resolves the target GitHub repository for issues/PRs (legacy filename kept for compatibility)
-- **docs/process/STATUS.md** – current implementation status
-- **docs/process/ROADMAP.md** – phased roadmap
-- **docs/process/PROJECT_PLAN.md** – milestones + success metrics
-- **docs/process/FEATURE_BACKLOG.md** – backlog by workstream
+- **docs/STATUS.md** – current implementation status (archived pointer; live status in issue #138)
+- **docs/ROADMAP.md** – roadmap pointer (archived in-repo, live in issue #138)
+- **docs/PROJECT_PLAN.md** – milestones + success metrics
+- **docs/FEATURE_BACKLOG.md** – backlog by workstream
 - **docs/NEXUS_2_0_M2_AUTHORITY_PLANE.md** – M2 authority map, policy gate, and override path
 - **docs/NEXUS_2_0_M4_OBSERVABILITY.md** – M4 replay authority surfaces (explain + control-health)
 - **docs/NEXUS_2_0_M6_PRODUCTION_READINESS_2026-02-21.md** – M6 readiness decision and evidence matrix
@@ -131,7 +131,7 @@
 - **SESSIONS_SPAWN_RETRY_WRAPPER.md** – sessions_spawn retry wrapper usage, logging, and integration points
 - **SESSIONS_SPAWN_ANTFARM_PATTERNS.md** – Antfarm-inspired workflow patterns (fresh context, verification loop, retries)
 - **TEST_COVERAGE_SPAWN_PATTERNS.md** – test coverage report for spawn pattern scripts
-- **docs/process/CRON_SPECS.md** – cron job definitions & schedules
+- **docs/CRON_SPECS.md** – cron job definitions & schedules
 - **docs/process/METRICS_PLAN.md** – KPI definitions + collection approach
 - **docs/process/TEST_PLAN.md** – verification & test cases
 - **docs/process/ROLLOUT_PLAN.md** – phased rollout + rollback

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,79 +1,15 @@
-# Status – VentureOS
+# VentureOS Status (Archived Snapshot)
 
-**As of:** 2026‑02‑07
+This file is retained for historical context.
 
-## ✅ Baseline Docs Complete (Phase 0.5 – Repo Reframe)
-- Implementation‑ready baseline package is complete (requirements → architecture → scripts → cron → tests → rollout → risks → metrics).
-- Policy docs are split into standalone files in this repo and linked from `IMPLEMENTATION_READY.md` + `DOC_INDEX.md`.
-- Templates added for AGENTS/HEARTBEAT workspace starters (portable paths).
-- Monitoring spec includes stale `gateway.lock` detection.
-- Task‑run retention policy documented in `SCRIPT_SPECS.md`.
-- Three‑layer memory system integrated into requirements/spec/tasks.
-- Docs‑lint CI added (broken links + placeholder scan; includes templates + JSON validation).
-- Script code moved to versioned files under `scripts/` and referenced from docs (source of truth).
-- DOC_INDEX template paths corrected; OPS_RUNBOOK expanded with concrete commands.
+## Source Of Truth
+Current execution status and roadmap are tracked in GitHub issue:
+- [#138 — Roadmap: VentureOS delivery plan (living)](https://github.com/zachyzissou/ventureos/issues/138)
 
-## ✅ VentureOS / Multi‑Agent Mission Control (Docs Integrated)
-- Added VentureOS system framing (system vs persona) and multi‑agent operating model.
-- Added 20‑role roster + default squad patterns.
-- Added Business Unit Registry concept (portfolio scalability; multi‑account media pattern).
-- Added Mission Control lifecycle + gates (Sentinel safety/IP/provenance; Verifier QA; Archivist durability).
-- Added templates: mission brief, role card, business unit registry.
-- Extended task queue schema to carry mission metadata (`businessUnit`, `missionType`, `role`, `expectedArtifacts`, `requiresApproval`).
+## Why Archived
+The previous status content reflected early-February 2026 implementation phases and no longer represented current repository reality.
+As of 2026-02-22, planning/status updates are maintained directly in GitHub issues and PRs to avoid drift.
 
-## ✅ Implemented in workspace (~/clawd)
-- Monitoring script updated to detect stale `~/.openclaw/gateway.lock` when gateway is down.
-- Backup coverage includes `memory/fix-reports` + `memory/bloom-content`; backup + verify run completed.
-- Restore workflow added (`restore-backup.sh`, dry‑run by default).
-- AGENTS.md + HEARTBEAT.md linked to policy docs.
-- Cron jobs installed: Nightly Backup, Weekly Verify, Monitor, Export Logs, Budget Check, Update Reminder, Archive Task Runs.
-- Task queue created (`runtime/task-queue.json`).
-- Entity store base created (`~/Obsidian/VaultZap/life/areas/entities`).
-- Fact Extraction + Weekly Memory Synthesis cron jobs updated for entity store.
-- Gateway network posture set to LAN (`bind=lan`), Tailscale Serve disabled, `remote.url=ws://openclaw.local:18789`.
-- PF hardening applied for port **18789** (interface‑scoped allow LAN + Tailnet; blocks others; loopback safe).
-- Control UI requires secure context: LAN access needs HTTPS proxy (localhost ok).
-
-## 🧾 Execution Checklist / Audit Log
-- [x] 2026‑02‑07 — Repo reframed to VentureOS (docs + templates updated)
-- [x] 2026‑02‑07 — Policy docs split + linked in repo
-- [x] 2026‑02‑07 — Monitoring stale gateway.lock detection implemented
-- [x] 2026‑02‑07 — Restore workflow added (dry‑run)
-- [x] 2026‑02‑07 — Backup coverage updated + verify run
-- [x] 2026‑02‑07 — AGENTS/HEARTBEAT linked to policy docs
-- [x] 2026‑02‑07 — Cron jobs installed (backup/verify/monitor/export/budget/update reminder)
-- [x] 2026‑02‑07 — Task queue created (`runtime/task-queue.json`)
-- [x] 2026‑02‑07 — Archive task‑runs cron installed (monthly)
-- [x] 2026‑02‑07 — TEST_PLAN executed (see TEST_RESULTS_2026-02-07.md)
-- [x] 2026‑02‑07 — Entity store base created + memory cron jobs updated
-- [x] 2026‑02‑07 — Gateway bind=lan; Tailscale Serve disabled; remote.url=ws://openclaw.local:18789
-- [x] 2026‑02‑07 — PF anchor applied for port 18789 (interface‑scoped allowlist + blocks)
-- [x] 2026‑02‑07 — Simulated stale `gateway.lock` scenario (reported complete).
-- [x] 2026‑02‑13 — Per-agent workspace isolation implemented (default-deny paths, shared allowlist, per-agent TMPDIR, 2-agent verification).
-
-## ⏳ Pending / Next
-- Roadmap Phases 1–5 remain in backlog (see ROADMAP.md + FEATURE_BACKLOG.md).
-- Seed workspace **business unit registry** (`~/clawd/runtime/business-units.json`) with initial units and links to canonical Obsidian notes.
-- Create initial **role cards** for the core operating roles (Echo, Sentinel, Verifier, Archivist, Atlas, Synth, Venture, Oracle, Ledger, Comms).
-- Implement **mission runner** workflow (mission brief → squad execution → gates → archive/register) and carry mission metadata through queue + run logs.
-- HTTPS proxy plan for LAN Control UI (secure context) — deferred to **SlurpNet Security Suite** project.
-- Optional config enhancements (subagent model pinning, heartbeat override, memory backend swap).
-
-## ✅ Recent Stabilization
-- Ollama model context windows corrected; RPC timeouts resolved; StantonTimes jobs re‑enabled sequentially without timeout.
-
-## ✅ Phase 1 Design Package Ready
-- Reliability playbook added (retry/backoff, timeouts, taxonomy, graceful degradation).
-- Helper scripts added: `retry.sh`, `with-timeout.sh`.
-- Payload hardening applied: Bloom PR Monitor uses retry/timeout + empty-list OK + Playwright fallback; gh/bird commands wrapped with retry+timeout.
-
-## ⏳ Phase 1 Implementation (in progress)
-- Added `guarded-run.sh` standard wrapper (retry + timeout).
-- `retry.sh` supports optional `RETRY_EXCLUDE_CODES` for non-retry exits.
-- Reliability playbook expanded with classification cues + degradation matrix.
-- Cron specs updated with guard pattern.
-- Ops runbook now includes taxonomy mapping + P2 handling.
-
-## 🟡 Phase 2 Drafting (started)
-- Proactive Engine draft added (SLA tiers + scheduler rules) and aligned with mission metadata fields.
-- VentureOS / Mission Control docs integrated (roles, squads, business units, templates).
+## Related
+- Project overview and active pointers: [`README.md`](../README.md)
+- Historical roadmap pointer: [`docs/ROADMAP.md`](./ROADMAP.md)


### PR DESCRIPTION
## Summary
- archive `docs/STATUS.md` into a pointer-style status doc
- fix `docs/DOC_INDEX.md` roadmap/status/project-plan/backlog + cron references to current paths
- refresh living roadmap issue #138 so "Now" reflects active stacked OpenClaw readiness work (#425/#426 and #427/#428)

Closes #429

## Stack
- base PR: #428
- ancestor PR: #426

## Verification
- `python3 scripts/tests/test_docs_lint.py`
- `gh issue view 138 --web` (manual verification of Now/Notes refresh)
