### PR TITLE
Installer onboarding UX + VB-003 watchdog cron integration

### DIFF
--- a/config/reliability.json
+++ b/config/reliability.json
@@ -127,6 +127,15 @@
       "has_network": false,
       "degradation_tier": "D1",
       "notes": "Builds rolling model-orchestration telemetry synthesis artifacts for VB-003 closure"
+    },
+    "vb003-watchdog": {
+      "script": "scripts/vb003-watchdog.sh",
+      "timeout_seconds": 60,
+      "max_attempts": 1,
+      "base_sleep_seconds": 0,
+      "has_network": false,
+      "degradation_tier": "D1",
+      "notes": "Checks VB-003 telemetry freshness and short-window cron health while 7-day evidence accumulates"
     }
   }
 }

--- a/docs/CRON_SPECS.md
+++ b/docs/CRON_SPECS.md
@@ -95,8 +95,22 @@
 - **Goal:** maintain a rolling 7-day evidence trail for VB-003 closure decisions.
 - **Added:** 2026-02-22
 
+## 14) VB-003 Watchdog
+- **Schedule:** `45 */3 * * *`
+- **Session:** isolated
+- **Agent:** main
+- **Payload:** run `scripts/vb003-watchdog.sh`
+- **Outputs:**
+  - `runtime/reports/model-orchestration/vb003-watchdog-<timestamp>.json`
+  - `runtime/reports/model-orchestration/vb003-watchdog-<timestamp>.md`
+  - `runtime/reports/model-orchestration/vb003-watchdog-latest.json`
+  - `runtime/reports/model-orchestration/vb003-watchdog-latest.md`
+- **Goal:** detect telemetry staleness or short-window job regressions while VB-003 7-day evidence accrues.
+- **Added:** 2026-02-22
+
 ## Current Next Steps (February 23, 2026)
 1. Roll this schedule onto the host with `bash scripts/install-cron.sh --force`.
 2. Validate first run via `runtime/logs/cron-runs/vb003-telemetry-synthesis.jsonl`.
 3. Validate latest synthesis artifacts under `runtime/reports/model-orchestration/`.
-4. Confirm `docs/LOCAL_INTEGRATION_READY.md` and Mission Control readiness card continue moving on cadence.
+4. Validate watchdog run via `runtime/logs/cron-runs/vb003-watchdog.jsonl` and latest watchdog artifacts.
+5. Confirm `docs/LOCAL_INTEGRATION_READY.md` and Mission Control readiness card continue moving on cadence.

--- a/docs/DEGRADATION_POLICY.md
+++ b/docs/DEGRADATION_POLICY.md
@@ -156,6 +156,7 @@ This matrix maps **every cron job** to its degradation behavior, timeout/retry c
 | 11 | **Routing Healthcheck** | `*/30 * * * *` | 30s | 2 | **Yes** | D2: routing unknown | D2: alert routing may be broken | D2 | Missed P1 alerts |
 | 12 | **OpenClaw Local Readiness Refresh** | `15 */4 * * *` | 180s | 1 | No | D1: keep prior readiness snapshot | D1: no doc/artifact refresh for this cycle | D1 | Stale local readiness card/evidence |
 | 13 | **VB-003 Telemetry Synthesis** | `30 */6 * * *` | 120s | 1 | No | D1: keep prior synthesis artifact | D1: telemetry summary not refreshed this cycle | D1 | Delayed VB-003 evidence updates |
+| 14 | **VB-003 Watchdog** | `45 */3 * * *` | 60s | 1 | No | D1: keep prior watchdog artifact | D1: short-window drift checks delayed | D1 | Telemetry freshness/regression detection lag |
 
 ### Failure Cascades
 

--- a/docs/SCRIPT_SPECS.md
+++ b/docs/SCRIPT_SPECS.md
@@ -319,7 +319,40 @@ bash scripts/tests/test-openclaw-local-ready-cron.sh
 
 ---
 
-## 16) vb003-telemetry-synthesis.sh
+## 16) vb003-watchdog.sh
+**Purpose:** Validate VB-003 telemetry freshness and recent cron health while 7-day evidence accumulates.
+
+**Usage:**
+```bash
+bash scripts/vb003-watchdog.sh
+```
+
+**Behavior:**
+- Reads latest synthesis artifact:
+  - `runtime/reports/model-orchestration/vb003-telemetry-latest.json`
+- Checks freshness (`VB003_WATCHDOG_MAX_TELEMETRY_AGE_MINUTES`, default `480`).
+- Evaluates recent cron health window (`VB003_WATCHDOG_LOOKBACK_MINUTES`, default `360`) across:
+  - `budget-check`
+  - `routing-healthcheck`
+  - `monitoring`
+- Emits timestamped + latest watchdog artifacts:
+  - `runtime/reports/model-orchestration/vb003-watchdog-<timestamp>.json`
+  - `runtime/reports/model-orchestration/vb003-watchdog-<timestamp>.md`
+  - `runtime/reports/model-orchestration/vb003-watchdog-latest.json`
+  - `runtime/reports/model-orchestration/vb003-watchdog-latest.md`
+- Returns non-zero when freshness or recent-failure checks detect degraded state.
+
+**Config env vars:**
+- `VB003_WATCHDOG_REPORT_DIR`
+- `VB003_TELEMETRY_LATEST_JSON`
+- `VB003_CRON_RUN_DIR`
+- `VB003_TARGET_HOURS` (default `168`)
+- `VB003_WATCHDOG_LOOKBACK_MINUTES` (default `360`)
+- `VB003_WATCHDOG_MAX_TELEMETRY_AGE_MINUTES` (default `480`)
+
+---
+
+## 17) vb003-telemetry-synthesis.sh
 **Purpose:** Generate a rolling telemetry synthesis artifact for VB-003 model-orchestration verification.
 
 **Usage:**
@@ -362,7 +395,7 @@ bash scripts/vb003-telemetry-synthesis.sh
 
 ---
 
-## 16) install-bridge-launchagent.sh
+## 18) install-bridge-launchagent.sh
 **Purpose:** Install/manage a persistent macOS LaunchAgent for the host Bridge API.
 
 **Usage:**
@@ -388,7 +421,7 @@ bash scripts/tests/test-install-bridge-launchagent.sh
 
 ---
 
-## 17) ventureos-install.sh
+## 19) ventureos-install.sh
 **Purpose:** Unified OpenClaw-style installer + onboarding wrapper for local VentureOS setup.
 
 **Usage:**
@@ -418,6 +451,7 @@ bash scripts/ventureos-install.sh --revert runtime/backups/ventureos-install/<re
   - cron installer (`scripts/install-cron.sh`)
   - readiness refresh (`scripts/refresh-local-integration-ready.sh`)
 - Reads current local state (OpenClaw directory, bridge env, dashboard health, cron marker) before apply and surfaces that in onboarding/plan output.
+- Interactive TTY mode uses staged onboarding sections with guided recommendations (for example: adopt existing healthy dashboard, skip bridge when bridge env is missing) before executing changes.
 - Captures a pre-install restore point by default under `runtime/backups/ventureos-install/<restore-point-id>/`:
   - user crontab snapshot
   - bridge env snapshot
@@ -444,7 +478,7 @@ bash scripts/tests/test-ventureos-install.sh
 
 ---
 
-## 18) pr-queue-sweep.sh
+## 20) pr-queue-sweep.sh
 **Purpose:** Classify open GitHub PR queue state and optionally merge approved+ready PRs.
 
 **Usage:**
@@ -475,7 +509,7 @@ bash scripts/tests/test-pr-queue-sweep.sh
 
 ---
 
-## 19) roadmap-status-sync.py
+## 21) roadmap-status-sync.py
 **Purpose:** Detect status drift between `README.md` active work and roadmap anchor issue `#138`.
 
 **Usage:**
@@ -512,7 +546,7 @@ bash scripts/tests/test-roadmap-status-sync.sh
 
 ---
 
-## 20) docs-lint.py
+## 22) docs-lint.py
 **Purpose:** Lint core documentation links/placeholders while minimizing false positives in instructional prose.
 
 **Usage:**

--- a/scripts/install-cron.sh
+++ b/scripts/install-cron.sh
@@ -106,6 +106,9 @@ NEW_CRON=$(cat <<EOF
 # 13) VB-003 telemetry synthesis — every 6 hours
 30 */6 * * * $RUNNER vb003-telemetry-synthesis >> $LOG_BASE/cron-vb003-telemetry.log 2>&1
 
+# 14) VB-003 watchdog — every 3 hours
+45 */3 * * * $RUNNER vb003-watchdog >> $LOG_BASE/cron-vb003-watchdog.log 2>&1
+
 # === END $CRON_MARKER ===
 EOF
 )

--- a/scripts/tests/test-reliability.sh
+++ b/scripts/tests/test-reliability.sh
@@ -394,7 +394,7 @@ else
   fi
 
   # Has all expected jobs?
-  EXPECTED_JOBS="nightly-backup weekly-backup-verify monitoring budget-check export-cron-logs archive-task-runs workspace-health phantom-detector session-rotation session-monitor routing-healthcheck openclaw-local-ready vb003-telemetry-synthesis"
+  EXPECTED_JOBS="nightly-backup weekly-backup-verify monitoring budget-check export-cron-logs archive-task-runs workspace-health phantom-detector session-rotation session-monitor routing-healthcheck openclaw-local-ready vb003-telemetry-synthesis vb003-watchdog"
   MISSING=""
   for job in $EXPECTED_JOBS; do
     if ! python3 -c "import json; assert '$job' in json.load(open('$CONFIG_FILE'))['cron_jobs']" 2>/dev/null; then
@@ -403,7 +403,7 @@ else
   done
 
   if [[ -z "$MISSING" ]]; then
-    pass "All 13 cron jobs defined in reliability config"
+    pass "All 14 cron jobs defined in reliability config"
   else
     fail "Missing jobs in config:$MISSING"
   fi
@@ -455,7 +455,8 @@ for script in \
   "$SCRIPTS_DIR/check-session-counts.sh" \
   "$SCRIPTS_DIR/routing-healthcheck.sh" \
   "$SCRIPTS_DIR/openclaw-local-ready-cron.sh" \
-  "$SCRIPTS_DIR/vb003-telemetry-synthesis.sh"; do
+  "$SCRIPTS_DIR/vb003-telemetry-synthesis.sh" \
+  "$SCRIPTS_DIR/vb003-watchdog.sh"; do
   if [[ -f "$script" && ! -x "$script" ]]; then
     NON_EXEC="$NON_EXEC $(basename "$script")"
   fi
@@ -627,14 +628,14 @@ section "Test 19: Degradation policy completeness"
 DEGRAD_FILE="$REPO_ROOT/docs/DEGRADATION_POLICY.md"
 if [[ -f "$DEGRAD_FILE" ]]; then
   MISSING_IN_DOC=""
-  for job in "Nightly Backup" "Backup Verify" "Monitoring" "Budget Check" "Export Cron Logs" "Archive Task Runs" "Workspace Health" "Phantom Detector" "Session Rotation" "Session Monitor" "Routing Healthcheck" "OpenClaw Local Readiness Refresh" "VB-003 Telemetry Synthesis"; do
+  for job in "Nightly Backup" "Backup Verify" "Monitoring" "Budget Check" "Export Cron Logs" "Archive Task Runs" "Workspace Health" "Phantom Detector" "Session Rotation" "Session Monitor" "Routing Healthcheck" "OpenClaw Local Readiness Refresh" "VB-003 Telemetry Synthesis" "VB-003 Watchdog"; do
     if ! grep -qi "$job" "$DEGRAD_FILE" 2>/dev/null; then
       MISSING_IN_DOC="$MISSING_IN_DOC '$job'"
     fi
   done
 
   if [[ -z "$MISSING_IN_DOC" ]]; then
-    pass "Degradation policy documents all 13 cron jobs"
+    pass "Degradation policy documents all 14 cron jobs"
   else
     fail "Degradation policy missing:$MISSING_IN_DOC"
   fi

--- a/scripts/vb003-watchdog.sh
+++ b/scripts/vb003-watchdog.sh
@@ -1,0 +1,248 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+export PATH="/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/agent-env.sh
+source "$SCRIPT_DIR/lib/agent-env.sh"
+
+AGENT_ID="$(agent_env_agent_id)"
+WORKSPACE_ROOT="$(agent_env_workspace_root)"
+TMPDIR="$(agent_env_tmp_dir)"
+export TMPDIR
+
+OUT_DIR="${VB003_WATCHDOG_REPORT_DIR:-$WORKSPACE_ROOT/runtime/reports/model-orchestration}"
+LATEST_TELEMETRY="${VB003_TELEMETRY_LATEST_JSON:-$OUT_DIR/vb003-telemetry-latest.json}"
+CRON_RUN_DIR="${VB003_CRON_RUN_DIR:-$WORKSPACE_ROOT/runtime/logs/cron-runs}"
+TARGET_HOURS="${VB003_TARGET_HOURS:-168}"
+LOOKBACK_MINUTES="${VB003_WATCHDOG_LOOKBACK_MINUTES:-360}"
+MAX_TELEMETRY_AGE_MINUTES="${VB003_WATCHDOG_MAX_TELEMETRY_AGE_MINUTES:-480}"
+
+if ! [[ "$TARGET_HOURS" =~ ^[0-9]+$ ]] || [[ "$TARGET_HOURS" -lt 1 ]]; then
+  echo "Invalid VB003_TARGET_HOURS: $TARGET_HOURS" >&2
+  exit 2
+fi
+if ! [[ "$LOOKBACK_MINUTES" =~ ^[0-9]+$ ]] || [[ "$LOOKBACK_MINUTES" -lt 1 ]]; then
+  echo "Invalid VB003_WATCHDOG_LOOKBACK_MINUTES: $LOOKBACK_MINUTES" >&2
+  exit 2
+fi
+if ! [[ "$MAX_TELEMETRY_AGE_MINUTES" =~ ^[0-9]+$ ]] || [[ "$MAX_TELEMETRY_AGE_MINUTES" -lt 1 ]]; then
+  echo "Invalid VB003_WATCHDOG_MAX_TELEMETRY_AGE_MINUTES: $MAX_TELEMETRY_AGE_MINUTES" >&2
+  exit 2
+fi
+
+mkdir -p "$OUT_DIR"
+
+python3 - <<'PY' \
+  "$OUT_DIR" \
+  "$LATEST_TELEMETRY" \
+  "$CRON_RUN_DIR" \
+  "$TARGET_HOURS" \
+  "$LOOKBACK_MINUTES" \
+  "$MAX_TELEMETRY_AGE_MINUTES" \
+  "$AGENT_ID" \
+  "$WORKSPACE_ROOT"
+import json
+import os
+import shutil
+import sys
+from datetime import datetime, timedelta, timezone
+
+out_dir = os.path.abspath(sys.argv[1])
+latest_telemetry = os.path.abspath(sys.argv[2])
+cron_run_dir = os.path.abspath(sys.argv[3])
+target_hours = int(sys.argv[4])
+lookback_minutes = int(sys.argv[5])
+max_age_minutes = int(sys.argv[6])
+agent_id = sys.argv[7]
+workspace_root = os.path.abspath(sys.argv[8])
+
+now = datetime.now(timezone.utc)
+cutoff = now - timedelta(minutes=lookback_minutes)
+
+
+def parse_iso_z(ts):
+    if not ts:
+        return None
+    try:
+        return datetime.strptime(ts, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+    except ValueError:
+        return None
+
+
+def load_json_line(line):
+    try:
+        return json.loads(line)
+    except json.JSONDecodeError:
+        patched = (
+            line.replace(":True", ":true")
+            .replace(":False", ":false")
+            .replace(": None", ": null")
+        )
+        try:
+            return json.loads(patched)
+        except json.JSONDecodeError:
+            return None
+
+
+telemetry_present = os.path.exists(latest_telemetry)
+telemetry = {}
+issues = []
+closure_ready = False
+coverage_hours = 0.0
+coverage_remaining_hours = float(target_hours)
+verification_state = "missing"
+telemetry_generated_at = None
+telemetry_age_minutes = None
+window_start_utc = None
+window_end_utc = None
+closure_eta_utc = None
+
+if telemetry_present:
+    try:
+        with open(latest_telemetry, "r", encoding="utf-8") as fh:
+            telemetry = json.load(fh)
+    except (OSError, json.JSONDecodeError) as exc:
+        issues.append(f"telemetry_unreadable:{exc.__class__.__name__}")
+        telemetry = {}
+else:
+    issues.append("telemetry_missing")
+
+if telemetry:
+    generated_at = telemetry.get("generated_at_utc")
+    telemetry_generated_at = generated_at if isinstance(generated_at, str) else None
+    generated_dt = parse_iso_z(telemetry_generated_at)
+    if generated_dt is None:
+        issues.append("telemetry_generated_at_invalid")
+    else:
+        telemetry_age_minutes = round((now - generated_dt).total_seconds() / 60.0, 2)
+        if telemetry_age_minutes > max_age_minutes:
+            issues.append(f"telemetry_stale:{telemetry_age_minutes}m")
+
+    window = telemetry.get("window") or {}
+    coverage_hours = float(window.get("coverage_hours_observed") or 0.0)
+    coverage_remaining_hours = round(max(0.0, target_hours - coverage_hours), 3)
+    verification_state = str(telemetry.get("verification_state") or "unknown")
+    window_start_utc = window.get("start_utc")
+    window_end_utc = window.get("end_utc")
+    if isinstance(window_start_utc, str):
+        start_dt = parse_iso_z(window_start_utc)
+        if start_dt is not None:
+            closure_eta_utc = (start_dt + timedelta(hours=target_hours)).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+job_window = {}
+for job in ("budget-check", "routing-healthcheck", "monitoring"):
+    path = os.path.join(cron_run_dir, f"{job}.jsonl")
+    stats = {"starts": 0, "success": 0, "failure": 0}
+    if os.path.exists(path):
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                for raw in fh:
+                    raw = raw.strip()
+                    if not raw:
+                        continue
+                    rec = load_json_line(raw)
+                    if rec is None:
+                        continue
+                    ts = parse_iso_z(rec.get("ts"))
+                    if ts is None or ts < cutoff:
+                        continue
+                    event = rec.get("event")
+                    if event == "start":
+                        stats["starts"] += 1
+                    elif event == "success":
+                        stats["success"] += 1
+                    elif event == "failure":
+                        stats["failure"] += 1
+        except OSError:
+            issues.append(f"log_unreadable:{job}")
+    else:
+        issues.append(f"log_missing:{job}")
+    if stats["failure"] > 0:
+        issues.append(f"recent_failures:{job}:{stats['failure']}")
+    job_window[job] = stats
+
+if coverage_hours >= target_hours and verification_state == "ready_for_closure_review":
+    closure_ready = True
+
+status = "healthy" if not issues else "degraded"
+exit_code = 0 if not issues else 1
+
+report = {
+    "generated_at_utc": now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "status": status,
+    "closure_ready": closure_ready,
+    "issues": issues,
+    "telemetry": {
+        "latest_path": latest_telemetry,
+        "present": telemetry_present,
+        "generated_at_utc": telemetry_generated_at,
+        "age_minutes": telemetry_age_minutes,
+        "verification_state": verification_state,
+        "coverage_hours_observed": round(coverage_hours, 3),
+        "coverage_hours_target": target_hours,
+        "coverage_hours_remaining": coverage_remaining_hours,
+        "window_start_utc": window_start_utc,
+        "window_end_utc": window_end_utc,
+        "closure_eta_utc": closure_eta_utc,
+    },
+    "job_window": {
+        "lookback_minutes": lookback_minutes,
+        "cutoff_utc": cutoff.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "jobs": job_window,
+    },
+    "agent_id": agent_id,
+    "workspace_root": workspace_root,
+}
+
+stamp = now.strftime("%Y%m%d-%H%M%SZ")
+json_path = os.path.join(out_dir, f"vb003-watchdog-{stamp}.json")
+md_path = os.path.join(out_dir, f"vb003-watchdog-{stamp}.md")
+latest_json = os.path.join(out_dir, "vb003-watchdog-latest.json")
+latest_md = os.path.join(out_dir, "vb003-watchdog-latest.md")
+
+with open(json_path, "w", encoding="utf-8") as fh:
+    json.dump(report, fh, indent=2)
+    fh.write("\n")
+
+jobs_md = []
+for name in ("budget-check", "routing-healthcheck", "monitoring"):
+    m = job_window.get(name, {})
+    jobs_md.append(
+        f"- {name}: starts={m.get('starts', 0)}, success={m.get('success', 0)}, failure={m.get('failure', 0)}"
+    )
+
+issues_md = "\n".join(f"- {item}" for item in issues) if issues else "- none"
+
+md = f"""# VB-003 Watchdog ({report['generated_at_utc']})
+
+## Status
+- status: {status}
+- closure_ready: {str(closure_ready)}
+
+## Telemetry Freshness
+- latest_report_present: {str(telemetry_present)}
+- telemetry_generated_at_utc: {telemetry_generated_at}
+- telemetry_age_minutes: {telemetry_age_minutes}
+- verification_state: {verification_state}
+- coverage_hours: {round(coverage_hours, 3)} / {target_hours}
+- coverage_remaining_hours: {coverage_remaining_hours}
+- closure_eta_utc: {closure_eta_utc}
+
+## Job Health (last {lookback_minutes} minutes)
+{os.linesep.join(jobs_md)}
+
+## Issues
+{issues_md}
+"""
+
+with open(md_path, "w", encoding="utf-8") as fh:
+    fh.write(md)
+
+shutil.copyfile(json_path, latest_json)
+shutil.copyfile(md_path, latest_md)
+
+print(f"VB003_WATCHDOG status={status} issues={len(issues)} closure_ready={closure_ready}")
+sys.exit(exit_code)
+PY

--- a/scripts/ventureos-install.sh
+++ b/scripts/ventureos-install.sh
@@ -13,6 +13,7 @@ VERIFY_TIMEOUT_SEC="${VENTUREOS_INSTALL_VERIFY_TIMEOUT_SEC:-3}"
 REVERT_FROM=""
 LIST_RESTORE_POINTS=0
 CAPTURE_RESTORE_POINT=1
+EXPLICIT_RESTORE_POINT=""
 
 SKIP_DASHBOARD_INSTALL=0
 SKIP_BRIDGE_LAUNCHAGENT=0
@@ -47,6 +48,14 @@ RESTORE_BASE_DIR="${VENTUREOS_INSTALL_RESTORE_BASE_DIR:-$REPO_ROOT/runtime/backu
 RESTORE_POINT_ID=""
 RESTORE_POINT_DIR=""
 RESTORE_MANIFEST_PATH=""
+NO_ANIMATION="${VENTUREOS_INSTALL_NO_ANIMATION:-0}"
+UI_ENABLED=0
+
+DISCOVER_DASHBOARD_STATE="unknown"
+DISCOVER_OPENCLAW_STATE="unknown"
+DISCOVER_BRIDGE_ENV_STATE="unknown"
+DISCOVER_CRON_STATE="unknown"
+DISCOVER_VENTURE_CRON_STATE="unknown"
 
 REPORT_DIR="${VENTUREOS_INSTALL_REPORT_DIR:-$REPO_ROOT/runtime/reports/ventureos-install}"
 SUMMARY_TSV="$(mktemp)"
@@ -102,6 +111,68 @@ need_value() {
   fi
 }
 
+ui_init() {
+  if [[ "$NON_INTERACTIVE" == "0" && -t 1 && "${TERM:-}" != "dumb" ]]; then
+    UI_ENABLED=1
+  else
+    UI_ENABLED=0
+  fi
+}
+
+ui_sleep() {
+  local seconds="${1:-0.06}"
+  if [[ "$UI_ENABLED" == "1" && "$NO_ANIMATION" != "1" ]]; then
+    sleep "$seconds"
+  fi
+}
+
+ui_section() {
+  local title="$1"
+  if [[ "$UI_ENABLED" == "1" ]]; then
+    printf '\n\033[1;36m[%s]\033[0m\n' "$title"
+  else
+    printf '\n[%s]\n' "$title"
+  fi
+}
+
+ui_step() {
+  local marker="$1"
+  local label="$2"
+  if [[ "$UI_ENABLED" == "1" ]]; then
+    printf '\033[1;34m%s\033[0m %s\n' "$marker" "$label"
+  else
+    printf '%s %s\n' "$marker" "$label"
+  fi
+  ui_sleep 0.04
+}
+
+ui_state_line() {
+  local key="$1"
+  local value="$2"
+  local detail="${3:-}"
+  local rendered="$value"
+  if [[ "$UI_ENABLED" == "1" ]]; then
+    case "$value" in
+      healthy|present|installed)
+        rendered="$(printf '\033[32m%s\033[0m' "$value")"
+        ;;
+      missing|unreachable|unavailable|not-installed)
+        rendered="$(printf '\033[33m%s\033[0m' "$value")"
+        ;;
+      *)
+        rendered="$(printf '\033[36m%s\033[0m' "$value")"
+        ;;
+    esac
+  fi
+
+  if [[ -n "$detail" ]]; then
+    echo "  $key: $rendered ($detail)"
+  else
+    echo "  $key: $rendered"
+  fi
+  ui_sleep 0.03
+}
+
 record_step() {
   local step="$1"
   local status="$2"
@@ -133,6 +204,11 @@ run_step() {
   if [[ -z "$next_command" ]]; then
     next_command="$command_text"
   fi
+
+  if [[ "$UI_ENABLED" == "1" ]]; then
+    ui_step "→" "$step :: $detail"
+  fi
+
   if [[ "$DRY_RUN" == "1" ]]; then
     echo "[dry-run] $step :: $detail"
     echo "          cmd: $command_text"
@@ -440,43 +516,49 @@ PY
 
 discover_existing_state() {
   local dashboard_url="$1"
-  local dashboard_state="unreachable"
-  local openclaw_state="missing"
-  local bridge_env_state="missing"
-  local cron_state="empty"
-  local venture_cron_state="not-installed"
+  local print_mode="${2:-print}"
+
+  DISCOVER_DASHBOARD_STATE="unreachable"
+  DISCOVER_OPENCLAW_STATE="missing"
+  DISCOVER_BRIDGE_ENV_STATE="missing"
+  DISCOVER_CRON_STATE="empty"
+  DISCOVER_VENTURE_CRON_STATE="not-installed"
 
   if verify_dashboard_health "$dashboard_url"; then
-    dashboard_state="healthy"
+    DISCOVER_DASHBOARD_STATE="healthy"
   fi
 
   if [[ -d "$OPENCLAW_DIR" ]]; then
-    openclaw_state="present"
+    DISCOVER_OPENCLAW_STATE="present"
   fi
 
   if [[ -f "$BRIDGE_ENV" ]]; then
-    bridge_env_state="present"
+    DISCOVER_BRIDGE_ENV_STATE="present"
   fi
 
   if command -v crontab >/dev/null 2>&1; then
     local existing_cron
     existing_cron="$(crontab -l 2>/dev/null || true)"
     if [[ -n "$existing_cron" ]]; then
-      cron_state="present"
+      DISCOVER_CRON_STATE="present"
       if printf '%s\n' "$existing_cron" | grep -Fq "VentureOS Managed Cron"; then
-        venture_cron_state="installed"
+        DISCOVER_VENTURE_CRON_STATE="installed"
       fi
     fi
   else
-    cron_state="unavailable"
+    DISCOVER_CRON_STATE="unavailable"
   fi
 
-  echo "Discovered existing configuration:"
-  echo "  openclaw dir: $openclaw_state ($OPENCLAW_DIR)"
-  echo "  bridge env: $bridge_env_state ($BRIDGE_ENV)"
-  echo "  dashboard health: $dashboard_state ($dashboard_url)"
-  echo "  user crontab: $cron_state"
-  echo "  ventureos managed cron block: $venture_cron_state"
+  if [[ "$print_mode" == "quiet" ]]; then
+    return 0
+  fi
+
+  ui_section "Discovery"
+  ui_state_line "openclaw dir" "$DISCOVER_OPENCLAW_STATE" "$OPENCLAW_DIR"
+  ui_state_line "bridge env" "$DISCOVER_BRIDGE_ENV_STATE" "$BRIDGE_ENV"
+  ui_state_line "dashboard health" "$DISCOVER_DASHBOARD_STATE" "$dashboard_url"
+  ui_state_line "user crontab" "$DISCOVER_CRON_STATE"
+  ui_state_line "ventureos managed cron block" "$DISCOVER_VENTURE_CRON_STATE"
 }
 
 prompt_yes_no() {
@@ -615,6 +697,7 @@ while [[ $# -gt 0 ]]; do
       ;;
     --no-restore-point)
       CAPTURE_RESTORE_POINT=0
+      EXPLICIT_RESTORE_POINT=0
       shift
       ;;
     --list-restore-points)
@@ -695,6 +778,8 @@ while [[ $# -gt 0 ]]; do
   esac
 done
 
+ui_init
+
 if [[ "$LIST_RESTORE_POINTS" == "1" && -n "$REVERT_FROM" ]]; then
   echo "Cannot combine --list-restore-points and --revert" >&2
   exit 2
@@ -729,12 +814,26 @@ fi
 
 if [[ "$NON_INTERACTIVE" == "0" && -t 0 ]]; then
   discovery_dashboard_url="$(resolve_dashboard_url)"
-  echo "VentureOS Installer Onboarding"
+  ui_section "VentureOS Onboarding"
   echo "Repo: $REPO_ROOT"
   echo "Platform: $OS_NAME"
-  echo ""
   discover_existing_state "$discovery_dashboard_url"
-  echo ""
+
+  ui_section "Recommendations"
+  if [[ "$DISCOVER_DASHBOARD_STATE" == "healthy" ]]; then
+    ui_step "•" "Dashboard is already healthy; adopting existing service is recommended."
+  else
+    ui_step "•" "Dashboard health is not confirmed; running dashboard install is recommended."
+  fi
+  if [[ "$DISCOVER_BRIDGE_ENV_STATE" != "present" ]]; then
+    ui_step "•" "Bridge env is missing; skip bridge install or provide --bridge-env first."
+  fi
+  if [[ "$DISCOVER_VENTURE_CRON_STATE" == "installed" ]]; then
+    ui_step "•" "Managed VentureOS cron block already exists; refresh is recommended."
+  fi
+  if [[ "$DISCOVER_OPENCLAW_STATE" != "present" ]]; then
+    ui_step "•" "OpenClaw directory missing; install can continue but readiness may fail."
+  fi
 
   if [[ "$(prompt_yes_no "Continue with onboarding plan?" "y")" != "y" ]]; then
     echo "Install cancelled."
@@ -742,10 +841,13 @@ if [[ "$NON_INTERACTIVE" == "0" && -t 0 ]]; then
   fi
 
   if [[ -z "$EXPLICIT_PRESET" ]]; then
+    ui_step "1/7" "Choose install preset"
     INSTALL_PRESET="$(prompt_value "Install preset (full|bridge|minimal)" "$INSTALL_PRESET")"
   fi
   apply_install_preset
   apply_explicit_overrides
+
+  ui_step "2/7" "Confirm runtime endpoints"
   DASHBOARD_PORT="$(prompt_value "Dashboard port" "$DASHBOARD_PORT")"
   if [[ -z "$EXPLICIT_PROFILE" ]]; then
     PROFILE="$(prompt_value "Readiness profile (quick|full|bridge)" "$PROFILE")"
@@ -753,8 +855,9 @@ if [[ "$NON_INTERACTIVE" == "0" && -t 0 ]]; then
   validate_dashboard_port
   validate_profile
 
+  ui_step "3/7" "Dashboard integration strategy"
   if [[ -z "$EXPLICIT_SKIP_DASHBOARD" ]]; then
-    if verify_dashboard_health "$(resolve_dashboard_url)"; then
+    if [[ "$DISCOVER_DASHBOARD_STATE" == "healthy" ]]; then
       if [[ "$(prompt_yes_no "Existing dashboard looks healthy. Adopt it and skip dashboard reinstall?" "y")" == "y" ]]; then
         SKIP_DASHBOARD_INSTALL=1
       else
@@ -764,12 +867,34 @@ if [[ "$NON_INTERACTIVE" == "0" && -t 0 ]]; then
       SKIP_DASHBOARD_INSTALL="$(prompt_run_toggle "Run dashboard installer?" "$SKIP_DASHBOARD_INSTALL")"
     fi
   fi
+
+  ui_step "4/7" "Bridge integration"
   if [[ "$OS_NAME" == "Darwin" && -z "$EXPLICIT_SKIP_BRIDGE" ]]; then
-    SKIP_BRIDGE_LAUNCHAGENT="$(prompt_run_toggle "Install/refresh bridge LaunchAgent?" "$SKIP_BRIDGE_LAUNCHAGENT")"
+    if [[ "$DISCOVER_BRIDGE_ENV_STATE" != "present" ]]; then
+      if [[ "$(prompt_yes_no "Bridge env file is missing. Skip bridge LaunchAgent install for now?" "y")" == "y" ]]; then
+        SKIP_BRIDGE_LAUNCHAGENT=1
+      else
+        SKIP_BRIDGE_LAUNCHAGENT=0
+      fi
+    else
+      SKIP_BRIDGE_LAUNCHAGENT="$(prompt_run_toggle "Install/refresh bridge LaunchAgent?" "$SKIP_BRIDGE_LAUNCHAGENT")"
+    fi
   fi
+
+  ui_step "5/7" "Cron integration"
   if [[ -z "$EXPLICIT_SKIP_CRON" ]]; then
-    SKIP_CRON_INSTALL="$(prompt_run_toggle "Install/refresh managed cron entries?" "$SKIP_CRON_INSTALL")"
+    if [[ "$DISCOVER_VENTURE_CRON_STATE" == "installed" ]]; then
+      if [[ "$(prompt_yes_no "Managed VentureOS cron block exists. Refresh it now?" "y")" == "y" ]]; then
+        SKIP_CRON_INSTALL=0
+      else
+        SKIP_CRON_INSTALL=1
+      fi
+    else
+      SKIP_CRON_INSTALL="$(prompt_run_toggle "Install/refresh managed cron entries?" "$SKIP_CRON_INSTALL")"
+    fi
   fi
+
+  ui_step "6/7" "Readiness and verification"
   if [[ -z "$EXPLICIT_SKIP_READINESS" ]]; then
     SKIP_READINESS="$(prompt_run_toggle "Run readiness refresh smoke now?" "$SKIP_READINESS")"
   fi
@@ -784,11 +909,20 @@ if [[ "$NON_INTERACTIVE" == "0" && -t 0 ]]; then
       VERIFY_POST_INSTALL=0
     fi
   fi
-  echo ""
+
+  ui_step "7/7" "Safety controls"
+  if [[ -z "$EXPLICIT_RESTORE_POINT" ]]; then
+    if [[ "$(prompt_yes_no "Capture a restore point before making changes?" "y")" == "y" ]]; then
+      CAPTURE_RESTORE_POINT=1
+    else
+      CAPTURE_RESTORE_POINT=0
+    fi
+  fi
 fi
 
 dashboard_url="$(resolve_dashboard_url)"
 
+ui_section "Execution Plan"
 echo "Install plan:"
 echo "  preset: $INSTALL_PRESET"
 echo "  dashboard port: $DASHBOARD_PORT"
@@ -804,11 +938,9 @@ echo "  restore base dir: $RESTORE_BASE_DIR"
 if [[ "$DRY_RUN" == "1" ]]; then
   echo "  mode: dry-run"
 fi
-echo ""
-
 discover_existing_state "$dashboard_url"
-echo ""
 
+ui_section "Preflight Safety"
 if [[ "$CAPTURE_RESTORE_POINT" == "1" ]]; then
   if [[ "$DRY_RUN" == "1" ]]; then
     record_step "restore-point" "planned" "would snapshot user config before install" "bash scripts/ventureos-install.sh --list-restore-points"


### PR DESCRIPTION
## Summary
- add guided interactive onboarding UX sections to `scripts/ventureos-install.sh` (discovery, recommendations, staged decision prompts)
- keep non-interactive/install automation behavior stable while improving TTY onboarding flow
- add VB-003 watchdog cron job wiring (`config/reliability.json`, `scripts/install-cron.sh`)
- add `scripts/vb003-watchdog.sh` for telemetry freshness + short-window cron health checks with JSON/MD artifacts
- update cron/degradation/script specs and reliability tests for 14 cron jobs

## Onboarding UX additions
- staged sections: onboarding intro, discovery, recommendations, execution plan, preflight safety
- guided choices based on discovered state:
  - adopt existing healthy dashboard vs reinstall
  - skip bridge install when bridge env is missing
  - refresh existing managed cron block when already installed
  - explicit restore-point capture choice in interactive mode

## Validation
- `bash -n scripts/ventureos-install.sh scripts/install-cron.sh scripts/vb003-watchdog.sh scripts/tests/test-ventureos-install.sh scripts/tests/test-reliability.sh`
- `bash scripts/tests/test-ventureos-install.sh`
- `bash scripts/tests/test-reliability.sh` (33/33 passed)
- `npm run docs:lint`
- `npm run roadmap:sync:check`
- `VB003_WATCHDOG_*` isolated smoke run produced watchdog artifacts and healthy status
