### PR TITLE
Add VB-003 telemetry cron synthesis and reliability wiring

### DIFF
--- a/config/reliability.json
+++ b/config/reliability.json
@@ -118,6 +118,15 @@
       "has_network": false,
       "degradation_tier": "D1",
       "notes": "Regenerates local readiness report + mission card artifacts with retention controls"
+    },
+    "vb003-telemetry-synthesis": {
+      "script": "scripts/vb003-telemetry-synthesis.sh",
+      "timeout_seconds": 120,
+      "max_attempts": 1,
+      "base_sleep_seconds": 0,
+      "has_network": false,
+      "degradation_tier": "D1",
+      "notes": "Builds rolling model-orchestration telemetry synthesis artifacts for VB-003 closure"
     }
   }
 }

--- a/docs/CRON_SPECS.md
+++ b/docs/CRON_SPECS.md
@@ -82,8 +82,21 @@
 - **Stale guardrail:** defaults to `--max-age-min 360`; job fails when latest paired report is older
 - **Added:** 2026-02-22
 
+## 13) VB-003 Telemetry Synthesis
+- **Schedule:** `30 */6 * * *`
+- **Session:** isolated
+- **Agent:** main
+- **Payload:** run `scripts/vb003-telemetry-synthesis.sh`
+- **Outputs:**
+  - `runtime/reports/model-orchestration/vb003-telemetry-<timestamp>.json`
+  - `runtime/reports/model-orchestration/vb003-telemetry-<timestamp>.md`
+  - `runtime/reports/model-orchestration/vb003-telemetry-latest.json`
+  - `runtime/reports/model-orchestration/vb003-telemetry-latest.md`
+- **Goal:** maintain a rolling 7-day evidence trail for VB-003 closure decisions.
+- **Added:** 2026-02-22
+
 ## Current Next Steps (February 23, 2026)
 1. Roll this schedule onto the host with `bash scripts/install-cron.sh --force`.
-2. Validate first run via `runtime/logs/cron-runs/openclaw-local-ready.jsonl`.
-3. Validate stale guardrail via `bash scripts/refresh-local-integration-ready.sh --skip-smoke --max-age-min 360`.
-4. Confirm `docs/LOCAL_INTEGRATION_READY.md` and Mission Control readiness card move forward on the next cadence tick.
+2. Validate first run via `runtime/logs/cron-runs/vb003-telemetry-synthesis.jsonl`.
+3. Validate latest synthesis artifacts under `runtime/reports/model-orchestration/`.
+4. Confirm `docs/LOCAL_INTEGRATION_READY.md` and Mission Control readiness card continue moving on cadence.

--- a/docs/DEGRADATION_POLICY.md
+++ b/docs/DEGRADATION_POLICY.md
@@ -155,6 +155,7 @@ This matrix maps **every cron job** to its degradation behavior, timeout/retry c
 | 10 | **Session Monitor** | `0 */6 * * *` | 60s | 2 | **Yes** | D1: check next 6h cycle | D1: auto-rotate skipped | D1 | 6h monitoring gap |
 | 11 | **Routing Healthcheck** | `*/30 * * * *` | 30s | 2 | **Yes** | D2: routing unknown | D2: alert routing may be broken | D2 | Missed P1 alerts |
 | 12 | **OpenClaw Local Readiness Refresh** | `15 */4 * * *` | 180s | 1 | No | D1: keep prior readiness snapshot | D1: no doc/artifact refresh for this cycle | D1 | Stale local readiness card/evidence |
+| 13 | **VB-003 Telemetry Synthesis** | `30 */6 * * *` | 120s | 1 | No | D1: keep prior synthesis artifact | D1: telemetry summary not refreshed this cycle | D1 | Delayed VB-003 evidence updates |
 
 ### Failure Cascades
 

--- a/docs/SCRIPT_SPECS.md
+++ b/docs/SCRIPT_SPECS.md
@@ -93,11 +93,16 @@
 ---
 
 ## 6) budget-check.sh
-**Purpose:** Emit quota usage report using `subscription-quota-tracker.js`.
+**Purpose:** Emit quota usage report using `subscription-quota-tracker.js`, with OpenClaw usage fallback when tracker is unavailable.
 
 **Outputs:**
 - stdout quota usage report
 - Cron job will parse/alert at 50/80/90%
+
+**Behavior:**
+- Uses `SUBSCRIPTION_TRACKER_PATH` override when set.
+- If tracker is missing, falls back to `openclaw channels list --json` and emits normalized JSON.
+- Supports `OPENCLAW_BIN` override for non-default CLI path.
 
 ---
 
@@ -312,10 +317,47 @@ bash scripts/openclaw-local-ready-cron.sh
 bash scripts/tests/test-openclaw-local-ready-cron.sh
 ```
 
+---
+
+## 16) vb003-telemetry-synthesis.sh
+**Purpose:** Generate a rolling telemetry synthesis artifact for VB-003 model-orchestration verification.
+
+**Usage:**
+```bash
+bash scripts/vb003-telemetry-synthesis.sh
+```
+
+**Behavior:**
+- Reads run telemetry from `~/.openclaw/cron/runs/*.jsonl`.
+- Applies a lookback window (default: `168h`, configurable via `VB003_LOOKBACK_HOURS`).
+- Aggregates model/runtime metrics:
+  - run counts and status counts
+  - latency distribution (`p50`, `p95`)
+  - token totals
+  - model/provider mix
+- Aggregates VentureOS cron metrics for:
+  - `budget-check`
+  - `routing-healthcheck`
+  - `monitoring`
+- Includes latest budget snapshot payload (if present) from `~/.openclaw/logs/cron-budget.log`.
+- Writes timestamped artifacts plus latest pointers:
+  - `runtime/reports/model-orchestration/vb003-telemetry-<timestamp>.json`
+  - `runtime/reports/model-orchestration/vb003-telemetry-<timestamp>.md`
+  - `runtime/reports/model-orchestration/vb003-telemetry-latest.json`
+  - `runtime/reports/model-orchestration/vb003-telemetry-latest.md`
+- Emits a verification state:
+  - `no_data`
+  - `window_insufficient`
+  - `ready_for_closure_review`
+
+**Cron integration:**
+- Wired as `vb003-telemetry-synthesis` in `config/reliability.json`.
+- Scheduled every 6 hours via `scripts/install-cron.sh`.
+
 **Current next steps (operator rollout):**
 1. `bash scripts/install-cron.sh --force`
-2. `bash scripts/openclaw-local-ready-cron.sh`
-3. `bash scripts/refresh-local-integration-ready.sh --skip-smoke --max-age-min 360`
+2. `bash scripts/vb003-telemetry-synthesis.sh`
+3. Validate `runtime/reports/model-orchestration/vb003-telemetry-latest.{json,md}`.
 4. Validate `docs/LOCAL_INTEGRATION_READY.md` timestamp and `runtime/reports/openclaw-local-smoke/` artifact rotation.
 
 ---

--- a/scripts/budget-check.sh
+++ b/scripts/budget-check.sh
@@ -3,5 +3,40 @@ set -euo pipefail
 
 export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
 
-node "$HOME/clawd/subscription-quota-tracker.js" report
-# Parsing + alerting handled by cron wrapper
+TRACKER_PATH="${SUBSCRIPTION_TRACKER_PATH:-$HOME/clawd/subscription-quota-tracker.js}"
+OPENCLAW_BIN="${OPENCLAW_BIN:-openclaw}"
+
+if [[ -f "$TRACKER_PATH" ]]; then
+  node "$TRACKER_PATH" report
+  exit 0
+fi
+
+echo "WARN: subscription tracker missing at $TRACKER_PATH; using OpenClaw usage fallback" >&2
+
+if ! command -v "$OPENCLAW_BIN" >/dev/null 2>&1; then
+  echo "ERROR: OpenClaw CLI not found ($OPENCLAW_BIN); cannot collect usage fallback" >&2
+  exit 1
+fi
+
+if ! command -v jq >/dev/null 2>&1; then
+  echo "ERROR: jq is required for fallback usage shaping" >&2
+  exit 1
+fi
+
+USAGE_JSON="$("$OPENCLAW_BIN" channels list --json 2>/dev/null || true)"
+if [[ -z "$USAGE_JSON" ]]; then
+  echo "ERROR: unable to fetch usage snapshot from openclaw channels list --json" >&2
+  exit 1
+fi
+
+echo "$USAGE_JSON" | jq -c '
+{
+  source: "openclaw.channels.list",
+  capturedAt: (.usage.updatedAt // null),
+  providers: ((.usage.providers // []) | map({
+    provider,
+    displayName,
+    plan,
+    windows
+  }))
+}'

--- a/scripts/discord-webhook-send.mjs
+++ b/scripts/discord-webhook-send.mjs
@@ -1,0 +1,73 @@
+#!/usr/bin/env node
+
+import fs from "node:fs";
+import path from "node:path";
+import os from "node:os";
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 0; i < argv.length; i += 1) {
+    const key = argv[i];
+    if (!key.startsWith("--")) continue;
+    const name = key.slice(2);
+    const value = argv[i + 1];
+    if (!value || value.startsWith("--")) {
+      throw new Error(`Missing value for --${name}`);
+    }
+    out[name] = value;
+    i += 1;
+  }
+  return out;
+}
+
+function resolvePath(input) {
+  if (!input) return input;
+  if (input === "~") return os.homedir();
+  if (input.startsWith("~/")) return path.join(os.homedir(), input.slice(2));
+  return input;
+}
+
+const args = parseArgs(process.argv.slice(2));
+const channel = args.channel;
+const text = args.text;
+const mapPath = resolvePath(
+  args.map || process.env.DISCORD_WEBHOOK_MAP_PATH || "~/.openclaw/credentials/discord/webhooks.json",
+);
+
+if (!channel || !text) {
+  console.error("Usage: discord-webhook-send.mjs --channel <channelId> --text <message> [--map <path>]");
+  process.exit(2);
+}
+
+if (!fs.existsSync(mapPath)) {
+  console.error(`Webhook map not found: ${mapPath}`);
+  process.exit(2);
+}
+
+let map;
+try {
+  map = JSON.parse(fs.readFileSync(mapPath, "utf8"));
+} catch (err) {
+  console.error(`Invalid webhook map JSON at ${mapPath}: ${err.message}`);
+  process.exit(2);
+}
+
+const webhookUrl = map[channel];
+if (!webhookUrl) {
+  console.error(`No webhook URL configured for channel: ${channel}`);
+  process.exit(2);
+}
+
+const resp = await fetch(webhookUrl, {
+  method: "POST",
+  headers: { "content-type": "application/json" },
+  body: JSON.stringify({ content: text }),
+});
+
+if (!resp.ok) {
+  const body = await resp.text().catch(() => "");
+  console.error(`Webhook send failed (${resp.status}) ${body.slice(0, 200)}`);
+  process.exit(1);
+}
+
+process.exit(0);

--- a/scripts/install-cron.sh
+++ b/scripts/install-cron.sh
@@ -103,6 +103,9 @@ NEW_CRON=$(cat <<EOF
 # 12) Local OpenClaw readiness refresh — every 4 hours
 15 */4 * * * $RUNNER openclaw-local-ready >> $LOG_BASE/cron-openclaw-local-ready.log 2>&1
 
+# 13) VB-003 telemetry synthesis — every 6 hours
+30 */6 * * * $RUNNER vb003-telemetry-synthesis >> $LOG_BASE/cron-vb003-telemetry.log 2>&1
+
 # === END $CRON_MARKER ===
 EOF
 )

--- a/scripts/monitor-openclaw.sh
+++ b/scripts/monitor-openclaw.sh
@@ -35,7 +35,7 @@ mkdir -p "$(dirname "$STATE")"
 [[ -f "$STATE" ]] || echo '{"last_check":0,"last_alert":0,"last_issue_hash":"","gateway_err_pos":0,"gateway_err_inode":""}' > "$STATE"
 
 NOW=$(date +%s)
-ISSUES=()
+declare -a ISSUES=()
 GATEWAY_OK=true
 
 if ! openclaw gateway status >/dev/null 2>&1; then
@@ -97,12 +97,12 @@ LAST_ALERT=$(jq -r '.last_alert // 0' "$STATE" 2>/dev/null || echo 0)
 LAST_HASH=$(jq -r '.last_issue_hash // ""' "$STATE" 2>/dev/null || echo "")
 
 # Fingerprint current issue state + (small) evidence so we can dedupe repeats.
-ISSUE_KEY=$(printf '%s;' "${ISSUES[@]}")
+ISSUE_KEY=$(printf '%s;' "${ISSUES[@]-}")
 CUR_HASH=$(printf '%s\n%s' "$ISSUE_KEY" "$MATCH_SNIPPET" | shasum -a 256 | awk '{print $1}')
 
 # Always emit P0 immediately; only dedupe repeated P1-only alerts.
 HAS_P0=false
-for i in "${ISSUES[@]}"; do
+for i in "${ISSUES[@]-}"; do
   if [[ "$i" == P0:* ]]; then
     HAS_P0=true
     break

--- a/scripts/tests/test-reliability.sh
+++ b/scripts/tests/test-reliability.sh
@@ -394,7 +394,7 @@ else
   fi
 
   # Has all expected jobs?
-  EXPECTED_JOBS="nightly-backup weekly-backup-verify monitoring budget-check export-cron-logs archive-task-runs workspace-health phantom-detector session-rotation session-monitor routing-healthcheck openclaw-local-ready"
+  EXPECTED_JOBS="nightly-backup weekly-backup-verify monitoring budget-check export-cron-logs archive-task-runs workspace-health phantom-detector session-rotation session-monitor routing-healthcheck openclaw-local-ready vb003-telemetry-synthesis"
   MISSING=""
   for job in $EXPECTED_JOBS; do
     if ! python3 -c "import json; assert '$job' in json.load(open('$CONFIG_FILE'))['cron_jobs']" 2>/dev/null; then
@@ -403,7 +403,7 @@ else
   done
 
   if [[ -z "$MISSING" ]]; then
-    pass "All 12 cron jobs defined in reliability config"
+    pass "All 13 cron jobs defined in reliability config"
   else
     fail "Missing jobs in config:$MISSING"
   fi
@@ -454,7 +454,8 @@ for script in \
   "$SCRIPTS_DIR/rotate-agent-sessions.sh" \
   "$SCRIPTS_DIR/check-session-counts.sh" \
   "$SCRIPTS_DIR/routing-healthcheck.sh" \
-  "$SCRIPTS_DIR/openclaw-local-ready-cron.sh"; do
+  "$SCRIPTS_DIR/openclaw-local-ready-cron.sh" \
+  "$SCRIPTS_DIR/vb003-telemetry-synthesis.sh"; do
   if [[ -f "$script" && ! -x "$script" ]]; then
     NON_EXEC="$NON_EXEC $(basename "$script")"
   fi
@@ -626,14 +627,14 @@ section "Test 19: Degradation policy completeness"
 DEGRAD_FILE="$REPO_ROOT/docs/DEGRADATION_POLICY.md"
 if [[ -f "$DEGRAD_FILE" ]]; then
   MISSING_IN_DOC=""
-  for job in "Nightly Backup" "Backup Verify" "Monitoring" "Budget Check" "Export Cron Logs" "Archive Task Runs" "Workspace Health" "Phantom Detector" "Session Rotation" "Session Monitor" "Routing Healthcheck" "OpenClaw Local Readiness Refresh"; do
+  for job in "Nightly Backup" "Backup Verify" "Monitoring" "Budget Check" "Export Cron Logs" "Archive Task Runs" "Workspace Health" "Phantom Detector" "Session Rotation" "Session Monitor" "Routing Healthcheck" "OpenClaw Local Readiness Refresh" "VB-003 Telemetry Synthesis"; do
     if ! grep -qi "$job" "$DEGRAD_FILE" 2>/dev/null; then
       MISSING_IN_DOC="$MISSING_IN_DOC '$job'"
     fi
   done
 
   if [[ -z "$MISSING_IN_DOC" ]]; then
-    pass "Degradation policy documents all 12 cron jobs"
+    pass "Degradation policy documents all 13 cron jobs"
   else
     fail "Degradation policy missing:$MISSING_IN_DOC"
   fi

--- a/scripts/vb003-telemetry-synthesis.sh
+++ b/scripts/vb003-telemetry-synthesis.sh
@@ -1,0 +1,317 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/agent-env.sh
+source "$SCRIPT_DIR/lib/agent-env.sh"
+
+AGENT_ID="$(agent_env_agent_id)"
+WORKSPACE_ROOT="$(agent_env_workspace_root)"
+TMPDIR="$(agent_env_tmp_dir)"
+export TMPDIR
+
+LOOKBACK_HOURS="${VB003_LOOKBACK_HOURS:-168}"
+if ! [[ "$LOOKBACK_HOURS" =~ ^[0-9]+$ ]] || [[ "$LOOKBACK_HOURS" -lt 1 ]]; then
+  echo "Invalid VB003_LOOKBACK_HOURS: $LOOKBACK_HOURS" >&2
+  exit 2
+fi
+
+OUT_DIR="${VB003_REPORT_DIR:-$WORKSPACE_ROOT/runtime/reports/model-orchestration}"
+RUNS_GLOB="${VB003_RUNS_GLOB:-$HOME/.openclaw/cron/runs/*.jsonl}"
+CRON_RUN_DIR="${VB003_CRON_RUN_DIR:-$WORKSPACE_ROOT/runtime/logs/cron-runs}"
+BUDGET_LOG="${VB003_BUDGET_LOG:-$HOME/.openclaw/logs/cron-budget.log}"
+
+mkdir -p "$OUT_DIR"
+
+python3 - <<'PY' "$OUT_DIR" "$LOOKBACK_HOURS" "$RUNS_GLOB" "$CRON_RUN_DIR" "$BUDGET_LOG" "$AGENT_ID" "$WORKSPACE_ROOT"
+import glob
+import json
+import os
+import subprocess
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+
+out_dir = os.path.abspath(sys.argv[1])
+lookback_hours = int(sys.argv[2])
+runs_glob = sys.argv[3]
+cron_run_dir = os.path.abspath(sys.argv[4])
+budget_log_path = os.path.abspath(sys.argv[5])
+agent_id = sys.argv[6]
+workspace_root = os.path.abspath(sys.argv[7])
+
+now = datetime.now(timezone.utc)
+window_start = now.timestamp() - (lookback_hours * 3600)
+window_start_ms = int(window_start * 1000)
+
+
+def percentile(values, pct):
+    if not values:
+        return None
+    values = sorted(values)
+    idx = int((len(values) * pct) // 100)
+    if idx >= len(values):
+        idx = len(values) - 1
+    return values[idx]
+
+
+def parse_iso_z(ts):
+    if not ts:
+        return None
+    try:
+        return datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def load_json_line(line):
+    try:
+        return json.loads(line)
+    except json.JSONDecodeError:
+        # Older cron-runner lines used Python-style booleans.
+        patched = (
+            line.replace(":True", ":true")
+            .replace(":False", ":false")
+            .replace(": None", ": null")
+        )
+        try:
+            return json.loads(patched)
+        except json.JSONDecodeError:
+            return None
+
+
+runs = []
+durations = []
+status_counts = Counter()
+model_counts = Counter()
+provider_counts = Counter()
+usage_totals = {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+
+for path in glob.glob(runs_glob):
+    try:
+        with open(path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                rec = load_json_line(line)
+                if rec is None:
+                    continue
+                if rec.get("action") != "finished":
+                    continue
+                run_ms = rec.get("runAtMs") or rec.get("ts")
+                if not isinstance(run_ms, (int, float)) or run_ms < window_start_ms:
+                    continue
+                runs.append(rec)
+                status_counts[str(rec.get("status", "unknown"))] += 1
+                dur = rec.get("durationMs")
+                if isinstance(dur, (int, float)):
+                    durations.append(int(dur))
+                model_counts[str(rec.get("model") or "unknown")] += 1
+                provider_counts[str(rec.get("provider") or "unknown")] += 1
+                usage = rec.get("usage") or {}
+                for k in ("input_tokens", "output_tokens", "total_tokens"):
+                    v = usage.get(k, 0)
+                    if isinstance(v, (int, float)):
+                        usage_totals[k] += int(v)
+    except OSError:
+        continue
+
+run_times = []
+for rec in runs:
+    ms = rec.get("runAtMs") or rec.get("ts")
+    if isinstance(ms, (int, float)):
+        run_times.append(int(ms))
+
+earliest_ms = min(run_times) if run_times else None
+latest_ms = max(run_times) if run_times else None
+coverage_hours = 0.0
+if earliest_ms is not None and latest_ms is not None and latest_ms >= earliest_ms:
+    coverage_hours = (latest_ms - earliest_ms) / 3_600_000
+
+job_metrics = {}
+for job in ("budget-check", "routing-healthcheck", "monitoring"):
+    path = os.path.join(cron_run_dir, f"{job}.jsonl")
+    metrics = {
+        "starts": 0,
+        "success": 0,
+        "failure": 0,
+        "first_utc": None,
+        "last_utc": None,
+    }
+    if os.path.exists(path):
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    rec = load_json_line(line)
+                    if rec is None:
+                        continue
+                    ts = parse_iso_z(rec.get("ts"))
+                    if ts is None or ts.timestamp() < window_start:
+                        continue
+                    if metrics["first_utc"] is None:
+                        metrics["first_utc"] = rec.get("ts")
+                    metrics["last_utc"] = rec.get("ts")
+                    event = rec.get("event")
+                    if event == "start":
+                        metrics["starts"] += 1
+                    elif event == "success":
+                        metrics["success"] += 1
+                    elif event == "failure":
+                        metrics["failure"] += 1
+        except OSError:
+            pass
+    job_metrics[job] = metrics
+
+latest_budget_snapshot = None
+if os.path.exists(budget_log_path):
+    try:
+        with open(budget_log_path, "r", encoding="utf-8") as fh:
+            for line in fh:
+                line = line.strip()
+                if not line:
+                    continue
+                if "{" not in line:
+                    continue
+                payload = line[line.find("{") :]
+                obj = load_json_line(payload)
+                if obj is None:
+                    continue
+                if isinstance(obj, dict) and "providers" in obj:
+                    latest_budget_snapshot = obj
+    except OSError:
+        pass
+
+if latest_budget_snapshot is None:
+    try:
+        proc = subprocess.run(
+            ["openclaw", "channels", "list", "--json"],
+            capture_output=True,
+            text=True,
+            check=False,
+        )
+        if proc.returncode == 0 and proc.stdout.strip():
+            payload = load_json_line(proc.stdout)
+            if isinstance(payload, dict):
+                usage = payload.get("usage")
+                if isinstance(usage, dict):
+                    latest_budget_snapshot = {
+                        "source": "openclaw.channels.list",
+                        "capturedAt": usage.get("updatedAt"),
+                        "providers": usage.get("providers", []),
+                    }
+    except OSError:
+        pass
+
+coverage_met = coverage_hours >= lookback_hours
+if not runs:
+    verification_state = "no_data"
+elif not coverage_met:
+    verification_state = "window_insufficient"
+else:
+    verification_state = "ready_for_closure_review"
+
+report = {
+    "generated_at_utc": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "window": {
+        "lookback_hours_target": lookback_hours,
+        "coverage_hours_observed": round(coverage_hours, 3),
+        "coverage_met": coverage_met,
+        "start_utc": (
+            datetime.fromtimestamp(earliest_ms / 1000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            if earliest_ms is not None
+            else None
+        ),
+        "end_utc": (
+            datetime.fromtimestamp(latest_ms / 1000, tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+            if latest_ms is not None
+            else None
+        ),
+    },
+    "model_runtime": {
+        "runs_total": len(runs),
+        "status_counts": dict(status_counts),
+        "duration_ms_p50": percentile(durations, 50),
+        "duration_ms_p95": percentile(durations, 95),
+        "usage_totals": usage_totals,
+        "model_counts": dict(model_counts),
+        "provider_counts": dict(provider_counts),
+    },
+    "job_runtime": job_metrics,
+    "budget_snapshot_latest": latest_budget_snapshot,
+    "verification_state": verification_state,
+    "agent_id": agent_id,
+    "workspace_root": workspace_root,
+}
+
+stamp = now.strftime("%Y%m%d-%H%M%SZ")
+json_path = os.path.join(out_dir, f"vb003-telemetry-{stamp}.json")
+md_path = os.path.join(out_dir, f"vb003-telemetry-{stamp}.md")
+latest_json = os.path.join(out_dir, "vb003-telemetry-latest.json")
+latest_md = os.path.join(out_dir, "vb003-telemetry-latest.md")
+
+with open(json_path, "w", encoding="utf-8") as fh:
+    json.dump(report, fh, indent=2)
+    fh.write("\n")
+
+budget_brief = "none"
+if latest_budget_snapshot:
+    providers = latest_budget_snapshot.get("providers") or []
+    chunks = []
+    for p in providers:
+        name = p.get("displayName") or p.get("provider") or "provider"
+        windows = p.get("windows") or []
+        win = ", ".join(
+            f"{w.get('label')}={w.get('usedPercent')}%" for w in windows if w.get("label") and w.get("usedPercent") is not None
+        )
+        chunks.append(f"{name} ({win})" if win else name)
+    budget_brief = "; ".join(chunks) if chunks else "present"
+
+status_counts_md = report["model_runtime"]["status_counts"]
+ok_count = status_counts_md.get("ok", 0)
+error_count = status_counts_md.get("error", 0)
+
+md = f"""# VB-003 Telemetry Synthesis ({report['generated_at_utc']})
+
+## Window
+- Target: {lookback_hours}h
+- Observed coverage: {report['window']['coverage_hours_observed']}h
+- Start: {report['window']['start_utc']}
+- End: {report['window']['end_utc']}
+- Coverage met: {report['window']['coverage_met']}
+
+## Model Runtime
+- Runs: {report['model_runtime']['runs_total']} (ok={ok_count}, error={error_count})
+- Duration: p50={report['model_runtime']['duration_ms_p50']}ms, p95={report['model_runtime']['duration_ms_p95']}ms
+- Usage totals: input={usage_totals['input_tokens']}, output={usage_totals['output_tokens']}, total={usage_totals['total_tokens']}
+
+## Job Runtime (window-scoped)
+- budget-check: starts={job_metrics['budget-check']['starts']}, success={job_metrics['budget-check']['success']}, failure={job_metrics['budget-check']['failure']}
+- routing-healthcheck: starts={job_metrics['routing-healthcheck']['starts']}, success={job_metrics['routing-healthcheck']['success']}, failure={job_metrics['routing-healthcheck']['failure']}
+- monitoring: starts={job_metrics['monitoring']['starts']}, success={job_metrics['monitoring']['success']}, failure={job_metrics['monitoring']['failure']}
+
+## Budget Snapshot
+- Latest: {budget_brief}
+
+## Verification State
+- {verification_state}
+"""
+
+with open(md_path, "w", encoding="utf-8") as fh:
+    fh.write(md)
+
+for src, dst in ((json_path, latest_json), (md_path, latest_md)):
+    with open(src, "r", encoding="utf-8") as rf, open(dst, "w", encoding="utf-8") as wf:
+        wf.write(rf.read())
+
+print(f"VB003_REPORT_JSON={json_path}")
+print(f"VB003_REPORT_MD={md_path}")
+print(f"VB003_REPORT_LATEST_JSON={latest_json}")
+print(f"VB003_REPORT_LATEST_MD={latest_md}")
+print(f"VB003_VERIFICATION_STATE={verification_state}")
+PY


### PR DESCRIPTION
## Summary
- add `vb003-telemetry-synthesis` cron job to `config/reliability.json` and `scripts/install-cron.sh`
- add `scripts/vb003-telemetry-synthesis.sh` to generate rolling JSON/MD evidence artifacts under `runtime/reports/model-orchestration/`
- harden `scripts/monitor-openclaw.sh` array handling for `set -u`
- add `scripts/discord-webhook-send.mjs` used by routing/retry wrappers
- harden `scripts/budget-check.sh` with tracker-path override + OpenClaw fallback (`OPENCLAW_BIN`) + explicit `jq` check
- update reliability/docs coverage (`docs/CRON_SPECS.md`, `docs/DEGRADATION_POLICY.md`, `docs/SCRIPT_SPECS.md`, `scripts/tests/test-reliability.sh`)

## Validation
- `bash -n scripts/budget-check.sh scripts/install-cron.sh scripts/monitor-openclaw.sh scripts/vb003-telemetry-synthesis.sh scripts/tests/test-reliability.sh`
- `node --check scripts/discord-webhook-send.mjs`
- `bash scripts/tests/test-reliability.sh` (33/33 passed)
- `npm run docs:lint`
- `npm run roadmap:sync:check`
- temp isolated run:
  - `VB003_REPORT_DIR=<tmp>/reports VB003_RUNS_GLOB=<tmp>/runs/*.jsonl VB003_CRON_RUN_DIR=<tmp>/cron-runs VB003_BUDGET_LOG=<tmp>/cron-budget.log bash scripts/vb003-telemetry-synthesis.sh` (emitted latest artifacts + `VB003_VERIFICATION_STATE=no_data`)
