### PR TITLE
Fix local-ready cron dashboard URL and tighten watchdog alerting

### DIFF
--- a/docs/CRON_SPECS.md
+++ b/docs/CRON_SPECS.md
@@ -76,6 +76,7 @@
 - **Session:** isolated
 - **Agent:** nexus
 - **Payload:** run `scripts/openclaw-local-ready-cron.sh`
+- **Default dashboard URL in managed cron:** `http://127.0.0.1:7000` via `OPENCLAW_LOCAL_READY_DASHBOARD_URL`
 - **Output:** refreshed `docs/LOCAL_INTEGRATION_READY.md` and paired JSON/MD/SVG artifacts
 - **Status artifact:** `runtime/reports/openclaw-local-smoke/openclaw-local-ready-latest.json`
 - **Retention:** defaults to keep newest 14 artifact sets (configurable via env)

--- a/docs/SCRIPT_SPECS.md
+++ b/docs/SCRIPT_SPECS.md
@@ -309,6 +309,7 @@ bash scripts/openclaw-local-ready-cron.sh
   - `OPENCLAW_LOCAL_READY_PRUNE_KEEP`
   - `OPENCLAW_LOCAL_READY_MAX_AGE_MIN`
   - `OPENCLAW_LOCAL_READY_PROFILE` (`quick|full|bridge`)
+  - `OPENCLAW_LOCAL_READY_DASHBOARD_URL` (must start with `http://` or `https://`)
 - Validates env inputs and exits `2` on invalid values before running refresh.
 - Forwards any additional CLI flags to the underlying refresh script (last flag wins).
 
@@ -335,6 +336,13 @@ bash scripts/vb003-watchdog.sh
   - `budget-check`
   - `routing-healthcheck`
   - `monitoring`
+- Applies active alert gating on a short window (`VB003_WATCHDOG_ALERT_WINDOW_MINUTES`, default `90`):
+  - flags when a job has all-fail behavior in the active window
+  - flags when a job has high active-window failure rate (`>=2` failures and `>=50%` fail rate)
+- Applies per-job start staleness thresholds to avoid false positives on lower-frequency jobs:
+  - `budget-check`: stale if no start for >30h
+  - `routing-healthcheck`: stale if no start for >90m
+  - `monitoring`: stale if no start for >45m
 - Emits timestamped + latest watchdog artifacts:
   - `runtime/reports/model-orchestration/vb003-watchdog-<timestamp>.json`
   - `runtime/reports/model-orchestration/vb003-watchdog-<timestamp>.md`
@@ -348,6 +356,7 @@ bash scripts/vb003-watchdog.sh
 - `VB003_CRON_RUN_DIR`
 - `VB003_TARGET_HOURS` (default `168`)
 - `VB003_WATCHDOG_LOOKBACK_MINUTES` (default `360`)
+- `VB003_WATCHDOG_ALERT_WINDOW_MINUTES` (default `90`)
 - `VB003_WATCHDOG_MAX_TELEMETRY_AGE_MINUTES` (default `480`)
 
 ---

--- a/scripts/install-cron.sh
+++ b/scripts/install-cron.sh
@@ -101,7 +101,7 @@ NEW_CRON=$(cat <<EOF
 */30 * * * * $RUNNER routing-healthcheck >> $LOG_BASE/cron-routing-healthcheck.log 2>&1
 
 # 12) Local OpenClaw readiness refresh — every 4 hours
-15 */4 * * * $RUNNER openclaw-local-ready >> $LOG_BASE/cron-openclaw-local-ready.log 2>&1
+15 */4 * * * OPENCLAW_LOCAL_READY_DASHBOARD_URL=http://127.0.0.1:7000 $RUNNER openclaw-local-ready >> $LOG_BASE/cron-openclaw-local-ready.log 2>&1
 
 # 13) VB-003 telemetry synthesis — every 6 hours
 30 */6 * * * $RUNNER vb003-telemetry-synthesis >> $LOG_BASE/cron-vb003-telemetry.log 2>&1

--- a/scripts/openclaw-local-ready-cron.sh
+++ b/scripts/openclaw-local-ready-cron.sh
@@ -9,6 +9,7 @@ HISTORY_LIMIT="${OPENCLAW_LOCAL_READY_HISTORY_LIMIT:-7}"
 PRUNE_KEEP="${OPENCLAW_LOCAL_READY_PRUNE_KEEP:-14}"
 PROFILE="${OPENCLAW_LOCAL_READY_PROFILE:-full}"
 MAX_AGE_MIN="${OPENCLAW_LOCAL_READY_MAX_AGE_MIN:-360}"
+DASHBOARD_URL="${OPENCLAW_LOCAL_READY_DASHBOARD_URL:-}"
 
 if ! [[ "$HISTORY_LIMIT" =~ ^[0-9]+$ ]] || [[ "$HISTORY_LIMIT" -lt 1 ]]; then
   echo "Invalid OPENCLAW_LOCAL_READY_HISTORY_LIMIT: $HISTORY_LIMIT" >&2
@@ -26,14 +27,26 @@ if [[ "$PROFILE" != "quick" && "$PROFILE" != "full" && "$PROFILE" != "bridge" ]]
   echo "Invalid OPENCLAW_LOCAL_READY_PROFILE: $PROFILE" >&2
   exit 2
 fi
+if [[ -n "$DASHBOARD_URL" && ! "$DASHBOARD_URL" =~ ^https?:// ]]; then
+  echo "Invalid OPENCLAW_LOCAL_READY_DASHBOARD_URL: $DASHBOARD_URL" >&2
+  exit 2
+fi
 if [[ ! -f "$REFRESH_SCRIPT" ]]; then
   echo "Missing refresh script: $REFRESH_SCRIPT" >&2
   exit 2
 fi
 
-bash "$REFRESH_SCRIPT" \
+cmd=(
+  bash "$REFRESH_SCRIPT"
   --history-limit "$HISTORY_LIMIT" \
   --prune-keep "$PRUNE_KEEP" \
   --max-age-min "$MAX_AGE_MIN" \
-  --profile "$PROFILE" \
-  "$@"
+  --profile "$PROFILE"
+)
+
+if [[ -n "$DASHBOARD_URL" ]]; then
+  cmd+=(--dashboard-url "$DASHBOARD_URL")
+fi
+
+cmd+=("$@")
+"${cmd[@]}"

--- a/scripts/tests/test-openclaw-local-ready-cron.sh
+++ b/scripts/tests/test-openclaw-local-ready-cron.sh
@@ -49,7 +49,8 @@ OPENCLAW_LOCAL_READY_HISTORY_LIMIT=3 \
 OPENCLAW_LOCAL_READY_PRUNE_KEEP=5 \
 OPENCLAW_LOCAL_READY_MAX_AGE_MIN=120 \
 OPENCLAW_LOCAL_READY_PROFILE=quick \
-bash "$CRON_SCRIPT" --profile bridge --history-limit 9 --max-age-min 240 >/tmp/openclaw-local-ready-cron-test-2.out
+OPENCLAW_LOCAL_READY_DASHBOARD_URL=http://127.0.0.1:7000 \
+bash "$CRON_SCRIPT" --profile bridge --history-limit 9 --max-age-min 240 --dashboard-url http://127.0.0.1:8123 >/tmp/openclaw-local-ready-cron-test-2.out
 
 python3 - "$CAPTURE_2" <<'PY'
 from pathlib import Path
@@ -69,6 +70,7 @@ assert pairs.get('--history-limit') == '9', pairs
 assert pairs.get('--prune-keep') == '5', pairs
 assert pairs.get('--max-age-min') == '240', pairs
 assert pairs.get('--profile') == 'bridge', pairs
+assert pairs.get('--dashboard-url') == 'http://127.0.0.1:8123', pairs
 print('OPENCLAW_LOCAL_READY_CRON_OVERRIDES_OK')
 PY
 
@@ -97,3 +99,16 @@ if [[ "$rc" -ne 2 ]]; then
 fi
 
 echo "OPENCLAW_LOCAL_READY_CRON_MAX_AGE_VALIDATION_OK"
+
+set +e
+OPENCLAW_LOCAL_READY_REFRESH_SCRIPT="$STUB_REFRESH" \
+OPENCLAW_LOCAL_READY_DASHBOARD_URL=127.0.0.1:7000 \
+bash "$CRON_SCRIPT" >/tmp/openclaw-local-ready-cron-test-bad-url.out 2>&1
+rc=$?
+set -e
+if [[ "$rc" -ne 2 ]]; then
+  echo "expected invalid dashboard URL to fail with exit 2, got $rc" >&2
+  exit 1
+fi
+
+echo "OPENCLAW_LOCAL_READY_CRON_DASHBOARD_URL_VALIDATION_OK"

--- a/scripts/vb003-watchdog.sh
+++ b/scripts/vb003-watchdog.sh
@@ -17,6 +17,7 @@ LATEST_TELEMETRY="${VB003_TELEMETRY_LATEST_JSON:-$OUT_DIR/vb003-telemetry-latest
 CRON_RUN_DIR="${VB003_CRON_RUN_DIR:-$WORKSPACE_ROOT/runtime/logs/cron-runs}"
 TARGET_HOURS="${VB003_TARGET_HOURS:-168}"
 LOOKBACK_MINUTES="${VB003_WATCHDOG_LOOKBACK_MINUTES:-360}"
+ALERT_WINDOW_MINUTES="${VB003_WATCHDOG_ALERT_WINDOW_MINUTES:-90}"
 MAX_TELEMETRY_AGE_MINUTES="${VB003_WATCHDOG_MAX_TELEMETRY_AGE_MINUTES:-480}"
 
 if ! [[ "$TARGET_HOURS" =~ ^[0-9]+$ ]] || [[ "$TARGET_HOURS" -lt 1 ]]; then
@@ -25,6 +26,10 @@ if ! [[ "$TARGET_HOURS" =~ ^[0-9]+$ ]] || [[ "$TARGET_HOURS" -lt 1 ]]; then
 fi
 if ! [[ "$LOOKBACK_MINUTES" =~ ^[0-9]+$ ]] || [[ "$LOOKBACK_MINUTES" -lt 1 ]]; then
   echo "Invalid VB003_WATCHDOG_LOOKBACK_MINUTES: $LOOKBACK_MINUTES" >&2
+  exit 2
+fi
+if ! [[ "$ALERT_WINDOW_MINUTES" =~ ^[0-9]+$ ]] || [[ "$ALERT_WINDOW_MINUTES" -lt 1 ]]; then
+  echo "Invalid VB003_WATCHDOG_ALERT_WINDOW_MINUTES: $ALERT_WINDOW_MINUTES" >&2
   exit 2
 fi
 if ! [[ "$MAX_TELEMETRY_AGE_MINUTES" =~ ^[0-9]+$ ]] || [[ "$MAX_TELEMETRY_AGE_MINUTES" -lt 1 ]]; then
@@ -40,6 +45,7 @@ python3 - <<'PY' \
   "$CRON_RUN_DIR" \
   "$TARGET_HOURS" \
   "$LOOKBACK_MINUTES" \
+  "$ALERT_WINDOW_MINUTES" \
   "$MAX_TELEMETRY_AGE_MINUTES" \
   "$AGENT_ID" \
   "$WORKSPACE_ROOT"
@@ -54,12 +60,14 @@ latest_telemetry = os.path.abspath(sys.argv[2])
 cron_run_dir = os.path.abspath(sys.argv[3])
 target_hours = int(sys.argv[4])
 lookback_minutes = int(sys.argv[5])
-max_age_minutes = int(sys.argv[6])
-agent_id = sys.argv[7]
-workspace_root = os.path.abspath(sys.argv[8])
+alert_window_minutes = int(sys.argv[6])
+max_age_minutes = int(sys.argv[7])
+agent_id = sys.argv[8]
+workspace_root = os.path.abspath(sys.argv[9])
 
 now = datetime.now(timezone.utc)
 cutoff = now - timedelta(minutes=lookback_minutes)
+alert_cutoff = now - timedelta(minutes=alert_window_minutes)
 
 
 def parse_iso_z(ts):
@@ -132,9 +140,17 @@ if telemetry:
             closure_eta_utc = (start_dt + timedelta(hours=target_hours)).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 job_window = {}
+alert_window = {}
+staleness_threshold_minutes = {
+    "budget-check": 1800,        # 30h (daily schedule + buffer)
+    "routing-healthcheck": 90,   # every 30m + buffer
+    "monitoring": 45,            # every 15m + buffer
+}
 for job in ("budget-check", "routing-healthcheck", "monitoring"):
     path = os.path.join(cron_run_dir, f"{job}.jsonl")
     stats = {"starts": 0, "success": 0, "failure": 0}
+    alert_stats = {"starts": 0, "success": 0, "failure": 0}
+    latest_start_dt = None
     if os.path.exists(path):
         try:
             with open(path, "r", encoding="utf-8") as fh:
@@ -151,17 +167,44 @@ for job in ("budget-check", "routing-healthcheck", "monitoring"):
                     event = rec.get("event")
                     if event == "start":
                         stats["starts"] += 1
+                        if latest_start_dt is None or ts > latest_start_dt:
+                            latest_start_dt = ts
                     elif event == "success":
                         stats["success"] += 1
-                    elif event == "failure":
+                    elif event in ("failure", "timeout"):
                         stats["failure"] += 1
+                    if ts >= alert_cutoff:
+                        if event == "start":
+                            alert_stats["starts"] += 1
+                            if latest_start_dt is None or ts > latest_start_dt:
+                                latest_start_dt = ts
+                        elif event == "success":
+                            alert_stats["success"] += 1
+                        elif event in ("failure", "timeout"):
+                            alert_stats["failure"] += 1
         except OSError:
             issues.append(f"log_unreadable:{job}")
     else:
         issues.append(f"log_missing:{job}")
-    if stats["failure"] > 0:
-        issues.append(f"recent_failures:{job}:{stats['failure']}")
+    if alert_stats["starts"] > 0:
+        fail_rate = alert_stats["failure"] / max(1, alert_stats["starts"])
+        if alert_stats["success"] == 0 and alert_stats["failure"] > 0:
+            issues.append(f"active_window_all_fail:{job}:{alert_stats['failure']}")
+        elif alert_stats["failure"] >= 2 and fail_rate >= 0.5:
+            issues.append(f"active_window_high_fail_rate:{job}:{alert_stats['failure']}/{alert_stats['starts']}")
+
+    if latest_start_dt is None:
+        issues.append(f"no_recent_start:{job}")
+    else:
+        age_minutes = (now - latest_start_dt).total_seconds() / 60.0
+        threshold = staleness_threshold_minutes.get(job, lookback_minutes)
+        if age_minutes > threshold:
+            issues.append(f"run_stale:{job}:{round(age_minutes,1)}m>{threshold}m")
     job_window[job] = stats
+    alert_window[job] = {
+        **alert_stats,
+        "latest_start_utc": latest_start_dt.strftime("%Y-%m-%dT%H:%M:%SZ") if latest_start_dt else None,
+    }
 
 if coverage_hours >= target_hours and verification_state == "ready_for_closure_review":
     closure_ready = True
@@ -192,6 +235,11 @@ report = {
         "cutoff_utc": cutoff.strftime("%Y-%m-%dT%H:%M:%SZ"),
         "jobs": job_window,
     },
+    "alert_window": {
+        "lookback_minutes": alert_window_minutes,
+        "cutoff_utc": alert_cutoff.strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "jobs": alert_window,
+    },
     "agent_id": agent_id,
     "workspace_root": workspace_root,
 }
@@ -210,6 +258,12 @@ jobs_md = []
 for name in ("budget-check", "routing-healthcheck", "monitoring"):
     m = job_window.get(name, {})
     jobs_md.append(
+        f"- {name}: starts={m.get('starts', 0)}, success={m.get('success', 0)}, failure={m.get('failure', 0)}"
+    )
+alert_jobs_md = []
+for name in ("budget-check", "routing-healthcheck", "monitoring"):
+    m = alert_window.get(name, {})
+    alert_jobs_md.append(
         f"- {name}: starts={m.get('starts', 0)}, success={m.get('success', 0)}, failure={m.get('failure', 0)}"
     )
 
@@ -232,6 +286,9 @@ md = f"""# VB-003 Watchdog ({report['generated_at_utc']})
 
 ## Job Health (last {lookback_minutes} minutes)
 {os.linesep.join(jobs_md)}
+
+## Active Alert Window (last {alert_window_minutes} minutes)
+{os.linesep.join(alert_jobs_md)}
 
 ## Issues
 {issues_md}


### PR DESCRIPTION
## Summary
- fix scheduled local readiness cron to target the validated local dashboard URL (`http://127.0.0.1:7000`) via `OPENCLAW_LOCAL_READY_DASHBOARD_URL`
- extend `scripts/openclaw-local-ready-cron.sh` with dashboard URL env support + validation
- add regression coverage for dashboard URL override/validation in `scripts/tests/test-openclaw-local-ready-cron.sh`
- document the managed cron dashboard URL default in `docs/CRON_SPECS.md` and `docs/SCRIPT_SPECS.md`
- harden `scripts/vb003-watchdog.sh` with active alert-window gating and staleness thresholds

## Validation
- `bash -n scripts/openclaw-local-ready-cron.sh scripts/install-cron.sh scripts/tests/test-openclaw-local-ready-cron.sh`
- `bash scripts/tests/test-openclaw-local-ready-cron.sh`
- `bash scripts/tests/test-reliability.sh` (33/33 passed)
- `npm run docs:lint`
- `npm run roadmap:sync:check`
- live run:
  - `OPENCLAW_LOCAL_READY_DASHBOARD_URL=http://127.0.0.1:7000 bash scripts/cron-runner.sh openclaw-local-ready` (PASS)
  - `bash scripts/install-cron.sh --force` writes cron line with URL env override
