### PR TITLE
Installer onboarding phase 2: verification mode + actionable reports (#459)

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ ventureos/
 ### In Progress
 
 - 🔄 **Next.js Hybrid Phase 3:** migrate authenticated interactive surfaces incrementally (#457)
-- 🔄 **Readiness Cadence v3:** add stale-state guardrails and operator summary artifacts (#458)
 - 🔄 **Installer Onboarding Phase 2:** add post-install verification mode and clearer reports (#459)
 
 ### Next Up
@@ -111,7 +110,6 @@ Implementation milestones (visible incremental rollout):
 ### Now (active)
 
 - Next.js hybrid phase 3 migration workstream (#457)
-- Local integration readiness cadence v3 hardening (#458)
 - Installer onboarding phase 2 verification/reporting improvements (#459)
 - Living roadmap stewardship in issue #138
 
@@ -161,6 +159,17 @@ Non-interactive automation example:
 npm run openclaw:install -- --non-interactive --profile bridge
 ```
 
+Preset-based onboarding examples:
+```bash
+npm run openclaw:install -- --non-interactive --preset minimal
+npm run openclaw:install -- --non-interactive --preset bridge
+```
+
+Run onboarding with post-install verification gates enabled:
+```bash
+npm run openclaw:install -- --non-interactive --verify
+```
+
 Run deterministic local OpenClaw integration smoke checks:
 ```bash
 npm run openclaw:local-smoke
@@ -192,6 +201,7 @@ Reference docs and artifacts:
 - `runtime/reports/openclaw-local-smoke/`
 - `runtime/reports/openclaw-local-smoke/openclaw-local-ready-latest.json`
 - `runtime/reports/openclaw-local-smoke/openclaw-local-ready-latest.md`
+- `runtime/reports/ventureos-install/` (installer onboarding reports with pass/fail + next command details)
 
 Current next steps (as of February 23, 2026):
 1. Run one command onboarding: `npm run openclaw:install`

--- a/docs/SCRIPT_SPECS.md
+++ b/docs/SCRIPT_SPECS.md
@@ -359,6 +359,11 @@ Non-interactive example:
 bash scripts/ventureos-install.sh --non-interactive --profile bridge
 ```
 
+Verification-focused example:
+```bash
+bash scripts/ventureos-install.sh --non-interactive --verify --preset full
+```
+
 **Behavior:**
 - Coordinates existing install primitives in one flow:
   - dashboard installer (`dashboard/scripts/install-macos.sh` or `dashboard/scripts/install.sh`)
@@ -367,8 +372,11 @@ bash scripts/ventureos-install.sh --non-interactive --profile bridge
   - readiness refresh (`scripts/refresh-local-integration-ready.sh`)
 - Supports interactive onboarding prompts (default on TTY) and non-interactive mode (`--non-interactive`).
 - Supports dry-run planning (`--dry-run`) to print execution plan without changes.
+- Supports post-install verification mode (`--verify`) across dashboard health, bridge status, cron marker, and readiness status summary artifact.
+- Supports installation presets (`--preset full|bridge|minimal`) with explicit `--skip-*`/`--profile` overrides.
 - Allows selective skips (`--skip-*`) and readiness profile selection (`--profile quick|full|bridge`).
 - Writes timestamped install reports to `runtime/reports/ventureos-install/`.
+- Install report includes a per-step `Next Command` column and a `Failed Steps` section for operator follow-up.
 
 **Regression test:**
 ```bash

--- a/scripts/tests/test-ventureos-install.sh
+++ b/scripts/tests/test-ventureos-install.sh
@@ -13,11 +13,19 @@ trap cleanup EXIT
 CALL_LOG="$TMP_DIR/calls.log"
 touch "$CALL_LOG"
 
+OUT_DIR="$TMP_DIR/out"
+REPORT_BASE="$TMP_DIR/reports"
+SMOKE_DIR="$TMP_DIR/smoke"
+BIN_DIR="$TMP_DIR/bin"
+mkdir -p "$OUT_DIR" "$REPORT_BASE" "$SMOKE_DIR" "$BIN_DIR"
+
 FAKE_DASHBOARD_MACOS="$TMP_DIR/install-macos.sh"
 FAKE_DASHBOARD_LINUX="$TMP_DIR/install-linux.sh"
 FAKE_BRIDGE="$TMP_DIR/install-bridge.sh"
 FAKE_CRON="$TMP_DIR/install-cron.sh"
 FAKE_READY="$TMP_DIR/refresh-ready.sh"
+FAKE_CURL="$BIN_DIR/curl"
+FAKE_CRONTAB="$BIN_DIR/crontab"
 
 cat > "$FAKE_DASHBOARD_MACOS" <<'SH'
 #!/usr/bin/env bash
@@ -51,10 +59,35 @@ cat > "$FAKE_READY" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
 echo "ready|$*|BRIDGE_TOKEN=${BRIDGE_TOKEN:-}" >> "$CALL_LOG"
+report_dir="${SMOKE_REPORT_DIR:-}"
+if [[ -n "$report_dir" ]]; then
+  mkdir -p "$report_dir"
+  cat > "$report_dir/openclaw-local-ready-latest.json" <<'JSON'
+{"status":"pass","summary":"readiness ok"}
+JSON
+fi
 exit 0
 SH
 
-chmod +x "$FAKE_DASHBOARD_MACOS" "$FAKE_DASHBOARD_LINUX" "$FAKE_BRIDGE" "$FAKE_CRON" "$FAKE_READY"
+cat > "$FAKE_CURL" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "curl|$*" >> "$CALL_LOG"
+exit 0
+SH
+
+cat > "$FAKE_CRONTAB" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+echo "crontab|$*" >> "$CALL_LOG"
+if [[ "${1:-}" == "-l" ]]; then
+  echo "# VentureOS Managed Cron"
+  exit 0
+fi
+exit 1
+SH
+
+chmod +x "$FAKE_DASHBOARD_MACOS" "$FAKE_DASHBOARD_LINUX" "$FAKE_BRIDGE" "$FAKE_CRON" "$FAKE_READY" "$FAKE_CURL" "$FAKE_CRONTAB"
 
 BRIDGE_ENV="$TMP_DIR/bridge.env"
 cat > "$BRIDGE_ENV" <<'EOF_ENV'
@@ -62,45 +95,133 @@ BRIDGE_TOKEN=test-bridge-token
 BRIDGE_PORT=18790
 EOF_ENV
 
+run_install() {
+  local run_name="$1"
+  shift
+  local out_file="$OUT_DIR/${run_name}.out"
+  local report_dir="$REPORT_BASE/${run_name}"
+  mkdir -p "$report_dir"
+  VENTUREOS_INSTALL_REPORT_DIR="$report_dir" \
+  SMOKE_REPORT_DIR="$SMOKE_DIR" \
+  PATH="$BIN_DIR:$PATH" \
+  bash "$SCRIPT" "$@" >"$out_file" 2>&1
+}
+
+run_install_expect_fail() {
+  local run_name="$1"
+  shift
+  local out_file="$OUT_DIR/${run_name}.out"
+  local report_dir="$REPORT_BASE/${run_name}"
+  mkdir -p "$report_dir"
+  set +e
+  VENTUREOS_INSTALL_REPORT_DIR="$report_dir" \
+  SMOKE_REPORT_DIR="$SMOKE_DIR" \
+  PATH="$BIN_DIR:$PATH" \
+  bash "$SCRIPT" "$@" >"$out_file" 2>&1
+  local rc=$?
+  set -e
+  if [[ "$rc" -eq 0 ]]; then
+    echo "Expected run '$run_name' to fail but it passed" >&2
+    exit 1
+  fi
+}
+
+latest_report() {
+  local run_name="$1"
+  ls -1 "$REPORT_BASE/${run_name}"/ventureos-install-*.md | tail -n 1
+}
+
 export CALL_LOG
 export VENTUREOS_INSTALL_DASHBOARD_MACOS_SCRIPT="$FAKE_DASHBOARD_MACOS"
 export VENTUREOS_INSTALL_DASHBOARD_LINUX_SCRIPT="$FAKE_DASHBOARD_LINUX"
 export VENTUREOS_INSTALL_BRIDGE_SCRIPT="$FAKE_BRIDGE"
 export VENTUREOS_INSTALL_CRON_SCRIPT="$FAKE_CRON"
 export VENTUREOS_INSTALL_READINESS_SCRIPT="$FAKE_READY"
-export VENTUREOS_INSTALL_REPORT_DIR="$TMP_DIR/reports"
 export VENTUREOS_INSTALL_OS="Darwin"
 
 # Dry-run should plan actions without executing scripts.
-bash "$SCRIPT" \
+: > "$CALL_LOG"
+run_install dry_run \
   --non-interactive \
   --dry-run \
+  --preset minimal \
+  --verify \
   --dashboard-port 8123 \
-  --profile bridge \
   --bridge-env "$BRIDGE_ENV" \
-  --bridge-token-file "$TMP_DIR/bridge-token" \
-  >/tmp/test-ventureos-install-dry-run.out
+  --bridge-token-file "$TMP_DIR/bridge-token"
 
 if [[ -s "$CALL_LOG" ]]; then
   echo "Expected dry-run mode to avoid executing installer primitives" >&2
   exit 1
 fi
 
-grep -q "VENTUREOS_INSTALL_RESULT=PLANNED" /tmp/test-ventureos-install-dry-run.out
+grep -q "VENTUREOS_INSTALL_RESULT=PLANNED" "$OUT_DIR/dry_run.out"
+dry_run_report="$(latest_report dry_run)"
+grep -q '| Step | Status | Detail | Next Command |' "$dry_run_report"
+grep -q -- '- Preset: `minimal`' "$dry_run_report"
+grep -q -- '- Post-install verify: `enabled`' "$dry_run_report"
+grep -q '`bridge-launchagent` | `skipped`' "$dry_run_report"
 echo "VENTUREOS_INSTALL_DRY_RUN_OK"
 
-# Executing mode should run each primitive once with expected args.
-bash "$SCRIPT" \
+# Executing mode with verification should run all install + verify primitives.
+: > "$CALL_LOG"
+run_install verify_success \
   --non-interactive \
+  --verify \
   --dashboard-port 8124 \
   --profile bridge \
   --bridge-env "$BRIDGE_ENV" \
-  --bridge-token-file "$TMP_DIR/bridge-token" \
-  >/tmp/test-ventureos-install-run.out
+  --bridge-token-file "$TMP_DIR/bridge-token"
 
 grep -q "dashboard-macos|" "$CALL_LOG"
 grep -q "bridge|--bridge-env $BRIDGE_ENV" "$CALL_LOG"
+grep -q "bridge|--bridge-env $BRIDGE_ENV --status" "$CALL_LOG"
 grep -q "cron|--force" "$CALL_LOG"
 grep -q "ready|--profile bridge --dashboard-url http://127.0.0.1:8124 --bridge-token-file $TMP_DIR/bridge-token|BRIDGE_TOKEN=test-bridge-token" "$CALL_LOG"
-grep -q "VENTUREOS_INSTALL_RESULT=PASS" /tmp/test-ventureos-install-run.out
-echo "VENTUREOS_INSTALL_EXECUTE_OK"
+grep -q "curl|-sSf --max-time 3 http://127.0.0.1:8124/api/health" "$CALL_LOG"
+grep -q "crontab|-l" "$CALL_LOG"
+grep -q "VENTUREOS_INSTALL_RESULT=PASS" "$OUT_DIR/verify_success.out"
+verify_report="$(latest_report verify_success)"
+grep -q -- '- Status: `pass`' "$verify_report"
+grep -q -- '- Post-install verify: `enabled`' "$verify_report"
+grep -q '| Step | Status | Detail | Next Command |' "$verify_report"
+echo "VENTUREOS_INSTALL_VERIFY_OK"
+
+# Minimal preset should skip bridge + cron by default while still running dashboard/readiness.
+: > "$CALL_LOG"
+run_install minimal_preset \
+  --non-interactive \
+  --preset minimal \
+  --dashboard-port 8125 \
+  --bridge-env "$BRIDGE_ENV"
+
+grep -q "dashboard-macos|" "$CALL_LOG"
+if grep -q 'bridge|' "$CALL_LOG"; then
+  echo "Minimal preset should not run bridge installer" >&2
+  exit 1
+fi
+if grep -q 'cron|' "$CALL_LOG"; then
+  echo "Minimal preset should not run cron installer" >&2
+  exit 1
+fi
+grep -q "ready|--profile quick --dashboard-url http://127.0.0.1:8125|BRIDGE_TOKEN=test-bridge-token" "$CALL_LOG"
+grep -q "VENTUREOS_INSTALL_RESULT=PASS" "$OUT_DIR/minimal_preset.out"
+minimal_report="$(latest_report minimal_preset)"
+grep -q -- '- Preset: `minimal`' "$minimal_report"
+echo "VENTUREOS_INSTALL_PRESET_OK"
+
+# Missing bridge env should fail with actionable failed-step report content.
+: > "$CALL_LOG"
+run_install_expect_fail missing_bridge_env \
+  --non-interactive \
+  --verify \
+  --dashboard-port 8126 \
+  --bridge-env "$TMP_DIR/missing-bridge.env" \
+  --skip-readiness
+
+grep -q "VENTUREOS_INSTALL_RESULT=FAIL" "$OUT_DIR/missing_bridge_env.out"
+fail_report="$(latest_report missing_bridge_env)"
+grep -q '## Failed Steps' "$fail_report"
+grep -q "Create bridge env file or pass --skip-bridge-launchagent" "$fail_report"
+grep -q '| Step | Status | Detail | Next Command |' "$fail_report"
+echo "VENTUREOS_INSTALL_FAILURE_REPORT_OK"

--- a/scripts/ventureos-install.sh
+++ b/scripts/ventureos-install.sh
@@ -8,12 +8,24 @@ OS_NAME="${VENTUREOS_INSTALL_OS:-$(uname)}"
 NON_INTERACTIVE=0
 YES=0
 DRY_RUN=0
+VERIFY_POST_INSTALL=0
+VERIFY_TIMEOUT_SEC="${VENTUREOS_INSTALL_VERIFY_TIMEOUT_SEC:-3}"
 
 SKIP_DASHBOARD_INSTALL=0
 SKIP_BRIDGE_LAUNCHAGENT=0
 SKIP_CRON_INSTALL=0
 SKIP_READINESS=0
 FORCE_CRON_INSTALL=1
+INSTALL_PRESET="${VENTUREOS_INSTALL_PRESET:-full}"
+
+EXPLICIT_SKIP_DASHBOARD=""
+EXPLICIT_SKIP_BRIDGE=""
+EXPLICIT_SKIP_CRON=""
+EXPLICIT_SKIP_READINESS=""
+EXPLICIT_PROFILE=""
+EXPLICIT_FORCE_CRON=""
+EXPLICIT_VERIFY=""
+EXPLICIT_PRESET=""
 
 DASHBOARD_PORT="${DASHBOARD_PORT:-7000}"
 DASHBOARD_URL_OVERRIDE=""
@@ -27,10 +39,12 @@ DASHBOARD_INSTALL_LINUX_SCRIPT="${VENTUREOS_INSTALL_DASHBOARD_LINUX_SCRIPT:-$REP
 BRIDGE_INSTALL_SCRIPT="${VENTUREOS_INSTALL_BRIDGE_SCRIPT:-$REPO_ROOT/scripts/install-bridge-launchagent.sh}"
 CRON_INSTALL_SCRIPT="${VENTUREOS_INSTALL_CRON_SCRIPT:-$REPO_ROOT/scripts/install-cron.sh}"
 READINESS_REFRESH_SCRIPT="${VENTUREOS_INSTALL_READINESS_SCRIPT:-$REPO_ROOT/scripts/refresh-local-integration-ready.sh}"
+READINESS_STATUS_JSON="${SMOKE_REPORT_DIR:-$REPO_ROOT/runtime/reports/openclaw-local-smoke}/openclaw-local-ready-latest.json"
 
 REPORT_DIR="${VENTUREOS_INSTALL_REPORT_DIR:-$REPO_ROOT/runtime/reports/ventureos-install}"
 SUMMARY_TSV="$(mktemp)"
 trap 'rm -f "$SUMMARY_TSV"' EXIT
+INSTALL_FAILED=0
 
 usage() {
   cat <<'EOF_USAGE'
@@ -50,6 +64,9 @@ Options:
   --non-interactive         Disable prompts and use flags/defaults
   --yes                     Auto-accept interactive prompts
   --dry-run                 Print planned actions without executing installers
+  --verify                  Run post-install verification checks and fail on verification errors
+  --verify-timeout-sec <n>  Timeout (seconds) for verification checks (default: 3)
+  --preset <name>           Install preset: full|bridge|minimal (default: full)
   --dashboard-port <port>   Dashboard port (default: 7000)
   --dashboard-url <url>     Override readiness dashboard URL (default: http://127.0.0.1:<dashboard-port>)
   --profile <name>          Readiness profile: quick|full|bridge (default: full)
@@ -76,32 +93,104 @@ record_step() {
   local step="$1"
   local status="$2"
   local detail="$3"
+  local next_command="${4:-n/a}"
   detail="${detail//$'\n'/ }"
   detail="${detail//$'\r'/ }"
   detail="${detail//$'\t'/ }"
-  printf '%s\t%s\t%s\n' "$step" "$status" "$detail" >> "$SUMMARY_TSV"
+  next_command="${next_command//$'\n'/ }"
+  next_command="${next_command//$'\r'/ }"
+  next_command="${next_command//$'\t'/ }"
+  printf '%s\t%s\t%s\t%s\n' "$step" "$status" "$detail" "$next_command" >> "$SUMMARY_TSV"
 }
 
 run_step() {
   local step="$1"
   local detail="$2"
   shift 2
+  local next_command=""
+  if [[ "${1:-}" == "--next-command" ]]; then
+    if [[ $# -lt 3 ]]; then
+      echo "run_step missing command after --next-command" >&2
+      exit 2
+    fi
+    next_command="$2"
+    shift 2
+  fi
+  local command_text="$*"
+  if [[ -z "$next_command" ]]; then
+    next_command="$command_text"
+  fi
   if [[ "$DRY_RUN" == "1" ]]; then
     echo "[dry-run] $step :: $detail"
-    echo "          cmd: $*"
-    record_step "$step" "planned" "$detail"
+    echo "          cmd: $command_text"
+    record_step "$step" "planned" "$detail" "$next_command"
     return 0
   fi
 
   if "$@"; then
     echo "PASS  $step :: $detail"
-    record_step "$step" "pass" "$detail"
+    record_step "$step" "pass" "$detail" "$next_command"
     return 0
   fi
 
   echo "FAIL  $step :: $detail" >&2
-  record_step "$step" "fail" "$detail"
+  record_step "$step" "fail" "$detail" "$next_command"
   return 1
+}
+
+apply_install_preset() {
+  case "$INSTALL_PRESET" in
+    full)
+      SKIP_DASHBOARD_INSTALL=0
+      SKIP_BRIDGE_LAUNCHAGENT=0
+      SKIP_CRON_INSTALL=0
+      SKIP_READINESS=0
+      PROFILE="${EXPLICIT_PROFILE:-full}"
+      ;;
+    bridge)
+      SKIP_DASHBOARD_INSTALL=0
+      SKIP_BRIDGE_LAUNCHAGENT=0
+      SKIP_CRON_INSTALL=0
+      SKIP_READINESS=0
+      PROFILE="${EXPLICIT_PROFILE:-bridge}"
+      ;;
+    minimal)
+      SKIP_DASHBOARD_INSTALL=0
+      SKIP_BRIDGE_LAUNCHAGENT=1
+      SKIP_CRON_INSTALL=1
+      SKIP_READINESS=0
+      PROFILE="${EXPLICIT_PROFILE:-quick}"
+      ;;
+    *)
+      echo "Invalid --preset: $INSTALL_PRESET (expected full|bridge|minimal)" >&2
+      exit 2
+      ;;
+  esac
+}
+
+verify_dashboard_health() {
+  curl -sSf --max-time "$VERIFY_TIMEOUT_SEC" "${1%/}/api/health" >/dev/null
+}
+
+verify_cron_marker() {
+  crontab -l 2>/dev/null | grep -Fq "VentureOS Managed Cron"
+}
+
+verify_readiness_status_artifact() {
+  python3 - "$READINESS_STATUS_JSON" <<'PY'
+import json
+import pathlib
+import sys
+
+path = pathlib.Path(sys.argv[1])
+if not path.exists():
+    raise SystemExit(1)
+payload = json.loads(path.read_text(encoding="utf-8"))
+if not isinstance(payload, dict):
+    raise SystemExit(1)
+if "status" not in payload or "summary" not in payload:
+    raise SystemExit(1)
+PY
 }
 
 prompt_yes_no() {
@@ -149,6 +238,58 @@ validate_profile() {
   fi
 }
 
+validate_dashboard_port() {
+  if ! [[ "$DASHBOARD_PORT" =~ ^[0-9]+$ ]] || [[ "$DASHBOARD_PORT" -lt 1 || "$DASHBOARD_PORT" -gt 65535 ]]; then
+    echo "Invalid --dashboard-port: $DASHBOARD_PORT" >&2
+    exit 2
+  fi
+}
+
+validate_verify_timeout() {
+  if ! [[ "$VERIFY_TIMEOUT_SEC" =~ ^[0-9]+$ ]] || [[ "$VERIFY_TIMEOUT_SEC" -lt 1 ]]; then
+    echo "Invalid --verify-timeout-sec: $VERIFY_TIMEOUT_SEC" >&2
+    exit 2
+  fi
+}
+
+apply_explicit_overrides() {
+  if [[ -n "$EXPLICIT_SKIP_DASHBOARD" ]]; then
+    SKIP_DASHBOARD_INSTALL="$EXPLICIT_SKIP_DASHBOARD"
+  fi
+  if [[ -n "$EXPLICIT_SKIP_BRIDGE" ]]; then
+    SKIP_BRIDGE_LAUNCHAGENT="$EXPLICIT_SKIP_BRIDGE"
+  fi
+  if [[ -n "$EXPLICIT_SKIP_CRON" ]]; then
+    SKIP_CRON_INSTALL="$EXPLICIT_SKIP_CRON"
+  fi
+  if [[ -n "$EXPLICIT_SKIP_READINESS" ]]; then
+    SKIP_READINESS="$EXPLICIT_SKIP_READINESS"
+  fi
+  if [[ -n "$EXPLICIT_PROFILE" ]]; then
+    PROFILE="$EXPLICIT_PROFILE"
+  fi
+  if [[ -n "$EXPLICIT_FORCE_CRON" ]]; then
+    FORCE_CRON_INSTALL="$EXPLICIT_FORCE_CRON"
+  fi
+  if [[ -n "$EXPLICIT_VERIFY" ]]; then
+    VERIFY_POST_INSTALL="$EXPLICIT_VERIFY"
+  fi
+}
+
+prompt_run_toggle() {
+  local prompt="$1"
+  local default_skip="$2"
+  local default_answer="y"
+  if [[ "$default_skip" == "1" ]]; then
+    default_answer="n"
+  fi
+  if [[ "$(prompt_yes_no "$prompt" "$default_answer")" == "n" ]]; then
+    echo "1"
+  else
+    echo "0"
+  fi
+}
+
 resolve_dashboard_url() {
   if [[ -n "$DASHBOARD_URL_OVERRIDE" ]]; then
     echo "$DASHBOARD_URL_OVERRIDE"
@@ -171,6 +312,22 @@ while [[ $# -gt 0 ]]; do
       DRY_RUN=1
       shift
       ;;
+    --verify)
+      VERIFY_POST_INSTALL=1
+      EXPLICIT_VERIFY=1
+      shift
+      ;;
+    --verify-timeout-sec)
+      need_value "$@"
+      VERIFY_TIMEOUT_SEC="$2"
+      shift 2
+      ;;
+    --preset)
+      need_value "$@"
+      INSTALL_PRESET="$2"
+      EXPLICIT_PRESET="$2"
+      shift 2
+      ;;
     --dashboard-port)
       need_value "$@"
       DASHBOARD_PORT="$2"
@@ -184,6 +341,7 @@ while [[ $# -gt 0 ]]; do
     --profile)
       need_value "$@"
       PROFILE="$2"
+      EXPLICIT_PROFILE="$2"
       shift 2
       ;;
     --bridge-env)
@@ -202,23 +360,23 @@ while [[ $# -gt 0 ]]; do
       shift 2
       ;;
     --skip-dashboard-install)
-      SKIP_DASHBOARD_INSTALL=1
+      EXPLICIT_SKIP_DASHBOARD=1
       shift
       ;;
     --skip-bridge-launchagent)
-      SKIP_BRIDGE_LAUNCHAGENT=1
+      EXPLICIT_SKIP_BRIDGE=1
       shift
       ;;
     --skip-cron)
-      SKIP_CRON_INSTALL=1
+      EXPLICIT_SKIP_CRON=1
       shift
       ;;
     --skip-readiness)
-      SKIP_READINESS=1
+      EXPLICIT_SKIP_READINESS=1
       shift
       ;;
     --no-force-cron)
-      FORCE_CRON_INSTALL=0
+      EXPLICIT_FORCE_CRON=0
       shift
       ;;
     -h|--help)
@@ -233,10 +391,11 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
-if ! [[ "$DASHBOARD_PORT" =~ ^[0-9]+$ ]] || [[ "$DASHBOARD_PORT" -lt 1 || "$DASHBOARD_PORT" -gt 65535 ]]; then
-  echo "Invalid --dashboard-port: $DASHBOARD_PORT" >&2
-  exit 2
-fi
+validate_dashboard_port
+validate_verify_timeout
+
+apply_install_preset
+apply_explicit_overrides
 
 validate_profile
 
@@ -251,23 +410,40 @@ if [[ "$NON_INTERACTIVE" == "0" && -t 0 ]]; then
   echo "Platform: $OS_NAME"
   echo ""
 
+  if [[ -z "$EXPLICIT_PRESET" ]]; then
+    INSTALL_PRESET="$(prompt_value "Install preset (full|bridge|minimal)" "$INSTALL_PRESET")"
+  fi
+  apply_install_preset
+  apply_explicit_overrides
   DASHBOARD_PORT="$(prompt_value "Dashboard port" "$DASHBOARD_PORT")"
-  PROFILE="$(prompt_value "Readiness profile (quick|full|bridge)" "$PROFILE")"
+  if [[ -z "$EXPLICIT_PROFILE" ]]; then
+    PROFILE="$(prompt_value "Readiness profile (quick|full|bridge)" "$PROFILE")"
+  fi
+  validate_dashboard_port
   validate_profile
 
-  if [[ "$(prompt_yes_no "Run dashboard installer?" "y")" == "n" ]]; then
-    SKIP_DASHBOARD_INSTALL=1
+  if [[ -z "$EXPLICIT_SKIP_DASHBOARD" ]]; then
+    SKIP_DASHBOARD_INSTALL="$(prompt_run_toggle "Run dashboard installer?" "$SKIP_DASHBOARD_INSTALL")"
   fi
-  if [[ "$OS_NAME" == "Darwin" ]]; then
-    if [[ "$(prompt_yes_no "Install/refresh bridge LaunchAgent?" "y")" == "n" ]]; then
-      SKIP_BRIDGE_LAUNCHAGENT=1
+  if [[ "$OS_NAME" == "Darwin" && -z "$EXPLICIT_SKIP_BRIDGE" ]]; then
+    SKIP_BRIDGE_LAUNCHAGENT="$(prompt_run_toggle "Install/refresh bridge LaunchAgent?" "$SKIP_BRIDGE_LAUNCHAGENT")"
+  fi
+  if [[ -z "$EXPLICIT_SKIP_CRON" ]]; then
+    SKIP_CRON_INSTALL="$(prompt_run_toggle "Install/refresh managed cron entries?" "$SKIP_CRON_INSTALL")"
+  fi
+  if [[ -z "$EXPLICIT_SKIP_READINESS" ]]; then
+    SKIP_READINESS="$(prompt_run_toggle "Run readiness refresh smoke now?" "$SKIP_READINESS")"
+  fi
+  if [[ -z "$EXPLICIT_VERIFY" ]]; then
+    verify_default="n"
+    if [[ "$VERIFY_POST_INSTALL" == "1" ]]; then
+      verify_default="y"
     fi
-  fi
-  if [[ "$(prompt_yes_no "Install/refresh managed cron entries?" "y")" == "n" ]]; then
-    SKIP_CRON_INSTALL=1
-  fi
-  if [[ "$(prompt_yes_no "Run readiness refresh smoke now?" "y")" == "n" ]]; then
-    SKIP_READINESS=1
+    if [[ "$(prompt_yes_no "Run post-install verification checks?" "$verify_default")" == "y" ]]; then
+      VERIFY_POST_INSTALL=1
+    else
+      VERIFY_POST_INSTALL=0
+    fi
   fi
   echo ""
 fi
@@ -275,12 +451,14 @@ fi
 dashboard_url="$(resolve_dashboard_url)"
 
 echo "Install plan:"
+echo "  preset: $INSTALL_PRESET"
 echo "  dashboard port: $DASHBOARD_PORT"
 echo "  readiness profile: $PROFILE"
 echo "  dashboard install: $([[ "$SKIP_DASHBOARD_INSTALL" == "1" ]] && echo skip || echo run)"
 echo "  bridge LaunchAgent: $([[ "$SKIP_BRIDGE_LAUNCHAGENT" == "1" ]] && echo skip || echo run)"
 echo "  cron install: $([[ "$SKIP_CRON_INSTALL" == "1" ]] && echo skip || echo run)"
 echo "  readiness refresh: $([[ "$SKIP_READINESS" == "1" ]] && echo skip || echo run)"
+echo "  post-install verify: $([[ "$VERIFY_POST_INSTALL" == "1" ]] && echo run || echo skip)"
 echo "  bridge env: $BRIDGE_ENV"
 if [[ "$DRY_RUN" == "1" ]]; then
   echo "  mode: dry-run"
@@ -289,57 +467,71 @@ echo ""
 
 if [[ "$SKIP_DASHBOARD_INSTALL" == "0" ]]; then
   if [[ "$OS_NAME" == "Darwin" ]]; then
-    run_step "dashboard-install" "dashboard/scripts/install-macos.sh" \
-      env DASHBOARD_PORT="$DASHBOARD_PORT" OPENCLAW_DIR="$OPENCLAW_DIR" bash "$DASHBOARD_INSTALL_MACOS_SCRIPT"
+    if ! run_step "dashboard-install" "dashboard/scripts/install-macos.sh" \
+      env DASHBOARD_PORT="$DASHBOARD_PORT" OPENCLAW_DIR="$OPENCLAW_DIR" bash "$DASHBOARD_INSTALL_MACOS_SCRIPT"; then
+      INSTALL_FAILED=1
+    fi
   else
     if [[ "$DRY_RUN" == "1" ]]; then
-      run_step "dashboard-install" "dashboard/scripts/install.sh (linux)" \
-        env DASHBOARD_PORT="$DASHBOARD_PORT" OPENCLAW_DIR="$OPENCLAW_DIR" bash "$DASHBOARD_INSTALL_LINUX_SCRIPT"
+      if ! run_step "dashboard-install" "dashboard/scripts/install.sh (linux)" \
+        env DASHBOARD_PORT="$DASHBOARD_PORT" OPENCLAW_DIR="$OPENCLAW_DIR" bash "$DASHBOARD_INSTALL_LINUX_SCRIPT"; then
+        INSTALL_FAILED=1
+      fi
     elif [[ "${EUID:-$(id -u)}" -eq 0 ]]; then
-      run_step "dashboard-install" "dashboard/scripts/install.sh (linux root)" \
-        env DASHBOARD_PORT="$DASHBOARD_PORT" OPENCLAW_DIR="$OPENCLAW_DIR" bash "$DASHBOARD_INSTALL_LINUX_SCRIPT"
+      if ! run_step "dashboard-install" "dashboard/scripts/install.sh (linux root)" \
+        env DASHBOARD_PORT="$DASHBOARD_PORT" OPENCLAW_DIR="$OPENCLAW_DIR" bash "$DASHBOARD_INSTALL_LINUX_SCRIPT"; then
+        INSTALL_FAILED=1
+      fi
     elif command -v sudo >/dev/null 2>&1; then
-      run_step "dashboard-install" "dashboard/scripts/install.sh (linux via sudo)" \
-        sudo env DASHBOARD_PORT="$DASHBOARD_PORT" OPENCLAW_DIR="$OPENCLAW_DIR" bash "$DASHBOARD_INSTALL_LINUX_SCRIPT"
+      if ! run_step "dashboard-install" "dashboard/scripts/install.sh (linux via sudo)" \
+        sudo env DASHBOARD_PORT="$DASHBOARD_PORT" OPENCLAW_DIR="$OPENCLAW_DIR" bash "$DASHBOARD_INSTALL_LINUX_SCRIPT"; then
+        INSTALL_FAILED=1
+      fi
     else
       echo "FAIL  dashboard-install :: sudo is required on Linux for systemd install" >&2
-      record_step "dashboard-install" "fail" "sudo required on Linux for dashboard installer"
-      exit 1
+      record_step "dashboard-install" "fail" "sudo required on Linux for dashboard installer" "Install sudo or run as root and re-run ventureos-install.sh"
+      INSTALL_FAILED=1
     fi
   fi
 else
   echo "SKIP  dashboard-install"
-  record_step "dashboard-install" "skipped" "skipped by flag"
+  record_step "dashboard-install" "skipped" "skipped by flag" "Re-run without --skip-dashboard-install"
 fi
 
 if [[ "$SKIP_BRIDGE_LAUNCHAGENT" == "0" ]]; then
   if [[ "$OS_NAME" != "Darwin" ]]; then
     echo "SKIP  bridge-launchagent :: not supported on $OS_NAME"
-    record_step "bridge-launchagent" "skipped" "bridge LaunchAgent installer is macOS-only"
+    record_step "bridge-launchagent" "skipped" "bridge LaunchAgent installer is macOS-only" "Use macOS for LaunchAgent install"
   elif [[ ! -f "$BRIDGE_ENV" ]]; then
     echo "FAIL  bridge-launchagent :: missing bridge env file: $BRIDGE_ENV" >&2
-    record_step "bridge-launchagent" "fail" "missing bridge env file"
-    exit 1
+    record_step "bridge-launchagent" "fail" "missing bridge env file" "Create bridge env file or pass --skip-bridge-launchagent"
+    INSTALL_FAILED=1
   else
-    run_step "bridge-launchagent" "scripts/install-bridge-launchagent.sh" \
-      bash "$BRIDGE_INSTALL_SCRIPT" --bridge-env "$BRIDGE_ENV"
+    if ! run_step "bridge-launchagent" "scripts/install-bridge-launchagent.sh" \
+      bash "$BRIDGE_INSTALL_SCRIPT" --bridge-env "$BRIDGE_ENV"; then
+      INSTALL_FAILED=1
+    fi
   fi
 else
   echo "SKIP  bridge-launchagent"
-  record_step "bridge-launchagent" "skipped" "skipped by flag"
+  record_step "bridge-launchagent" "skipped" "skipped by flag" "Re-run without --skip-bridge-launchagent"
 fi
 
 if [[ "$SKIP_CRON_INSTALL" == "0" ]]; then
   if [[ "$FORCE_CRON_INSTALL" == "1" ]]; then
-    run_step "cron-install" "scripts/install-cron.sh --force" \
-      bash "$CRON_INSTALL_SCRIPT" --force
+    if ! run_step "cron-install" "scripts/install-cron.sh --force" \
+      bash "$CRON_INSTALL_SCRIPT" --force; then
+      INSTALL_FAILED=1
+    fi
   else
-    run_step "cron-install" "scripts/install-cron.sh" \
-      bash "$CRON_INSTALL_SCRIPT"
+    if ! run_step "cron-install" "scripts/install-cron.sh" \
+      bash "$CRON_INSTALL_SCRIPT"; then
+      INSTALL_FAILED=1
+    fi
   fi
 else
   echo "SKIP  cron-install"
-  record_step "cron-install" "skipped" "skipped by flag"
+  record_step "cron-install" "skipped" "skipped by flag" "Re-run without --skip-cron"
 fi
 
 if [[ "$SKIP_READINESS" == "0" ]]; then
@@ -350,7 +542,9 @@ if [[ "$SKIP_READINESS" == "0" ]]; then
 
   if [[ -f "$BRIDGE_ENV" ]]; then
     if [[ "$DRY_RUN" == "1" ]]; then
-      run_step "readiness-refresh" "refresh-local-integration-ready.sh (with bridge env)" "${readiness_cmd[@]}"
+      if ! run_step "readiness-refresh" "refresh-local-integration-ready.sh (with bridge env)" "${readiness_cmd[@]}"; then
+        INSTALL_FAILED=1
+      fi
     else
       if (
         set -a
@@ -359,26 +553,75 @@ if [[ "$SKIP_READINESS" == "0" ]]; then
         "${readiness_cmd[@]}"
       ); then
         echo "PASS  readiness-refresh :: scripts/refresh-local-integration-ready.sh"
-        record_step "readiness-refresh" "pass" "readiness refresh succeeded"
+        record_step "readiness-refresh" "pass" "readiness refresh succeeded" "${readiness_cmd[*]}"
       else
         echo "FAIL  readiness-refresh :: scripts/refresh-local-integration-ready.sh" >&2
-        record_step "readiness-refresh" "fail" "readiness refresh failed"
-        exit 1
+        record_step "readiness-refresh" "fail" "readiness refresh failed" "${readiness_cmd[*]}"
+        INSTALL_FAILED=1
       fi
     fi
   else
-    run_step "readiness-refresh" "refresh-local-integration-ready.sh" "${readiness_cmd[@]}"
+    if ! run_step "readiness-refresh" "refresh-local-integration-ready.sh" "${readiness_cmd[@]}"; then
+      INSTALL_FAILED=1
+    fi
   fi
 else
   echo "SKIP  readiness-refresh"
-  record_step "readiness-refresh" "skipped" "skipped by flag"
+  record_step "readiness-refresh" "skipped" "skipped by flag" "Re-run without --skip-readiness"
+fi
+
+if [[ "$VERIFY_POST_INSTALL" == "1" ]]; then
+  if [[ "$SKIP_DASHBOARD_INSTALL" == "0" ]]; then
+    if ! run_step "verify-dashboard-health" "GET /api/health returns 200" \
+      --next-command "curl -sSf --max-time $VERIFY_TIMEOUT_SEC ${dashboard_url%/}/api/health" \
+      verify_dashboard_health "$dashboard_url"; then
+      INSTALL_FAILED=1
+    fi
+  else
+    record_step "verify-dashboard-health" "skipped" "dashboard install skipped; health verify skipped" "Run dashboard install, then re-run with --verify"
+  fi
+
+  if [[ "$SKIP_BRIDGE_LAUNCHAGENT" == "0" && "$OS_NAME" == "Darwin" ]]; then
+    if ! run_step "verify-bridge-launchagent" "bridge launchagent status check" \
+      --next-command "bash scripts/install-bridge-launchagent.sh --bridge-env $BRIDGE_ENV --status" \
+      bash "$BRIDGE_INSTALL_SCRIPT" --bridge-env "$BRIDGE_ENV" --status; then
+      INSTALL_FAILED=1
+    fi
+  else
+    record_step "verify-bridge-launchagent" "skipped" "bridge verify skipped by platform/flags" "Ensure bridge install is enabled on macOS, then re-run with --verify"
+  fi
+
+  if [[ "$SKIP_CRON_INSTALL" == "0" ]]; then
+    if ! run_step "verify-cron-marker" "crontab contains VentureOS managed marker" \
+      --next-command "crontab -l | grep -F 'VentureOS Managed Cron'" \
+      verify_cron_marker; then
+      INSTALL_FAILED=1
+    fi
+  else
+    record_step "verify-cron-marker" "skipped" "cron install skipped; cron verify skipped" "Run cron install, then re-run with --verify"
+  fi
+
+  if [[ "$SKIP_READINESS" == "0" ]]; then
+    if ! run_step "verify-readiness-status-artifact" "latest readiness status summary json is present" \
+      --next-command "python3 -m json.tool $READINESS_STATUS_JSON >/dev/null" \
+      verify_readiness_status_artifact; then
+      INSTALL_FAILED=1
+    fi
+  else
+    record_step "verify-readiness-status-artifact" "skipped" "readiness refresh skipped; status artifact verify skipped" "Run readiness refresh, then re-run with --verify"
+  fi
+else
+  record_step "verify-dashboard-health" "skipped" "post-install verify disabled" "Re-run with --verify"
+  record_step "verify-bridge-launchagent" "skipped" "post-install verify disabled" "Re-run with --verify"
+  record_step "verify-cron-marker" "skipped" "post-install verify disabled" "Re-run with --verify"
+  record_step "verify-readiness-status-artifact" "skipped" "post-install verify disabled" "Re-run with --verify"
 fi
 
 mkdir -p "$REPORT_DIR"
 timestamp_utc="$(date -u +%Y%m%dT%H%M%SZ)"
 report_file="$REPORT_DIR/ventureos-install-${timestamp_utc}.md"
 
-python3 - "$SUMMARY_TSV" "$report_file" "$timestamp_utc" "$OS_NAME" "$DASHBOARD_PORT" "$PROFILE" "$dashboard_url" "$DRY_RUN" <<'PY'
+python3 - "$SUMMARY_TSV" "$report_file" "$timestamp_utc" "$OS_NAME" "$DASHBOARD_PORT" "$PROFILE" "$dashboard_url" "$DRY_RUN" "$INSTALL_PRESET" "$VERIFY_POST_INSTALL" <<'PY'
 import csv
 import pathlib
 import sys
@@ -391,14 +634,16 @@ dashboard_port = sys.argv[5]
 profile = sys.argv[6]
 dashboard_url = sys.argv[7]
 dry_run = sys.argv[8] == "1"
+preset = sys.argv[9]
+verify_enabled = sys.argv[10] == "1"
 
 rows = []
 with summary_tsv.open("r", encoding="utf-8") as fh:
     reader = csv.reader(fh, delimiter="\t")
     for row in reader:
-        if len(row) != 3:
+        if len(row) != 4:
             continue
-        rows.append({"step": row[0], "status": row[1], "detail": row[2]})
+        rows.append({"step": row[0], "status": row[1], "detail": row[2], "next": row[3]})
 
 pass_count = sum(1 for r in rows if r["status"] == "pass")
 fail_count = sum(1 for r in rows if r["status"] == "fail")
@@ -416,9 +661,11 @@ lines = [
     "",
     f"- Generated: `{generated_at}`",
     f"- Platform: `{os_name}`",
+    f"- Preset: `{preset}`",
     f"- Dashboard port: `{dashboard_port}`",
     f"- Dashboard URL: `{dashboard_url}`",
     f"- Readiness profile: `{profile}`",
+    f"- Post-install verify: `{'enabled' if verify_enabled else 'disabled'}`",
     f"- Mode: `{'dry-run' if dry_run else 'execute'}`",
     f"- Status: `{status}`",
     f"- Pass: `{pass_count}`",
@@ -426,12 +673,23 @@ lines = [
     f"- Skipped: `{skip_count}`",
     f"- Planned: `{planned_count}`",
     "",
-    "| Step | Status | Detail |",
-    "|---|---|---|",
+    "| Step | Status | Detail | Next Command |",
+    "|---|---|---|---|",
 ]
 
 for row in rows:
-    lines.append(f"| `{row['step']}` | `{row['status']}` | {row['detail']} |")
+    lines.append(f"| `{row['step']}` | `{row['status']}` | {row['detail']} | `{row['next']}` |")
+
+failed_rows = [row for row in rows if row["status"] == "fail"]
+if failed_rows:
+    lines.extend([
+        "",
+        "## Failed Steps",
+    ])
+    for row in failed_rows:
+        lines.append(
+            f"- `{row['step']}`: {row['detail']} -> next: `{row['next']}`"
+        )
 
 report_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
 PY
@@ -443,6 +701,11 @@ echo "  - $report_file"
 if [[ "$DRY_RUN" == "1" ]]; then
   echo "VENTUREOS_INSTALL_RESULT=PLANNED"
   exit 0
+fi
+
+if [[ "$INSTALL_FAILED" != "0" ]]; then
+  echo "VENTUREOS_INSTALL_RESULT=FAIL"
+  exit 1
 fi
 
 echo "VENTUREOS_INSTALL_RESULT=PASS"


### PR DESCRIPTION
## Summary
- add installer verification mode (`--verify`) with checks for dashboard health, bridge status, cron marker, and readiness status artifact
- add install presets (`--preset full|bridge|minimal`) with deterministic explicit override handling for `--skip-*` and `--profile`
- improve installer report output with `Next Command` per step plus `Failed Steps` operator summary
- expand installer regression coverage for dry-run stability, verify flow, preset behavior, and failure report clarity

## Files
- `scripts/ventureos-install.sh`
- `scripts/tests/test-ventureos-install.sh`
- `README.md`
- `docs/SCRIPT_SPECS.md`

## Validation
- `bash -n scripts/ventureos-install.sh`
- `bash -n scripts/tests/test-ventureos-install.sh`
- `bash scripts/tests/test-ventureos-install.sh`
- `npm run docs:lint`
- `npm run roadmap:sync:check`

Closes #459
