### PR TITLE
Readiness cadence v3: stale-state guardrails + operator summary artifacts

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,11 @@ Run the cron-safe local readiness cadence wrapper:
 npm run openclaw:local-ready:cron
 ```
 
+Check latest readiness status without running a new smoke cycle (fails if stale > 360 min):
+```bash
+npm run openclaw:local-ready:status
+```
+
 Install/manage persistent host bridge LaunchAgent:
 ```bash
 npm run openclaw:bridge:launchagent
@@ -185,12 +190,15 @@ Reference docs and artifacts:
 - `docs/OPENCLAW_LOCAL_INTEGRATION_SMOKE.md`
 - `docs/LOCAL_INTEGRATION_READY.md`
 - `runtime/reports/openclaw-local-smoke/`
+- `runtime/reports/openclaw-local-smoke/openclaw-local-ready-latest.json`
+- `runtime/reports/openclaw-local-smoke/openclaw-local-ready-latest.md`
 
-Current next steps (as of February 22, 2026):
+Current next steps (as of February 23, 2026):
 1. Run one command onboarding: `npm run openclaw:install`
 2. Keep cadence active: `npm run openclaw:local-ready:cron`
-3. Confirm Mission Control shows the latest `/api/openclaw-local-readiness` snapshot.
-4. If bridge checks should pass, set `BRIDGE_TOKEN_FILE` and rerun `npm run openclaw:local-smoke -- --profile bridge`.
+3. Confirm stale guardrail status: `npm run openclaw:local-ready:status`
+4. Confirm Mission Control shows the latest `/api/openclaw-local-readiness` snapshot.
+5. If bridge checks should pass, set `BRIDGE_TOKEN_FILE` and rerun `npm run openclaw:local-smoke -- --profile bridge`.
 
 ### Next.js Hybrid Frontend (Incremental)
 Launch the new Next.js migration surface:

--- a/docs/CRON_SPECS.md
+++ b/docs/CRON_SPECS.md
@@ -77,10 +77,13 @@
 - **Agent:** nexus
 - **Payload:** run `scripts/openclaw-local-ready-cron.sh`
 - **Output:** refreshed `docs/LOCAL_INTEGRATION_READY.md` and paired JSON/MD/SVG artifacts
+- **Status artifact:** `runtime/reports/openclaw-local-smoke/openclaw-local-ready-latest.json`
 - **Retention:** defaults to keep newest 14 artifact sets (configurable via env)
+- **Stale guardrail:** defaults to `--max-age-min 360`; job fails when latest paired report is older
 - **Added:** 2026-02-22
 
-## Current Next Steps (February 22, 2026)
+## Current Next Steps (February 23, 2026)
 1. Roll this schedule onto the host with `bash scripts/install-cron.sh --force`.
 2. Validate first run via `runtime/logs/cron-runs/openclaw-local-ready.jsonl`.
-3. Confirm `docs/LOCAL_INTEGRATION_READY.md` and Mission Control readiness card move forward on the next cadence tick.
+3. Validate stale guardrail via `bash scripts/refresh-local-integration-ready.sh --skip-smoke --max-age-min 360`.
+4. Confirm `docs/LOCAL_INTEGRATION_READY.md` and Mission Control readiness card move forward on the next cadence tick.

--- a/docs/LOCAL_INTEGRATION_READY.md
+++ b/docs/LOCAL_INTEGRATION_READY.md
@@ -1,6 +1,6 @@
 # Local Integration Ready Checklist
 
-Date: 2026-02-22 (UTC)
+Date: 2026-02-23 (UTC)
 Owner: automated refresh via `scripts/refresh-local-integration-ready.sh`
 
 ## Mission Control Card
@@ -16,6 +16,8 @@ Owner: automated refresh via `scripts/refresh-local-integration-ready.sh`
 - JSON: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T231659Z.json`
 - Markdown: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T231659Z.md`
 - Status strip SVG: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T231659Z.svg`
+- Status summary JSON: `runtime/reports/openclaw-local-smoke/openclaw-local-ready-latest.json`
+- Status summary Markdown: `runtime/reports/openclaw-local-smoke/openclaw-local-ready-latest.md`
 
 ## Top 3 Blockers
 - No blockers in latest run.

--- a/docs/OPENCLAW_LOCAL_INTEGRATION_SMOKE.md
+++ b/docs/OPENCLAW_LOCAL_INTEGRATION_SMOKE.md
@@ -39,6 +39,11 @@ Cron-safe wrapper for unattended cadence:
 bash scripts/openclaw-local-ready-cron.sh
 ```
 
+Status-only stale guard check (no new smoke run):
+```bash
+bash scripts/refresh-local-integration-ready.sh --skip-smoke --max-age-min 360
+```
+
 Bridge-mode prerequisite (when `DASHBOARD_DATA_MODE=bridge`):
 ```bash
 npm run openclaw:bridge:launchagent
@@ -84,6 +89,10 @@ Each run writes timestamped artifacts under:
 - `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-<UTC timestamp>.md`
 - `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-<UTC timestamp>.svg`
 
+Readiness refresh also writes rolling status artifacts:
+- `runtime/reports/openclaw-local-smoke/openclaw-local-ready-latest.json`
+- `runtime/reports/openclaw-local-smoke/openclaw-local-ready-latest.md`
+
 The JSON report includes machine-readable check metadata and readiness summary fields:
 - `summary.verdict`: `go|hold|blocked`
 - `summary.readinessScore`: `0..100`
@@ -97,11 +106,13 @@ Use `--prune-keep <n>` if you want refresh to keep only the newest `n` timestamp
 `scripts/openclaw-local-ready-cron.sh` defaults:
 - `--history-limit 7`
 - `--prune-keep 14`
+- `--max-age-min 360`
 - `--profile full`
 
 Optional env overrides for cron wrapper:
 - `OPENCLAW_LOCAL_READY_HISTORY_LIMIT`
 - `OPENCLAW_LOCAL_READY_PRUNE_KEEP`
+- `OPENCLAW_LOCAL_READY_MAX_AGE_MIN`
 - `OPENCLAW_LOCAL_READY_PROFILE` (`quick|full|bridge`)
 
 Mission Control API note (dashboard route):
@@ -119,12 +130,16 @@ bash scripts/install-cron.sh --force
 ```bash
 bash scripts/openclaw-local-ready-cron.sh
 ```
-3. Verify Mission Control shows the latest readiness payload from `/api/openclaw-local-readiness`.
-4. If bridge direct-check coverage is expected, configure `BRIDGE_TOKEN_FILE` and rerun bridge profile smoke:
+3. Validate stale guardrail status from latest artifact age:
+```bash
+bash scripts/refresh-local-integration-ready.sh --skip-smoke --max-age-min 360
+```
+4. Verify Mission Control shows the latest readiness payload from `/api/openclaw-local-readiness`.
+5. If bridge direct-check coverage is expected, configure `BRIDGE_TOKEN_FILE` and rerun bridge profile smoke:
 ```bash
 bash scripts/openclaw-local-smoke.sh --profile bridge
 ```
-5. Keep bridge startup + readiness artifact wiring persistent across restarts.
+6. Keep bridge startup + readiness artifact wiring persistent across restarts.
 
 ## Regression Test
 Run the mock-server regression test:

--- a/docs/SCRIPT_SPECS.md
+++ b/docs/SCRIPT_SPECS.md
@@ -265,12 +265,17 @@ bash scripts/refresh-local-integration-ready.sh \
 - Validates required smoke JSON schema before rendering readiness markdown.
 - Supports `--history-limit <n>` to control trend rows in the output.
 - Supports `--prune-keep <n>` to retain only newest `n` timestamp groups after refresh.
+- Supports `--max-age-min <n>` stale guardrail checks against the latest paired artifact timestamp.
 - Rewrites readiness summary markdown with:
   - mission control card (`GO/HOLD/BLOCKED`, score, confidence)
   - top blockers and next commands
   - trend table from the latest N paired runs
-  - latest artifact references (JSON/MD/SVG)
+  - latest artifact references (JSON/MD/SVG + latest status summary paths)
+- Emits rolling operator status artifacts:
+  - `runtime/reports/openclaw-local-smoke/openclaw-local-ready-latest.json`
+  - `runtime/reports/openclaw-local-smoke/openclaw-local-ready-latest.md`
 - Preserves smoke exit status when smoke is executed.
+- Returns non-zero (`3`) when stale guardrail is enabled and violated.
 
 **Regression test:**
 ```bash
@@ -292,10 +297,12 @@ bash scripts/openclaw-local-ready-cron.sh
 - Applies defaults optimized for unattended cadence:
   - `--history-limit 7`
   - `--prune-keep 14`
+  - `--max-age-min 360`
   - `--profile full`
 - Allows env overrides:
   - `OPENCLAW_LOCAL_READY_HISTORY_LIMIT`
   - `OPENCLAW_LOCAL_READY_PRUNE_KEEP`
+  - `OPENCLAW_LOCAL_READY_MAX_AGE_MIN`
   - `OPENCLAW_LOCAL_READY_PROFILE` (`quick|full|bridge`)
 - Validates env inputs and exits `2` on invalid values before running refresh.
 - Forwards any additional CLI flags to the underlying refresh script (last flag wins).
@@ -308,7 +315,8 @@ bash scripts/tests/test-openclaw-local-ready-cron.sh
 **Current next steps (operator rollout):**
 1. `bash scripts/install-cron.sh --force`
 2. `bash scripts/openclaw-local-ready-cron.sh`
-3. Validate `docs/LOCAL_INTEGRATION_READY.md` timestamp and `runtime/reports/openclaw-local-smoke/` artifact rotation.
+3. `bash scripts/refresh-local-integration-ready.sh --skip-smoke --max-age-min 360`
+4. Validate `docs/LOCAL_INTEGRATION_READY.md` timestamp and `runtime/reports/openclaw-local-smoke/` artifact rotation.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "openclaw:install": "bash scripts/ventureos-install.sh",
     "openclaw:local-ready": "bash scripts/refresh-local-integration-ready.sh",
     "openclaw:local-ready:cron": "bash scripts/openclaw-local-ready-cron.sh",
+    "openclaw:local-ready:status": "bash scripts/refresh-local-integration-ready.sh --skip-smoke --max-age-min 360",
     "openclaw:bridge:launchagent": "bash scripts/install-bridge-launchagent.sh",
     "test:openclaw:local-smoke": "bash scripts/tests/test-openclaw-local-smoke.sh",
     "test:openclaw:local-ready": "bash scripts/tests/test-refresh-local-integration-ready.sh",

--- a/scripts/openclaw-local-ready-cron.sh
+++ b/scripts/openclaw-local-ready-cron.sh
@@ -8,6 +8,7 @@ REFRESH_SCRIPT="${OPENCLAW_LOCAL_READY_REFRESH_SCRIPT:-$REPO_ROOT/scripts/refres
 HISTORY_LIMIT="${OPENCLAW_LOCAL_READY_HISTORY_LIMIT:-7}"
 PRUNE_KEEP="${OPENCLAW_LOCAL_READY_PRUNE_KEEP:-14}"
 PROFILE="${OPENCLAW_LOCAL_READY_PROFILE:-full}"
+MAX_AGE_MIN="${OPENCLAW_LOCAL_READY_MAX_AGE_MIN:-360}"
 
 if ! [[ "$HISTORY_LIMIT" =~ ^[0-9]+$ ]] || [[ "$HISTORY_LIMIT" -lt 1 ]]; then
   echo "Invalid OPENCLAW_LOCAL_READY_HISTORY_LIMIT: $HISTORY_LIMIT" >&2
@@ -15,6 +16,10 @@ if ! [[ "$HISTORY_LIMIT" =~ ^[0-9]+$ ]] || [[ "$HISTORY_LIMIT" -lt 1 ]]; then
 fi
 if ! [[ "$PRUNE_KEEP" =~ ^[0-9]+$ ]]; then
   echo "Invalid OPENCLAW_LOCAL_READY_PRUNE_KEEP: $PRUNE_KEEP" >&2
+  exit 2
+fi
+if ! [[ "$MAX_AGE_MIN" =~ ^[0-9]+$ ]]; then
+  echo "Invalid OPENCLAW_LOCAL_READY_MAX_AGE_MIN: $MAX_AGE_MIN" >&2
   exit 2
 fi
 if [[ "$PROFILE" != "quick" && "$PROFILE" != "full" && "$PROFILE" != "bridge" ]]; then
@@ -29,5 +34,6 @@ fi
 bash "$REFRESH_SCRIPT" \
   --history-limit "$HISTORY_LIMIT" \
   --prune-keep "$PRUNE_KEEP" \
+  --max-age-min "$MAX_AGE_MIN" \
   --profile "$PROFILE" \
   "$@"

--- a/scripts/refresh-local-integration-ready.sh
+++ b/scripts/refresh-local-integration-ready.sh
@@ -8,6 +8,7 @@ REPORT_DIR="${SMOKE_REPORT_DIR:-$REPO_ROOT/runtime/reports/openclaw-local-smoke}
 OUTPUT_DOC="$REPO_ROOT/docs/LOCAL_INTEGRATION_READY.md"
 HISTORY_LIMIT=7
 PRUNE_KEEP=0
+MAX_AGE_MIN="${OPENCLAW_LOCAL_READY_MAX_AGE_MIN:-0}"
 RUN_SMOKE=1
 SMOKE_ARGS=()
 
@@ -23,6 +24,7 @@ Options:
   --report-dir <path>          Smoke report directory (default: runtime/reports/openclaw-local-smoke)
   --history-limit <n>          Number of historical runs in trend table (default: 7)
   --prune-keep <n>             Keep only newest N timestamped artifact sets after refresh (default: 0=disabled)
+  --max-age-min <n>            Fail stale guardrail when latest paired report is older than N minutes (default: 0=disabled)
   --skip-smoke                 Do not run smoke; refresh doc from existing artifacts
 
   Forwarded smoke options:
@@ -69,6 +71,11 @@ while [[ $# -gt 0 ]]; do
       PRUNE_KEEP="$2"
       shift 2
       ;;
+    --max-age-min)
+      need_value "$@"
+      MAX_AGE_MIN="$2"
+      shift 2
+      ;;
     --skip-smoke)
       RUN_SMOKE=0
       shift
@@ -102,6 +109,10 @@ if ! [[ "$PRUNE_KEEP" =~ ^[0-9]+$ ]]; then
   echo "Invalid --prune-keep: $PRUNE_KEEP" >&2
   exit 2
 fi
+if ! [[ "$MAX_AGE_MIN" =~ ^[0-9]+$ ]]; then
+  echo "Invalid --max-age-min: $MAX_AGE_MIN" >&2
+  exit 2
+fi
 
 if [[ "${#SMOKE_ARGS[@]}" -gt 0 ]]; then
   SMOKE_ARGS=(--report-dir "$REPORT_DIR" "${SMOKE_ARGS[@]}")
@@ -117,7 +128,7 @@ if [[ "$RUN_SMOKE" == "1" ]]; then
   set -e
 fi
 
-python3 - "$REPORT_DIR" "$OUTPUT_DOC" "$REPO_ROOT" "$smoke_rc" "$HISTORY_LIMIT" "$PRUNE_KEEP" <<'PY'
+PYTHON_OUTPUT="$(python3 - "$REPORT_DIR" "$OUTPUT_DOC" "$REPO_ROOT" "$smoke_rc" "$HISTORY_LIMIT" "$PRUNE_KEEP" "$MAX_AGE_MIN" <<'PY'
 from __future__ import annotations
 
 import json
@@ -132,6 +143,7 @@ repo_root = pathlib.Path(sys.argv[3]).resolve()
 smoke_rc = int(sys.argv[4])
 history_limit = int(sys.argv[5])
 prune_keep = int(sys.argv[6])
+max_age_min = int(sys.argv[7])
 
 if not report_dir.exists() or not report_dir.is_dir():
     raise SystemExit(f"No report directory found: {report_dir}")
@@ -181,6 +193,11 @@ latest_ts = paired_timestamps[-1]
 latest_json = json_by_ts[latest_ts]
 latest_md = md_by_ts[latest_ts]
 latest_svg = svg_by_ts[latest_ts]
+latest_dt = datetime.strptime(latest_ts, "%Y%m%dT%H%M%SZ").replace(tzinfo=timezone.utc)
+now_dt = datetime.now(timezone.utc)
+latest_age_seconds = max(0, int((now_dt - latest_dt).total_seconds()))
+is_stale = max_age_min > 0 and latest_age_seconds > max_age_min * 60
+guardrail_rc = 3 if is_stale else 0
 
 payload = json.loads(latest_json.read_text(encoding="utf-8"))
 
@@ -282,6 +299,8 @@ now_utc = datetime.now(timezone.utc).strftime("%Y-%m-%d")
 verdict = str(summary["verdict"]).upper()
 
 status_strip_rel = rel(latest_svg)
+status_json_path = (report_dir / "openclaw-local-ready-latest.json").resolve()
+status_md_path = (report_dir / "openclaw-local-ready-latest.md").resolve()
 
 out = [
     "# Local Integration Ready Checklist",
@@ -302,6 +321,8 @@ out = [
     f"- JSON: `{rel(latest_json)}`",
     f"- Markdown: `{rel(latest_md)}`",
     f"- Status strip SVG: `{status_strip_rel}`",
+    f"- Status summary JSON: `{rel(status_json_path)}`",
+    f"- Status summary Markdown: `{rel(status_md_path)}`",
 ]
 
 if latest_svg:
@@ -423,9 +444,91 @@ if smoke_rc != 0:
         "## Run Exit Note",
         f"- The smoke command exited non-zero (`{smoke_rc}`). This document still reflects the latest generated report.",
     ])
+if is_stale:
+    out.extend([
+        "",
+        "## Stale Guardrail",
+        f"- Latest paired report age (`{latest_age_seconds}s`) exceeded `--max-age-min {max_age_min}`.",
+        "- Cadence should be treated as degraded until a fresh run succeeds.",
+    ])
 
 output_path.parent.mkdir(parents=True, exist_ok=True)
 output_path.write_text("\n".join(out) + "\n", encoding="utf-8")
+
+top_blockers: list[dict] = []
+for blocker in failed_checks[:3]:
+    top_blockers.append(
+        {
+            "id": blocker.get("id", "unknown"),
+            "owner": blocker.get("owner", "Ops"),
+            "severity": blocker.get("severity", "warn"),
+            "likelyCause": blocker.get("likelyCause", "unknown cause"),
+            "nextCommand": blocker.get("nextCommand", "n/a"),
+            "required": bool(blocker.get("required")),
+        }
+    )
+
+status_payload = {
+    "generatedAt": now_dt.isoformat(),
+    "latestTimestamp": latest_ts,
+    "latestAgeSeconds": latest_age_seconds,
+    "status": (
+        "alert"
+        if smoke_rc != 0 or is_stale or int(summary.get("requiredFailures", 0)) > 0
+        else "ok"
+    ),
+    "summary": {
+        "verdict": summary.get("verdict"),
+        "status": summary.get("status"),
+        "readinessScore": summary.get("readinessScore"),
+        "confidence": summary.get("confidence"),
+        "requiredFailures": summary.get("requiredFailures"),
+        "warnings": summary.get("warnings"),
+        "profile": summary.get("profile"),
+    },
+    "guardrails": {
+        "maxAgeMin": max_age_min,
+        "stale": is_stale,
+        "guardrailRc": guardrail_rc,
+    },
+    "smokeExitCode": smoke_rc,
+    "artifacts": {
+        "json": rel(latest_json),
+        "markdown": rel(latest_md),
+        "svg": rel(latest_svg),
+        "readinessDoc": rel(output_path),
+    },
+    "topBlockers": top_blockers,
+}
+status_json_path.write_text(json.dumps(status_payload, indent=2) + "\n", encoding="utf-8")
+
+status_md_lines = [
+    "# Local Readiness Status Summary",
+    "",
+    f"- Status: `{status_payload['status'].upper()}`",
+    f"- Verdict: `{str(summary.get('verdict', 'unknown')).upper()}`",
+    f"- Readiness score: `{summary.get('readinessScore', 'n/a')}`",
+    f"- Confidence: `{summary.get('confidence', 'n/a')}`",
+    f"- Required failures: `{summary.get('requiredFailures', 'n/a')}`",
+    f"- Warnings: `{summary.get('warnings', 'n/a')}`",
+    f"- Latest report timestamp: `{latest_ts}`",
+    f"- Latest report age seconds: `{latest_age_seconds}`",
+    f"- Stale guardrail: `{'STALE' if is_stale else 'fresh'}` (maxAgeMin={max_age_min})",
+    f"- Smoke exit code: `{smoke_rc}`",
+]
+if top_blockers:
+    status_md_lines.extend(["", "## Top Blockers"])
+    for blocker in top_blockers:
+        status_md_lines.append(
+            f"- `{blocker['id']}` owner=`{blocker['owner']}` "
+            f"severity=`{blocker['severity']}` "
+            f"cause: {blocker['likelyCause']} "
+            f"next: `{blocker['nextCommand']}`"
+        )
+else:
+    status_md_lines.extend(["", "## Top Blockers", "- none"])
+
+status_md_path.write_text("\n".join(status_md_lines) + "\n", encoding="utf-8")
 
 pruned_files = 0
 if prune_keep > 0:
@@ -443,14 +546,35 @@ print(f"REFRESH_SOURCE_JSON={latest_json}")
 print(f"REFRESH_SOURCE_MD={latest_md}")
 if latest_svg:
     print(f"REFRESH_SOURCE_SVG={latest_svg}")
+print(f"REFRESH_STATUS_JSON={status_json_path}")
+print(f"REFRESH_STATUS_MD={status_md_path}")
+print(f"REFRESH_LATEST_AGE_SEC={latest_age_seconds}")
+print(f"REFRESH_STALE={'true' if is_stale else 'false'}")
+print(f"REFRESH_GUARDRAIL_RC={guardrail_rc}")
 if prune_keep > 0:
     print(f"REFRESH_PRUNED_FILES={pruned_files}")
 PY
+)"
+
+echo "$PYTHON_OUTPUT"
+
+GUARDRAIL_RC="$(echo "$PYTHON_OUTPUT" | awk -F= '/^REFRESH_GUARDRAIL_RC=/{print $2}' | tail -n 1)"
+if [[ -z "$GUARDRAIL_RC" ]]; then
+  GUARDRAIL_RC=0
+fi
 
 echo "Local integration readiness refreshed:"
 echo "  - $OUTPUT_DOC"
 
-if [[ "$RUN_SMOKE" == "1" ]]; then
+if ! [[ "$GUARDRAIL_RC" =~ ^[0-9]+$ ]]; then
+  echo "Invalid REFRESH_GUARDRAIL_RC from refresh helper: $GUARDRAIL_RC" >&2
+  exit 2
+fi
+
+if [[ "$smoke_rc" -ne 0 ]]; then
   exit "$smoke_rc"
+fi
+if [[ "$GUARDRAIL_RC" -ne 0 ]]; then
+  exit "$GUARDRAIL_RC"
 fi
 exit 0

--- a/scripts/tests/test-openclaw-local-ready-cron.sh
+++ b/scripts/tests/test-openclaw-local-ready-cron.sh
@@ -35,6 +35,7 @@ args = Path(sys.argv[1]).read_text(encoding='utf-8').splitlines()
 assert args == [
     '--history-limit', '7',
     '--prune-keep', '14',
+    '--max-age-min', '360',
     '--profile', 'full',
     '--skip-smoke',
 ], args
@@ -46,8 +47,9 @@ CAPTURE_ARGS_FILE="$CAPTURE_2" \
 OPENCLAW_LOCAL_READY_REFRESH_SCRIPT="$STUB_REFRESH" \
 OPENCLAW_LOCAL_READY_HISTORY_LIMIT=3 \
 OPENCLAW_LOCAL_READY_PRUNE_KEEP=5 \
+OPENCLAW_LOCAL_READY_MAX_AGE_MIN=120 \
 OPENCLAW_LOCAL_READY_PROFILE=quick \
-bash "$CRON_SCRIPT" --profile bridge --history-limit 9 >/tmp/openclaw-local-ready-cron-test-2.out
+bash "$CRON_SCRIPT" --profile bridge --history-limit 9 --max-age-min 240 >/tmp/openclaw-local-ready-cron-test-2.out
 
 python3 - "$CAPTURE_2" <<'PY'
 from pathlib import Path
@@ -65,6 +67,7 @@ while i < len(args):
         i += 1
 assert pairs.get('--history-limit') == '9', pairs
 assert pairs.get('--prune-keep') == '5', pairs
+assert pairs.get('--max-age-min') == '240', pairs
 assert pairs.get('--profile') == 'bridge', pairs
 print('OPENCLAW_LOCAL_READY_CRON_OVERRIDES_OK')
 PY
@@ -81,3 +84,16 @@ if [[ "$rc" -ne 2 ]]; then
 fi
 
 echo "OPENCLAW_LOCAL_READY_CRON_VALIDATION_OK"
+
+set +e
+OPENCLAW_LOCAL_READY_REFRESH_SCRIPT="$STUB_REFRESH" \
+OPENCLAW_LOCAL_READY_MAX_AGE_MIN=bad \
+bash "$CRON_SCRIPT" >/tmp/openclaw-local-ready-cron-test-bad-age.out 2>&1
+rc=$?
+set -e
+if [[ "$rc" -ne 2 ]]; then
+  echo "expected invalid max age to fail with exit 2, got $rc" >&2
+  exit 1
+fi
+
+echo "OPENCLAW_LOCAL_READY_CRON_MAX_AGE_VALIDATION_OK"

--- a/scripts/tests/test-refresh-local-integration-ready.sh
+++ b/scripts/tests/test-refresh-local-integration-ready.sh
@@ -217,17 +217,26 @@ json_reports = sorted(report_dir.glob("openclaw-local-smoke-*.json"))
 svg_reports = sorted(report_dir.glob("openclaw-local-smoke-*.svg"))
 assert len(json_reports) >= 2, "expected multiple smoke reports"
 assert svg_reports, "missing status strip svg"
+status_summary_json = report_dir / "openclaw-local-ready-latest.json"
+status_summary_md = report_dir / "openclaw-local-ready-latest.md"
+assert status_summary_json.exists(), "missing latest status summary json"
+assert status_summary_md.exists(), "missing latest status summary markdown"
 
 latest = json.loads(json_reports[-1].read_text(encoding="utf-8"))
 summary = latest.get("summary", {})
 assert summary.get("verdict") == "go", summary
 assert summary.get("requiredFailures") == 0, summary
 
+status_payload = json.loads(status_summary_json.read_text(encoding="utf-8"))
+assert status_payload.get("status") == "ok", status_payload
+assert status_payload.get("guardrails", {}).get("stale") is False, status_payload
+
 text = doc_path.read_text(encoding="utf-8")
 assert "## Mission Control Card" in text, text
 assert "Verdict: `GO`" in text, text
 assert "## Trend (Last 1 Runs)" in text, text
 assert "Status strip SVG" in text, text
+assert "Status summary JSON" in text, text
 assert "Top 3 Blockers" in text, text
 assert "## Current Next Steps" in text, text
 print("REFRESH_LOCAL_INTEGRATION_READY_GO_SCENARIO_OK")
@@ -268,6 +277,23 @@ if ! has_pattern "Invalid --prune-keep" /tmp/refresh-local-prune-invalid.out; th
 fi
 
 echo "REFRESH_LOCAL_INTEGRATION_READY_PRUNE_VALIDATION_OK"
+
+# Input validation: max-age-min must be numeric.
+set +e
+bash "$REFRESH_SCRIPT" --skip-smoke --max-age-min nope --report-dir "$REPORT_DIR" --output-doc "$OUT_DOC" >/tmp/refresh-local-max-age-invalid.out 2>&1
+rc=$?
+set -e
+if [[ "$rc" -eq 0 ]]; then
+  echo "expected invalid max-age-min failure" >&2
+  exit 1
+fi
+if ! has_pattern "Invalid --max-age-min" /tmp/refresh-local-max-age-invalid.out; then
+  echo "expected max-age-min validation message" >&2
+  cat /tmp/refresh-local-max-age-invalid.out >&2
+  exit 1
+fi
+
+echo "REFRESH_LOCAL_INTEGRATION_READY_MAX_AGE_VALIDATION_OK"
 
 # Mismatch check: create a newer JSON without matching markdown.
 sleep 1
@@ -336,3 +362,40 @@ if ! has_pattern "SVG" /tmp/refresh-local-svg.out; then
 fi
 
 echo "REFRESH_LOCAL_INTEGRATION_READY_SVG_CHECK_OK"
+
+# Stale guardrail check: old latest artifacts should fail when max-age is configured.
+STALE_DIR="$TMP_DIR/reports-stale"
+mkdir -p "$STALE_DIR"
+cp "$(ls -1 "$REPORT_DIR"/openclaw-local-smoke-*.json | tail -n 1)" "$STALE_DIR/openclaw-local-smoke-20000101T000000Z.json"
+cp "$(ls -1 "$REPORT_DIR"/openclaw-local-smoke-*.md | tail -n 1)" "$STALE_DIR/openclaw-local-smoke-20000101T000000Z.md"
+cp "$(ls -1 "$REPORT_DIR"/openclaw-local-smoke-*.svg | tail -n 1)" "$STALE_DIR/openclaw-local-smoke-20000101T000000Z.svg"
+set +e
+bash "$REFRESH_SCRIPT" --skip-smoke --max-age-min 1 --report-dir "$STALE_DIR" --output-doc "$OUT_DOC" >/tmp/refresh-local-stale.out 2>&1
+rc=$?
+set -e
+if [[ "$rc" -eq 0 ]]; then
+  echo "expected stale guardrail failure" >&2
+  exit 1
+fi
+if ! has_pattern "REFRESH_STALE=true" /tmp/refresh-local-stale.out; then
+  echo "expected stale marker in refresh output" >&2
+  cat /tmp/refresh-local-stale.out >&2
+  exit 1
+fi
+if ! has_pattern "REFRESH_GUARDRAIL_RC=3" /tmp/refresh-local-stale.out; then
+  echo "expected guardrail rc marker in refresh output" >&2
+  cat /tmp/refresh-local-stale.out >&2
+  exit 1
+fi
+
+python3 - "$STALE_DIR/openclaw-local-ready-latest.json" <<'PY'
+from pathlib import Path
+import json
+import sys
+
+payload = json.loads(Path(sys.argv[1]).read_text(encoding="utf-8"))
+assert payload.get("status") == "alert", payload
+assert payload.get("guardrails", {}).get("stale") is True, payload
+assert payload.get("guardrails", {}).get("guardrailRc") == 3, payload
+print("REFRESH_LOCAL_INTEGRATION_READY_STALE_GUARD_OK")
+PY


### PR DESCRIPTION
## Summary
Implements `#458` by hardening local readiness cadence with explicit stale-state guardrails and concise operator summary artifacts.

## What changed
- Added stale guardrail support to readiness refresh:
  - `--max-age-min <n>` in `scripts/refresh-local-integration-ready.sh`
  - env default support via `OPENCLAW_LOCAL_READY_MAX_AGE_MIN`
  - guardrail failure exit code `3` when enabled and stale
- Added rolling status artifacts for operators:
  - `runtime/reports/openclaw-local-smoke/openclaw-local-ready-latest.json`
  - `runtime/reports/openclaw-local-smoke/openclaw-local-ready-latest.md`
- Extended cron wrapper defaults/validation:
  - `scripts/openclaw-local-ready-cron.sh` now passes `--max-age-min 360` by default
- Added status-only command path:
  - `npm run openclaw:local-ready:status`
- Updated readiness docs/runbooks for cadence + stale guardrail workflow.

## Validation
- `bash -n scripts/refresh-local-integration-ready.sh`
- `bash -n scripts/openclaw-local-ready-cron.sh`
- `bash scripts/tests/test-openclaw-local-ready-cron.sh`
- `bash scripts/tests/test-refresh-local-integration-ready.sh`
- `npm run openclaw:local-ready:status`
- `npm run docs:lint`
- `npm run roadmap:sync:check`

Closes #458
