### PR TITLE
Dashboard: freshness timeline + dedupe + runbook

### DIFF
--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -90,7 +90,8 @@ dashboard/
 │   └── rollback.sh             # Emergency rollback
 ├── docs/             # Dashboard-specific documentation
 │   ├── API.md        # Complete API reference
-│   └── MIGRATION.md  # Full migration guide
+│   ├── MIGRATION.md  # Full migration guide
+│   └── OVERVIEW_FRESHNESS_RUNBOOK.md # Freshness tuning + operations guide
 ├── examples/         # Service templates
 │   ├── launchd.plist       # macOS service template
 │   └── systemd.service     # Linux service template
@@ -156,6 +157,8 @@ All paths are resolved through `lib/paths.ts`. Override with environment variabl
 | `DASHBOARD_OVERVIEW_FRESHNESS_AGENT_HEALTH_STALE_MS` | `7200000` (2h) | Agent Health badge `Stale` threshold |
 | `DASHBOARD_OVERVIEW_FRESHNESS_OBSERVATIONS_FRESH_MS` | `21600000` (6h) | Observations badge `Fresh` threshold |
 | `DASHBOARD_OVERVIEW_FRESHNESS_OBSERVATIONS_STALE_MS` | `86400000` (24h) | Observations badge `Stale` threshold |
+| `DASHBOARD_OVERVIEW_FRESHNESS_TIMELINE_LIMIT` | `8` | Number of timeline transitions returned to Overview |
+| `DASHBOARD_OVERVIEW_FRESHNESS_EVENT_DEDUPE_WINDOW_MS` | `30000` (30s) | Server-side duplicate suppression window for multi-tab event spam |
 
 ## API Reference
 
@@ -189,6 +192,7 @@ See **[docs/API.md](docs/API.md)** for the complete API reference covering all e
 | `GET /api/proposal-lifecycle/summary` | Read proposal queue + active mission progress for Mission Control |
 | `GET /api/living-files/dashboard` | Freshness counts + stale/missing file status for living docs registry |
 | `POST /api/living-files/check-run` | Run staleness detection and auto-trigger responsible owner tasks |
+| `GET /api/overview-freshness-events` | Read newest-first freshness transition timeline for Overview |
 | `POST /api/overview-freshness-event` | Persist overview stale/aging transitions for local audit trail |
 | `GET /api/live` | SSE real-time feed |
 
@@ -398,6 +402,7 @@ cd dashboard && npm run test:parity
 ## Related Documentation
 
 - **[docs/API.md](docs/API.md)** — Complete API reference
+- **[docs/OVERVIEW_FRESHNESS_RUNBOOK.md](docs/OVERVIEW_FRESHNESS_RUNBOOK.md)** — Threshold tuning profiles, dedupe behavior, and operator checks
 - **[docs/DASHBOARD.md](../docs/DASHBOARD.md)** — VentureOS integration guide
 - **[docs/ARCHITECTURE.md](../docs/ARCHITECTURE.md)** — System architecture
 - **[ADR-001](../docs/decisions/001-merge-dashboard-into-monorepo.md)** — Merge decision record

--- a/dashboard/client/index.html
+++ b/dashboard/client/index.html
@@ -4496,6 +4496,15 @@ details[open] > .tb-detail-expand-header .tb-detail-expand-icon {
         <div id="overviewStaleBanner" style="display:none;margin-top:10px;padding:10px 12px;border-radius:10px;border:1px solid rgba(239,68,68,0.45);background:rgba(239,68,68,0.12);color:var(--red);font-size:12px;font-weight:600;">
           Freshness alert: stale dashboard sources detected.
         </div>
+        <div id="overviewFreshnessTimelineCard" style="margin-top:10px;padding:10px 12px;border-radius:10px;border:1px solid var(--border);background:var(--bg-card);">
+          <div style="display:flex;align-items:center;justify-content:space-between;gap:8px;margin-bottom:8px;">
+            <div style="font-size:12px;font-weight:700;color:var(--text-secondary);">Freshness Event Timeline</div>
+            <div id="overviewFreshnessTimelineMeta" style="font-size:11px;color:var(--text-muted);">Recent transitions</div>
+          </div>
+          <div id="overviewFreshnessTimeline" style="display:flex;flex-direction:column;gap:6px;">
+            <div class="empty-state-text">Loading freshness timeline…</div>
+          </div>
+        </div>
       </div>
 
       <div class="grid mb-24" style="grid-template-columns: repeat(3, 1fr);">
@@ -6531,6 +6540,10 @@ let overviewFreshnessConfigLoading = false;
 let overviewFreshnessLastSummaryState = null;
 const OVERVIEW_FRESHNESS_EVENT_COOLDOWN_MS = 60 * 1000;
 let overviewFreshnessLastEventAt = 0;
+let overviewFreshnessTimelineLimit = 8;
+let overviewFreshnessEventDedupeWindowMs = 30 * 1000;
+let overviewFreshnessEvents = [];
+let overviewFreshnessEventsError = null;
 
 let selectedAgentId = 'oracle';
 
@@ -6573,6 +6586,14 @@ function normalizeThresholdMs(raw, fallback) {
   return Math.round(n);
 }
 
+function normalizeIntInRange(raw, fallback, min, max) {
+  const n = Number(raw);
+  if (!Number.isFinite(n)) return fallback;
+  if (n < min) return min;
+  if (n > max) return max;
+  return Math.round(n);
+}
+
 function applyOverviewFreshnessThresholdConfig(config) {
   const cfg = config && typeof config === 'object'
     ? config.overviewFreshnessThresholdsMs
@@ -6598,6 +6619,22 @@ function applyOverviewFreshnessThresholdConfig(config) {
   if (next.agentHealth.staleMs <= next.agentHealth.freshMs) next.agentHealth.staleMs = next.agentHealth.freshMs + 1;
   if (next.observations.staleMs <= next.observations.freshMs) next.observations.staleMs = next.observations.freshMs + 1;
   overviewFreshnessThresholds = next;
+
+  overviewFreshnessTimelineLimit = normalizeIntInRange(
+    config?.overviewFreshnessTimelineLimit,
+    overviewFreshnessTimelineLimit,
+    1,
+    40,
+  );
+  overviewFreshnessEventDedupeWindowMs = normalizeIntInRange(
+    config?.overviewFreshnessEventDedupeWindowMs,
+    overviewFreshnessEventDedupeWindowMs,
+    0,
+    10 * 60 * 1000,
+  );
+  if (Array.isArray(overviewFreshnessEvents) && overviewFreshnessEvents.length > overviewFreshnessTimelineLimit) {
+    overviewFreshnessEvents = overviewFreshnessEvents.slice(0, overviewFreshnessTimelineLimit);
+  }
 }
 
 async function loadOverviewFreshnessConfigOnce() {
@@ -6639,7 +6676,38 @@ function emitOverviewFreshnessEvent(summary, states) {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(payload),
+  }).then(async (res) => {
+    if (!res || !res.ok) return;
+    try {
+      const body = await res.json();
+      if (body && body.accepted === false) return;
+      await refreshOverviewFreshnessTimeline();
+    } catch {
+      // no-op
+    }
   }).catch(() => {});
+}
+
+async function refreshOverviewFreshnessTimeline() {
+  try {
+    const payload = await fetchJson(`/api/overview-freshness-events?limit=${encodeURIComponent(overviewFreshnessTimelineLimit)}`);
+    if (payload && Array.isArray(payload.events)) {
+      overviewFreshnessEvents = payload.events;
+      overviewFreshnessEventsError = null;
+      if (typeof payload.dedupeWindowMs === 'number' && Number.isFinite(payload.dedupeWindowMs)) {
+        overviewFreshnessEventDedupeWindowMs = Math.max(0, Math.round(payload.dedupeWindowMs));
+      }
+      updateOverviewFreshnessTimeline(overviewFreshnessEvents, null);
+      return;
+    }
+    overviewFreshnessEvents = [];
+    overviewFreshnessEventsError = 'freshness timeline unavailable';
+    updateOverviewFreshnessTimeline(overviewFreshnessEvents, overviewFreshnessEventsError);
+  } catch {
+    overviewFreshnessEvents = [];
+    overviewFreshnessEventsError = 'freshness timeline unavailable';
+    updateOverviewFreshnessTimeline(overviewFreshnessEvents, overviewFreshnessEventsError);
+  }
 }
 
 // Observations
@@ -6765,7 +6833,8 @@ async function fetchData() {
       fetchJson('/api/kpis/latest'),
       fetchJson('/api/kpis/history?days=7'),
       fetchJson('/api/agent-health'),
-      fetchJson('/api/observations/recent?hours=24')
+      fetchJson('/api/observations/recent?hours=24'),
+      fetchJson(`/api/overview-freshness-events?limit=${encodeURIComponent(overviewFreshnessTimelineLimit)}`),
     ]).then(res => {
       const r0 = res[0];
       if (r0?.status === 'fulfilled' && !isApiErrorPayload(r0.value)) {
@@ -6806,6 +6875,20 @@ async function fetchData() {
           ? `Observations fetch failed: ${r3.reason.message}`
           : 'Observations fetch failed';
       }
+
+      const r4 = res[4];
+      if (r4?.status === 'fulfilled' && Array.isArray(r4.value?.events)) {
+        overviewFreshnessEvents = r4.value.events;
+        overviewFreshnessEventsError = null;
+        if (typeof r4.value?.dedupeWindowMs === 'number' && Number.isFinite(r4.value.dedupeWindowMs)) {
+          overviewFreshnessEventDedupeWindowMs = Math.max(0, Math.round(r4.value.dedupeWindowMs));
+        }
+      } else {
+        overviewFreshnessEvents = [];
+        overviewFreshnessEventsError = (r4?.status === 'rejected' && r4.reason?.message)
+          ? `Freshness timeline fetch failed: ${r4.reason.message}`
+          : 'Freshness timeline fetch failed';
+      }
       try { updateDashboard(); } catch {}
     }).catch(() => {});
 
@@ -6831,6 +6914,8 @@ async function fetchData() {
     costs = {};
     usage = {};
     systemStats = {};
+    overviewFreshnessEvents = [];
+    overviewFreshnessEventsError = err?.message || 'freshness timeline unavailable';
     setCoreDataHealth('sessions', false, err?.message || 'sessions unavailable');
     setCoreDataHealth('costs', false, err?.message || 'costs unavailable');
     setCoreDataHealth('usage', false, err?.message || 'usage unavailable');
@@ -7248,6 +7333,7 @@ function updateVentureWidgets() {
   }
 
   updateOverviewFreshnessSummary(freshnessStates);
+  updateOverviewFreshnessTimeline(overviewFreshnessEvents, overviewFreshnessEventsError);
 }
 
 let sessionFilter = 'all';
@@ -8235,6 +8321,64 @@ function updateOverviewFreshnessSummary(states) {
   }
 
   emitOverviewFreshnessEvent(summary, states);
+}
+
+function freshnessStateVisuals(state) {
+  if (state === 'stale') {
+    return { label: 'STALE', bg: 'rgba(239,68,68,0.16)', color: 'var(--red)' };
+  }
+  if (state === 'aging') {
+    return { label: 'AGING', bg: 'rgba(245,158,11,0.16)', color: 'var(--yellow)' };
+  }
+  if (state === 'unavailable' || state === 'no-data') {
+    return { label: 'UNAVAILABLE', bg: 'rgba(113,113,122,0.16)', color: 'var(--text-muted)' };
+  }
+  return { label: 'FRESH', bg: 'rgba(16,185,129,0.16)', color: 'var(--green)' };
+}
+
+function updateOverviewFreshnessTimeline(events, error) {
+  const listEl = document.getElementById('overviewFreshnessTimeline');
+  const metaEl = document.getElementById('overviewFreshnessTimelineMeta');
+  if (!listEl) return;
+
+  const rows = Array.isArray(events) ? events : [];
+  if (metaEl) {
+    const windowSecs = Math.max(0, Math.round((overviewFreshnessEventDedupeWindowMs || 0) / 1000));
+    metaEl.textContent = `Last ${overviewFreshnessTimelineLimit} events · dedupe ${windowSecs}s`;
+  }
+
+  if (error) {
+    listEl.innerHTML = `<div class="empty-state-text">${escapeHtml(error)}</div>`;
+    return;
+  }
+
+  if (!rows.length) {
+    listEl.innerHTML = '<div class="empty-state-text">No freshness transitions recorded yet.</div>';
+    return;
+  }
+
+  listEl.innerHTML = rows.map((event) => {
+    const ts = Number(event?.receivedAt) || Number(event?.emittedAt) || 0;
+    const when = ts > 0 ? timeAgo(ts) : '--';
+    const title = ts > 0 ? new Date(ts).toLocaleString() : 'Unknown event time';
+    const state = freshnessStateVisuals((event?.state || '').toString().toLowerCase());
+    const stale = Math.max(0, Number(event?.stale) || 0);
+    const aging = Math.max(0, Number(event?.aging) || 0);
+    const unavailable = Math.max(0, Number(event?.unavailable) || 0);
+    const total = Math.max(0, Number(event?.total) || 0);
+    const source = (event?.source || 'overview-widget').toString();
+
+    return `<div style="display:flex;align-items:center;justify-content:space-between;gap:10px;padding:7px 8px;border-radius:8px;background:var(--bg-secondary);border:1px solid var(--border);">
+      <div style="display:flex;align-items:center;gap:8px;min-width:0;">
+        <span style="font-size:10px;padding:2px 8px;border-radius:999px;background:${state.bg};color:${state.color};letter-spacing:0.04em;">${state.label}</span>
+        <div style="font-size:11px;color:var(--text-secondary);min-width:0;white-space:nowrap;overflow:hidden;text-overflow:ellipsis;" title="${escapeHtml(source)}">${escapeHtml(source)}</div>
+      </div>
+      <div style="display:flex;align-items:center;gap:10px;font-size:11px;color:var(--text-muted);flex-shrink:0;" title="${escapeHtml(title)}">
+        <span class="mono">${stale}S/${aging}A/${unavailable}U/${total}T</span>
+        <span>${escapeHtml(when)}</span>
+      </div>
+    </div>`;
+  }).join('');
 }
 
 function escapeHtml(s) {

--- a/dashboard/docs/API.md
+++ b/dashboard/docs/API.md
@@ -579,7 +579,9 @@ Also includes Overview freshness thresholds consumed by the Overview cards:
     "kpi": { "freshMs": 129600000, "staleMs": 345600000 },
     "agentHealth": { "freshMs": 900000, "staleMs": 7200000 },
     "observations": { "freshMs": 21600000, "staleMs": 86400000 }
-  }
+  },
+  "overviewFreshnessTimelineLimit": 8,
+  "overviewFreshnessEventDedupeWindowMs": 30000
 }
 ```
 
@@ -590,11 +592,42 @@ Environment overrides:
 - `DASHBOARD_OVERVIEW_FRESHNESS_AGENT_HEALTH_STALE_MS`
 - `DASHBOARD_OVERVIEW_FRESHNESS_OBSERVATIONS_FRESH_MS`
 - `DASHBOARD_OVERVIEW_FRESHNESS_OBSERVATIONS_STALE_MS`
+- `DASHBOARD_OVERVIEW_FRESHNESS_TIMELINE_LIMIT`
+- `DASHBOARD_OVERVIEW_FRESHNESS_EVENT_DEDUPE_WINDOW_MS`
+
+### `GET /api/overview-freshness-events?limit=8`
+
+Returns newest-first Overview freshness transition history from
+`data/overview-freshness-events.jsonl`.
+
+**Response (200):**
+```json
+{
+  "ok": true,
+  "limit": 8,
+  "dedupeWindowMs": 30000,
+  "events": [
+    {
+      "state": "fresh",
+      "stale": 0,
+      "aging": 0,
+      "unavailable": 0,
+      "total": 3,
+      "source": "overview-widget",
+      "emittedAt": 1700000002000,
+      "receivedAt": 1700000002300
+    }
+  ]
+}
+```
 
 ### `POST /api/overview-freshness-event`
 
 Ingests stale/aging/freshness state transitions from the Overview UI and appends them to
 `data/overview-freshness-events.jsonl` for local auditing.
+
+Duplicate events (same state/count/source tuple) are suppressed within
+`DASHBOARD_OVERVIEW_FRESHNESS_EVENT_DEDUPE_WINDOW_MS` to reduce multi-tab noise.
 
 **Request:**
 ```json
@@ -614,7 +647,10 @@ Ingests stale/aging/freshness state transitions from the Overview UI and appends
 {
   "ok": true,
   "state": "stale",
-  "recordedAt": 1700000000300
+  "recordedAt": 1700000000300,
+  "accepted": true,
+  "dedupeWindowMs": 30000,
+  "duplicateOfReceivedAt": null
 }
 ```
 

--- a/dashboard/docs/OVERVIEW_FRESHNESS_RUNBOOK.md
+++ b/dashboard/docs/OVERVIEW_FRESHNESS_RUNBOOK.md
@@ -1,0 +1,84 @@
+# Overview Freshness Runbook
+
+Operational guide for the Overview data-freshness lane (KPI, Agent Health, Observations), transition timeline, and event dedupe controls.
+
+## Scope
+- UI surfaces:
+  - Overview freshness summary chip
+  - stale banner
+  - freshness transition timeline
+- APIs:
+  - `GET /api/config`
+  - `GET /api/overview-freshness-events`
+  - `POST /api/overview-freshness-event`
+- Storage:
+  - `dashboard/data/overview-freshness-events.jsonl` (or workspace `data/overview-freshness-events.jsonl` in source mode)
+
+## Configuration
+Threshold controls:
+- `DASHBOARD_OVERVIEW_FRESHNESS_KPI_FRESH_MS`
+- `DASHBOARD_OVERVIEW_FRESHNESS_KPI_STALE_MS`
+- `DASHBOARD_OVERVIEW_FRESHNESS_AGENT_HEALTH_FRESH_MS`
+- `DASHBOARD_OVERVIEW_FRESHNESS_AGENT_HEALTH_STALE_MS`
+- `DASHBOARD_OVERVIEW_FRESHNESS_OBSERVATIONS_FRESH_MS`
+- `DASHBOARD_OVERVIEW_FRESHNESS_OBSERVATIONS_STALE_MS`
+
+Timeline + noise controls:
+- `DASHBOARD_OVERVIEW_FRESHNESS_TIMELINE_LIMIT` (default `8`, range `1..40`)
+- `DASHBOARD_OVERVIEW_FRESHNESS_EVENT_DEDUPE_WINDOW_MS` (default `30000`, range `0..600000`)
+
+## Recommended Profiles
+
+### Dev / active debugging
+Use aggressive stale detection for rapid feedback.
+
+```bash
+export DASHBOARD_OVERVIEW_FRESHNESS_KPI_FRESH_MS=1800000
+export DASHBOARD_OVERVIEW_FRESHNESS_KPI_STALE_MS=7200000
+export DASHBOARD_OVERVIEW_FRESHNESS_AGENT_HEALTH_FRESH_MS=120000
+export DASHBOARD_OVERVIEW_FRESHNESS_AGENT_HEALTH_STALE_MS=900000
+export DASHBOARD_OVERVIEW_FRESHNESS_OBSERVATIONS_FRESH_MS=900000
+export DASHBOARD_OVERVIEW_FRESHNESS_OBSERVATIONS_STALE_MS=3600000
+export DASHBOARD_OVERVIEW_FRESHNESS_TIMELINE_LIMIT=12
+export DASHBOARD_OVERVIEW_FRESHNESS_EVENT_DEDUPE_WINDOW_MS=10000
+```
+
+### Prod / operator-facing stability
+Use conservative thresholds to avoid alert fatigue.
+
+```bash
+export DASHBOARD_OVERVIEW_FRESHNESS_KPI_FRESH_MS=129600000
+export DASHBOARD_OVERVIEW_FRESHNESS_KPI_STALE_MS=345600000
+export DASHBOARD_OVERVIEW_FRESHNESS_AGENT_HEALTH_FRESH_MS=900000
+export DASHBOARD_OVERVIEW_FRESHNESS_AGENT_HEALTH_STALE_MS=7200000
+export DASHBOARD_OVERVIEW_FRESHNESS_OBSERVATIONS_FRESH_MS=21600000
+export DASHBOARD_OVERVIEW_FRESHNESS_OBSERVATIONS_STALE_MS=86400000
+export DASHBOARD_OVERVIEW_FRESHNESS_TIMELINE_LIMIT=8
+export DASHBOARD_OVERVIEW_FRESHNESS_EVENT_DEDUPE_WINDOW_MS=30000
+```
+
+## Validation Checklist
+1. Confirm runtime config:
+   - `curl -sS http://127.0.0.1:8001/api/config | jq '.overviewFreshnessThresholdsMs, .overviewFreshnessTimelineLimit, .overviewFreshnessEventDedupeWindowMs'`
+2. Confirm timeline API returns newest-first events:
+   - `curl -sS http://127.0.0.1:8001/api/overview-freshness-events?limit=8 | jq '.events[0]'`
+3. Trigger a stale transition and verify append:
+   - `curl -sS -X POST http://127.0.0.1:8001/api/overview-freshness-event -H 'content-type: application/json' -d '{"state":"stale","stale":1,"aging":0,"unavailable":0,"total":3,"source":"manual-check","emittedAt":1700000000000}'`
+4. Verify dedupe suppression (same payload within window):
+   - second POST should return `"accepted": false`.
+
+## Troubleshooting
+- Timeline empty with expected events:
+  - verify `overview-freshness-events.jsonl` exists under the active dashboard data directory.
+  - check for malformed JSONL lines; parser skips bad lines.
+- Too many duplicate transitions:
+  - increase `DASHBOARD_OVERVIEW_FRESHNESS_EVENT_DEDUPE_WINDOW_MS`.
+- Alerts too noisy:
+  - widen fresh/stale windows or lower event frequency by increasing dedupe window.
+- Alerts too slow:
+  - tighten fresh/stale windows and reduce dedupe window.
+
+## Current Next Steps (February 22, 2026)
+1. Add correlation IDs from freshness events to operator incident summaries.
+2. Extend timeline drill-down with link-outs to source API health checks.
+3. Evaluate optional daily compaction for `overview-freshness-events.jsonl` in long-running hosts.

--- a/dashboard/server/overview-freshness.ts
+++ b/dashboard/server/overview-freshness.ts
@@ -25,11 +25,22 @@ export interface OverviewFreshnessEvent {
   receivedAt: number;
 }
 
+export interface OverviewFreshnessDedupeResult {
+  accepted: boolean;
+  dedupeKey: string;
+  duplicateOfReceivedAt: number | null;
+}
+
 const MIN_THRESHOLD_MS = 1_000;
 const MAX_THRESHOLD_MS = 30 * 24 * 60 * 60 * 1000;
 const MAX_EVENT_COUNT = 100;
 const MAX_SOURCE_LENGTH = 64;
 const EVENT_FILE_NAME = 'overview-freshness-events.jsonl';
+const DEFAULT_TIMELINE_LIMIT = 8;
+const MIN_TIMELINE_LIMIT = 1;
+const MAX_TIMELINE_LIMIT = 40;
+const DEFAULT_EVENT_DEDUPE_WINDOW_MS = 30_000;
+const MAX_EVENT_DEDUPE_WINDOW_MS = 10 * 60 * 1000;
 
 const DEFAULT_THRESHOLDS: OverviewFreshnessThresholds = {
   kpi: { freshMs: 36 * 60 * 60 * 1000, staleMs: 96 * 60 * 60 * 1000 },
@@ -67,6 +78,22 @@ function clampCount(raw: unknown, fallback = 0): number {
 function clampTimestamp(raw: unknown, fallback: number): number {
   const parsed = Number.parseInt(String(raw ?? ''), 10);
   if (!Number.isFinite(parsed) || parsed <= 0) return fallback;
+  return parsed;
+}
+
+function clampTimelineLimit(raw: unknown, fallback = DEFAULT_TIMELINE_LIMIT): number {
+  const parsed = Number.parseInt(String(raw ?? ''), 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  if (parsed < MIN_TIMELINE_LIMIT) return MIN_TIMELINE_LIMIT;
+  if (parsed > MAX_TIMELINE_LIMIT) return MAX_TIMELINE_LIMIT;
+  return parsed;
+}
+
+function clampEventDedupeWindowMs(raw: unknown, fallback = DEFAULT_EVENT_DEDUPE_WINDOW_MS): number {
+  const parsed = Number.parseInt(String(raw ?? ''), 10);
+  if (!Number.isFinite(parsed)) return fallback;
+  if (parsed < 0) return 0;
+  if (parsed > MAX_EVENT_DEDUPE_WINDOW_MS) return MAX_EVENT_DEDUPE_WINDOW_MS;
   return parsed;
 }
 
@@ -131,6 +158,18 @@ export function resolveOverviewFreshnessThresholds(
   };
 }
 
+export function resolveOverviewFreshnessTimelineLimit(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  return clampTimelineLimit(env.DASHBOARD_OVERVIEW_FRESHNESS_TIMELINE_LIMIT);
+}
+
+export function resolveOverviewFreshnessEventDedupeWindowMs(
+  env: NodeJS.ProcessEnv = process.env,
+): number {
+  return clampEventDedupeWindowMs(env.DASHBOARD_OVERVIEW_FRESHNESS_EVENT_DEDUPE_WINDOW_MS);
+}
+
 export function parseOverviewFreshnessEvent(
   payload: unknown,
   nowMs: number = Date.now(),
@@ -155,6 +194,91 @@ export function parseOverviewFreshnessEvent(
     emittedAt: clampTimestamp(row.emittedAt, nowMs),
     receivedAt: nowMs,
   };
+}
+
+export function readOverviewFreshnessEvents(
+  dataDir: string,
+  opts: { limit?: number } = {},
+): OverviewFreshnessEvent[] {
+  const filePath = getOverviewFreshnessEventFilePath(dataDir);
+  const limit = clampTimelineLimit(opts.limit, DEFAULT_TIMELINE_LIMIT);
+  if (!fs.existsSync(filePath)) return [];
+
+  let lines: string[] = [];
+  try {
+    lines = fs.readFileSync(filePath, 'utf8').split('\n');
+  } catch {
+    return [];
+  }
+
+  const out: OverviewFreshnessEvent[] = [];
+  for (let i = lines.length - 1; i >= 0 && out.length < limit; i -= 1) {
+    const line = lines[i].trim();
+    if (!line) continue;
+    try {
+      const parsed = JSON.parse(line) as unknown;
+      if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) continue;
+      const row = parsed as Record<string, unknown>;
+      const state = normalizeState(row.state);
+      if (!state) continue;
+      const event: OverviewFreshnessEvent = {
+        state,
+        stale: clampCount(row.stale, 0),
+        aging: clampCount(row.aging, 0),
+        unavailable: clampCount(row.unavailable, 0),
+        total: clampCount(row.total, 0),
+        source: sanitizeSource(row.source),
+        emittedAt: clampTimestamp(row.emittedAt, 0),
+        receivedAt: clampTimestamp(row.receivedAt, 0),
+      };
+      out.push(event);
+    } catch {
+      // Ignore malformed lines and continue scanning.
+    }
+  }
+  return out;
+}
+
+function dedupeKeyForEvent(event: OverviewFreshnessEvent): string {
+  return [
+    event.state,
+    event.stale,
+    event.aging,
+    event.unavailable,
+    event.total,
+    event.source,
+  ].join('|');
+}
+
+export function evaluateOverviewFreshnessEventForPersistence(
+  event: OverviewFreshnessEvent,
+  dedupeWindowMs: number,
+  lastEventAtByKey: Map<string, number>,
+  nowMs: number = Date.now(),
+): OverviewFreshnessDedupeResult {
+  const windowMs = clampEventDedupeWindowMs(dedupeWindowMs, DEFAULT_EVENT_DEDUPE_WINDOW_MS);
+  const dedupeKey = dedupeKeyForEvent(event);
+  const prev = lastEventAtByKey.get(dedupeKey) ?? 0;
+  const eventTs = event.receivedAt || nowMs;
+
+  if (windowMs <= 0) {
+    lastEventAtByKey.set(dedupeKey, eventTs);
+    return { accepted: true, dedupeKey, duplicateOfReceivedAt: null };
+  }
+
+  if (prev > 0 && eventTs - prev < windowMs) {
+    return { accepted: false, dedupeKey, duplicateOfReceivedAt: prev };
+  }
+
+  lastEventAtByKey.set(dedupeKey, eventTs);
+
+  // Keep dedupe memory bounded.
+  const pruneBefore = nowMs - Math.max(windowMs * 4, 60_000);
+  for (const [key, ts] of lastEventAtByKey.entries()) {
+    if (ts < pruneBefore) lastEventAtByKey.delete(key);
+  }
+
+  return { accepted: true, dedupeKey, duplicateOfReceivedAt: null };
 }
 
 export function appendOverviewFreshnessEvent(

--- a/dashboard/server/server.ts
+++ b/dashboard/server/server.ts
@@ -141,8 +141,12 @@ import {
 } from './routes/openclaw-local-readiness.js';
 import {
   appendOverviewFreshnessEvent,
+  evaluateOverviewFreshnessEventForPersistence,
   parseOverviewFreshnessEvent,
+  readOverviewFreshnessEvents,
+  resolveOverviewFreshnessEventDedupeWindowMs,
   resolveOverviewFreshnessThresholds,
+  resolveOverviewFreshnessTimelineLimit,
 } from './overview-freshness.js';
 import { getSchedulerJobs } from './scheduler-jobs.js';
 import {
@@ -193,6 +197,9 @@ const OPENCLAW_LOCAL_READINESS_REPORT_DIR: string = resolveOpenclawLocalReadines
   process.env,
 );
 const OVERVIEW_FRESHNESS_THRESHOLDS_MS = resolveOverviewFreshnessThresholds(process.env);
+const OVERVIEW_FRESHNESS_TIMELINE_LIMIT = resolveOverviewFreshnessTimelineLimit(process.env);
+const OVERVIEW_FRESHNESS_EVENT_DEDUPE_WINDOW_MS = resolveOverviewFreshnessEventDedupeWindowMs(process.env);
+const overviewFreshnessEventDedupeState = new Map<string, number>();
 
 // Client HTML paths — served from client/ directory
 const htmlPath: string = path.join(import.meta.dirname, '..', 'client', 'index.html');
@@ -2421,6 +2428,8 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
       name: 'OpenClaw Dashboard',
       version: '1.0.0',
       overviewFreshnessThresholdsMs: OVERVIEW_FRESHNESS_THRESHOLDS_MS,
+      overviewFreshnessTimelineLimit: OVERVIEW_FRESHNESS_TIMELINE_LIMIT,
+      overviewFreshnessEventDedupeWindowMs: OVERVIEW_FRESHNESS_EVENT_DEDUPE_WINDOW_MS,
       ventureos: {
         VENTUREOS_ROOT,
         SHARED_CONTEXT,
@@ -2441,6 +2450,27 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
     });
     return;
   }
+  if (req.url && req.url.startsWith('/api/overview-freshness-events') && req.method === 'GET') {
+    try {
+      const params = new URL(req.url, 'http://localhost').searchParams;
+      const limit = clampInt(
+        params.get('limit') ?? String(OVERVIEW_FRESHNESS_TIMELINE_LIMIT),
+        1,
+        40,
+        OVERVIEW_FRESHNESS_TIMELINE_LIMIT,
+      );
+      const events = readOverviewFreshnessEvents(dataDir, { limit });
+      sendJson(res, {
+        ok: true,
+        limit,
+        events,
+        dedupeWindowMs: OVERVIEW_FRESHNESS_EVENT_DEDUPE_WINDOW_MS,
+      });
+    } catch {
+      sendJson(res, { ok: false, error: 'Invalid freshness events query' }, 400);
+    }
+    return;
+  }
   if (req.url === '/api/overview-freshness-event' && req.method === 'POST') {
     try {
       const raw = await readRequestBody(req, { maxBytes: 32 * 1024 });
@@ -2451,27 +2481,52 @@ const server: Server = http.createServer((req: IncomingMessage, res: ServerRespo
         return;
       }
 
-      appendOverviewFreshnessEvent(dataDir, event);
-      if (event.state === 'stale') {
-        logWarn('dashboard', 'overview_freshness_stale', 'Overview freshness stale state reported', {
-          stale: event.stale,
-          aging: event.aging,
-          unavailable: event.unavailable,
-          total: event.total,
-          source: event.source,
-        });
+      const dedupe = evaluateOverviewFreshnessEventForPersistence(
+        event,
+        OVERVIEW_FRESHNESS_EVENT_DEDUPE_WINDOW_MS,
+        overviewFreshnessEventDedupeState,
+        event.receivedAt || Date.now(),
+      );
+      if (dedupe.accepted) {
+        appendOverviewFreshnessEvent(dataDir, event);
+        if (event.state === 'stale') {
+          logWarn('dashboard', 'overview_freshness_stale', 'Overview freshness stale state reported', {
+            stale: event.stale,
+            aging: event.aging,
+            unavailable: event.unavailable,
+            total: event.total,
+            source: event.source,
+          });
+        } else {
+          logInfo('dashboard', 'overview_freshness_update', 'Overview freshness non-stale update reported', {
+            state: event.state,
+            stale: event.stale,
+            aging: event.aging,
+            unavailable: event.unavailable,
+            total: event.total,
+            source: event.source,
+          });
+        }
       } else {
-        logInfo('dashboard', 'overview_freshness_update', 'Overview freshness non-stale update reported', {
+        logInfo('dashboard', 'overview_freshness_duplicate_suppressed', 'Suppressed duplicate overview freshness event', {
           state: event.state,
           stale: event.stale,
           aging: event.aging,
           unavailable: event.unavailable,
           total: event.total,
           source: event.source,
+          dedupeWindowMs: OVERVIEW_FRESHNESS_EVENT_DEDUPE_WINDOW_MS,
         });
       }
 
-      sendJson(res, { ok: true, state: event.state, recordedAt: event.receivedAt });
+      sendJson(res, {
+        ok: true,
+        state: event.state,
+        recordedAt: event.receivedAt,
+        accepted: dedupe.accepted,
+        dedupeWindowMs: OVERVIEW_FRESHNESS_EVENT_DEDUPE_WINDOW_MS,
+        duplicateOfReceivedAt: dedupe.duplicateOfReceivedAt,
+      });
     } catch {
       sendJson(res, { ok: false, error: 'Invalid freshness event payload' }, 400);
     }

--- a/dashboard/tests/integration/http-smoke.test.ts
+++ b/dashboard/tests/integration/http-smoke.test.ts
@@ -167,6 +167,8 @@ beforeAll(async () => {
   process.env.DASHBOARD_OVERVIEW_FRESHNESS_AGENT_HEALTH_STALE_MS = '300000';
   process.env.DASHBOARD_OVERVIEW_FRESHNESS_OBSERVATIONS_FRESH_MS = '900000';
   process.env.DASHBOARD_OVERVIEW_FRESHNESS_OBSERVATIONS_STALE_MS = '3600000';
+  process.env.DASHBOARD_OVERVIEW_FRESHNESS_TIMELINE_LIMIT = '6';
+  process.env.DASHBOARD_OVERVIEW_FRESHNESS_EVENT_DEDUPE_WINDOW_MS = '60000';
 
   fs.writeFileSync(process.env.OBSIDIAN_CONFIG_PATH, JSON.stringify({
     vaults: {
@@ -487,35 +489,74 @@ describe('Dashboard HTTP smoke tests', () => {
     expect(body.overviewFreshnessThresholdsMs?.kpi).toEqual({ freshMs: 60000, staleMs: 180000 });
     expect(body.overviewFreshnessThresholdsMs?.agentHealth).toEqual({ freshMs: 45000, staleMs: 300000 });
     expect(body.overviewFreshnessThresholdsMs?.observations).toEqual({ freshMs: 900000, staleMs: 3600000 });
+    expect(body.overviewFreshnessTimelineLimit).toBe(6);
+    expect(body.overviewFreshnessEventDedupeWindowMs).toBe(60000);
   });
 
-  it('accepts freshness events and persists them in workspace data', async () => {
+  it('accepts freshness events, suppresses duplicates, and serves timeline history', async () => {
+    const payload = {
+      state: 'stale',
+      stale: 1,
+      aging: 0,
+      unavailable: 0,
+      total: 3,
+      source: 'overview-widget',
+      emittedAt: Date.now() - 5000,
+    };
     const eventRes = await fetch(`${BASE_URL}/api/overview-freshness-event`, {
       method: 'POST',
       headers: { ...authHeaders(), 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        state: 'stale',
-        stale: 1,
-        aging: 0,
-        unavailable: 0,
-        total: 3,
-        source: 'overview-widget',
-        emittedAt: Date.now() - 5000,
-      }),
+      body: JSON.stringify(payload),
     });
     expect(eventRes.status).toBe(200);
     const eventBody = await eventRes.json();
     expect(eventBody.ok).toBe(true);
     expect(eventBody.state).toBe('stale');
+    expect(eventBody.accepted).toBe(true);
 
     const eventFile = path.join(tmpRoot, 'workspace', 'data', 'overview-freshness-events.jsonl');
     expect(fs.existsSync(eventFile)).toBe(true);
-    const lines = fs.readFileSync(eventFile, 'utf8').trim().split('\n');
-    expect(lines.length).toBeGreaterThanOrEqual(1);
-    const latest = JSON.parse(lines[lines.length - 1]) as { state: string; stale: number; source: string };
-    expect(latest.state).toBe('stale');
-    expect(latest.stale).toBe(1);
-    expect(latest.source).toBe('overview-widget');
+    const linesAfterFirst = fs.readFileSync(eventFile, 'utf8').trim().split('\n');
+    expect(linesAfterFirst.length).toBeGreaterThanOrEqual(1);
+
+    const duplicateRes = await fetch(`${BASE_URL}/api/overview-freshness-event`, {
+      method: 'POST',
+      headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+    });
+    expect(duplicateRes.status).toBe(200);
+    const duplicateBody = await duplicateRes.json();
+    expect(duplicateBody.ok).toBe(true);
+    expect(duplicateBody.accepted).toBe(false);
+
+    const linesAfterDuplicate = fs.readFileSync(eventFile, 'utf8').trim().split('\n');
+    expect(linesAfterDuplicate.length).toBe(linesAfterFirst.length);
+
+    const freshRes = await fetch(`${BASE_URL}/api/overview-freshness-event`, {
+      method: 'POST',
+      headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        ...payload,
+        state: 'fresh',
+        stale: 0,
+      }),
+    });
+    expect(freshRes.status).toBe(200);
+    const freshBody = await freshRes.json();
+    expect(freshBody.ok).toBe(true);
+    expect(freshBody.accepted).toBe(true);
+
+    const historyRes = await fetch(`${BASE_URL}/api/overview-freshness-events?limit=6`, {
+      headers: authHeaders(),
+    });
+    expect(historyRes.status).toBe(200);
+    const historyBody = await historyRes.json();
+    expect(historyBody.ok).toBe(true);
+    expect(historyBody.limit).toBe(6);
+    expect(Array.isArray(historyBody.events)).toBe(true);
+    expect(historyBody.events.length).toBeGreaterThanOrEqual(2);
+    expect(historyBody.events[0]?.state).toBe('fresh');
+    expect(historyBody.events[1]?.state).toBe('stale');
 
     const badRes = await fetch(`${BASE_URL}/api/overview-freshness-event`, {
       method: 'POST',

--- a/dashboard/tests/unit/overview-freshness.test.ts
+++ b/dashboard/tests/unit/overview-freshness.test.ts
@@ -6,10 +6,14 @@ import { describe, expect, it } from 'vitest';
 
 import {
   appendOverviewFreshnessEvent,
+  evaluateOverviewFreshnessEventForPersistence,
   getOverviewFreshnessDefaultThresholds,
   getOverviewFreshnessEventFilePath,
   parseOverviewFreshnessEvent,
+  readOverviewFreshnessEvents,
+  resolveOverviewFreshnessEventDedupeWindowMs,
   resolveOverviewFreshnessThresholds,
+  resolveOverviewFreshnessTimelineLimit,
 } from '../../server/overview-freshness.js';
 
 describe('overview freshness server helpers', () => {
@@ -44,6 +48,17 @@ describe('overview freshness server helpers', () => {
 
     expect(thresholds.kpi.freshMs).toBe(5000);
     expect(thresholds.kpi.staleMs).toBe(5001);
+  });
+
+  it('resolves timeline limit and dedupe window from environment', () => {
+    const limit = resolveOverviewFreshnessTimelineLimit({
+      DASHBOARD_OVERVIEW_FRESHNESS_TIMELINE_LIMIT: '12',
+    });
+    const dedupeWindow = resolveOverviewFreshnessEventDedupeWindowMs({
+      DASHBOARD_OVERVIEW_FRESHNESS_EVENT_DEDUPE_WINDOW_MS: '45000',
+    });
+    expect(limit).toBe(12);
+    expect(dedupeWindow).toBe(45000);
   });
 
   it('parses and sanitizes event payload', () => {
@@ -96,5 +111,61 @@ describe('overview freshness server helpers', () => {
     expect(parsed.stale).toBe(1);
 
     fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('reads latest timeline events newest-first with limit', () => {
+    const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'overview-freshness-read-'));
+    const base = 1700000000000;
+    for (let i = 0; i < 4; i += 1) {
+      const event = parseOverviewFreshnessEvent({
+        state: i % 2 === 0 ? 'stale' : 'fresh',
+        stale: i % 2 === 0 ? 1 : 0,
+        aging: 0,
+        unavailable: 0,
+        total: 3,
+        source: `overview-${i}`,
+        emittedAt: base + i * 1000,
+      }, base + i * 1000)!;
+      appendOverviewFreshnessEvent(tmpDir, event);
+    }
+
+    const latestTwo = readOverviewFreshnessEvents(tmpDir, { limit: 2 });
+    expect(latestTwo.length).toBe(2);
+    expect(latestTwo[0]?.source).toBe('overview-3');
+    expect(latestTwo[1]?.source).toBe('overview-2');
+
+    fs.rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  it('suppresses duplicate events inside dedupe window', () => {
+    const state = new Map<string, number>();
+    const t0 = 1700000000000;
+    const event = parseOverviewFreshnessEvent({
+      state: 'stale',
+      stale: 1,
+      aging: 0,
+      unavailable: 0,
+      total: 3,
+      source: 'overview-widget',
+      emittedAt: t0 - 10,
+    }, t0)!;
+
+    const first = evaluateOverviewFreshnessEventForPersistence(event, 60000, state, t0);
+    const second = evaluateOverviewFreshnessEventForPersistence(event, 60000, state, t0 + 1000);
+    const thirdEvent = parseOverviewFreshnessEvent({
+      state: 'stale',
+      stale: 1,
+      aging: 0,
+      unavailable: 0,
+      total: 3,
+      source: 'overview-widget',
+      emittedAt: t0 + 61000 - 10,
+    }, t0 + 61000)!;
+    const third = evaluateOverviewFreshnessEventForPersistence(thirdEvent, 60000, state, t0 + 61000);
+
+    expect(first.accepted).toBe(true);
+    expect(second.accepted).toBe(false);
+    expect(second.duplicateOfReceivedAt).toBe(t0);
+    expect(third.accepted).toBe(true);
   });
 });

--- a/docs/DOC_INDEX.md
+++ b/docs/DOC_INDEX.md
@@ -10,6 +10,7 @@
 ## Dashboard
 - **[dashboard/README.md](../dashboard/README.md)** – Quick start, build commands, deployment, configuration, migration guide
 - **[dashboard/docs/API.md](../dashboard/docs/API.md)** – Complete API reference (all endpoints, schemas, auth, rate limiting)
+- **[dashboard/docs/OVERVIEW_FRESHNESS_RUNBOOK.md](../dashboard/docs/OVERVIEW_FRESHNESS_RUNBOOK.md)** – Freshness thresholds, timeline/dedupe tuning, and operator troubleshooting
 - **[docs/DASHBOARD.md](DASHBOARD.md)** – VentureOS integration guide (data flow, caching, security, architecture)
 
 ## Core


### PR DESCRIPTION
## Summary
- add a compact Overview freshness transition timeline UI under the freshness summary/banners
- add `GET /api/overview-freshness-events` for newest-first timeline history
- add server-side duplicate suppression for `POST /api/overview-freshness-event` (multi-tab noise control)
- expose freshness timeline + dedupe settings in `/api/config`
- add operator runbook for freshness threshold tuning profiles and troubleshooting
- update API + README + doc index references for the new controls and endpoints

## Validation
- `npm run test --workspace=dashboard -- tests/unit/overview-freshness.test.ts tests/unit/client/overview-freshness.test.ts`
- `npm run test --workspace=dashboard -- tests/integration/http-smoke.test.ts`
- `npm run build --workspace=dashboard`

## Notes
- left unrelated local artifacts untouched (`docs/LOCAL_INTEGRATION_READY.md`, `node_modules` binaries/lock entries, `runtime/`, `config/bridge.env`).
