### PR TITLE
Docs: add current OpenClaw readiness next steps

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,13 @@ Reference docs and artifacts:
 - `docs/LOCAL_INTEGRATION_READY.md`
 - `runtime/reports/openclaw-local-smoke/`
 
+Current next steps (as of February 22, 2026):
+1. `bash scripts/install-cron.sh --force`
+2. `npm run openclaw:local-ready:cron`
+3. Confirm Mission Control shows the latest `/api/openclaw-local-readiness` snapshot.
+4. If bridge checks should pass, set `BRIDGE_TOKEN_FILE` and rerun `npm run openclaw:local-smoke -- --profile bridge`.
+5. Track rollout follow-ups in issues `#431` and `#432`.
+
 ### Production Dashboard
 Tactical map integrates with the VentureOS dashboard on port 8001:
 ```bash

--- a/docs/CRON_SPECS.md
+++ b/docs/CRON_SPECS.md
@@ -79,3 +79,8 @@
 - **Output:** refreshed `docs/LOCAL_INTEGRATION_READY.md` and paired JSON/MD/SVG artifacts
 - **Retention:** defaults to keep newest 14 artifact sets (configurable via env)
 - **Added:** 2026-02-22
+
+## Current Next Steps (February 22, 2026)
+1. Roll this schedule onto the host with `bash scripts/install-cron.sh --force`.
+2. Validate first run via `runtime/logs/cron-runs/openclaw-local-ready.jsonl`.
+3. Confirm `docs/LOCAL_INTEGRATION_READY.md` and Mission Control readiness card move forward on the next cadence tick.

--- a/docs/LOCAL_INTEGRATION_READY.md
+++ b/docs/LOCAL_INTEGRATION_READY.md
@@ -13,9 +13,9 @@ Owner: automated refresh via `scripts/refresh-local-integration-ready.sh`
 - Warnings: `1`
 
 ## Latest Evidence Artifacts
-- JSON: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T054949Z.json`
-- Markdown: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T054949Z.md`
-- Status strip SVG: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T054949Z.svg`
+- JSON: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T085747Z.json`
+- Markdown: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T085747Z.md`
+- Status strip SVG: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T085747Z.svg`
 
 ## Top 3 Blockers
 - `bridge-scheduler-jobs` owner=`Bridge Ops`; cause: Bridge token/source is not configured or bridge API is unreachable.; next: `export BRIDGE_TOKEN_FILE=~/.openclaw/bridge/bridge-token && bash scripts/openclaw-local-smoke.sh --profile bridge`
@@ -23,13 +23,13 @@ Owner: automated refresh via `scripts/refresh-local-integration-ready.sh`
 ## Trend (Last 7 Runs)
 | Timestamp | Verdict | Score | Required Failures | Warnings | Bridge |
 |---|---|---:|---:|---:|---|
-| `20260222T051821Z` | `UNKNOWN` | n/a | 6 | 2 | `fail` |
 | `20260222T051907Z` | `UNKNOWN` | n/a | 6 | 1 | `skipped` |
 | `20260222T051943Z` | `UNKNOWN` | n/a | 0 | 1 | `fail` |
 | `20260222T052026Z` | `UNKNOWN` | n/a | 0 | 1 | `fail` |
 | `20260222T053133Z` | `UNKNOWN` | n/a | 0 | 1 | `fail` |
 | `20260222T053305Z` | `UNKNOWN` | n/a | 0 | 1 | `fail` |
 | `20260222T054949Z` | `GO` | 93 | 0 | 1 | `fail` |
+| `20260222T085747Z` | `GO` | 93 | 0 | 1 | `fail` |
 
 ## Required Checks
 - [x] `openclaw-cli` — `pass` group=`core` severity=`critical` (openclaw CLI found)
@@ -44,11 +44,18 @@ Owner: automated refresh via `scripts/refresh-local-integration-ready.sh`
 
 ## Optional Checks
 - [x] `dashboard-map-route` — `pass` group=`apis` severity=`info` (map route reachable)
-- [ ] `bridge-scheduler-jobs` — `fail` group=`bridge` severity=`warn` (Missing BRIDGE_TOKEN (set env, BRIDGE_TOKEN_FILE, or default OpenClaw bridge token file)); cause: Bridge token/source is not configured or bridge API is unreachable.; next: `export BRIDGE_TOKEN_FILE=~/.openclaw/bridge/bridge-token && bash scripts/openclaw-local-smoke.sh --profile bridge`
+- [ ] `bridge-scheduler-jobs` — `fail` group=`bridge` severity=`warn` (bridge token file not found); cause: Bridge token/source is not configured or bridge API is unreachable.; next: `export BRIDGE_TOKEN_FILE=~/.openclaw/bridge/bridge-token && bash scripts/openclaw-local-smoke.sh --profile bridge`
 
 ## Bridge Token Setup Note
 - Direct bridge checks support `--bridge-token-file`, `BRIDGE_TOKEN`, `BRIDGE_TOKEN_FILE`, or default `OPENCLAW_DIR/bridge/bridge-token`.
-- Latest bridge check: `fail: Missing BRIDGE_TOKEN (set env, BRIDGE_TOKEN_FILE, or default OpenClaw bridge token file)`
+- Latest bridge check: `fail: bridge token file not found`
+
+## Current Next Steps
+1. Install or refresh managed cron entries: `bash scripts/install-cron.sh --force`
+2. Run one manual cadence cycle and verify artifact generation: `bash scripts/openclaw-local-ready-cron.sh`
+3. Address optional blockers to raise confidence and reduce warning-only drift.
+4. If bridge coverage is expected, configure bridge token and rerun bridge profile: `export BRIDGE_TOKEN_FILE=~/.openclaw/bridge/bridge-token && bash scripts/openclaw-local-smoke.sh --profile bridge`
+5. Confirm Mission Control shows the latest readiness payload from `/api/openclaw-local-readiness`.
 
 ## Refresh Command
 ```bash

--- a/docs/OPENCLAW_LOCAL_INTEGRATION_SMOKE.md
+++ b/docs/OPENCLAW_LOCAL_INTEGRATION_SMOKE.md
@@ -89,6 +89,22 @@ Optional env overrides for cron wrapper:
 - `OPENCLAW_LOCAL_READY_PRUNE_KEEP`
 - `OPENCLAW_LOCAL_READY_PROFILE` (`quick|full|bridge`)
 
+## Current Next Steps (February 22, 2026)
+1. Install or refresh managed cron entries:
+```bash
+bash scripts/install-cron.sh --force
+```
+2. Run one manual cadence cycle and confirm doc/artifact refresh:
+```bash
+bash scripts/openclaw-local-ready-cron.sh
+```
+3. Verify Mission Control shows the latest readiness payload from `/api/openclaw-local-readiness`.
+4. If bridge direct-check coverage is expected, configure `BRIDGE_TOKEN_FILE` and rerun bridge profile smoke:
+```bash
+bash scripts/openclaw-local-smoke.sh --profile bridge
+```
+5. Track active rollout work in issues `#431` (ops rollout) and `#432` (bridge readiness parity).
+
 ## Regression Test
 Run the mock-server regression test:
 ```bash

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -16,3 +16,7 @@ As of 2026-02-21, active planning and prioritization happen in GitHub issues/PRs
 
 - Current project snapshot: [`README.md`](../README.md)
 - Hybrid deployment guide: [`docs/HYBRID_DEPLOYMENT.md`](./HYBRID_DEPLOYMENT.md)
+
+## Current Next Steps
+- Keep active roadmap execution in issue #138.
+- For OpenClaw local readiness operations, follow `docs/OPENCLAW_LOCAL_INTEGRATION_SMOKE.md` and `docs/LOCAL_INTEGRATION_READY.md`.

--- a/docs/SCRIPT_SPECS.md
+++ b/docs/SCRIPT_SPECS.md
@@ -300,3 +300,8 @@ bash scripts/openclaw-local-ready-cron.sh
 ```bash
 bash scripts/tests/test-openclaw-local-ready-cron.sh
 ```
+
+**Current next steps (operator rollout):**
+1. `bash scripts/install-cron.sh --force`
+2. `bash scripts/openclaw-local-ready-cron.sh`
+3. Validate `docs/LOCAL_INTEGRATION_READY.md` timestamp and `runtime/reports/openclaw-local-smoke/` artifact rotation.

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -13,3 +13,9 @@ As of 2026-02-22, planning/status updates are maintained directly in GitHub issu
 ## Related
 - Project overview and active pointers: [`README.md`](../README.md)
 - Historical roadmap pointer: [`docs/ROADMAP.md`](./ROADMAP.md)
+
+## Current Next Steps
+- Operate and verify local readiness cadence using:
+  - `bash scripts/install-cron.sh --force`
+  - `bash scripts/openclaw-local-ready-cron.sh`
+- Track active work and follow-up priorities in issue #138.

--- a/scripts/refresh-local-integration-ready.sh
+++ b/scripts/refresh-local-integration-ready.sh
@@ -388,6 +388,29 @@ out.extend([
     "- Direct bridge checks support `--bridge-token-file`, `BRIDGE_TOKEN`, `BRIDGE_TOKEN_FILE`, or default `OPENCLAW_DIR/bridge/bridge-token`.",
     f"- Latest bridge check: `{bridge_note}`",
     "",
+    "## Current Next Steps",
+    "1. Install or refresh managed cron entries: `bash scripts/install-cron.sh --force`",
+    "2. Run one manual cadence cycle and verify artifact generation: `bash scripts/openclaw-local-ready-cron.sh`",
+])
+
+if summary["requiredFailures"] > 0:
+    out.append("3. Resolve required check failures before relying on automated readiness cadence.")
+elif failed_checks:
+    out.append("3. Address optional blockers to raise confidence and reduce warning-only drift.")
+else:
+    out.append("3. Keep cadence running and monitor trend score/confidence for regressions.")
+
+if bridge_check and bridge_check.get("status") == "fail":
+    out.append(
+        "4. If bridge coverage is expected, configure bridge token and rerun bridge profile: "
+        "`export BRIDGE_TOKEN_FILE=~/.openclaw/bridge/bridge-token && bash scripts/openclaw-local-smoke.sh --profile bridge`"
+    )
+    out.append("5. Confirm Mission Control shows the latest readiness payload from `/api/openclaw-local-readiness`.")
+else:
+    out.append("4. Confirm Mission Control shows the latest readiness payload from `/api/openclaw-local-readiness`.")
+
+out.extend([
+    "",
     "## Refresh Command",
     "```bash",
     "bash scripts/refresh-local-integration-ready.sh",

--- a/scripts/tests/test-refresh-local-integration-ready.sh
+++ b/scripts/tests/test-refresh-local-integration-ready.sh
@@ -229,6 +229,7 @@ assert "Verdict: `GO`" in text, text
 assert "## Trend (Last 1 Runs)" in text, text
 assert "Status strip SVG" in text, text
 assert "Top 3 Blockers" in text, text
+assert "## Current Next Steps" in text, text
 print("REFRESH_LOCAL_INTEGRATION_READY_GO_SCENARIO_OK")
 PY
 


### PR DESCRIPTION
## Summary
- add explicit current next-step guidance to README and OpenClaw readiness docs
- update generated readiness markdown contract to always emit `## Current Next Steps`
- extend refresh regression test to assert the new section is present
- refresh living roadmap issue #138 now-active items and create new follow-up issues #431/#432

Closes #433

## Verification
- `npm run test:openclaw:local-ready`
- `npm run test:openclaw:local-ready-cron`
- `python3 scripts/tests/test_docs_lint.py`
- `npm run openclaw:local-ready`
