### PR TITLE
[codex] sanity-fix hybrid readiness wiring and gateway smoke signals

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ Current next steps (as of February 22, 2026):
 2. `npm run openclaw:local-ready:cron`
 3. Confirm Mission Control shows the latest `/api/openclaw-local-readiness` snapshot.
 4. If bridge checks should pass, set `BRIDGE_TOKEN_FILE` and rerun `npm run openclaw:local-smoke -- --profile bridge`.
-5. Track rollout follow-ups in issues `#431` and `#432`.
+5. Ensure dashboard container has report artifact access via `OPENCLAW_LOCAL_READINESS_REPORT_DIR` + bind mount in `docker-compose.yml`.
 
 ### Production Dashboard
 Tactical map integrates with the VentureOS dashboard on port 8001:

--- a/dashboard/server/routes/openclaw-local-readiness.ts
+++ b/dashboard/server/routes/openclaw-local-readiness.ts
@@ -50,6 +50,15 @@ const SEVERITY_RANK: Record<CheckSeverity, number> = {
   info: 1,
 };
 
+export function resolveOpenclawLocalReadinessReportDir(
+  ventureosRoot: string,
+  env: NodeJS.ProcessEnv = process.env,
+): string {
+  const explicit = (env.OPENCLAW_LOCAL_READINESS_REPORT_DIR ?? '').trim();
+  if (explicit) return explicit;
+  return path.join(ventureosRoot, 'runtime', 'reports', 'openclaw-local-smoke');
+}
+
 function toRecord(value: unknown): Record<string, unknown> | null {
   if (!value || typeof value !== 'object' || Array.isArray(value)) return null;
   return value as Record<string, unknown>;

--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -135,7 +135,10 @@ import { handleWebMcp } from './routes/webmcp.js';
 import { handleVisualExplainer } from './routes/visual-explainer.js';
 import { handleProposalLifecycle, handleProposalLifecycleUpgrade } from './routes/proposal-lifecycle.js';
 import { handleLivingFiles } from './routes/living-files.js';
-import { handleOpenclawLocalReadiness } from './routes/openclaw-local-readiness.js';
+import {
+  handleOpenclawLocalReadiness,
+  resolveOpenclawLocalReadinessReportDir,
+} from './routes/openclaw-local-readiness.js';
 import { getSchedulerJobs } from './scheduler-jobs.js';
 import {
   buildAvgResponseTime,
@@ -180,6 +183,10 @@ const heartbeatPath: string = path.join(WORKSPACE_DIR, 'HEARTBEAT.md');
 const healthHistoryFile: string = path.join(dataDir, 'health-history.json');
 const claudeUsageFile: string = path.join(dataDir, 'claude-usage.json');
 const scrapeScript: string = path.join(WORKSPACE_DIR, 'scripts', 'scrape-claude-usage.sh');
+const OPENCLAW_LOCAL_READINESS_REPORT_DIR: string = resolveOpenclawLocalReadinessReportDir(
+  VENTUREOS_ROOT,
+  process.env,
+);
 
 // Client HTML paths — served from client/ directory
 const htmlPath: string = path.join(import.meta.dirname, '..', 'client', 'index.html');
@@ -1943,7 +1950,7 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
   // Local OpenClaw readiness summary (Mission Control card)
   try {
     if (handleOpenclawLocalReadiness(req, res, {
-      reportDir: path.join(VENTUREOS_ROOT, 'runtime', 'reports', 'openclaw-local-smoke'),
+      reportDir: OPENCLAW_LOCAL_READINESS_REPORT_DIR,
       sendJson,
     })) return;
   } catch {

--- a/dashboard/tests/unit/routes/openclaw-local-readiness.test.ts
+++ b/dashboard/tests/unit/routes/openclaw-local-readiness.test.ts
@@ -8,6 +8,7 @@ import { mockRequest, mockResponse, parseJsonBody } from '../../helpers.js';
 import {
   handleOpenclawLocalReadiness,
   type OpenclawLocalReadinessDeps,
+  resolveOpenclawLocalReadinessReportDir,
 } from '../../../server/routes/openclaw-local-readiness.js';
 
 const tmpRoot = path.join(os.tmpdir(), `openclaw-local-readiness-${process.pid}`);
@@ -45,6 +46,18 @@ describe('openclaw local readiness route', () => {
 
     expect(handleOpenclawLocalReadiness(mockRequest({ url: '/api/scheduler-jobs' }), res, deps)).toBe(false);
     expect(handleOpenclawLocalReadiness(mockRequest({ url: '/api/openclaw-local-readiness', method: 'POST' }), res, deps)).toBe(false);
+  });
+
+  it('resolves report directory from OPENCLAW_LOCAL_READINESS_REPORT_DIR when set', () => {
+    const resolved = resolveOpenclawLocalReadinessReportDir('/opt/ventureos', {
+      OPENCLAW_LOCAL_READINESS_REPORT_DIR: '/var/ventureos-host/runtime/reports/openclaw-local-smoke',
+    });
+    expect(resolved).toBe('/var/ventureos-host/runtime/reports/openclaw-local-smoke');
+  });
+
+  it('resolves report directory from ventureos root when env override is missing', () => {
+    const resolved = resolveOpenclawLocalReadinessReportDir('/opt/ventureos', {});
+    expect(resolved).toBe('/opt/ventureos/runtime/reports/openclaw-local-smoke');
   });
 
   it('returns available=false when no artifacts exist', () => {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,7 @@ services:
       DASHBOARD_ALLOW_LAN_BYPASS: "false"
       DASHBOARD_TRUST_PROXY: "false"
       DASHBOARD_ENABLE_ACTIONS: "false"
+      OPENCLAW_LOCAL_READINESS_REPORT_DIR: /var/ventureos-host/runtime/reports/openclaw-local-smoke
       # Hybrid mode: data sourced from host Bridge API
       DASHBOARD_DATA_MODE: bridge
       BRIDGE_URL: ${BRIDGE_URL:-http://host.docker.internal:18790}
@@ -62,6 +63,8 @@ services:
       DATABASE_URL: ${DATABASE_URL:-postgres://${POSTGRES_USER:-ventureos}:${POSTGRES_PASSWORD}@db:5432/${POSTGRES_DB:-ventureos}}
     ports:
       - "${DASHBOARD_PORT:-8001}:8001"
+    volumes:
+      - ./runtime/reports/openclaw-local-smoke:/var/ventureos-host/runtime/reports/openclaw-local-smoke:ro
     extra_hosts:
       - "host.docker.internal:host-gateway"
     healthcheck:

--- a/docs/LOCAL_INTEGRATION_READY.md
+++ b/docs/LOCAL_INTEGRATION_READY.md
@@ -5,31 +5,31 @@ Owner: automated refresh via `scripts/refresh-local-integration-ready.sh`
 
 ## Mission Control Card
 - Verdict: `GO`
-- Readiness score: `100`
-- Confidence: `high`
+- Readiness score: `93`
+- Confidence: `medium`
 - Profile: `full`
 - Required failures: `0`
 - Required skipped: `0`
-- Warnings: `0`
+- Warnings: `1`
 
 ## Latest Evidence Artifacts
-- JSON: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T205446Z.json`
-- Markdown: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T205446Z.md`
-- Status strip SVG: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T205446Z.svg`
+- JSON: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T211244Z.json`
+- Markdown: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T211244Z.md`
+- Status strip SVG: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T211244Z.svg`
 
 ## Top 3 Blockers
-- No blockers in latest run.
+- `bridge-scheduler-jobs` owner=`Bridge Ops`; cause: API rate limit window was exhausted by concurrent local requests.; next: `sleep 60 && bash scripts/openclaw-local-smoke.sh --profile full`
 
 ## Trend (Last 7 Runs)
 | Timestamp | Verdict | Score | Required Failures | Warnings | Bridge |
 |---|---|---:|---:|---:|---|
-| `20260222T204825Z` | `BLOCKED` | 62 | 3 | 1 | `fail` |
-| `20260222T204851Z` | `GO` | 100 | 0 | 0 | `pass` |
-| `20260222T204902Z` | `BLOCKED` | 63 | 3 | 1 | `fail` |
-| `20260222T205052Z` | `GO` | 100 | 0 | 0 | `pass` |
-| `20260222T205126Z` | `BLOCKED` | 63 | 3 | 1 | `fail` |
 | `20260222T205427Z` | `GO` | 100 | 0 | 0 | `pass` |
 | `20260222T205446Z` | `GO` | 100 | 0 | 0 | `pass` |
+| `20260222T205623Z` | `BLOCKED` | 63 | 3 | 1 | `fail` |
+| `20260222T205731Z` | `HOLD` | 92 | 0 | 1 | `fail` |
+| `20260222T205733Z` | `GO` | 100 | 0 | 0 | `pass` |
+| `20260222T211046Z` | `GO` | 93 | 0 | 1 | `fail` |
+| `20260222T211244Z` | `GO` | 93 | 0 | 1 | `fail` |
 
 ## Required Checks
 - [x] `openclaw-cli` — `pass` group=`core` severity=`critical` (openclaw CLI found)
@@ -44,17 +44,18 @@ Owner: automated refresh via `scripts/refresh-local-integration-ready.sh`
 
 ## Optional Checks
 - [x] `dashboard-map-route` — `pass` group=`apis` severity=`info` (map route reachable)
-- [x] `bridge-scheduler-jobs` — `pass` group=`bridge` severity=`warn` (bridge scheduler endpoint reachable)
+- [ ] `bridge-scheduler-jobs` — `fail` group=`bridge` severity=`warn` (expected 200, got 429); cause: API rate limit window was exhausted by concurrent local requests.; next: `sleep 60 && bash scripts/openclaw-local-smoke.sh --profile full`
 
 ## Bridge Token Setup Note
 - Direct bridge checks support `--bridge-token-file`, `BRIDGE_TOKEN`, `BRIDGE_TOKEN_FILE`, or default `OPENCLAW_DIR/bridge/bridge-token`.
-- Latest bridge check: `pass: bridge scheduler endpoint reachable`
+- Latest bridge check: `fail: expected 200, got 429`
 
 ## Current Next Steps
 1. Install or refresh managed cron entries: `bash scripts/install-cron.sh --force`
 2. Run one manual cadence cycle and verify artifact generation: `bash scripts/openclaw-local-ready-cron.sh`
-3. Keep cadence running and monitor trend score/confidence for regressions.
-4. Confirm Mission Control shows the latest readiness payload from `/api/openclaw-local-readiness`.
+3. Address optional blockers to raise confidence and reduce warning-only drift.
+4. If bridge coverage is expected, configure bridge token and rerun bridge profile: `export BRIDGE_TOKEN_FILE=~/.openclaw/bridge/bridge-token && bash scripts/openclaw-local-smoke.sh --profile bridge`
+5. Confirm Mission Control shows the latest readiness payload from `/api/openclaw-local-readiness`.
 
 ## Refresh Command
 ```bash

--- a/docs/OPENCLAW_LOCAL_INTEGRATION_SMOKE.md
+++ b/docs/OPENCLAW_LOCAL_INTEGRATION_SMOKE.md
@@ -101,6 +101,12 @@ Optional env overrides for cron wrapper:
 - `OPENCLAW_LOCAL_READY_PRUNE_KEEP`
 - `OPENCLAW_LOCAL_READY_PROFILE` (`quick|full|bridge`)
 
+Mission Control API note (dashboard route):
+- `GET /api/openclaw-local-readiness` reads artifacts from:
+  - `OPENCLAW_LOCAL_READINESS_REPORT_DIR` when set
+  - otherwise `VENTUREOS_ROOT/runtime/reports/openclaw-local-smoke`
+- In hybrid Docker mode, ensure the report directory is bind-mounted into the dashboard container and wired via `OPENCLAW_LOCAL_READINESS_REPORT_DIR`.
+
 ## Current Next Steps (February 22, 2026)
 1. Install or refresh managed cron entries:
 ```bash
@@ -115,7 +121,7 @@ bash scripts/openclaw-local-ready-cron.sh
 ```bash
 bash scripts/openclaw-local-smoke.sh --profile bridge
 ```
-5. Track active rollout work in issues `#431` (ops rollout) and `#432` (bridge readiness parity).
+5. Keep bridge startup + readiness artifact wiring persistent across restarts.
 
 ## Regression Test
 Run the mock-server regression test:

--- a/docs/SCRIPT_SPECS.md
+++ b/docs/SCRIPT_SPECS.md
@@ -236,6 +236,7 @@ bash scripts/openclaw-local-smoke.sh \
 - Built-in transient retry behavior:
   - Retries HTTP `429` responses (dashboard + bridge checks) using `Retry-After` when present.
   - Retry controls: `SMOKE_HTTP_RETRY_MAX` (default `2`), `SMOKE_HTTP_RETRY_BASE_SEC` (default `1`), `SMOKE_HTTP_RETRY_MAX_DELAY_SEC` (default `15`).
+- Gateway status check requires a healthy runtime signal (`RPC probe: ok` or `Listening:`) to pass.
 - Emits timestamped JSON + markdown + SVG reports to `runtime/reports/openclaw-local-smoke/`.
 - JSON summary includes `verdict`, `readinessScore`, `confidence`; each check includes `group`, `severity`, `likelyCause`, and `nextCommand`.
 - Exits with code `2` when any required check fails.

--- a/scripts/openclaw-local-smoke.sh
+++ b/scripts/openclaw-local-smoke.sh
@@ -258,11 +258,19 @@ check_openclaw_gateway_status() {
     return 1
   fi
   local output
-  if output="$(openclaw gateway status 2>&1)"; then
+  if ! output="$(openclaw gateway status 2>&1)"; then
+    CHECK_DETAIL="$(echo "$output" | head -n 1 | sed 's/[[:space:]]\+/ /g')"
+    return 1
+  fi
+
+  local normalized
+  normalized="$(echo "$output" | tr '[:upper:]' '[:lower:]')"
+  if [[ "$normalized" == *"rpc probe: ok"* ]] || [[ "$normalized" == *"listening:"* ]]; then
     CHECK_DETAIL="$(echo "$output" | head -n 1 | sed 's/[[:space:]]\+/ /g')"
     return 0
   fi
-  CHECK_DETAIL="$(echo "$output" | head -n 1 | sed 's/[[:space:]]\+/ /g')"
+
+  CHECK_DETAIL="gateway status returned without healthy runtime signal"
   return 1
 }
 

--- a/scripts/tests/test-openclaw-local-smoke.sh
+++ b/scripts/tests/test-openclaw-local-smoke.sh
@@ -47,6 +47,36 @@ TOKEN_FILE="$TMP_DIR/token.txt"
 echo "test-token" > "$TOKEN_FILE"
 BRIDGE_TOKEN_FILE="$TMP_DIR/bridge-token.txt"
 echo "bridge-token" > "$BRIDGE_TOKEN_FILE"
+FAKE_OPENCLAW_BIN_DIR="$TMP_DIR/fake-openclaw-bin"
+mkdir -p "$FAKE_OPENCLAW_BIN_DIR"
+
+cat > "$FAKE_OPENCLAW_BIN_DIR/openclaw" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ "${1:-}" == "gateway" && "${2:-}" == "status" ]]; then
+  mode="${OPENCLAW_FAKE_STATUS_MODE:-healthy}"
+  if [[ "$mode" == "healthy" ]]; then
+    cat <<'OUT'
+Service: LaunchAgent (not loaded)
+RPC probe: ok
+Listening: 127.0.0.1:18789
+OUT
+    exit 0
+  fi
+
+  cat <<'OUT'
+Service: LaunchAgent (not loaded)
+Runtime: unknown
+Service unit not found.
+OUT
+  exit 0
+fi
+
+echo "unsupported fake openclaw invocation: $*" >&2
+exit 1
+SH
+chmod +x "$FAKE_OPENCLAW_BIN_DIR/openclaw"
 
 cat > "$TMP_DIR/mock-dashboard.py" <<'PY'
 import json
@@ -408,4 +438,58 @@ assert summary.get("status") == "pass", summary
 checks = {c["id"]: c for c in payload.get("checks", [])}
 assert checks["dashboard-services"]["status"] == "pass", checks["dashboard-services"]
 print("OPENCLAW_LOCAL_SMOKE_RETRY_429_OK")
+PY
+
+REPORT_DIR_OPENCLAW_HEALTHY="$TMP_DIR/reports-openclaw-healthy"
+env PATH="$FAKE_OPENCLAW_BIN_DIR:$PATH" OPENCLAW_FAKE_STATUS_MODE=healthy bash "$SMOKE_SCRIPT" \
+  --dashboard-url "http://127.0.0.1:$PORT" \
+  --token-file "$TOKEN_FILE" \
+  --report-dir "$REPORT_DIR_OPENCLAW_HEALTHY" \
+  --profile quick \
+  --timeout-sec 3 >/tmp/openclaw-local-smoke-test-openclaw-healthy.out
+
+python3 - "$REPORT_DIR_OPENCLAW_HEALTHY" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+report_dir = Path(sys.argv[1])
+json_reports = sorted(report_dir.glob("openclaw-local-smoke-*.json"))
+assert json_reports, "missing openclaw healthy json report"
+payload = json.loads(json_reports[-1].read_text())
+summary = payload.get("summary", {})
+assert summary.get("status") == "pass", summary
+checks = {c["id"]: c for c in payload.get("checks", [])}
+assert checks["openclaw-gateway-status"]["status"] == "pass", checks["openclaw-gateway-status"]
+print("OPENCLAW_LOCAL_SMOKE_GATEWAY_SIGNAL_HEALTHY_OK")
+PY
+
+REPORT_DIR_OPENCLAW_UNHEALTHY="$TMP_DIR/reports-openclaw-unhealthy"
+set +e
+env PATH="$FAKE_OPENCLAW_BIN_DIR:$PATH" OPENCLAW_FAKE_STATUS_MODE=unhealthy bash "$SMOKE_SCRIPT" \
+  --dashboard-url "http://127.0.0.1:$PORT" \
+  --token-file "$TOKEN_FILE" \
+  --report-dir "$REPORT_DIR_OPENCLAW_UNHEALTHY" \
+  --profile quick \
+  --timeout-sec 3 >/tmp/openclaw-local-smoke-test-openclaw-unhealthy.out
+UNHEALTHY_RC=$?
+set -e
+
+if [[ "$UNHEALTHY_RC" -ne 2 ]]; then
+  echo "Expected unhealthy gateway smoke run to exit 2, got $UNHEALTHY_RC" >&2
+  exit 1
+fi
+
+python3 - "$REPORT_DIR_OPENCLAW_UNHEALTHY" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+report_dir = Path(sys.argv[1])
+json_reports = sorted(report_dir.glob("openclaw-local-smoke-*.json"))
+assert json_reports, "missing openclaw unhealthy json report"
+payload = json.loads(json_reports[-1].read_text())
+checks = {c["id"]: c for c in payload.get("checks", [])}
+assert checks["openclaw-gateway-status"]["status"] == "fail", checks["openclaw-gateway-status"]
+print("OPENCLAW_LOCAL_SMOKE_GATEWAY_SIGNAL_UNHEALTHY_OK")
 PY


### PR DESCRIPTION
## Summary
- fix hybrid dashboard readiness wiring so `/api/openclaw-local-readiness` can read host-generated smoke artifacts in Docker mode
  - add `OPENCLAW_LOCAL_READINESS_REPORT_DIR` resolution in server route wiring
  - wire dashboard container env + bind mount for `runtime/reports/openclaw-local-smoke`
- tighten `openclaw-local-smoke` gateway required check to require a healthy runtime signal (`RPC probe: ok` or `Listening:`) rather than command exit code alone
- extend smoke regressions with deterministic fake-CLI scenarios for healthy vs unhealthy gateway status output
- update operator docs/README to reflect container readiness artifact mapping and revised gateway check semantics

## Validation
- `bash -n scripts/openclaw-local-smoke.sh`
- `bash scripts/tests/test-openclaw-local-smoke.sh`
- `bash scripts/tests/test-refresh-local-integration-ready.sh`
- `bash scripts/tests/test-openclaw-local-ready-cron.sh`
- `npm run test --workspace=dashboard -- tests/unit/routes/openclaw-local-readiness.test.ts`
- `npm run build --workspace=dashboard`
- `docker compose --env-file .env.hybrid up -d --build dashboard`
- `curl -H "Authorization: Bearer ..." http://127.0.0.1:8001/api/openclaw-local-readiness` now returns `available: true` with latest timestamp

## Notes
- Existing unrelated local workspace changes (`node_modules` artifacts, runtime dirs, local config files) were intentionally not modified.
