### PR TITLE
Dashboard: active freshness alerts + configurable thresholds

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -146,6 +146,17 @@ All paths are resolved through `lib/paths.ts`. Override with environment variabl
 | `AGENT_HEALTH_CACHE_TTL_MS` | `15000` | 1000–60000 | Agent health endpoint cache |
 | `VENTUREOS_CACHE_TTL_MS` | `5000` | 1000–60000 | VentureOS data cache |
 
+### Overview Freshness Thresholds
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `DASHBOARD_OVERVIEW_FRESHNESS_KPI_FRESH_MS` | `129600000` (36h) | KPI badge `Fresh` threshold |
+| `DASHBOARD_OVERVIEW_FRESHNESS_KPI_STALE_MS` | `345600000` (96h) | KPI badge `Stale` threshold |
+| `DASHBOARD_OVERVIEW_FRESHNESS_AGENT_HEALTH_FRESH_MS` | `900000` (15m) | Agent Health badge `Fresh` threshold |
+| `DASHBOARD_OVERVIEW_FRESHNESS_AGENT_HEALTH_STALE_MS` | `7200000` (2h) | Agent Health badge `Stale` threshold |
+| `DASHBOARD_OVERVIEW_FRESHNESS_OBSERVATIONS_FRESH_MS` | `21600000` (6h) | Observations badge `Fresh` threshold |
+| `DASHBOARD_OVERVIEW_FRESHNESS_OBSERVATIONS_STALE_MS` | `86400000` (24h) | Observations badge `Stale` threshold |
+
 ## API Reference
 
 See **[docs/API.md](docs/API.md)** for the complete API reference covering all endpoints, schemas, authentication, and rate limiting.
@@ -178,6 +189,7 @@ See **[docs/API.md](docs/API.md)** for the complete API reference covering all e
 | `GET /api/proposal-lifecycle/summary` | Read proposal queue + active mission progress for Mission Control |
 | `GET /api/living-files/dashboard` | Freshness counts + stale/missing file status for living docs registry |
 | `POST /api/living-files/check-run` | Run staleness detection and auto-trigger responsible owner tasks |
+| `POST /api/overview-freshness-event` | Persist overview stale/aging transitions for local audit trail |
 | `GET /api/live` | SSE real-time feed |
 
 ## Architecture

--- a/dashboard/client/assets/overview-freshness.js
+++ b/dashboard/client/assets/overview-freshness.js
@@ -1,0 +1,49 @@
+(function initOverviewFreshnessUtils(globalScope) {
+  function normalizeThresholds(thresholds) {
+    const freshRaw = Number(thresholds && thresholds.freshMs);
+    const staleRaw = Number(thresholds && thresholds.staleMs);
+    const freshMs = Number.isFinite(freshRaw) && freshRaw > 0 ? freshRaw : 1;
+    const staleMs = Number.isFinite(staleRaw) && staleRaw > freshMs ? staleRaw : freshMs + 1;
+    return { freshMs, staleMs };
+  }
+
+  function formatFreshnessAge(ageMs) {
+    const age = Math.max(0, Number(ageMs) || 0);
+    if (age < 60000) return String(Math.max(1, Math.round(age / 1000))) + 's';
+    if (age < 3600000) return String(Math.round(age / 60000)) + 'm';
+    if (age < 86400000) return String(Math.round(age / 3600000)) + 'h';
+    return String(Math.round(age / 86400000)) + 'd';
+  }
+
+  function classifyFreshnessState(sourceMs, thresholds, nowMs) {
+    const ts = Number(sourceMs) || 0;
+    if (ts <= 0) return { state: 'no-data', ageMs: null, sourceMs: 0 };
+
+    const safeNow = Number.isFinite(Number(nowMs)) ? Number(nowMs) : Date.now();
+    const ageMs = Math.max(0, safeNow - ts);
+    const t = normalizeThresholds(thresholds);
+
+    if (ageMs > t.staleMs) return { state: 'stale', ageMs, sourceMs: ts };
+    if (ageMs > t.freshMs) return { state: 'aging', ageMs, sourceMs: ts };
+    return { state: 'fresh', ageMs, sourceMs: ts };
+  }
+
+  function summarizeFreshnessStates(states) {
+    const rows = Array.isArray(states) ? states : [];
+    const stale = rows.filter((r) => r && r.state === 'stale').length;
+    const aging = rows.filter((r) => r && r.state === 'aging').length;
+    const unavailable = rows.filter((r) => r && r.state === 'no-data').length;
+
+    if (stale > 0) return { state: 'stale', stale, aging, unavailable };
+    if (aging > 0) return { state: 'aging', stale, aging, unavailable };
+    if (unavailable > 0) return { state: 'unavailable', stale, aging, unavailable };
+    return { state: 'fresh', stale, aging, unavailable };
+  }
+
+  globalScope.OverviewFreshnessUtils = {
+    normalizeThresholds,
+    formatFreshnessAge,
+    classifyFreshnessState,
+    summarizeFreshnessStates,
+  };
+})(typeof globalThis !== 'undefined' ? globalThis : window);

--- a/dashboard/client/index.html
+++ b/dashboard/client/index.html
@@ -4493,6 +4493,9 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
             Data freshness unknown
           </span>
         </div>
+        <div id="overviewStaleBanner" style="display:none;margin-top:10px;padding:10px 12px;border-radius:10px;border:1px solid rgba(239,68,68,0.45);background:rgba(239,68,68,0.12);color:var(--red);font-size:12px;font-weight:600;">
+          Freshness alert: stale dashboard sources detected.
+        </div>
       </div>
 
       <div class="grid mb-24" style="grid-template-columns: repeat(3, 1fr);">
@@ -6459,6 +6462,7 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
 
 <script type="module" src="/rpg/components/index.js"></script>
 <script src="/assets/feed-search-highlight.js"></script>
+<script src="/assets/overview-freshness.js"></script>
 <script>
 // Authenticated fetch helper (Phase 5.1 security + P0-5 429 handling)
 // Uses an HttpOnly cookie set via /api/login. Token is never exposed to JS.
@@ -6522,6 +6526,11 @@ let recentObs = null;
 let kpisLatestError = null;
 let agentHealthError = null;
 let recentObsError = null;
+let overviewFreshnessConfigLoaded = false;
+let overviewFreshnessConfigLoading = false;
+let overviewFreshnessLastSummaryState = null;
+const OVERVIEW_FRESHNESS_EVENT_COOLDOWN_MS = 60 * 1000;
+let overviewFreshnessLastEventAt = 0;
 
 let selectedAgentId = 'oracle';
 
@@ -6556,6 +6565,81 @@ function describeFetchFailure(res, payload, fallback = 'unavailable') {
 
 function isApiErrorPayload(payload) {
   return !!(payload && typeof payload === 'object' && (payload.error || payload.ok === false));
+}
+
+function normalizeThresholdMs(raw, fallback) {
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n <= 0) return fallback;
+  return Math.round(n);
+}
+
+function applyOverviewFreshnessThresholdConfig(config) {
+  const cfg = config && typeof config === 'object'
+    ? config.overviewFreshnessThresholdsMs
+    : null;
+  if (!cfg || typeof cfg !== 'object') return;
+
+  const next = {
+    kpi: {
+      freshMs: normalizeThresholdMs(cfg.kpi?.freshMs, overviewFreshnessThresholds.kpi.freshMs),
+      staleMs: normalizeThresholdMs(cfg.kpi?.staleMs, overviewFreshnessThresholds.kpi.staleMs),
+    },
+    agentHealth: {
+      freshMs: normalizeThresholdMs(cfg.agentHealth?.freshMs, overviewFreshnessThresholds.agentHealth.freshMs),
+      staleMs: normalizeThresholdMs(cfg.agentHealth?.staleMs, overviewFreshnessThresholds.agentHealth.staleMs),
+    },
+    observations: {
+      freshMs: normalizeThresholdMs(cfg.observations?.freshMs, overviewFreshnessThresholds.observations.freshMs),
+      staleMs: normalizeThresholdMs(cfg.observations?.staleMs, overviewFreshnessThresholds.observations.staleMs),
+    },
+  };
+
+  if (next.kpi.staleMs <= next.kpi.freshMs) next.kpi.staleMs = next.kpi.freshMs + 1;
+  if (next.agentHealth.staleMs <= next.agentHealth.freshMs) next.agentHealth.staleMs = next.agentHealth.freshMs + 1;
+  if (next.observations.staleMs <= next.observations.freshMs) next.observations.staleMs = next.observations.freshMs + 1;
+  overviewFreshnessThresholds = next;
+}
+
+async function loadOverviewFreshnessConfigOnce() {
+  if (overviewFreshnessConfigLoaded || overviewFreshnessConfigLoading) return;
+  overviewFreshnessConfigLoading = true;
+  try {
+    const cfg = await fetchJson('/api/config');
+    applyOverviewFreshnessThresholdConfig(cfg);
+    overviewFreshnessConfigLoaded = true;
+  } catch {
+    // Leave defaults in place
+  } finally {
+    overviewFreshnessConfigLoading = false;
+  }
+}
+
+function emitOverviewFreshnessEvent(summary, states) {
+  const now = Date.now();
+  const state = summary?.state || 'unknown';
+  if (state === overviewFreshnessLastSummaryState && now - overviewFreshnessLastEventAt < OVERVIEW_FRESHNESS_EVENT_COOLDOWN_MS) {
+    return;
+  }
+  const prevState = overviewFreshnessLastSummaryState;
+  overviewFreshnessLastSummaryState = state;
+  overviewFreshnessLastEventAt = now;
+
+  if (state !== 'stale' && prevState !== 'stale') return;
+
+  const payload = {
+    state,
+    stale: summary?.stale || 0,
+    aging: summary?.aging || 0,
+    unavailable: summary?.unavailable || 0,
+    total: Array.isArray(states) ? states.length : 0,
+    source: 'overview-widget',
+    emittedAt: now,
+  };
+  authFetch('/api/overview-freshness-event', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  }).catch(() => {});
 }
 
 // Observations
@@ -6620,6 +6704,7 @@ document.querySelectorAll('.view-all-link').forEach(link => {
 });
 
 async function fetchData() {
+  void loadOverviewFreshnessConfigOnce();
   try {
     // Fast path: load sessions, costs, system first
     const [sessRes, costsRes, sysRes] = await Promise.all([
@@ -7060,7 +7145,7 @@ function updateVentureWidgets() {
   const kpiSourceMs = kpiMtimeMs > 0
     ? kpiMtimeMs
     : (parseDateOnlyMs(latest?.date) || parseDateOnlyMs((kpisLatest?.file || '').replace(/\.json$/, '')));
-  const kpiFreshness = setFreshnessBadge(kpiFreshnessEl, kpiSourceMs, OVERVIEW_FRESHNESS_THRESHOLDS.kpi);
+  const kpiFreshness = setFreshnessBadge(kpiFreshnessEl, kpiSourceMs, overviewFreshnessThresholds.kpi);
   if (kpiFreshness) freshnessStates.push(kpiFreshness);
 
   const sr = latest?.overall?.success_rate;
@@ -7106,7 +7191,7 @@ function updateVentureWidgets() {
   const healthSourceMs = (typeof agentHealth?.lastActiveMs === 'number' && agentHealth.lastActiveMs > 0)
     ? agentHealth.lastActiveMs
     : 0;
-  const healthFreshness = setFreshnessBadge(healthFreshnessEl, healthSourceMs, OVERVIEW_FRESHNESS_THRESHOLDS.agentHealth);
+  const healthFreshness = setFreshnessBadge(healthFreshnessEl, healthSourceMs, overviewFreshnessThresholds.agentHealth);
   if (healthFreshness) freshnessStates.push(healthFreshness);
   if (healthEl) {
     if (!agentHealth?.agents) {
@@ -7138,7 +7223,7 @@ function updateVentureWidgets() {
   if (obsErrEl) obsErrEl.textContent = recentObsError ? recentObsError : '';
   const obsItems = Array.isArray(recentObs?.items) ? recentObs.items : [];
   const obsSourceMs = obsItems.reduce((max, item) => Math.max(max, Number(item?.mtimeMs) || 0), 0);
-  const obsFreshness = setFreshnessBadge(obsFreshnessEl, obsSourceMs, OVERVIEW_FRESHNESS_THRESHOLDS.observations);
+  const obsFreshness = setFreshnessBadge(obsFreshnessEl, obsSourceMs, overviewFreshnessThresholds.observations);
   if (obsFreshness) freshnessStates.push(obsFreshness);
   if (obsEl) {
     const items = obsItems.length ? obsItems : (recentObs?.items || null);
@@ -8023,7 +8108,7 @@ function timeAgo(ms) {
   return Math.round(age / 86400000) + 'd ago';
 }
 
-const OVERVIEW_FRESHNESS_THRESHOLDS = {
+let overviewFreshnessThresholds = {
   kpi: { freshMs: 36 * 60 * 60 * 1000, staleMs: 96 * 60 * 60 * 1000 },
   agentHealth: { freshMs: 15 * 60 * 1000, staleMs: 2 * 60 * 60 * 1000 },
   observations: { freshMs: 6 * 60 * 60 * 1000, staleMs: 24 * 60 * 60 * 1000 },
@@ -8036,18 +8121,29 @@ function parseDateOnlyMs(raw) {
   return Number.isFinite(ms) ? ms : 0;
 }
 
-function formatAgeCompact(ageMs) {
-  const age = Math.max(0, ageMs || 0);
-  if (age < 60000) return `${Math.max(1, Math.round(age / 1000))}s`;
-  if (age < 3600000) return `${Math.round(age / 60000)}m`;
-  if (age < 86400000) return `${Math.round(age / 3600000)}h`;
-  return `${Math.round(age / 86400000)}d`;
+function getOverviewFreshnessUtils() {
+  const utils = window.OverviewFreshnessUtils;
+  return utils && typeof utils === 'object' ? utils : null;
 }
 
 function setFreshnessBadge(el, sourceMs, thresholds) {
   if (!el) return;
-  const ts = Number(sourceMs) || 0;
-  if (ts <= 0) {
+  const utils = getOverviewFreshnessUtils();
+  const result = utils
+    ? utils.classifyFreshnessState(sourceMs, thresholds, Date.now())
+    : (() => {
+        const ts = Number(sourceMs) || 0;
+        if (ts <= 0) return { state: 'no-data', ageMs: null, sourceMs: 0 };
+        const ageMs = Math.max(0, Date.now() - ts);
+        if (ageMs > thresholds.staleMs) return { state: 'stale', ageMs, sourceMs: ts };
+        if (ageMs > thresholds.freshMs) return { state: 'aging', ageMs, sourceMs: ts };
+        return { state: 'fresh', ageMs, sourceMs: ts };
+      })();
+  const state = result.state;
+  const ts = result.sourceMs || 0;
+  const ageMs = result.ageMs;
+
+  if (state === 'no-data') {
     el.textContent = 'No data';
     el.style.background = 'rgba(113,113,122,0.16)';
     el.style.color = 'var(--text-muted)';
@@ -8055,24 +8151,30 @@ function setFreshnessBadge(el, sourceMs, thresholds) {
     return { state: 'no-data', ageMs: null, sourceMs: 0 };
   }
 
-  const ageMs = Math.max(0, Date.now() - ts);
+  const ageLabel = utils
+    ? utils.formatFreshnessAge(ageMs)
+    : (() => {
+        const age = Math.max(0, Number(ageMs) || 0);
+        if (age < 60000) return `${Math.max(1, Math.round(age / 1000))}s`;
+        if (age < 3600000) return `${Math.round(age / 60000)}m`;
+        if (age < 86400000) return `${Math.round(age / 3600000)}h`;
+        return `${Math.round(age / 86400000)}d`;
+      })();
+
   let label = 'Fresh';
   let bg = 'rgba(16,185,129,0.16)';
   let color = 'var(--green)';
-  let state = 'fresh';
-  if (ageMs > thresholds.staleMs) {
+  if (state === 'stale') {
     label = 'Stale';
     bg = 'rgba(239,68,68,0.16)';
     color = 'var(--red)';
-    state = 'stale';
-  } else if (ageMs > thresholds.freshMs) {
+  } else if (state === 'aging') {
     label = 'Aging';
     bg = 'rgba(245,158,11,0.16)';
     color = 'var(--yellow)';
-    state = 'aging';
   }
 
-  el.textContent = `${label} · ${formatAgeCompact(ageMs)} old`;
+  el.textContent = `${label} · ${ageLabel} old`;
   el.style.background = bg;
   el.style.color = color;
   el.title = `Source timestamp: ${new Date(ts).toLocaleString()}`;
@@ -8082,34 +8184,57 @@ function setFreshnessBadge(el, sourceMs, thresholds) {
 function updateOverviewFreshnessSummary(states) {
   const el = document.getElementById('overviewFreshnessSummary');
   if (!el) return;
+  const banner = document.getElementById('overviewStaleBanner');
+  const prevState = overviewFreshnessLastSummaryState;
 
-  const valid = Array.isArray(states) ? states : [];
-  const stale = valid.filter((s) => s?.state === 'stale').length;
-  const aging = valid.filter((s) => s?.state === 'aging').length;
-  const noData = valid.filter((s) => s?.state === 'no-data').length;
+  const utils = getOverviewFreshnessUtils();
+  const summary = utils
+    ? utils.summarizeFreshnessStates(Array.isArray(states) ? states : [])
+    : (() => {
+        const rows = Array.isArray(states) ? states : [];
+        const stale = rows.filter((s) => s?.state === 'stale').length;
+        const aging = rows.filter((s) => s?.state === 'aging').length;
+        const unavailable = rows.filter((s) => s?.state === 'no-data').length;
+        if (stale > 0) return { state: 'stale', stale, aging, unavailable };
+        if (aging > 0) return { state: 'aging', stale, aging, unavailable };
+        if (unavailable > 0) return { state: 'unavailable', stale, aging, unavailable };
+        return { state: 'fresh', stale, aging, unavailable };
+      })();
 
-  if (stale > 0) {
-    el.textContent = `Data freshness: ${stale} stale`;
+  if (summary.state === 'stale') {
+    el.textContent = `Data freshness: ${summary.stale} stale`;
     el.style.background = 'rgba(239,68,68,0.16)';
     el.style.color = 'var(--red)';
-    return;
-  }
-  if (aging > 0) {
-    el.textContent = `Data freshness: ${aging} aging`;
+  } else if (summary.state === 'aging') {
+    el.textContent = `Data freshness: ${summary.aging} aging`;
     el.style.background = 'rgba(245,158,11,0.16)';
     el.style.color = 'var(--yellow)';
-    return;
-  }
-  if (noData > 0) {
-    el.textContent = `Data freshness: ${noData} unavailable`;
+  } else if (summary.state === 'unavailable') {
+    el.textContent = `Data freshness: ${summary.unavailable} unavailable`;
     el.style.background = 'rgba(113,113,122,0.16)';
     el.style.color = 'var(--text-muted)';
-    return;
+  } else {
+    el.textContent = 'Data freshness: all fresh';
+    el.style.background = 'rgba(16,185,129,0.16)';
+    el.style.color = 'var(--green)';
   }
 
-  el.textContent = 'Data freshness: all fresh';
-  el.style.background = 'rgba(16,185,129,0.16)';
-  el.style.color = 'var(--green)';
+  if (banner) {
+    if (summary.state === 'stale') {
+      banner.style.display = 'block';
+      banner.textContent = `Freshness alert: ${summary.stale} source${summary.stale === 1 ? '' : 's'} stale. Verify bridge/runtime feeds before trusting overview decisions.`;
+    } else {
+      banner.style.display = 'none';
+    }
+  }
+
+  if (summary.state === 'stale' && prevState !== 'stale' && typeof showToast === 'function') {
+    showToast('Overview freshness is stale. Verify live sources.', 'warning', 6000);
+  } else if (prevState === 'stale' && summary.state !== 'stale' && typeof showToast === 'function') {
+    showToast('Overview freshness recovered from stale state.', 'success', 4500);
+  }
+
+  emitOverviewFreshnessEvent(summary, states);
 }
 
 function escapeHtml(s) {

--- a/dashboard/docs/API.md
+++ b/dashboard/docs/API.md
@@ -571,6 +571,58 @@ Returns CPU/RAM snapshots (sampled every 5 minutes, up to 288 entries = 24 hours
 
 Returns dashboard configuration and capability inventory.
 
+Also includes Overview freshness thresholds consumed by the Overview cards:
+
+```json
+{
+  "overviewFreshnessThresholdsMs": {
+    "kpi": { "freshMs": 129600000, "staleMs": 345600000 },
+    "agentHealth": { "freshMs": 900000, "staleMs": 7200000 },
+    "observations": { "freshMs": 21600000, "staleMs": 86400000 }
+  }
+}
+```
+
+Environment overrides:
+- `DASHBOARD_OVERVIEW_FRESHNESS_KPI_FRESH_MS`
+- `DASHBOARD_OVERVIEW_FRESHNESS_KPI_STALE_MS`
+- `DASHBOARD_OVERVIEW_FRESHNESS_AGENT_HEALTH_FRESH_MS`
+- `DASHBOARD_OVERVIEW_FRESHNESS_AGENT_HEALTH_STALE_MS`
+- `DASHBOARD_OVERVIEW_FRESHNESS_OBSERVATIONS_FRESH_MS`
+- `DASHBOARD_OVERVIEW_FRESHNESS_OBSERVATIONS_STALE_MS`
+
+### `POST /api/overview-freshness-event`
+
+Ingests stale/aging/freshness state transitions from the Overview UI and appends them to
+`data/overview-freshness-events.jsonl` for local auditing.
+
+**Request:**
+```json
+{
+  "state": "stale",
+  "stale": 1,
+  "aging": 0,
+  "unavailable": 0,
+  "total": 3,
+  "source": "overview-widget",
+  "emittedAt": 1700000000000
+}
+```
+
+**Response (200):**
+```json
+{
+  "ok": true,
+  "state": "stale",
+  "recordedAt": 1700000000300
+}
+```
+
+**Error (400):**
+```json
+{ "ok": false, "error": "Invalid freshness event payload" }
+```
+
 ### `GET /api/live`
 
 **Server-Sent Events (SSE)** stream of real-time session activity.

--- a/dashboard/server/overview-freshness.ts
+++ b/dashboard/server/overview-freshness.ts
@@ -1,0 +1,168 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+export interface OverviewFreshnessThreshold {
+  freshMs: number;
+  staleMs: number;
+}
+
+export interface OverviewFreshnessThresholds {
+  kpi: OverviewFreshnessThreshold;
+  agentHealth: OverviewFreshnessThreshold;
+  observations: OverviewFreshnessThreshold;
+}
+
+export type OverviewFreshnessState = 'fresh' | 'aging' | 'stale' | 'unavailable' | 'unknown';
+
+export interface OverviewFreshnessEvent {
+  state: OverviewFreshnessState;
+  stale: number;
+  aging: number;
+  unavailable: number;
+  total: number;
+  source: string;
+  emittedAt: number;
+  receivedAt: number;
+}
+
+const MIN_THRESHOLD_MS = 1_000;
+const MAX_THRESHOLD_MS = 30 * 24 * 60 * 60 * 1000;
+const MAX_EVENT_COUNT = 100;
+const MAX_SOURCE_LENGTH = 64;
+const EVENT_FILE_NAME = 'overview-freshness-events.jsonl';
+
+const DEFAULT_THRESHOLDS: OverviewFreshnessThresholds = {
+  kpi: { freshMs: 36 * 60 * 60 * 1000, staleMs: 96 * 60 * 60 * 1000 },
+  agentHealth: { freshMs: 15 * 60 * 1000, staleMs: 2 * 60 * 60 * 1000 },
+  observations: { freshMs: 6 * 60 * 60 * 1000, staleMs: 24 * 60 * 60 * 1000 },
+};
+
+function clampMs(raw: string | undefined, fallback: number): number {
+  const parsed = Number.parseInt(String(raw ?? ''), 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  if (parsed < MIN_THRESHOLD_MS) return MIN_THRESHOLD_MS;
+  if (parsed > MAX_THRESHOLD_MS) return MAX_THRESHOLD_MS;
+  return parsed;
+}
+
+function normalizeWindow(
+  freshRaw: string | undefined,
+  staleRaw: string | undefined,
+  defaults: OverviewFreshnessThreshold,
+): OverviewFreshnessThreshold {
+  const freshMs = clampMs(freshRaw, defaults.freshMs);
+  const staleCandidate = clampMs(staleRaw, defaults.staleMs);
+  const staleMs = staleCandidate <= freshMs ? freshMs + 1 : staleCandidate;
+  return { freshMs, staleMs };
+}
+
+function clampCount(raw: unknown, fallback = 0): number {
+  const parsed = Number.parseInt(String(raw ?? ''), 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  if (parsed < 0) return 0;
+  if (parsed > MAX_EVENT_COUNT) return MAX_EVENT_COUNT;
+  return parsed;
+}
+
+function clampTimestamp(raw: unknown, fallback: number): number {
+  const parsed = Number.parseInt(String(raw ?? ''), 10);
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+function sanitizeSource(raw: unknown): string {
+  const asString = typeof raw === 'string' ? raw : '';
+  const trimmed = asString.trim();
+  if (!trimmed) return 'overview-widget';
+  const safe = trimmed
+    .replace(/[^a-zA-Z0-9_.:-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, MAX_SOURCE_LENGTH);
+  return safe || 'overview-widget';
+}
+
+function normalizeState(raw: unknown): OverviewFreshnessState | null {
+  const value = typeof raw === 'string' ? raw.trim().toLowerCase() : '';
+  if (!value) return null;
+  if (
+    value === 'fresh' ||
+    value === 'aging' ||
+    value === 'stale' ||
+    value === 'unavailable' ||
+    value === 'unknown'
+  ) {
+    return value;
+  }
+  return null;
+}
+
+export function getOverviewFreshnessEventFilePath(dataDir: string): string {
+  return path.join(dataDir, EVENT_FILE_NAME);
+}
+
+export function getOverviewFreshnessDefaultThresholds(): OverviewFreshnessThresholds {
+  return {
+    kpi: { ...DEFAULT_THRESHOLDS.kpi },
+    agentHealth: { ...DEFAULT_THRESHOLDS.agentHealth },
+    observations: { ...DEFAULT_THRESHOLDS.observations },
+  };
+}
+
+export function resolveOverviewFreshnessThresholds(
+  env: NodeJS.ProcessEnv = process.env,
+): OverviewFreshnessThresholds {
+  return {
+    kpi: normalizeWindow(
+      env.DASHBOARD_OVERVIEW_FRESHNESS_KPI_FRESH_MS,
+      env.DASHBOARD_OVERVIEW_FRESHNESS_KPI_STALE_MS,
+      DEFAULT_THRESHOLDS.kpi,
+    ),
+    agentHealth: normalizeWindow(
+      env.DASHBOARD_OVERVIEW_FRESHNESS_AGENT_HEALTH_FRESH_MS,
+      env.DASHBOARD_OVERVIEW_FRESHNESS_AGENT_HEALTH_STALE_MS,
+      DEFAULT_THRESHOLDS.agentHealth,
+    ),
+    observations: normalizeWindow(
+      env.DASHBOARD_OVERVIEW_FRESHNESS_OBSERVATIONS_FRESH_MS,
+      env.DASHBOARD_OVERVIEW_FRESHNESS_OBSERVATIONS_STALE_MS,
+      DEFAULT_THRESHOLDS.observations,
+    ),
+  };
+}
+
+export function parseOverviewFreshnessEvent(
+  payload: unknown,
+  nowMs: number = Date.now(),
+): OverviewFreshnessEvent | null {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return null;
+  const row = payload as Record<string, unknown>;
+  const state = normalizeState(row.state);
+  if (!state) return null;
+
+  const total = clampCount(row.total, 0);
+  const stale = Math.min(total || MAX_EVENT_COUNT, clampCount(row.stale, 0));
+  const aging = Math.min(total || MAX_EVENT_COUNT, clampCount(row.aging, 0));
+  const unavailable = Math.min(total || MAX_EVENT_COUNT, clampCount(row.unavailable, 0));
+
+  return {
+    state,
+    stale,
+    aging,
+    unavailable,
+    total,
+    source: sanitizeSource(row.source),
+    emittedAt: clampTimestamp(row.emittedAt, nowMs),
+    receivedAt: nowMs,
+  };
+}
+
+export function appendOverviewFreshnessEvent(
+  dataDir: string,
+  event: OverviewFreshnessEvent,
+): string {
+  const filePath = getOverviewFreshnessEventFilePath(dataDir);
+  fs.mkdirSync(dataDir, { recursive: true });
+  fs.appendFileSync(filePath, JSON.stringify(event) + '\n', 'utf8');
+  return filePath;
+}

--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -139,6 +139,11 @@ import {
   handleOpenclawLocalReadiness,
   resolveOpenclawLocalReadinessReportDir,
 } from './routes/openclaw-local-readiness.js';
+import {
+  appendOverviewFreshnessEvent,
+  parseOverviewFreshnessEvent,
+  resolveOverviewFreshnessThresholds,
+} from './overview-freshness.js';
 import { getSchedulerJobs } from './scheduler-jobs.js';
 import {
   buildAvgResponseTime,
@@ -187,6 +192,7 @@ const OPENCLAW_LOCAL_READINESS_REPORT_DIR: string = resolveOpenclawLocalReadines
   VENTUREOS_ROOT,
   process.env,
 );
+const OVERVIEW_FRESHNESS_THRESHOLDS_MS = resolveOverviewFreshnessThresholds(process.env);
 
 // Client HTML paths — served from client/ directory
 const htmlPath: string = path.join(import.meta.dirname, '..', 'client', 'index.html');
@@ -2414,6 +2420,7 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
     sendJson(res, {
       name: 'OpenClaw Dashboard',
       version: '1.0.0',
+      overviewFreshnessThresholdsMs: OVERVIEW_FRESHNESS_THRESHOLDS_MS,
       ventureos: {
         VENTUREOS_ROOT,
         SHARED_CONTEXT,
@@ -2432,6 +2439,42 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
         { id: 'workflow-patterns', name: 'Workflow Patterns', status: 'active' },
       ],
     });
+    return;
+  }
+  if (req.url === '/api/overview-freshness-event' && req.method === 'POST') {
+    try {
+      const raw = await readRequestBody(req, { maxBytes: 32 * 1024 });
+      const payload: unknown = JSON.parse(raw || '{}');
+      const event = parseOverviewFreshnessEvent(payload);
+      if (!event) {
+        sendJson(res, { ok: false, error: 'Invalid freshness event payload' }, 400);
+        return;
+      }
+
+      appendOverviewFreshnessEvent(dataDir, event);
+      if (event.state === 'stale') {
+        logWarn('dashboard', 'overview_freshness_stale', 'Overview freshness stale state reported', {
+          stale: event.stale,
+          aging: event.aging,
+          unavailable: event.unavailable,
+          total: event.total,
+          source: event.source,
+        });
+      } else {
+        logInfo('dashboard', 'overview_freshness_update', 'Overview freshness non-stale update reported', {
+          state: event.state,
+          stale: event.stale,
+          aging: event.aging,
+          unavailable: event.unavailable,
+          total: event.total,
+          source: event.source,
+        });
+      }
+
+      sendJson(res, { ok: true, state: event.state, recordedAt: event.receivedAt });
+    } catch {
+      sendJson(res, { ok: false, error: 'Invalid freshness event payload' }, 400);
+    }
     return;
   }
   if (req.url === '/api/claude-usage-scrape' && req.method === 'POST') {

--- a/dashboard/tests/integration/http-smoke.test.ts
+++ b/dashboard/tests/integration/http-smoke.test.ts
@@ -161,6 +161,12 @@ beforeAll(async () => {
   process.env.VENTUREOS_AGENTS = 'main,oracle';
   process.env.VENTUREOS_OFFICE_VIEW_ENABLED = '1';
   process.env.OBSIDIAN_CONFIG_PATH = path.join(tmpRoot, 'obsidian.json');
+  process.env.DASHBOARD_OVERVIEW_FRESHNESS_KPI_FRESH_MS = '60000';
+  process.env.DASHBOARD_OVERVIEW_FRESHNESS_KPI_STALE_MS = '180000';
+  process.env.DASHBOARD_OVERVIEW_FRESHNESS_AGENT_HEALTH_FRESH_MS = '45000';
+  process.env.DASHBOARD_OVERVIEW_FRESHNESS_AGENT_HEALTH_STALE_MS = '300000';
+  process.env.DASHBOARD_OVERVIEW_FRESHNESS_OBSERVATIONS_FRESH_MS = '900000';
+  process.env.DASHBOARD_OVERVIEW_FRESHNESS_OBSERVATIONS_STALE_MS = '3600000';
 
   fs.writeFileSync(process.env.OBSIDIAN_CONFIG_PATH, JSON.stringify({
     vaults: {
@@ -472,6 +478,51 @@ describe('Dashboard HTTP smoke tests', () => {
     expect(replayHealthRes.status).toBe(200);
     const replayHealth = await replayHealthRes.json();
     expect(replayHealth.health?.counts?.arbitrationAccepted).toBeGreaterThanOrEqual(1);
+  });
+
+  it('returns overview freshness threshold config to the client', async () => {
+    const res = await fetch(`${BASE_URL}/api/config`, { headers: authHeaders() });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.overviewFreshnessThresholdsMs?.kpi).toEqual({ freshMs: 60000, staleMs: 180000 });
+    expect(body.overviewFreshnessThresholdsMs?.agentHealth).toEqual({ freshMs: 45000, staleMs: 300000 });
+    expect(body.overviewFreshnessThresholdsMs?.observations).toEqual({ freshMs: 900000, staleMs: 3600000 });
+  });
+
+  it('accepts freshness events and persists them in workspace data', async () => {
+    const eventRes = await fetch(`${BASE_URL}/api/overview-freshness-event`, {
+      method: 'POST',
+      headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        state: 'stale',
+        stale: 1,
+        aging: 0,
+        unavailable: 0,
+        total: 3,
+        source: 'overview-widget',
+        emittedAt: Date.now() - 5000,
+      }),
+    });
+    expect(eventRes.status).toBe(200);
+    const eventBody = await eventRes.json();
+    expect(eventBody.ok).toBe(true);
+    expect(eventBody.state).toBe('stale');
+
+    const eventFile = path.join(tmpRoot, 'workspace', 'data', 'overview-freshness-events.jsonl');
+    expect(fs.existsSync(eventFile)).toBe(true);
+    const lines = fs.readFileSync(eventFile, 'utf8').trim().split('\n');
+    expect(lines.length).toBeGreaterThanOrEqual(1);
+    const latest = JSON.parse(lines[lines.length - 1]) as { state: string; stale: number; source: string };
+    expect(latest.state).toBe('stale');
+    expect(latest.stale).toBe(1);
+    expect(latest.source).toBe('overview-widget');
+
+    const badRes = await fetch(`${BASE_URL}/api/overview-freshness-event`, {
+      method: 'POST',
+      headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({ state: 'bogus' }),
+    });
+    expect(badRes.status).toBe(400);
   });
 
   it('reports system metrics and redirects unauthenticated dashboard access', async () => {

--- a/dashboard/tests/unit/client/overview-freshness.test.ts
+++ b/dashboard/tests/unit/client/overview-freshness.test.ts
@@ -1,0 +1,126 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import vm from 'node:vm';
+import { describe, expect, it } from 'vitest';
+
+type FreshnessState = 'fresh' | 'aging' | 'stale' | 'no-data';
+
+type FreshnessResult = {
+  state: FreshnessState;
+  ageMs: number | null;
+  sourceMs: number;
+};
+
+type FreshnessSummary = {
+  state: 'fresh' | 'aging' | 'stale' | 'unavailable';
+  stale: number;
+  aging: number;
+  unavailable: number;
+};
+
+type FreshnessUtils = {
+  normalizeThresholds: (
+    thresholds: { freshMs: number; staleMs: number },
+  ) => { freshMs: number; staleMs: number };
+  formatFreshnessAge: (ageMs: number | null) => string;
+  classifyFreshnessState: (
+    sourceMs: number,
+    thresholds: { freshMs: number; staleMs: number },
+    nowMs?: number,
+  ) => FreshnessResult;
+  summarizeFreshnessStates: (states: FreshnessResult[]) => FreshnessSummary;
+};
+
+function loadUtils(): FreshnessUtils {
+  const filePath = path.resolve(import.meta.dirname, '../../../client/assets/overview-freshness.js');
+  const code = fs.readFileSync(filePath, 'utf8');
+  const context: Record<string, unknown> = {};
+  context.globalThis = context;
+  vm.runInNewContext(code, context);
+  return context.OverviewFreshnessUtils as FreshnessUtils;
+}
+
+describe('overview-freshness utils', () => {
+  const utils = loadUtils();
+  const thresholds = { freshMs: 100, staleMs: 500 };
+
+  it('returns no-data when source timestamp is missing', () => {
+    const result = utils.classifyFreshnessState(0, thresholds, 1000);
+    expect(result.state).toBe('no-data');
+    expect(result.ageMs).toBeNull();
+  });
+
+  it('normalizes threshold windows with stale strictly above fresh', () => {
+    const normalized = utils.normalizeThresholds({ freshMs: 1000, staleMs: 900 });
+    expect(normalized.freshMs).toBe(1000);
+    expect(normalized.staleMs).toBe(1001);
+  });
+
+  it('formats ages into compact labels', () => {
+    expect(utils.formatFreshnessAge(500)).toBe('1s');
+    expect(utils.formatFreshnessAge(90000)).toBe('2m');
+    expect(utils.formatFreshnessAge(3 * 60 * 60 * 1000)).toBe('3h');
+    expect(utils.formatFreshnessAge(2 * 24 * 60 * 60 * 1000)).toBe('2d');
+  });
+
+  it('returns fresh inside fresh threshold', () => {
+    const result = utils.classifyFreshnessState(980, thresholds, 1000);
+    expect(result.state).toBe('fresh');
+    expect(result.ageMs).toBe(20);
+  });
+
+  it('returns aging between fresh and stale thresholds', () => {
+    const result = utils.classifyFreshnessState(850, thresholds, 1000);
+    expect(result.state).toBe('aging');
+    expect(result.ageMs).toBe(150);
+  });
+
+  it('returns stale above stale threshold', () => {
+    const result = utils.classifyFreshnessState(100, thresholds, 1000);
+    expect(result.state).toBe('stale');
+    expect(result.ageMs).toBe(900);
+  });
+
+  it('clamps future timestamps to zero-age fresh', () => {
+    const result = utils.classifyFreshnessState(1200, thresholds, 1000);
+    expect(result.state).toBe('fresh');
+    expect(result.ageMs).toBe(0);
+  });
+
+  it('summarizes with stale priority', () => {
+    const summary = utils.summarizeFreshnessStates([
+      { state: 'fresh', ageMs: 1, sourceMs: 99 },
+      { state: 'aging', ageMs: 120, sourceMs: 10 },
+      { state: 'stale', ageMs: 900, sourceMs: 1 },
+    ]);
+    expect(summary.state).toBe('stale');
+    expect(summary.stale).toBe(1);
+    expect(summary.aging).toBe(1);
+    expect(summary.unavailable).toBe(0);
+  });
+
+  it('summarizes with aging priority over unavailable', () => {
+    const summary = utils.summarizeFreshnessStates([
+      { state: 'fresh', ageMs: 1, sourceMs: 99 },
+      { state: 'aging', ageMs: 120, sourceMs: 10 },
+      { state: 'no-data', ageMs: null, sourceMs: 0 },
+    ]);
+    expect(summary.state).toBe('aging');
+  });
+
+  it('summarizes unavailable when only no-data and fresh exist', () => {
+    const summary = utils.summarizeFreshnessStates([
+      { state: 'fresh', ageMs: 1, sourceMs: 99 },
+      { state: 'no-data', ageMs: null, sourceMs: 0 },
+    ]);
+    expect(summary.state).toBe('unavailable');
+  });
+
+  it('summarizes fresh when all inputs are fresh', () => {
+    const summary = utils.summarizeFreshnessStates([
+      { state: 'fresh', ageMs: 10, sourceMs: 990 },
+      { state: 'fresh', ageMs: 20, sourceMs: 980 },
+    ]);
+    expect(summary.state).toBe('fresh');
+  });
+});

--- a/dashboard/tests/unit/overview-freshness.test.ts
+++ b/dashboard/tests/unit/overview-freshness.test.ts
@@ -1,0 +1,100 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { describe, expect, it } from 'vitest';
+
+import {
+  appendOverviewFreshnessEvent,
+  getOverviewFreshnessDefaultThresholds,
+  getOverviewFreshnessEventFilePath,
+  parseOverviewFreshnessEvent,
+  resolveOverviewFreshnessThresholds,
+} from '../../server/overview-freshness.js';
+
+describe('overview freshness server helpers', () => {
+  it('returns immutable default thresholds', () => {
+    const defaults = getOverviewFreshnessDefaultThresholds();
+    expect(defaults.kpi.freshMs).toBe(36 * 60 * 60 * 1000);
+    defaults.kpi.freshMs = 1;
+    const again = getOverviewFreshnessDefaultThresholds();
+    expect(again.kpi.freshMs).toBe(36 * 60 * 60 * 1000);
+  });
+
+  it('resolves threshold overrides from environment', () => {
+    const thresholds = resolveOverviewFreshnessThresholds({
+      DASHBOARD_OVERVIEW_FRESHNESS_KPI_FRESH_MS: '60000',
+      DASHBOARD_OVERVIEW_FRESHNESS_KPI_STALE_MS: '120000',
+      DASHBOARD_OVERVIEW_FRESHNESS_AGENT_HEALTH_FRESH_MS: '45000',
+      DASHBOARD_OVERVIEW_FRESHNESS_AGENT_HEALTH_STALE_MS: '300000',
+      DASHBOARD_OVERVIEW_FRESHNESS_OBSERVATIONS_FRESH_MS: '3600000',
+      DASHBOARD_OVERVIEW_FRESHNESS_OBSERVATIONS_STALE_MS: '7200000',
+    });
+
+    expect(thresholds.kpi).toEqual({ freshMs: 60000, staleMs: 120000 });
+    expect(thresholds.agentHealth).toEqual({ freshMs: 45000, staleMs: 300000 });
+    expect(thresholds.observations).toEqual({ freshMs: 3600000, staleMs: 7200000 });
+  });
+
+  it('normalizes stale thresholds when stale <= fresh', () => {
+    const thresholds = resolveOverviewFreshnessThresholds({
+      DASHBOARD_OVERVIEW_FRESHNESS_KPI_FRESH_MS: '5000',
+      DASHBOARD_OVERVIEW_FRESHNESS_KPI_STALE_MS: '5000',
+    });
+
+    expect(thresholds.kpi.freshMs).toBe(5000);
+    expect(thresholds.kpi.staleMs).toBe(5001);
+  });
+
+  it('parses and sanitizes event payload', () => {
+    const event = parseOverviewFreshnessEvent({
+      state: 'stale',
+      stale: 2,
+      aging: 1,
+      unavailable: 0,
+      total: 3,
+      source: 'overview widget (/tmp/path)',
+      emittedAt: 1700000000000,
+    }, 1700000000100);
+
+    expect(event).not.toBeNull();
+    expect(event?.state).toBe('stale');
+    expect(event?.source).toBe('overview-widget-tmp-path');
+    expect(event?.receivedAt).toBe(1700000000100);
+    expect(event?.emittedAt).toBe(1700000000000);
+  });
+
+  it('rejects invalid event payloads', () => {
+    expect(parseOverviewFreshnessEvent(null)).toBeNull();
+    expect(parseOverviewFreshnessEvent({})).toBeNull();
+    expect(parseOverviewFreshnessEvent({ state: 'invalid' })).toBeNull();
+  });
+
+  it('appends events to the jsonl store', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'overview-freshness-'));
+    const now = Date.now();
+    const event = parseOverviewFreshnessEvent({
+      state: 'stale',
+      stale: 1,
+      aging: 0,
+      unavailable: 0,
+      total: 1,
+      source: 'overview-widget',
+      emittedAt: now - 5,
+    }, now);
+
+    expect(event).not.toBeNull();
+    appendOverviewFreshnessEvent(tmpDir, event!);
+
+    const filePath = getOverviewFreshnessEventFilePath(tmpDir);
+    expect(fs.existsSync(filePath)).toBe(true);
+    const lines = fs.readFileSync(filePath, 'utf8').trim().split('\n');
+    expect(lines.length).toBe(1);
+
+    const parsed = JSON.parse(lines[0]) as { state: string; stale: number };
+    expect(parsed.state).toBe('stale');
+    expect(parsed.stale).toBe(1);
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## Summary
- add reusable `overview-freshness` client utility module and unit tests for classification/summary regression coverage
- add active stale-data alerting UX (overview stale banner + transition toasts) and keep freshness summary deterministic
- add server-side freshness module to expose env-configurable thresholds in `/api/config` and ingest stale transition events via `POST /api/overview-freshness-event`
- persist freshness events in `data/overview-freshness-events.jsonl` and log stale/non-stale transitions for operator visibility
- document new config vars + API contract in dashboard docs and README

## Validation
- `npm run test --workspace=dashboard -- tests/unit/overview-freshness.test.ts tests/unit/client/overview-freshness.test.ts`
- `npm run test --workspace=dashboard -- tests/integration/http-smoke.test.ts`
- `npm run build --workspace=dashboard`

## Notes
- left existing unrelated local workspace artifacts untouched (`node_modules`, `runtime/`, `config/bridge.env`, generated readiness markdown).
