### PR TITLE
[codex] harden openclaw readiness cadence against rate-limit flapping

### DIFF
--- a/docs/LOCAL_INTEGRATION_READY.md
+++ b/docs/LOCAL_INTEGRATION_READY.md
@@ -5,35 +5,35 @@ Owner: automated refresh via `scripts/refresh-local-integration-ready.sh`
 
 ## Mission Control Card
 - Verdict: `GO`
-- Readiness score: `93`
-- Confidence: `medium`
+- Readiness score: `100`
+- Confidence: `high`
 - Profile: `full`
 - Required failures: `0`
 - Required skipped: `0`
-- Warnings: `1`
+- Warnings: `0`
 
 ## Latest Evidence Artifacts
-- JSON: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T085747Z.json`
-- Markdown: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T085747Z.md`
-- Status strip SVG: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T085747Z.svg`
+- JSON: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T205446Z.json`
+- Markdown: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T205446Z.md`
+- Status strip SVG: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T205446Z.svg`
 
 ## Top 3 Blockers
-- `bridge-scheduler-jobs` owner=`Bridge Ops`; cause: Bridge token/source is not configured or bridge API is unreachable.; next: `export BRIDGE_TOKEN_FILE=~/.openclaw/bridge/bridge-token && bash scripts/openclaw-local-smoke.sh --profile bridge`
+- No blockers in latest run.
 
 ## Trend (Last 7 Runs)
 | Timestamp | Verdict | Score | Required Failures | Warnings | Bridge |
 |---|---|---:|---:|---:|---|
-| `20260222T051907Z` | `UNKNOWN` | n/a | 6 | 1 | `skipped` |
-| `20260222T051943Z` | `UNKNOWN` | n/a | 0 | 1 | `fail` |
-| `20260222T052026Z` | `UNKNOWN` | n/a | 0 | 1 | `fail` |
-| `20260222T053133Z` | `UNKNOWN` | n/a | 0 | 1 | `fail` |
-| `20260222T053305Z` | `UNKNOWN` | n/a | 0 | 1 | `fail` |
-| `20260222T054949Z` | `GO` | 93 | 0 | 1 | `fail` |
-| `20260222T085747Z` | `GO` | 93 | 0 | 1 | `fail` |
+| `20260222T204825Z` | `BLOCKED` | 62 | 3 | 1 | `fail` |
+| `20260222T204851Z` | `GO` | 100 | 0 | 0 | `pass` |
+| `20260222T204902Z` | `BLOCKED` | 63 | 3 | 1 | `fail` |
+| `20260222T205052Z` | `GO` | 100 | 0 | 0 | `pass` |
+| `20260222T205126Z` | `BLOCKED` | 63 | 3 | 1 | `fail` |
+| `20260222T205427Z` | `GO` | 100 | 0 | 0 | `pass` |
+| `20260222T205446Z` | `GO` | 100 | 0 | 0 | `pass` |
 
 ## Required Checks
 - [x] `openclaw-cli` — `pass` group=`core` severity=`critical` (openclaw CLI found)
-- [x] `openclaw-gateway-status` — `pass` group=`core` severity=`critical` (Service: LaunchAgent (loaded))
+- [x] `openclaw-gateway-status` — `pass` group=`core` severity=`critical` (Service: LaunchAgent (not loaded))
 - [x] `dashboard-token` — `pass` group=`core` severity=`critical` (dashboard token loaded from token file)
 - [x] `dashboard-health` — `pass` group=`apis` severity=`critical` (health endpoint reachable)
 - [x] `dashboard-config-auth` — `pass` group=`apis` severity=`critical` (authenticated config access ok)
@@ -44,18 +44,17 @@ Owner: automated refresh via `scripts/refresh-local-integration-ready.sh`
 
 ## Optional Checks
 - [x] `dashboard-map-route` — `pass` group=`apis` severity=`info` (map route reachable)
-- [ ] `bridge-scheduler-jobs` — `fail` group=`bridge` severity=`warn` (bridge token file not found); cause: Bridge token/source is not configured or bridge API is unreachable.; next: `export BRIDGE_TOKEN_FILE=~/.openclaw/bridge/bridge-token && bash scripts/openclaw-local-smoke.sh --profile bridge`
+- [x] `bridge-scheduler-jobs` — `pass` group=`bridge` severity=`warn` (bridge scheduler endpoint reachable)
 
 ## Bridge Token Setup Note
 - Direct bridge checks support `--bridge-token-file`, `BRIDGE_TOKEN`, `BRIDGE_TOKEN_FILE`, or default `OPENCLAW_DIR/bridge/bridge-token`.
-- Latest bridge check: `fail: bridge token file not found`
+- Latest bridge check: `pass: bridge scheduler endpoint reachable`
 
 ## Current Next Steps
 1. Install or refresh managed cron entries: `bash scripts/install-cron.sh --force`
 2. Run one manual cadence cycle and verify artifact generation: `bash scripts/openclaw-local-ready-cron.sh`
-3. Address optional blockers to raise confidence and reduce warning-only drift.
-4. If bridge coverage is expected, configure bridge token and rerun bridge profile: `export BRIDGE_TOKEN_FILE=~/.openclaw/bridge/bridge-token && bash scripts/openclaw-local-smoke.sh --profile bridge`
-5. Confirm Mission Control shows the latest readiness payload from `/api/openclaw-local-readiness`.
+3. Keep cadence running and monitor trend score/confidence for regressions.
+4. Confirm Mission Control shows the latest readiness payload from `/api/openclaw-local-readiness`.
 
 ## Refresh Command
 ```bash

--- a/docs/OPENCLAW_LOCAL_INTEGRATION_SMOKE.md
+++ b/docs/OPENCLAW_LOCAL_INTEGRATION_SMOKE.md
@@ -34,6 +34,14 @@ Cron-safe wrapper for unattended cadence:
 bash scripts/openclaw-local-ready-cron.sh
 ```
 
+Bridge-mode prerequisite (when `DASHBOARD_DATA_MODE=bridge`):
+```bash
+REPO_ROOT="/absolute/path/to/ventureos"
+launchctl remove com.ventureos.bridge 2>/dev/null || true
+launchctl submit -l com.ventureos.bridge -- /bin/zsh -lc "cd \"$REPO_ROOT\" && set -a && source config/bridge.env && set +a && exec node dashboard/dist/dashboard/server/bridge.js >> runtime/logs/bridge.log 2>&1"
+curl -sS http://127.0.0.1:18790/health | jq .
+```
+
 Common options:
 ```bash
 bash scripts/openclaw-local-smoke.sh \
@@ -55,6 +63,9 @@ Profiles:
 - `DASHBOARD_TOKEN_FILE`: default token file path
 - `SMOKE_REPORT_DIR`: output directory for smoke reports
 - `SMOKE_HTTP_TIMEOUT_SEC`: per-request timeout
+- `SMOKE_HTTP_RETRY_MAX`: retry count for transient HTTP failures (default: `2`)
+- `SMOKE_HTTP_RETRY_BASE_SEC`: base retry delay in seconds (default: `1`)
+- `SMOKE_HTTP_RETRY_MAX_DELAY_SEC`: maximum retry delay in seconds (default: `15`)
 - `BRIDGE_URL`: optional direct bridge URL (`http://127.0.0.1:18790` default)
 - `BRIDGE_TOKEN`: auth token for direct bridge check
 - `BRIDGE_TOKEN_FILE`: optional token file for direct bridge check
@@ -75,6 +86,7 @@ The JSON report includes machine-readable check metadata and readiness summary f
 - `summary.readinessScore`: `0..100`
 - `summary.confidence`: `high|medium|low`
 - Per-check metadata: `group`, `severity`, `likelyCause`, `nextCommand`
+- If a check fails with HTTP `429`, smoke classifies it as rate-limit pressure and emits a `sleep 60 && bash scripts/openclaw-local-smoke.sh --profile <profile>` next-command hint.
 
 `scripts/refresh-local-integration-ready.sh` now enforces strict latest JSON/MD/SVG timestamp pairing and schema validation before regenerating `docs/LOCAL_INTEGRATION_READY.md`.
 Use `--prune-keep <n>` if you want refresh to keep only the newest `n` timestamp groups of smoke artifacts after regeneration.

--- a/docs/SCRIPT_SPECS.md
+++ b/docs/SCRIPT_SPECS.md
@@ -233,6 +233,9 @@ bash scripts/openclaw-local-smoke.sh \
   - `BRIDGE_TOKEN`
   - `BRIDGE_TOKEN_FILE`
   - default OpenClaw token file (`$OPENCLAW_DIR/bridge/bridge-token`)
+- Built-in transient retry behavior:
+  - Retries HTTP `429` responses (dashboard + bridge checks) using `Retry-After` when present.
+  - Retry controls: `SMOKE_HTTP_RETRY_MAX` (default `2`), `SMOKE_HTTP_RETRY_BASE_SEC` (default `1`), `SMOKE_HTTP_RETRY_MAX_DELAY_SEC` (default `15`).
 - Emits timestamped JSON + markdown + SVG reports to `runtime/reports/openclaw-local-smoke/`.
 - JSON summary includes `verdict`, `readinessScore`, `confidence`; each check includes `group`, `severity`, `likelyCause`, and `nextCommand`.
 - Exits with code `2` when any required check fails.

--- a/scripts/openclaw-local-smoke.sh
+++ b/scripts/openclaw-local-smoke.sh
@@ -8,6 +8,9 @@ DASHBOARD_URL="${DASHBOARD_URL:-http://127.0.0.1:8001}"
 TOKEN_FILE="${DASHBOARD_TOKEN_FILE:-$REPO_ROOT/dashboard/data/.api-token}"
 REPORT_DIR="${SMOKE_REPORT_DIR:-$REPO_ROOT/runtime/reports/openclaw-local-smoke}"
 HTTP_TIMEOUT_SEC="${SMOKE_HTTP_TIMEOUT_SEC:-5}"
+HTTP_RETRY_MAX="${SMOKE_HTTP_RETRY_MAX:-2}"
+HTTP_RETRY_BASE_SEC="${SMOKE_HTTP_RETRY_BASE_SEC:-1}"
+HTTP_RETRY_MAX_DELAY_SEC="${SMOKE_HTTP_RETRY_MAX_DELAY_SEC:-15}"
 PROFILE="full"
 SKIP_OPENCLAW_CLI=0
 SKIP_MAP=0
@@ -46,6 +49,11 @@ Env overrides:
   BRIDGE_URL              Direct bridge URL for optional check (default: http://127.0.0.1:18790)
   BRIDGE_TOKEN            Direct bridge token override
   BRIDGE_TOKEN_FILE       Optional bridge token file (fallback: \$OPENCLAW_DIR/bridge/bridge-token)
+  SMOKE_HTTP_RETRY_MAX    Retry attempts for transient HTTP failures (default: 2)
+  SMOKE_HTTP_RETRY_BASE_SEC
+                          Base delay in seconds for retry backoff (default: 1)
+  SMOKE_HTTP_RETRY_MAX_DELAY_SEC
+                          Maximum retry delay in seconds (default: 15)
 EOF_USAGE
 }
 
@@ -141,6 +149,18 @@ fi
 
 if ! [[ "$HTTP_TIMEOUT_SEC" =~ ^[0-9]+$ ]] || [[ "$HTTP_TIMEOUT_SEC" -lt 1 ]]; then
   echo "Invalid --timeout-sec: $HTTP_TIMEOUT_SEC" >&2
+  exit 2
+fi
+if ! [[ "$HTTP_RETRY_MAX" =~ ^[0-9]+$ ]]; then
+  echo "Invalid SMOKE_HTTP_RETRY_MAX: $HTTP_RETRY_MAX" >&2
+  exit 2
+fi
+if ! [[ "$HTTP_RETRY_BASE_SEC" =~ ^[0-9]+$ ]] || [[ "$HTTP_RETRY_BASE_SEC" -lt 1 ]]; then
+  echo "Invalid SMOKE_HTTP_RETRY_BASE_SEC: $HTTP_RETRY_BASE_SEC" >&2
+  exit 2
+fi
+if ! [[ "$HTTP_RETRY_MAX_DELAY_SEC" =~ ^[0-9]+$ ]] || [[ "$HTTP_RETRY_MAX_DELAY_SEC" -lt 1 ]]; then
+  echo "Invalid SMOKE_HTTP_RETRY_MAX_DELAY_SEC: $HTTP_RETRY_MAX_DELAY_SEC" >&2
   exit 2
 fi
 
@@ -268,31 +288,102 @@ HTTP_STATUS=""
 HTTP_BODY_FILE=""
 HTTP_HEADER_FILE=""
 
+extract_retry_after_seconds() {
+  local header_file="$1"
+  python3 - "$header_file" <<'PY'
+import pathlib
+import sys
+
+value = 0
+for raw in pathlib.Path(sys.argv[1]).read_text(encoding='utf-8', errors='ignore').splitlines():
+    line = raw.strip()
+    if not line.lower().startswith('retry-after:'):
+        continue
+    token = line.split(':', 1)[1].strip()
+    if token.isdigit():
+        parsed = int(token)
+        if parsed > value:
+            value = parsed
+print(value)
+PY
+}
+
+extract_http_status_from_headers() {
+  local header_file="$1"
+  python3 - "$header_file" <<'PY'
+import pathlib
+import re
+import sys
+
+status = '000'
+pattern = re.compile(r'^HTTP/\d(?:\.\d)?\s+(\d{3})\b', re.IGNORECASE)
+for raw in pathlib.Path(sys.argv[1]).read_text(encoding='utf-8', errors='ignore').splitlines():
+    match = pattern.match(raw.strip())
+    if match:
+        status = match.group(1)
+print(status)
+PY
+}
+
+compute_retry_delay_sec() {
+  local attempt_index="$1"
+  local header_file="$2"
+  local delay retry_after
+  retry_after="$(extract_retry_after_seconds "$header_file")"
+  if [[ "$retry_after" =~ ^[0-9]+$ ]] && [[ "$retry_after" -gt 0 ]]; then
+    delay="$retry_after"
+  else
+    delay=$((HTTP_RETRY_BASE_SEC * (attempt_index + 1)))
+  fi
+  if [[ "$delay" -gt "$HTTP_RETRY_MAX_DELAY_SEC" ]]; then
+    delay="$HTTP_RETRY_MAX_DELAY_SEC"
+  fi
+  if [[ "$delay" -lt 1 ]]; then
+    delay=1
+  fi
+  echo "$delay"
+}
+
 http_get() {
   local path="$1"
   local use_auth="$2"
   local url="${DASHBOARD_URL}${path}"
-  local body_file header_file err_file
+  local body_file header_file err_file attempt status delay_sec
 
-  body_file="$(mktemp "$TMP_DIR/body.XXXXXX")"
-  header_file="$(mktemp "$TMP_DIR/header.XXXXXX")"
-  err_file="$(mktemp "$TMP_DIR/err.XXXXXX")"
+  attempt=0
+  while true; do
+    body_file="$(mktemp "$TMP_DIR/body.XXXXXX")"
+    header_file="$(mktemp "$TMP_DIR/header.XXXXXX")"
+    err_file="$(mktemp "$TMP_DIR/err.XXXXXX")"
 
-  local -a cmd=(curl -sS -m "$HTTP_TIMEOUT_SEC" -D "$header_file" -o "$body_file" -w "%{http_code}")
-  if [[ "$use_auth" == "1" ]]; then
-    cmd+=(-H "Authorization: Bearer ${DASHBOARD_TOKEN}")
-  fi
-  cmd+=("$url")
+    local -a cmd=(curl -sS -m "$HTTP_TIMEOUT_SEC" -D "$header_file" -o "$body_file" -w "%{http_code}")
+    if [[ "$use_auth" == "1" ]]; then
+      cmd+=(-H "Authorization: Bearer ${DASHBOARD_TOKEN}")
+    fi
+    cmd+=("$url")
 
-  local status
-  if ! status="$("${cmd[@]}" 2>"$err_file")"; then
-    CHECK_DETAIL="curl failed for ${path}"
-    return 1
-  fi
-  HTTP_STATUS="$status"
-  HTTP_BODY_FILE="$body_file"
-  HTTP_HEADER_FILE="$header_file"
-  return 0
+    if ! status="$("${cmd[@]}" 2>"$err_file")"; then
+      if [[ "$attempt" -lt "$HTTP_RETRY_MAX" ]]; then
+        sleep "$HTTP_RETRY_BASE_SEC"
+        attempt=$((attempt + 1))
+        continue
+      fi
+      CHECK_DETAIL="curl failed for ${path}"
+      return 1
+    fi
+
+    if [[ "$status" == "429" ]] && [[ "$attempt" -lt "$HTTP_RETRY_MAX" ]]; then
+      delay_sec="$(compute_retry_delay_sec "$attempt" "$header_file")"
+      sleep "$delay_sec"
+      attempt=$((attempt + 1))
+      continue
+    fi
+
+    HTTP_STATUS="$status"
+    HTTP_BODY_FILE="$body_file"
+    HTTP_HEADER_FILE="$header_file"
+    return 0
+  done
 }
 
 check_dashboard_health() {
@@ -418,21 +509,34 @@ check_tactical_map_route() {
 
 check_live_telemetry_handshake() {
   local url="${DASHBOARD_URL}/api/live-telemetry"
-  local header_file body_file err_file
-  header_file="$(mktemp "$TMP_DIR/sse-header.XXXXXX")"
-  body_file="$(mktemp "$TMP_DIR/sse-body.XXXXXX")"
-  err_file="$(mktemp "$TMP_DIR/sse-err.XXXXXX")"
-
+  local header_file body_file err_file status delay_sec
   local rc=0
-  if curl -sS -N -m "$HTTP_TIMEOUT_SEC" \
-    -H "Authorization: Bearer ${DASHBOARD_TOKEN}" \
-    -D "$header_file" \
-    -o "$body_file" \
-    "$url" 2>"$err_file"; then
-    rc=0
-  else
-    rc=$?
-  fi
+  local attempt=0
+
+  while true; do
+    header_file="$(mktemp "$TMP_DIR/sse-header.XXXXXX")"
+    body_file="$(mktemp "$TMP_DIR/sse-body.XXXXXX")"
+    err_file="$(mktemp "$TMP_DIR/sse-err.XXXXXX")"
+
+    if curl -sS -N -m "$HTTP_TIMEOUT_SEC" \
+      -H "Authorization: Bearer ${DASHBOARD_TOKEN}" \
+      -D "$header_file" \
+      -o "$body_file" \
+      "$url" 2>"$err_file"; then
+      rc=0
+    else
+      rc=$?
+    fi
+
+    status="$(extract_http_status_from_headers "$header_file")"
+    if [[ "$status" == "429" ]] && [[ "$attempt" -lt "$HTTP_RETRY_MAX" ]]; then
+      delay_sec="$(compute_retry_delay_sec "$attempt" "$header_file")"
+      sleep "$delay_sec"
+      attempt=$((attempt + 1))
+      continue
+    fi
+    break
+  done
 
   if [[ "$rc" -ne 0 && "$rc" -ne 28 ]]; then
     CHECK_DETAIL="SSE curl failed"
@@ -544,15 +648,31 @@ check_bridge_scheduler_jobs() {
     return 1
   fi
 
-  local body_file err_file status
-  body_file="$(mktemp "$TMP_DIR/bridge-body.XXXXXX")"
-  err_file="$(mktemp "$TMP_DIR/bridge-err.XXXXXX")"
-  if ! status="$(curl -sS -m "$HTTP_TIMEOUT_SEC" -o "$body_file" -w "%{http_code}" \
-    -H "Authorization: Bearer ${BRIDGE_TOKEN}" \
-    "${bridge_url}/api/bridge/scheduler-jobs" 2>"$err_file")"; then
-    CHECK_DETAIL="bridge request failed"
-    return 1
-  fi
+  local body_file header_file err_file status delay_sec
+  local attempt=0
+  while true; do
+    body_file="$(mktemp "$TMP_DIR/bridge-body.XXXXXX")"
+    header_file="$(mktemp "$TMP_DIR/bridge-header.XXXXXX")"
+    err_file="$(mktemp "$TMP_DIR/bridge-err.XXXXXX")"
+    if ! status="$(curl -sS -m "$HTTP_TIMEOUT_SEC" -D "$header_file" -o "$body_file" -w "%{http_code}" \
+      -H "Authorization: Bearer ${BRIDGE_TOKEN}" \
+      "${bridge_url}/api/bridge/scheduler-jobs" 2>"$err_file")"; then
+      if [[ "$attempt" -lt "$HTTP_RETRY_MAX" ]]; then
+        sleep "$HTTP_RETRY_BASE_SEC"
+        attempt=$((attempt + 1))
+        continue
+      fi
+      CHECK_DETAIL="bridge request failed"
+      return 1
+    fi
+    if [[ "$status" == "429" ]] && [[ "$attempt" -lt "$HTTP_RETRY_MAX" ]]; then
+      delay_sec="$(compute_retry_delay_sec "$attempt" "$header_file")"
+      sleep "$delay_sec"
+      attempt=$((attempt + 1))
+      continue
+    fi
+    break
+  done
   if [[ "$status" != "200" ]]; then
     CHECK_DETAIL="expected 200, got $status"
     return 1
@@ -743,6 +863,15 @@ with tsv_path.open('r', encoding='utf-8') as fh:
                 'owner': meta['owner'],
             }
         )
+
+for check in checks:
+    detail = str(check.get('detail', '')).lower()
+    if check.get('status') != 'fail':
+        continue
+    if 'got 429' not in detail:
+        continue
+    check['likelyCause'] = 'API rate limit window was exhausted by concurrent local requests.'
+    check['nextCommand'] = f"sleep 60 && bash scripts/openclaw-local-smoke.sh --profile {profile}"
 
 pass_count = sum(1 for c in checks if c['status'] == 'pass')
 fail_count = sum(1 for c in checks if c['status'] == 'fail')

--- a/scripts/tests/test-openclaw-local-smoke.sh
+++ b/scripts/tests/test-openclaw-local-smoke.sh
@@ -6,6 +6,7 @@ SMOKE_SCRIPT="$ROOT/scripts/openclaw-local-smoke.sh"
 TMP_DIR="$(mktemp -d)"
 SERVER_PID=""
 BRIDGE_SERVER_PID=""
+RATE_LIMIT_SERVER_PID=""
 
 cleanup() {
   if [[ -n "$SERVER_PID" ]]; then
@@ -15,6 +16,10 @@ cleanup() {
   if [[ -n "$BRIDGE_SERVER_PID" ]]; then
     kill "$BRIDGE_SERVER_PID" 2>/dev/null || true
     wait "$BRIDGE_SERVER_PID" 2>/dev/null || true
+  fi
+  if [[ -n "$RATE_LIMIT_SERVER_PID" ]]; then
+    kill "$RATE_LIMIT_SERVER_PID" 2>/dev/null || true
+    wait "$RATE_LIMIT_SERVER_PID" 2>/dev/null || true
   fi
   rm -rf "$TMP_DIR"
 }
@@ -50,6 +55,8 @@ import sys
 
 PORT = int(sys.argv[1])
 TOKEN = "Bearer test-token"
+RATE_LIMIT_ONCE_PATH = sys.argv[2] if len(sys.argv) > 2 else ""
+REQUEST_COUNTS = {}
 
 class Handler(BaseHTTPRequestHandler):
     def log_message(self, format, *args):
@@ -65,6 +72,24 @@ class Handler(BaseHTTPRequestHandler):
 
     def _auth_ok(self):
         return self.headers.get("Authorization", "") == TOKEN
+
+    def _send_rate_limited(self):
+        body = json.dumps({"ok": False, "error": "rate_limited"}).encode("utf-8")
+        self.send_response(429)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Retry-After", "1")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def _should_rate_limit_once(self):
+        if not RATE_LIMIT_ONCE_PATH:
+            return False
+        if self.path != RATE_LIMIT_ONCE_PATH:
+            return False
+        count = REQUEST_COUNTS.get(self.path, 0)
+        REQUEST_COUNTS[self.path] = count + 1
+        return count == 0
 
     def do_GET(self):
         if self.path == "/api/health":
@@ -98,6 +123,10 @@ class Handler(BaseHTTPRequestHandler):
 
         if not self._auth_ok():
             self._send_json(401, {"ok": False, "error": "unauthorized"})
+            return
+
+        if self._should_rate_limit_once():
+            self._send_rate_limited()
             return
 
         if self.path == "/api/config":
@@ -156,10 +185,21 @@ class Handler(BaseHTTPRequestHandler):
 HTTPServer(("127.0.0.1", PORT), Handler).serve_forever()
 PY
 
+RATE_LIMIT_PORT="$(python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(('127.0.0.1', 0))
+print(s.getsockname()[1])
+s.close()
+PY
+)"
+
 python3 "$TMP_DIR/mock-dashboard.py" "$PORT" >/dev/null 2>&1 &
 SERVER_PID=$!
 python3 "$TMP_DIR/mock-bridge.py" "$BRIDGE_PORT" >/dev/null 2>&1 &
 BRIDGE_SERVER_PID=$!
+python3 "$TMP_DIR/mock-dashboard.py" "$RATE_LIMIT_PORT" "/api/services" >/dev/null 2>&1 &
+RATE_LIMIT_SERVER_PID=$!
 sleep 0.3
 
 REPORT_DIR_BASELINE="$TMP_DIR/reports-baseline"
@@ -341,4 +381,31 @@ assert summary.get("profile") == "full", summary
 checks = {c["id"]: c for c in payload.get("checks", [])}
 assert checks["dashboard-map-route"]["status"] == "skipped", checks["dashboard-map-route"]
 print("OPENCLAW_LOCAL_SMOKE_SKIP_OVERRIDE_OK")
+PY
+
+REPORT_DIR_RETRY="$TMP_DIR/reports-retry"
+bash "$SMOKE_SCRIPT" \
+  --dashboard-url "http://127.0.0.1:$RATE_LIMIT_PORT" \
+  --token-file "$TOKEN_FILE" \
+  --report-dir "$REPORT_DIR_RETRY" \
+  --profile full \
+  --skip-openclaw-cli \
+  --skip-map \
+  --skip-bridge \
+  --timeout-sec 3 >/tmp/openclaw-local-smoke-test-retry.out
+
+python3 - "$REPORT_DIR_RETRY" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+report_dir = Path(sys.argv[1])
+json_reports = sorted(report_dir.glob("openclaw-local-smoke-*.json"))
+assert json_reports, "missing retry json report"
+payload = json.loads(json_reports[-1].read_text())
+summary = payload.get("summary", {})
+assert summary.get("status") == "pass", summary
+checks = {c["id"]: c for c in payload.get("checks", [])}
+assert checks["dashboard-services"]["status"] == "pass", checks["dashboard-services"]
+print("OPENCLAW_LOCAL_SMOKE_RETRY_429_OK")
 PY


### PR DESCRIPTION
## Summary
- harden `scripts/openclaw-local-smoke.sh` with bounded retry/backoff for transient HTTP `429` responses across dashboard API checks, SSE handshake, and direct bridge checks
- classify `429` failures with explicit likely-cause/next-command guidance in smoke JSON (`sleep 60 && ...`)
- add regression coverage in `scripts/tests/test-openclaw-local-smoke.sh` that forces a one-time `429` on `/api/services` and verifies the run still succeeds
- update smoke operator docs/specs and refresh `docs/LOCAL_INTEGRATION_READY.md` with current GO evidence

## Validation
- `bash -n scripts/openclaw-local-smoke.sh`
- `bash scripts/tests/test-openclaw-local-smoke.sh`
- `bash scripts/tests/test-refresh-local-integration-ready.sh`
- `bash scripts/tests/test-openclaw-local-ready-cron.sh`
- `bash scripts/openclaw-local-ready-cron.sh`
- `bash scripts/cron-runner.sh openclaw-local-ready`

## Ops Evidence
- managed cron entry confirmed: `15 */4 * * * ... cron-runner.sh openclaw-local-ready ...`
- cadence runner log now contains a successful run in `runtime/logs/cron-runs/openclaw-local-ready.jsonl`
- bridge profile smoke passes with canonical token file at `~/.openclaw/bridge/bridge-token`

Closes #431
Closes #432
