### PR TITLE
Dashboard Next.js phase 3: authenticated shell + interactive task-board (#457)

### DIFF
--- a/dashboard-next/README.md
+++ b/dashboard-next/README.md
@@ -29,6 +29,7 @@ The readiness page (`/readiness`) calls backend endpoints directly and supports:
 - `/readiness` (read-only): consumes `/api/openclaw-local-readiness`
 - `/overview` (read-only): consumes `/api/health`, `/api/services`, `/api/system`
 - `/logs` (read-only): consumes `/api/logs/sources`, `/api/logs/entries`
+- `/task-board` (interactive): consumes `/api/task-board`, `/api/task-board/summary`, and task mutation routes
 
 ## Parity Guard
 
@@ -36,7 +37,7 @@ The readiness page (`/readiness`) calls backend endpoints directly and supports:
 npm run dashboard:next:parity
 ```
 
-This runs parity guards for readiness, overview, and logs view-model mappings.
+This runs parity guards for readiness, overview, logs, and task-board view-model mappings.
 
 ## Migration Notes
 

--- a/dashboard-next/app/globals.css
+++ b/dashboard-next/app/globals.css
@@ -68,6 +68,49 @@ a {
   padding: 14px;
 }
 
+.shell-card {
+  margin-bottom: 18px;
+}
+
+.shell-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+}
+
+.shell-title-wrap {
+  display: grid;
+  gap: 4px;
+}
+
+.shell-title {
+  font-size: 1rem;
+  letter-spacing: 0.02em;
+}
+
+.nav-row {
+  margin-top: 12px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.nav-chip {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 6px 10px;
+  color: var(--muted);
+  text-decoration: none;
+  font-size: 0.85rem;
+}
+
+.nav-chip.active {
+  color: var(--text);
+  border-color: var(--accent);
+  background: rgba(47, 212, 181, 0.12);
+}
+
 .card h3 {
   margin: 0 0 8px;
   color: var(--muted);
@@ -90,6 +133,8 @@ a {
   display: inline-flex;
   align-items: center;
   letter-spacing: 0.02em;
+  background: rgba(152, 184, 202, 0.14);
+  color: var(--muted);
 }
 
 .chip.go {
@@ -112,6 +157,10 @@ a {
   display: flex;
   flex-wrap: wrap;
   gap: 10px;
+}
+
+.compact-actions {
+  margin-top: 0;
 }
 
 input[type="text"] {
@@ -192,6 +241,11 @@ th {
 
 .muted {
   color: var(--muted);
+}
+
+.error-text {
+  margin-top: 10px;
+  color: var(--danger);
 }
 
 @media (max-width: 640px) {

--- a/dashboard-next/app/layout.js
+++ b/dashboard-next/app/layout.js
@@ -1,4 +1,5 @@
 import "./globals.css";
+import { DashboardSessionProvider } from "@/components/dashboard-session-context";
 
 export const metadata = {
   title: "VentureOS Dashboard Next",
@@ -8,7 +9,9 @@ export const metadata = {
 export default function RootLayout({ children }) {
   return (
     <html lang="en">
-      <body>{children}</body>
+      <body>
+        <DashboardSessionProvider>{children}</DashboardSessionProvider>
+      </body>
     </html>
   );
 }

--- a/dashboard-next/app/logs/page.js
+++ b/dashboard-next/app/logs/page.js
@@ -2,12 +2,9 @@
 
 import { useMemo, useState } from "react";
 
-import {
-  DEFAULT_API_BASE,
-  fetchDashboardJson,
-  loginWithToken,
-  normalizeApiBase,
-} from "@/lib/dashboard-api";
+import { DashboardShell } from "@/components/dashboard-shell";
+import { useDashboardSession } from "@/components/dashboard-session-context";
+import { fetchDashboardJson } from "@/lib/dashboard-api";
 import {
   normalizeLogEntriesPayload,
   normalizeLogSourcesPayload,
@@ -33,8 +30,12 @@ async function fetchEntries(apiBase, token, sourceId, opts) {
 }
 
 export default function LogsPage() {
-  const [apiBase, setApiBase] = useState(DEFAULT_API_BASE);
-  const [token, setToken] = useState("");
+  const {
+    normalizedApiBase,
+    token,
+    authenticateIfNeeded,
+  } = useDashboardSession();
+
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [sources, setSources] = useState([]);
@@ -51,10 +52,9 @@ export default function LogsPage() {
     setLoading(true);
     setError("");
     try {
-      const base = normalizeApiBase(apiBase);
-      if (!base) throw new Error("API base URL is required");
-      if (includeLogin && token.trim()) await loginWithToken(base, token);
-      const payload = await fetchSources(base, token);
+      if (!normalizedApiBase) throw new Error("API base URL is required");
+      if (includeLogin) await authenticateIfNeeded();
+      const payload = await fetchSources(normalizedApiBase, token);
       setSources(payload.sources);
       if (!selectedSource && payload.sources[0]?.id) {
         setSelectedSource(payload.sources[0].id);
@@ -71,11 +71,10 @@ export default function LogsPage() {
     setLoading(true);
     setError("");
     try {
-      const base = normalizeApiBase(apiBase);
-      if (!base) throw new Error("API base URL is required");
+      if (!normalizedApiBase) throw new Error("API base URL is required");
       if (!selectedSource) throw new Error("Select a log source first");
       const limitNum = Math.max(10, Math.min(2000, Number.parseInt(limit, 10) || 200));
-      const payload = await fetchEntries(base, token, selectedSource, {
+      const payload = await fetchEntries(normalizedApiBase, token, selectedSource, {
         limit: limitNum,
         search: search.trim(),
         level,
@@ -90,37 +89,17 @@ export default function LogsPage() {
   }
 
   return (
-    <main className="page">
-      <section className="hero">
-        <h1 className="title">Logs (Next Hybrid)</h1>
-        <p className="subtitle">
-          Read-only logs UI powered by backend routes <code>/api/logs/sources</code>{" "}
-          and <code>/api/logs/entries</code>.
-        </p>
-      </section>
-
-      <section className="card">
-        <h3>Connection</h3>
-        <div className="actions">
-          <input
-            type="text"
-            value={apiBase}
-            onChange={(e) => setApiBase(e.target.value)}
-            placeholder="Dashboard API base URL"
-          />
-          <input
-            type="text"
-            value={token}
-            onChange={(e) => setToken(e.target.value)}
-            placeholder="Optional token (used for login/header)"
-          />
-        </div>
-        <div className="actions">
+    <DashboardShell
+      title="Logs (Next Hybrid)"
+      subtitle="Read-only logs interface backed by /api/logs/sources and /api/logs/entries."
+      loadedAt={loadedAt}
+      actionButtons={(
+        <>
           <button
             disabled={loading}
             onClick={() => loadSources({ includeLogin: true })}
           >
-            {loading ? "Loading..." : "Login + Load Sources"}
+            {loading ? "Loading..." : "Authenticate + Load Sources"}
           </button>
           <button
             className="secondary"
@@ -129,10 +108,9 @@ export default function LogsPage() {
           >
             Load Sources Only
           </button>
-        </div>
-        {loadedAt ? <p className="muted">Last loaded: {loadedAt}</p> : null}
-      </section>
-
+        </>
+      )}
+    >
       {error ? (
         <section className="section card">
           <h3>Error</h3>
@@ -238,6 +216,6 @@ export default function LogsPage() {
           </table>
         )}
       </section>
-    </main>
+    </DashboardShell>
   );
 }

--- a/dashboard-next/app/overview/page.js
+++ b/dashboard-next/app/overview/page.js
@@ -2,12 +2,9 @@
 
 import { useMemo, useState } from "react";
 
-import {
-  DEFAULT_API_BASE,
-  fetchDashboardJson,
-  loginWithToken,
-  normalizeApiBase,
-} from "@/lib/dashboard-api";
+import { DashboardShell } from "@/components/dashboard-shell";
+import { useDashboardSession } from "@/components/dashboard-session-context";
+import { fetchDashboardJson } from "@/lib/dashboard-api";
 import { normalizeOverviewPayload } from "@/lib/overview";
 
 async function fetchOverview(apiBase, token) {
@@ -20,8 +17,12 @@ async function fetchOverview(apiBase, token) {
 }
 
 export default function OverviewPage() {
-  const [apiBase, setApiBase] = useState(DEFAULT_API_BASE);
-  const [token, setToken] = useState("");
+  const {
+    normalizedApiBase,
+    token,
+    authenticateIfNeeded,
+  } = useDashboardSession();
+
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [rawPayload, setRawPayload] = useState(null);
@@ -36,10 +37,9 @@ export default function OverviewPage() {
     setLoading(true);
     setError("");
     try {
-      const base = normalizeApiBase(apiBase);
-      if (!base) throw new Error("API base URL is required");
-      if (includeLogin && token.trim()) await loginWithToken(base, token);
-      const payload = await fetchOverview(base, token);
+      if (!normalizedApiBase) throw new Error("API base URL is required");
+      if (includeLogin) await authenticateIfNeeded();
+      const payload = await fetchOverview(normalizedApiBase, token);
       setRawPayload(payload);
       setLoadedAt(new Date().toISOString());
     } catch (err) {
@@ -50,34 +50,14 @@ export default function OverviewPage() {
   }
 
   return (
-    <main className="page">
-      <section className="hero">
-        <h1 className="title">Overview (Next Hybrid)</h1>
-        <p className="subtitle">
-          Read-only operational overview powered by existing backend contracts:
-          <code> /api/health</code>, <code>/api/services</code>, <code>/api/system</code>.
-        </p>
-      </section>
-
-      <section className="card">
-        <h3>Connection</h3>
-        <div className="actions">
-          <input
-            type="text"
-            value={apiBase}
-            onChange={(e) => setApiBase(e.target.value)}
-            placeholder="Dashboard API base URL"
-          />
-          <input
-            type="text"
-            value={token}
-            onChange={(e) => setToken(e.target.value)}
-            placeholder="Optional token (used for login/header)"
-          />
-        </div>
-        <div className="actions">
+    <DashboardShell
+      title="Overview (Next Hybrid)"
+      subtitle="Operational overview backed by /api/health, /api/services, and /api/system."
+      loadedAt={loadedAt}
+      actionButtons={(
+        <>
           <button disabled={loading} onClick={() => load({ includeLogin: true })}>
-            {loading ? "Loading..." : "Login + Load"}
+            {loading ? "Loading..." : "Authenticate + Load"}
           </button>
           <button
             className="secondary"
@@ -86,10 +66,9 @@ export default function OverviewPage() {
           >
             Load Only
           </button>
-        </div>
-        {loadedAt ? <p className="muted">Last loaded: {loadedAt}</p> : null}
-      </section>
-
+        </>
+      )}
+    >
       {error ? (
         <section className="section card">
           <h3>Error</h3>
@@ -165,6 +144,6 @@ export default function OverviewPage() {
           <p className="muted">Load overview data to see system and service metrics.</p>
         </section>
       )}
-    </main>
+    </DashboardShell>
   );
 }

--- a/dashboard-next/app/page.js
+++ b/dashboard-next/app/page.js
@@ -29,6 +29,10 @@ export default function HomePage() {
             <Link href="/logs">/logs</Link> (
             <code>/api/logs/sources</code>, <code>/api/logs/entries</code>)
           </li>
+          <li>
+            <Link href="/task-board">/task-board</Link> (
+            <code>/api/task-board</code>, <code>/api/task-board/summary</code>)
+          </li>
         </ul>
       </section>
     </main>

--- a/dashboard-next/app/readiness/page.js
+++ b/dashboard-next/app/readiness/page.js
@@ -1,13 +1,11 @@
 "use client";
 
 import { useMemo, useState } from "react";
+
+import { DashboardShell } from "@/components/dashboard-shell";
+import { useDashboardSession } from "@/components/dashboard-session-context";
+import { fetchDashboardJson } from "@/lib/dashboard-api";
 import { normalizeReadinessPayload } from "@/lib/readiness";
-import {
-  DEFAULT_API_BASE,
-  fetchDashboardJson,
-  loginWithToken,
-  normalizeApiBase,
-} from "@/lib/dashboard-api";
 
 function verdictClass(verdict) {
   if (verdict === "go") return "chip go";
@@ -20,8 +18,12 @@ async function fetchReadiness(apiBase, token) {
 }
 
 export default function ReadinessPage() {
-  const [apiBase, setApiBase] = useState(DEFAULT_API_BASE);
-  const [token, setToken] = useState("");
+  const {
+    normalizedApiBase,
+    token,
+    authenticateIfNeeded,
+  } = useDashboardSession();
+
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState("");
   const [rawPayload, setRawPayload] = useState(null);
@@ -36,12 +38,9 @@ export default function ReadinessPage() {
     setLoading(true);
     setError("");
     try {
-      const base = normalizeApiBase(apiBase);
-      if (!base) throw new Error("API base URL is required");
-      if (includeLogin && token.trim()) {
-        await loginWithToken(base, token);
-      }
-      const payload = await fetchReadiness(base, token);
+      if (!normalizedApiBase) throw new Error("API base URL is required");
+      if (includeLogin) await authenticateIfNeeded();
+      const payload = await fetchReadiness(normalizedApiBase, token);
       setRawPayload(payload);
       setLoadedAt(new Date().toISOString());
     } catch (err) {
@@ -56,38 +55,17 @@ export default function ReadinessPage() {
   const blockers = normalized.latest?.blockers ?? [];
 
   return (
-    <main className="page">
-      <section className="hero">
-        <h1 className="title">Local Readiness (Next Hybrid)</h1>
-        <p className="subtitle">
-          This page consumes the existing backend contract at{" "}
-          <code>/api/openclaw-local-readiness</code>. Authentication remains
-          backend-owned via <code>/api/login</code> and standard auth middleware.
-        </p>
-      </section>
-
-      <section className="card">
-        <h3>Connection</h3>
-        <div className="actions">
-          <input
-            type="text"
-            value={apiBase}
-            onChange={(e) => setApiBase(e.target.value)}
-            placeholder="Dashboard API base URL"
-          />
-          <input
-            type="text"
-            value={token}
-            onChange={(e) => setToken(e.target.value)}
-            placeholder="Optional token (used for login/header)"
-          />
-        </div>
-        <div className="actions">
+    <DashboardShell
+      title="Local Readiness (Next Hybrid)"
+      subtitle="Consumes /api/openclaw-local-readiness from the existing backend with cookie/token auth parity."
+      loadedAt={loadedAt}
+      actionButtons={(
+        <>
           <button
             disabled={loading}
             onClick={() => loadReadiness({ includeLogin: true })}
           >
-            {loading ? "Loading..." : "Login + Load"}
+            {loading ? "Loading..." : "Authenticate + Load"}
           </button>
           <button
             className="secondary"
@@ -96,12 +74,9 @@ export default function ReadinessPage() {
           >
             Load Only
           </button>
-        </div>
-        {loadedAt ? (
-          <p className="muted">Last loaded: {loadedAt}</p>
-        ) : null}
-      </section>
-
+        </>
+      )}
+    >
       {error ? (
         <section className="section card">
           <h3>Error</h3>
@@ -155,7 +130,8 @@ export default function ReadinessPage() {
           <h2>Top Blockers</h2>
           {blockers.map((blocker) => (
             <div key={blocker.id} className="blocker">
-              <strong>{blocker.id}</strong> ({blocker.severity})<br />
+              <strong>{blocker.id}</strong> ({blocker.severity})
+              <br />
               {blocker.description}
               <br />
               <span className="muted">
@@ -195,6 +171,6 @@ export default function ReadinessPage() {
           </table>
         </section>
       ) : null}
-    </main>
+    </DashboardShell>
   );
 }

--- a/dashboard-next/app/task-board/page.js
+++ b/dashboard-next/app/task-board/page.js
@@ -1,0 +1,312 @@
+"use client";
+
+import { useMemo, useState } from "react";
+
+import { DashboardShell } from "@/components/dashboard-shell";
+import { useDashboardSession } from "@/components/dashboard-session-context";
+import {
+  fetchDashboardJson,
+  requestDashboardJson,
+} from "@/lib/dashboard-api";
+import {
+  allowedTransitions,
+  normalizeTaskBoardPayload,
+  TASK_PRIORITIES,
+} from "@/lib/task-board";
+
+function formatTs(epochMs) {
+  if (!epochMs || !Number.isFinite(epochMs)) return "n/a";
+  try {
+    return new Date(epochMs).toISOString();
+  } catch {
+    return "n/a";
+  }
+}
+
+export default function TaskBoardPage() {
+  const {
+    normalizedApiBase,
+    token,
+    authenticateIfNeeded,
+  } = useDashboardSession();
+
+  const [loading, setLoading] = useState(false);
+  const [creating, setCreating] = useState(false);
+  const [transitioningId, setTransitioningId] = useState("");
+  const [error, setError] = useState("");
+  const [rawListPayload, setRawListPayload] = useState(null);
+  const [rawSummaryPayload, setRawSummaryPayload] = useState(null);
+  const [loadedAt, setLoadedAt] = useState("");
+  const [transitionTargets, setTransitionTargets] = useState({});
+  const [draft, setDraft] = useState({
+    title: "",
+    description: "",
+    assigneeId: "",
+    missionId: "",
+    priority: "medium",
+    status: "queued",
+  });
+
+  const board = useMemo(() => {
+    return normalizeTaskBoardPayload(rawListPayload, rawSummaryPayload);
+  }, [rawListPayload, rawSummaryPayload]);
+
+  async function loadBoard({ includeLogin }) {
+    setLoading(true);
+    setError("");
+    try {
+      if (!normalizedApiBase) throw new Error("API base URL is required");
+      if (includeLogin) await authenticateIfNeeded();
+      const [listPayload, summaryPayload] = await Promise.all([
+        fetchDashboardJson(normalizedApiBase, "/api/task-board", token),
+        fetchDashboardJson(normalizedApiBase, "/api/task-board/summary", token),
+      ]);
+      const normalized = normalizeTaskBoardPayload(listPayload, summaryPayload);
+      const nextTargets = {};
+      for (const task of normalized.tasks) {
+        const options = allowedTransitions(task.status);
+        if (options[0]) nextTargets[task.id] = options[0];
+      }
+      setTransitionTargets(nextTargets);
+      setRawListPayload(listPayload);
+      setRawSummaryPayload(summaryPayload);
+      setLoadedAt(new Date().toISOString());
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function createTask() {
+    setCreating(true);
+    setError("");
+    try {
+      if (!normalizedApiBase) throw new Error("API base URL is required");
+      if (!draft.title.trim()) throw new Error("Task title is required");
+      await authenticateIfNeeded();
+      await requestDashboardJson(normalizedApiBase, "/api/task-board", {
+        method: "POST",
+        token,
+        body: {
+          title: draft.title.trim(),
+          description: draft.description.trim(),
+          assigneeId: draft.assigneeId.trim() || null,
+          missionId: draft.missionId.trim() || null,
+          priority: draft.priority,
+          status: draft.status,
+        },
+      });
+      setDraft((prev) => ({
+        ...prev,
+        title: "",
+        description: "",
+      }));
+      await loadBoard({ includeLogin: false });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setCreating(false);
+    }
+  }
+
+  async function transitionTask(taskId) {
+    const target = transitionTargets[taskId];
+    if (!target) return;
+    setTransitioningId(taskId);
+    setError("");
+    try {
+      if (!normalizedApiBase) throw new Error("API base URL is required");
+      await authenticateIfNeeded();
+      await requestDashboardJson(normalizedApiBase, `/api/task-board/${taskId}`, {
+        method: "PATCH",
+        token,
+        body: { status: target },
+      });
+      await loadBoard({ includeLogin: false });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : "Unknown error");
+    } finally {
+      setTransitioningId("");
+    }
+  }
+
+  return (
+    <DashboardShell
+      title="Task Board (Next Hybrid, Interactive)"
+      subtitle="Interactive operational surface backed by existing /api/task-board contracts (create + transition)."
+      loadedAt={loadedAt}
+      actionButtons={(
+        <>
+          <button
+            disabled={loading || creating || Boolean(transitioningId)}
+            onClick={() => loadBoard({ includeLogin: true })}
+          >
+            {loading ? "Loading..." : "Authenticate + Load Board"}
+          </button>
+          <button
+            className="secondary"
+            disabled={loading || creating || Boolean(transitioningId)}
+            onClick={() => loadBoard({ includeLogin: false })}
+          >
+            Load Only
+          </button>
+        </>
+      )}
+    >
+      {error ? (
+        <section className="section card">
+          <h3>Error</h3>
+          <p>{error}</p>
+        </section>
+      ) : null}
+
+      <section className="section grid">
+        <article className="card">
+          <h3>Total</h3>
+          <div className="metric">{board.total}</div>
+        </article>
+        <article className="card">
+          <h3>Queued</h3>
+          <div className="metric">{board.summary.columns.queued}</div>
+        </article>
+        <article className="card">
+          <h3>Running</h3>
+          <div className="metric">{board.summary.columns.running}</div>
+        </article>
+        <article className="card">
+          <h3>Blocked</h3>
+          <div className="metric">{board.summary.columns.blocked}</div>
+        </article>
+        <article className="card">
+          <h3>Review</h3>
+          <div className="metric">{board.summary.columns.review}</div>
+        </article>
+        <article className="card">
+          <h3>Failed</h3>
+          <div className="metric">{board.summary.columns.failed}</div>
+        </article>
+      </section>
+
+      <section className="section card">
+        <h2>Create Task</h2>
+        <div className="actions">
+          <input
+            type="text"
+            value={draft.title}
+            onChange={(e) => setDraft((prev) => ({ ...prev, title: e.target.value }))}
+            placeholder="Title (required)"
+          />
+          <input
+            type="text"
+            value={draft.description}
+            onChange={(e) => setDraft((prev) => ({ ...prev, description: e.target.value }))}
+            placeholder="Description"
+          />
+          <input
+            type="text"
+            value={draft.assigneeId}
+            onChange={(e) => setDraft((prev) => ({ ...prev, assigneeId: e.target.value }))}
+            placeholder="Assignee ID"
+          />
+          <input
+            type="text"
+            value={draft.missionId}
+            onChange={(e) => setDraft((prev) => ({ ...prev, missionId: e.target.value }))}
+            placeholder="Mission ID"
+          />
+          <select
+            value={draft.priority}
+            onChange={(e) => setDraft((prev) => ({ ...prev, priority: e.target.value }))}
+          >
+            {TASK_PRIORITIES.map((priority) => (
+              <option key={priority} value={priority}>
+                priority: {priority}
+              </option>
+            ))}
+          </select>
+          <select
+            value={draft.status}
+            onChange={(e) => setDraft((prev) => ({ ...prev, status: e.target.value }))}
+          >
+            <option value="backlog">status: backlog</option>
+            <option value="queued">status: queued</option>
+          </select>
+          <button disabled={creating || loading} onClick={createTask}>
+            {creating ? "Creating..." : "Create Task"}
+          </button>
+        </div>
+      </section>
+
+      <section className="section card">
+        <h2>Tasks</h2>
+        {board.tasks.length === 0 ? (
+          <p className="muted">Load task-board data to view cards.</p>
+        ) : (
+          <table>
+            <thead>
+              <tr>
+                <th>Title</th>
+                <th>Status</th>
+                <th>Priority</th>
+                <th>Owner</th>
+                <th>Mission</th>
+                <th>Updated</th>
+                <th>Transition</th>
+              </tr>
+            </thead>
+            <tbody>
+              {board.tasks.map((task) => {
+                const transitionOptions = allowedTransitions(task.status);
+                const hasTransition = transitionOptions.length > 0;
+                return (
+                  <tr key={task.id}>
+                    <td>
+                      <strong>{task.title}</strong>
+                      {task.description ? <div className="muted">{task.description}</div> : null}
+                    </td>
+                    <td>{task.status}</td>
+                    <td>{task.priority}</td>
+                    <td>{task.assigneeId || "unassigned"}</td>
+                    <td>{task.missionId || "n/a"}</td>
+                    <td>{formatTs(task.updatedAt || task.createdAt)}</td>
+                    <td>
+                      {hasTransition ? (
+                        <div className="actions compact-actions">
+                          <select
+                            value={transitionTargets[task.id] ?? transitionOptions[0]}
+                            onChange={(e) =>
+                              setTransitionTargets((prev) => ({
+                                ...prev,
+                                [task.id]: e.target.value,
+                              }))
+                            }
+                          >
+                            {transitionOptions.map((status) => (
+                              <option key={`${task.id}-${status}`} value={status}>
+                                {status}
+                              </option>
+                            ))}
+                          </select>
+                          <button
+                            className="secondary"
+                            disabled={transitioningId === task.id || loading || creating}
+                            onClick={() => transitionTask(task.id)}
+                          >
+                            {transitioningId === task.id ? "Applying..." : "Apply"}
+                          </button>
+                        </div>
+                      ) : (
+                        <span className="muted">no transitions</span>
+                      )}
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        )}
+      </section>
+    </DashboardShell>
+  );
+}

--- a/dashboard-next/components/dashboard-session-context.js
+++ b/dashboard-next/components/dashboard-session-context.js
@@ -1,0 +1,120 @@
+"use client";
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
+
+import {
+  DEFAULT_API_BASE,
+  loginWithToken,
+  normalizeApiBase,
+} from "@/lib/dashboard-api";
+
+const SESSION_STORAGE_API_BASE = "ventureos.dashboardNext.apiBase";
+const SESSION_STORAGE_TOKEN = "ventureos.dashboardNext.token";
+
+const DashboardSessionContext = createContext(null);
+
+function readStorage(key, fallbackValue) {
+  if (typeof window === "undefined") return fallbackValue;
+  const raw = window.localStorage.getItem(key);
+  return raw == null ? fallbackValue : raw;
+}
+
+export function DashboardSessionProvider({ children }) {
+  const [apiBase, setApiBase] = useState(DEFAULT_API_BASE);
+  const [token, setToken] = useState("");
+  const [authState, setAuthState] = useState("idle");
+  const [authError, setAuthError] = useState("");
+  const [lastAuthAt, setLastAuthAt] = useState("");
+
+  useEffect(() => {
+    setApiBase(readStorage(SESSION_STORAGE_API_BASE, DEFAULT_API_BASE));
+    setToken(readStorage(SESSION_STORAGE_TOKEN, ""));
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(SESSION_STORAGE_API_BASE, apiBase);
+  }, [apiBase]);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    window.localStorage.setItem(SESSION_STORAGE_TOKEN, token);
+  }, [token]);
+
+  useEffect(() => {
+    setAuthState("idle");
+    setAuthError("");
+    setLastAuthAt("");
+  }, [apiBase, token]);
+
+  const authenticate = useCallback(async () => {
+    const base = normalizeApiBase(apiBase);
+    const cleanToken = String(token ?? "").trim();
+    if (!base) throw new Error("API base URL is required");
+    if (!cleanToken) throw new Error("Token is required to authenticate session");
+
+    setAuthState("authenticating");
+    setAuthError("");
+    try {
+      await loginWithToken(base, cleanToken);
+      setAuthState("authenticated");
+      setLastAuthAt(new Date().toISOString());
+      setAuthError("");
+    } catch (err) {
+      setAuthState("error");
+      const message = err instanceof Error ? err.message : "Authentication failed";
+      setAuthError(message);
+      throw err;
+    }
+  }, [apiBase, token]);
+
+  const authenticateIfNeeded = useCallback(async () => {
+    if (authState === "authenticated") return;
+    await authenticate();
+  }, [authState, authenticate]);
+
+  const value = useMemo(
+    () => ({
+      apiBase,
+      setApiBase,
+      token,
+      setToken,
+      authState,
+      authError,
+      lastAuthAt,
+      authenticate,
+      authenticateIfNeeded,
+      normalizedApiBase: normalizeApiBase(apiBase),
+    }),
+    [
+      apiBase,
+      token,
+      authState,
+      authError,
+      lastAuthAt,
+      authenticate,
+      authenticateIfNeeded,
+    ],
+  );
+
+  return (
+    <DashboardSessionContext.Provider value={value}>
+      {children}
+    </DashboardSessionContext.Provider>
+  );
+}
+
+export function useDashboardSession() {
+  const ctx = useContext(DashboardSessionContext);
+  if (!ctx) {
+    throw new Error("useDashboardSession must be used inside DashboardSessionProvider");
+  }
+  return ctx;
+}

--- a/dashboard-next/components/dashboard-shell.js
+++ b/dashboard-next/components/dashboard-shell.js
@@ -1,0 +1,115 @@
+"use client";
+
+import Link from "next/link";
+import { usePathname } from "next/navigation";
+
+import { useDashboardSession } from "@/components/dashboard-session-context";
+
+const ROUTES = [
+  { href: "/readiness", label: "Readiness" },
+  { href: "/overview", label: "Overview" },
+  { href: "/logs", label: "Logs" },
+  { href: "/task-board", label: "Task Board" },
+];
+
+function authBadgeClass(authState) {
+  if (authState === "authenticated") return "chip go";
+  if (authState === "authenticating") return "chip hold";
+  if (authState === "error") return "chip blocked";
+  return "chip";
+}
+
+function authLabel(authState) {
+  if (authState === "authenticated") return "authenticated";
+  if (authState === "authenticating") return "authenticating";
+  if (authState === "error") return "auth error";
+  return "idle";
+}
+
+export function DashboardShell({
+  title,
+  subtitle,
+  loadedAt,
+  actionButtons,
+  children,
+}) {
+  const pathname = usePathname();
+  const {
+    apiBase,
+    setApiBase,
+    token,
+    setToken,
+    authState,
+    authError,
+    lastAuthAt,
+    authenticate,
+  } = useDashboardSession();
+
+  async function onAuthenticate() {
+    try {
+      await authenticate();
+    } catch {
+      // Error details are already captured in shared session state.
+    }
+  }
+
+  return (
+    <main className="page">
+      <section className="card shell-card">
+        <div className="shell-row">
+          <div className="shell-title-wrap">
+            <strong className="shell-title">Dashboard Next Hybrid</strong>
+            <span className="muted">Backend auth + API routes remain source of truth</span>
+          </div>
+          <span className={authBadgeClass(authState)}>{authLabel(authState)}</span>
+        </div>
+        <div className="nav-row">
+          {ROUTES.map((route) => (
+            <Link
+              key={route.href}
+              href={route.href}
+              className={`nav-chip${pathname === route.href ? " active" : ""}`}
+            >
+              {route.label}
+            </Link>
+          ))}
+        </div>
+        <div className="actions">
+          <input
+            type="text"
+            value={apiBase}
+            onChange={(e) => setApiBase(e.target.value)}
+            placeholder="Dashboard API base URL"
+          />
+          <input
+            type="text"
+            value={token}
+            onChange={(e) => setToken(e.target.value)}
+            placeholder="Token for /api/login and Authorization header"
+          />
+          <button
+            disabled={authState === "authenticating"}
+            onClick={onAuthenticate}
+          >
+            {authState === "authenticating" ? "Authenticating..." : "Authenticate Session"}
+          </button>
+        </div>
+        {lastAuthAt ? <p className="muted">Last authenticated: {lastAuthAt}</p> : null}
+        {authError ? <p className="error-text">{authError}</p> : null}
+      </section>
+
+      <section className="hero">
+        <h1 className="title">{title}</h1>
+        <p className="subtitle">{subtitle}</p>
+      </section>
+
+      <section className="card">
+        <h3>Actions</h3>
+        <div className="actions">{actionButtons}</div>
+        {loadedAt ? <p className="muted">Last loaded: {loadedAt}</p> : null}
+      </section>
+
+      {children}
+    </main>
+  );
+}

--- a/dashboard-next/docs/MIGRATION_CHECKLIST.md
+++ b/dashboard-next/docs/MIGRATION_CHECKLIST.md
@@ -1,7 +1,7 @@
 # Next Hybrid Migration Checklist
 
-Date: 2026-02-22
-Issue: #454
+Date: 2026-02-23
+Issue: #457
 
 ## Scope
 
@@ -14,6 +14,7 @@ Incrementally adopt Next.js for dashboard UI while preserving existing backend A
 | Readiness | `dashboard/client/index.html` readiness card | `/readiness` | `GET /api/openclaw-local-readiness` | Phase 1 shipped |
 | Overview | `dashboard/client/index.html` overview panel | `/overview` | `GET /api/health`, `GET /api/services`, `GET /api/system` | Phase 2 shipped |
 | Logs | `dashboard/client/index.html` logs panels | `/logs` | `GET /api/logs/sources`, `GET /api/logs/entries` | Phase 2 shipped |
+| Task Board (Interactive) | `dashboard/client/index.html` task board surface | `/task-board` | `GET /api/task-board`, `GET /api/task-board/summary`, `POST /api/task-board`, `PATCH /api/task-board/:id` | Phase 3 shipped |
 
 ## Auth + Security Constraints
 
@@ -28,7 +29,8 @@ Incrementally adopt Next.js for dashboard UI while preserving existing backend A
   - `npm run dashboard:next:parity`
 - Manual endpoint verification:
   - Login against backend (`/api/login`)
-  - Load `/readiness`, `/overview`, `/logs` pages
+  - Load `/readiness`, `/overview`, `/logs`, `/task-board` pages
+  - Create a task and transition status in `/task-board`
   - Confirm displayed metrics/rows align with backend API payloads
 
 ## Rollback Notes

--- a/dashboard-next/fixtures/task-board.sample.json
+++ b/dashboard-next/fixtures/task-board.sample.json
@@ -1,0 +1,64 @@
+{
+  "listPayload": {
+    "tasks": [
+      {
+        "id": "task-001",
+        "title": "Verify bridge auth",
+        "description": "Confirm bridge scheduler endpoint auth parity",
+        "status": "queued",
+        "priority": "high",
+        "assigneeId": "oracle",
+        "missionId": "mc-310",
+        "createdAt": 1763863200000,
+        "updatedAt": 1763863500000
+      },
+      {
+        "id": "task-002",
+        "title": "Ship parity check",
+        "description": "Add Next parity fixture",
+        "status": "running",
+        "priority": "critical",
+        "assigneeId": "sherlock",
+        "missionId": "mc-310",
+        "createdAt": 1763863100000,
+        "updatedAt": 1763863600000
+      },
+      {
+        "id": "task-003",
+        "title": "Archive stale cards",
+        "description": "Cleanup done cards",
+        "status": "done",
+        "priority": "low",
+        "assigneeId": "",
+        "missionId": "",
+        "createdAt": 1763863000000,
+        "updatedAt": 1763863400000
+      }
+    ],
+    "total": 3
+  },
+  "summaryPayload": {
+    "updatedAt": 1763863700000,
+    "total": 3,
+    "columns": {
+      "backlog": 0,
+      "queued": 1,
+      "running": 1,
+      "blocked": 0,
+      "review": 0,
+      "done": 1,
+      "failed": 0
+    },
+    "byAgent": {
+      "oracle": {
+        "backlog": 0,
+        "queued": 1,
+        "running": 0,
+        "blocked": 0,
+        "review": 0,
+        "done": 0,
+        "failed": 0
+      }
+    }
+  }
+}

--- a/dashboard-next/lib/dashboard-api.js
+++ b/dashboard-next/lib/dashboard-api.js
@@ -13,6 +13,14 @@ export function buildAuthHeaders(token, extra = {}) {
   return headers;
 }
 
+async function readResponseJson(res) {
+  try {
+    return await res.json();
+  } catch {
+    return null;
+  }
+}
+
 export async function loginWithToken(apiBase, token) {
   const base = normalizeApiBase(apiBase);
   const clean = String(token ?? "").trim();
@@ -26,14 +34,39 @@ export async function loginWithToken(apiBase, token) {
   if (!res.ok) throw new Error(`Login failed (${res.status})`);
 }
 
-export async function fetchDashboardJson(apiBase, path, token = "") {
+export async function requestDashboardJson(
+  apiBase,
+  path,
+  { method = "GET", token = "", body = undefined } = {},
+) {
   const base = normalizeApiBase(apiBase);
   if (!base) throw new Error("API base URL is required");
-  const res = await fetch(`${base}${path}`, {
-    method: "GET",
+  const headers = buildAuthHeaders(token);
+  const init = {
+    method,
     credentials: "include",
-    headers: buildAuthHeaders(token),
+    headers,
+  };
+  if (body !== undefined) {
+    headers["Content-Type"] = "application/json";
+    init.body = JSON.stringify(body);
+  }
+
+  const res = await fetch(`${base}${path}`, {
+    ...init,
   });
-  if (!res.ok) throw new Error(`${path} failed (${res.status})`);
-  return res.json();
+  if (!res.ok) {
+    const payload = await readResponseJson(res);
+    const detail =
+      payload && typeof payload.error === "string" ? payload.error : "";
+    if (detail) {
+      throw new Error(`${path} failed (${res.status}): ${detail}`);
+    }
+    throw new Error(`${path} failed (${res.status})`);
+  }
+  return readResponseJson(res);
+}
+
+export async function fetchDashboardJson(apiBase, path, token = "") {
+  return requestDashboardJson(apiBase, path, { method: "GET", token });
 }

--- a/dashboard-next/lib/task-board.js
+++ b/dashboard-next/lib/task-board.js
@@ -1,0 +1,112 @@
+const TASK_STATUSES = [
+  "backlog",
+  "queued",
+  "running",
+  "blocked",
+  "review",
+  "done",
+  "failed",
+];
+
+const TASK_PRIORITIES = ["critical", "high", "medium", "low"];
+
+const TASK_TRANSITIONS = {
+  backlog: ["queued", "blocked", "review", "done"],
+  queued: ["running", "blocked", "backlog", "done"],
+  running: ["review", "blocked", "done", "failed"],
+  blocked: ["queued", "running", "review", "done"],
+  review: ["running", "done", "blocked"],
+  done: ["backlog"],
+  failed: ["backlog", "queued", "blocked"],
+};
+
+function asRecord(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return value;
+}
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function asString(value, fallback = "") {
+  if (typeof value === "string" && value.trim()) return value.trim();
+  if (typeof value === "number" && Number.isFinite(value)) return String(value);
+  return fallback;
+}
+
+function asNumber(value, fallback = 0) {
+  if (typeof value === "number" && Number.isFinite(value)) return value;
+  const parsed = Number.parseFloat(String(value ?? ""));
+  return Number.isFinite(parsed) ? parsed : fallback;
+}
+
+function normalizeStatus(status) {
+  const clean = asString(status, "backlog").toLowerCase();
+  return TASK_STATUSES.includes(clean) ? clean : "backlog";
+}
+
+function normalizePriority(priority) {
+  const clean = asString(priority, "medium").toLowerCase();
+  return TASK_PRIORITIES.includes(clean) ? clean : "medium";
+}
+
+function normalizeTaskCard(row) {
+  const card = asRecord(row) ?? {};
+  return {
+    id: asString(card.id, ""),
+    title: asString(card.title, "Untitled task"),
+    description: asString(card.description, ""),
+    status: normalizeStatus(card.status),
+    priority: normalizePriority(card.priority),
+    assigneeId: asString(card.assigneeId, card.agentId ? asString(card.agentId, "") : ""),
+    missionId: asString(card.missionId, ""),
+    missionBrief: asString(card.missionBrief, ""),
+    createdAt: asNumber(card.createdAt, 0),
+    updatedAt: asNumber(card.updatedAt, 0),
+  };
+}
+
+function normalizeColumnCounts(value) {
+  const raw = asRecord(value) ?? {};
+  const columns = {};
+  for (const status of TASK_STATUSES) {
+    columns[status] = asNumber(raw[status], 0);
+  }
+  return columns;
+}
+
+export function normalizeTaskBoardListPayload(payload) {
+  const root = asRecord(payload) ?? {};
+  const tasks = asArray(root.tasks).map((row) => normalizeTaskCard(row));
+  return {
+    tasks,
+    total: asNumber(root.total, tasks.length),
+  };
+}
+
+export function normalizeTaskBoardSummaryPayload(payload) {
+  const root = asRecord(payload) ?? {};
+  return {
+    total: asNumber(root.total, 0),
+    updatedAt: asNumber(root.updatedAt, 0),
+    columns: normalizeColumnCounts(root.columns),
+  };
+}
+
+export function normalizeTaskBoardPayload(listPayload, summaryPayload) {
+  const list = normalizeTaskBoardListPayload(listPayload);
+  const summary = normalizeTaskBoardSummaryPayload(summaryPayload);
+  return {
+    tasks: list.tasks,
+    total: list.total,
+    summary,
+  };
+}
+
+export function allowedTransitions(status) {
+  const current = normalizeStatus(status);
+  return TASK_TRANSITIONS[current] ?? [];
+}
+
+export { TASK_PRIORITIES, TASK_STATUSES };

--- a/dashboard-next/package.json
+++ b/dashboard-next/package.json
@@ -11,7 +11,8 @@
     "parity:readiness": "node scripts/parity-check-readiness.mjs",
     "parity:overview": "node scripts/parity-check-overview.mjs",
     "parity:logs": "node scripts/parity-check-logs.mjs",
-    "parity:all": "npm run parity:readiness && npm run parity:overview && npm run parity:logs"
+    "parity:task-board": "node scripts/parity-check-task-board.mjs",
+    "parity:all": "npm run parity:readiness && npm run parity:overview && npm run parity:logs && npm run parity:task-board"
   },
   "dependencies": {
     "next": "^14.2.5",

--- a/dashboard-next/scripts/parity-check-task-board.mjs
+++ b/dashboard-next/scripts/parity-check-task-board.mjs
@@ -1,0 +1,37 @@
+import assert from "node:assert/strict";
+import fs from "node:fs";
+import path from "node:path";
+import url from "node:url";
+
+import {
+  allowedTransitions,
+  normalizeTaskBoardPayload,
+} from "../lib/task-board.js";
+
+const __dirname = path.dirname(url.fileURLToPath(import.meta.url));
+const fixturePath = path.join(__dirname, "..", "fixtures", "task-board.sample.json");
+const fixture = JSON.parse(fs.readFileSync(fixturePath, "utf8"));
+
+const normalized = normalizeTaskBoardPayload(
+  fixture.listPayload,
+  fixture.summaryPayload,
+);
+
+assert.equal(normalized.total, 3);
+assert.equal(normalized.tasks.length, 3);
+assert.equal(normalized.tasks[0]?.id, "task-001");
+assert.equal(normalized.tasks[1]?.status, "running");
+assert.equal(normalized.tasks[2]?.priority, "low");
+
+assert.equal(normalized.summary.total, 3);
+assert.equal(normalized.summary.columns.queued, 1);
+assert.equal(normalized.summary.columns.running, 1);
+assert.equal(normalized.summary.columns.done, 1);
+
+const queuedTransitions = allowedTransitions("queued");
+assert.deepEqual(queuedTransitions, ["running", "blocked", "backlog", "done"]);
+
+const doneTransitions = allowedTransitions("done");
+assert.deepEqual(doneTransitions, ["backlog"]);
+
+console.log("DASHBOARD_NEXT_TASK_BOARD_PARITY_OK");


### PR DESCRIPTION
## Summary
- add a shared authenticated shell in `dashboard-next` with session controls and route navigation parity across migrated pages
- migrate one interactive operational surface to Next.js via new `/task-board` route (list, summary, create, and status transitions)
- preserve existing backend contracts and auth ownership by continuing to use `/api/login` + existing `/api/task-board*` routes without backend changes
- extend parity guard coverage with a task-board fixture and `parity-check-task-board.mjs`
- update migration docs/checklist for phase 3

## Files
- `dashboard-next/components/dashboard-session-context.js`
- `dashboard-next/components/dashboard-shell.js`
- `dashboard-next/app/task-board/page.js`
- `dashboard-next/lib/task-board.js`
- `dashboard-next/scripts/parity-check-task-board.mjs`
- `dashboard-next/fixtures/task-board.sample.json`
- `dashboard-next/app/readiness/page.js`
- `dashboard-next/app/overview/page.js`
- `dashboard-next/app/logs/page.js`
- `dashboard-next/lib/dashboard-api.js`
- `dashboard-next/app/layout.js`
- `dashboard-next/app/globals.css`
- `dashboard-next/app/page.js`
- `dashboard-next/package.json`
- `dashboard-next/README.md`
- `dashboard-next/docs/MIGRATION_CHECKLIST.md`

## Validation
- `npm run dashboard:next:parity`
- `npm run dashboard:next:build`
- `npm run docs:lint`
- `npm run roadmap:sync:check`

Closes #457
