### PR TITLE
Refresh OpenClaw local readiness snapshot

### DIFF
--- a/docs/LOCAL_INTEGRATION_READY.md
+++ b/docs/LOCAL_INTEGRATION_READY.md
@@ -5,31 +5,31 @@ Owner: automated refresh via `scripts/refresh-local-integration-ready.sh`
 
 ## Mission Control Card
 - Verdict: `GO`
-- Readiness score: `93`
-- Confidence: `medium`
+- Readiness score: `100`
+- Confidence: `high`
 - Profile: `full`
 - Required failures: `0`
 - Required skipped: `0`
-- Warnings: `1`
+- Warnings: `0`
 
 ## Latest Evidence Artifacts
-- JSON: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T211244Z.json`
-- Markdown: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T211244Z.md`
-- Status strip SVG: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T211244Z.svg`
+- JSON: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T212745Z.json`
+- Markdown: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T212745Z.md`
+- Status strip SVG: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T212745Z.svg`
 
 ## Top 3 Blockers
-- `bridge-scheduler-jobs` owner=`Bridge Ops`; cause: API rate limit window was exhausted by concurrent local requests.; next: `sleep 60 && bash scripts/openclaw-local-smoke.sh --profile full`
+- No blockers in latest run.
 
 ## Trend (Last 7 Runs)
 | Timestamp | Verdict | Score | Required Failures | Warnings | Bridge |
 |---|---|---:|---:|---:|---|
-| `20260222T205427Z` | `GO` | 100 | 0 | 0 | `pass` |
 | `20260222T205446Z` | `GO` | 100 | 0 | 0 | `pass` |
 | `20260222T205623Z` | `BLOCKED` | 63 | 3 | 1 | `fail` |
 | `20260222T205731Z` | `HOLD` | 92 | 0 | 1 | `fail` |
 | `20260222T205733Z` | `GO` | 100 | 0 | 0 | `pass` |
 | `20260222T211046Z` | `GO` | 93 | 0 | 1 | `fail` |
 | `20260222T211244Z` | `GO` | 93 | 0 | 1 | `fail` |
+| `20260222T212745Z` | `GO` | 100 | 0 | 0 | `pass` |
 
 ## Required Checks
 - [x] `openclaw-cli` — `pass` group=`core` severity=`critical` (openclaw CLI found)
@@ -44,18 +44,17 @@ Owner: automated refresh via `scripts/refresh-local-integration-ready.sh`
 
 ## Optional Checks
 - [x] `dashboard-map-route` — `pass` group=`apis` severity=`info` (map route reachable)
-- [ ] `bridge-scheduler-jobs` — `fail` group=`bridge` severity=`warn` (expected 200, got 429); cause: API rate limit window was exhausted by concurrent local requests.; next: `sleep 60 && bash scripts/openclaw-local-smoke.sh --profile full`
+- [x] `bridge-scheduler-jobs` — `pass` group=`bridge` severity=`warn` (bridge scheduler endpoint reachable)
 
 ## Bridge Token Setup Note
 - Direct bridge checks support `--bridge-token-file`, `BRIDGE_TOKEN`, `BRIDGE_TOKEN_FILE`, or default `OPENCLAW_DIR/bridge/bridge-token`.
-- Latest bridge check: `fail: expected 200, got 429`
+- Latest bridge check: `pass: bridge scheduler endpoint reachable`
 
 ## Current Next Steps
 1. Install or refresh managed cron entries: `bash scripts/install-cron.sh --force`
 2. Run one manual cadence cycle and verify artifact generation: `bash scripts/openclaw-local-ready-cron.sh`
-3. Address optional blockers to raise confidence and reduce warning-only drift.
-4. If bridge coverage is expected, configure bridge token and rerun bridge profile: `export BRIDGE_TOKEN_FILE=~/.openclaw/bridge/bridge-token && bash scripts/openclaw-local-smoke.sh --profile bridge`
-5. Confirm Mission Control shows the latest readiness payload from `/api/openclaw-local-readiness`.
+3. Keep cadence running and monitor trend score/confidence for regressions.
+4. Confirm Mission Control shows the latest readiness payload from `/api/openclaw-local-readiness`.
 
 ## Refresh Command
 ```bash


### PR DESCRIPTION
## Summary
- refresh `docs/LOCAL_INTEGRATION_READY.md` to the latest generated mission-control snapshot
- capture current state after bridge hardening rollout (`GO`, score 100, confidence high)
- update "Current Next Steps" block to ongoing cadence/monitoring flow

## Validation
- `bash scripts/openclaw-local-ready-cron.sh`
