### PR TITLE
Fix #478: adopt healthy bridge LaunchAgent when bridge.env is missing

### DIFF
--- a/docs/LOCAL_INTEGRATION_READY.md
+++ b/docs/LOCAL_INTEGRATION_READY.md
@@ -8,34 +8,45 @@ Owner: automated refresh via `scripts/refresh-local-integration-ready.sh`
 - Readiness score: `100`
 - Confidence: `high`
 - Profile: `bridge`
+- Dashboard URL: `http://127.0.0.1:7000`
+- Token source: `token-file`
+- Token health: `ok`
+- Token repair action: `none`
 - Required failures: `0`
 - Required skipped: `0`
 - Warnings: `0`
 
 ## Latest Evidence Artifacts
-- JSON: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T231659Z.json`
-- Markdown: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T231659Z.md`
-- Status strip SVG: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260222T231659Z.svg`
+- JSON: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260223T065224Z.json`
+- Markdown: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260223T065224Z.md`
+- Status strip SVG: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260223T065224Z.svg`
 - Status summary JSON: `runtime/reports/openclaw-local-smoke/openclaw-local-ready-latest.json`
 - Status summary Markdown: `runtime/reports/openclaw-local-smoke/openclaw-local-ready-latest.md`
 
 ## Top 3 Blockers
 - No blockers in latest run.
 
-## Trend (Last 7 Runs)
+## Required Check Status Map
+- `dashboard-agent-health`: `pass`
+- `dashboard-config-auth`: `pass`
+- `dashboard-health`: `pass`
+- `dashboard-live-telemetry-sse`: `pass`
+- `dashboard-scheduler-jobs`: `pass`
+- `dashboard-services`: `pass`
+- `dashboard-token`: `pass`
+- `openclaw-cli`: `pass`
+- `openclaw-gateway-status`: `pass`
+
+## Trend (Last 3 Runs)
 | Timestamp | Verdict | Score | Required Failures | Warnings | Bridge |
 |---|---|---:|---:|---:|---|
-| `20260222T205733Z` | `GO` | 100 | 0 | 0 | `pass` |
-| `20260222T211046Z` | `GO` | 93 | 0 | 1 | `fail` |
-| `20260222T211244Z` | `GO` | 93 | 0 | 1 | `fail` |
-| `20260222T212745Z` | `GO` | 100 | 0 | 0 | `pass` |
-| `20260222T221513Z` | `GO` | 100 | 0 | 0 | `pass` |
-| `20260222T231635Z` | `GO` | 100 | 0 | 0 | `pass` |
-| `20260222T231659Z` | `GO` | 100 | 0 | 0 | `pass` |
+| `20260223T061513Z` | `GO` | 100 | 0 | 0 | `pass` |
+| `20260223T064406Z` | `GO` | 100 | 0 | 0 | `pass` |
+| `20260223T065224Z` | `GO` | 100 | 0 | 0 | `pass` |
 
 ## Required Checks
 - [x] `openclaw-cli` — `pass` group=`core` severity=`critical` (openclaw CLI found)
-- [x] `openclaw-gateway-status` — `pass` group=`core` severity=`critical` (Service: LaunchAgent (not loaded))
+- [x] `openclaw-gateway-status` — `pass` group=`core` severity=`critical` (Service: LaunchAgent (loaded))
 - [x] `dashboard-token` — `pass` group=`core` severity=`critical` (dashboard token loaded from token file)
 - [x] `dashboard-health` — `pass` group=`apis` severity=`critical` (health endpoint reachable)
 - [x] `dashboard-config-auth` — `pass` group=`apis` severity=`critical` (authenticated config access ok)

--- a/scripts/tests/test-ventureos-install.sh
+++ b/scripts/tests/test-ventureos-install.sh
@@ -62,7 +62,32 @@ SH
 cat > "$FAKE_BRIDGE" <<'SH'
 #!/usr/bin/env bash
 set -euo pipefail
-echo "bridge|$*" >> "$CALL_LOG"
+original_args="$*"
+bridge_env_path=""
+status_mode=0
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --bridge-env)
+      bridge_env_path="${2:-}"
+      shift 2
+      ;;
+    --status)
+      status_mode=1
+      shift
+      ;;
+    *)
+      shift
+      ;;
+    esac
+done
+
+echo "bridge|$original_args" >> "$CALL_LOG"
+if [[ "$status_mode" == "1" ]]; then
+  exit "${FAKE_BRIDGE_STATUS_RC:-0}"
+fi
+if [[ -n "$bridge_env_path" && ! -f "$bridge_env_path" ]]; then
+  exit 2
+fi
 exit 0
 SH
 
@@ -187,6 +212,7 @@ export VENTUREOS_INSTALL_READINESS_SCRIPT="$FAKE_READY"
 export VENTUREOS_INSTALL_OS="Darwin"
 export CRONTAB_STATE
 export VENTUREOS_INSTALL_RESTORE_BASE_DIR="$RESTORE_BASE"
+export FAKE_BRIDGE_STATUS_RC=0
 
 # Dry-run should plan actions without executing scripts.
 : > "$CALL_LOG"
@@ -199,9 +225,15 @@ run_install dry_run \
   --bridge-env "$BRIDGE_ENV" \
   --bridge-token-file "$TMP_DIR/bridge-token"
 
-if grep -E -q '^(dashboard-macos|dashboard-linux|bridge\||cron\||ready\|)' "$CALL_LOG"; then
+if grep -E -q '^(dashboard-macos|dashboard-linux|cron\||ready\|)' "$CALL_LOG"; then
   echo "Expected dry-run mode to avoid executing installer primitives" >&2
   exit 1
+fi
+if grep -E '^bridge\|' "$CALL_LOG" >/dev/null 2>&1; then
+  if grep -E '^bridge\|' "$CALL_LOG" | grep -vq -- '--status'; then
+    echo "Expected dry-run mode to avoid bridge install execution (status checks are allowed)" >&2
+    exit 1
+  fi
 fi
 
 grep -q "VENTUREOS_INSTALL_RESULT=PLANNED" "$OUT_DIR/dry_run.out"
@@ -290,9 +322,11 @@ run_install minimal_preset \
   --bridge-env "$BRIDGE_ENV"
 
 grep -q "dashboard-macos|" "$CALL_LOG"
-if grep -q 'bridge|' "$CALL_LOG"; then
-  echo "Minimal preset should not run bridge installer" >&2
-  exit 1
+if grep -E '^bridge\|' "$CALL_LOG" >/dev/null 2>&1; then
+  if grep -E '^bridge\|' "$CALL_LOG" | grep -vq -- '--status'; then
+    echo "Minimal preset should not run bridge installer" >&2
+    exit 1
+  fi
 fi
 if grep -q 'cron|' "$CALL_LOG"; then
   echo "Minimal preset should not run cron installer" >&2
@@ -304,9 +338,9 @@ minimal_report="$(latest_report minimal_preset)"
 grep -q -- '- Preset: `minimal`' "$minimal_report"
 echo "VENTUREOS_INSTALL_PRESET_OK"
 
-# Missing bridge env should fail with actionable failed-step report content.
+# Missing bridge env should adopt existing healthy launchagent state (non-destructive mode).
 : > "$CALL_LOG"
-run_install_expect_fail missing_bridge_env \
+run_install missing_bridge_env_adopt \
   --non-interactive \
   --verify \
   --dashboard-port 8126 \
@@ -314,9 +348,28 @@ run_install_expect_fail missing_bridge_env \
   --bridge-env "$TMP_DIR/missing-bridge.env" \
   --skip-readiness
 
-grep -q "VENTUREOS_INSTALL_RESULT=FAIL" "$OUT_DIR/missing_bridge_env.out"
-fail_report="$(latest_report missing_bridge_env)"
+grep -q "VENTUREOS_INSTALL_RESULT=PASS" "$OUT_DIR/missing_bridge_env_adopt.out"
+adopt_report="$(latest_report missing_bridge_env_adopt)"
+grep -q "bridge env missing; adopted existing healthy launchagent" "$adopt_report"
+grep -q '`bridge-launchagent` | `pass`' "$adopt_report"
+echo "VENTUREOS_INSTALL_MISSING_BRIDGE_ENV_ADOPT_OK"
+
+# Missing bridge env should still fail when existing launchagent status is unhealthy.
+export FAKE_BRIDGE_STATUS_RC=1
+: > "$CALL_LOG"
+run_install_expect_fail missing_bridge_env_unhealthy \
+  --non-interactive \
+  --verify \
+  --dashboard-port 8127 \
+  --openclaw-dir "$OPENCLAW_FIXTURE_DIR" \
+  --bridge-env "$TMP_DIR/missing-bridge.env" \
+  --skip-readiness
+export FAKE_BRIDGE_STATUS_RC=0
+
+grep -q "VENTUREOS_INSTALL_RESULT=FAIL" "$OUT_DIR/missing_bridge_env_unhealthy.out"
+fail_report="$(latest_report missing_bridge_env_unhealthy)"
 grep -q '## Failed Steps' "$fail_report"
+grep -q "missing bridge env file and no healthy launchagent to adopt" "$fail_report"
 grep -q "Create bridge env file or pass --skip-bridge-launchagent" "$fail_report"
 grep -q '| Step | Status | Detail | Next Command |' "$fail_report"
 echo "VENTUREOS_INSTALL_FAILURE_REPORT_OK"

--- a/scripts/ventureos-install.sh
+++ b/scripts/ventureos-install.sh
@@ -55,6 +55,7 @@ UI_ENABLED=0
 DISCOVER_DASHBOARD_STATE="unknown"
 DISCOVER_OPENCLAW_STATE="unknown"
 DISCOVER_BRIDGE_ENV_STATE="unknown"
+DISCOVER_BRIDGE_LAUNCHAGENT_STATE="unknown"
 DISCOVER_CRON_STATE="unknown"
 DISCOVER_VENTURE_CRON_STATE="unknown"
 
@@ -526,6 +527,7 @@ discover_existing_state() {
   DISCOVER_DASHBOARD_STATE="unreachable"
   DISCOVER_OPENCLAW_STATE="missing"
   DISCOVER_BRIDGE_ENV_STATE="missing"
+  DISCOVER_BRIDGE_LAUNCHAGENT_STATE="unavailable"
   DISCOVER_CRON_STATE="empty"
   DISCOVER_VENTURE_CRON_STATE="not-installed"
 
@@ -539,6 +541,14 @@ discover_existing_state() {
 
   if [[ -f "$BRIDGE_ENV" ]]; then
     DISCOVER_BRIDGE_ENV_STATE="present"
+  fi
+
+  if [[ "$OS_NAME" == "Darwin" && -f "$BRIDGE_INSTALL_SCRIPT" ]]; then
+    if bash "$BRIDGE_INSTALL_SCRIPT" --bridge-env "$BRIDGE_ENV" --status >/dev/null 2>&1; then
+      DISCOVER_BRIDGE_LAUNCHAGENT_STATE="healthy"
+    else
+      DISCOVER_BRIDGE_LAUNCHAGENT_STATE="unhealthy"
+    fi
   fi
 
   if command -v crontab >/dev/null 2>&1; then
@@ -561,6 +571,9 @@ discover_existing_state() {
   ui_section "Discovery"
   ui_state_line "openclaw dir" "$DISCOVER_OPENCLAW_STATE" "$OPENCLAW_DIR"
   ui_state_line "bridge env" "$DISCOVER_BRIDGE_ENV_STATE" "$BRIDGE_ENV"
+  if [[ "$OS_NAME" == "Darwin" ]]; then
+    ui_state_line "bridge launchagent" "$DISCOVER_BRIDGE_LAUNCHAGENT_STATE"
+  fi
   ui_state_line "dashboard health" "$DISCOVER_DASHBOARD_STATE" "$dashboard_url"
   ui_state_line "user crontab" "$DISCOVER_CRON_STATE"
   ui_state_line "ventureos managed cron block" "$DISCOVER_VENTURE_CRON_STATE"
@@ -711,7 +724,9 @@ generate_integration_adoption_plan() {
       record_adoption_target "bridge-env-auth-source" "adopt" "$bridge_env_exists" "$BRIDGE_ENV" "platform does not run bridge launchagent installer"
     fi
   else
-    if [[ "$SKIP_BRIDGE_LAUNCHAGENT" == "0" && "$OS_NAME" == "Darwin" ]]; then
+    if [[ "$SKIP_BRIDGE_LAUNCHAGENT" == "0" && "$OS_NAME" == "Darwin" && "$DISCOVER_BRIDGE_LAUNCHAGENT_STATE" == "healthy" ]]; then
+      record_adoption_target "bridge-env-auth-source" "adopt" "$bridge_env_exists" "$BRIDGE_ENV" "bridge env missing but existing launchagent is healthy; installer adopts existing bridge state"
+    elif [[ "$SKIP_BRIDGE_LAUNCHAGENT" == "0" && "$OS_NAME" == "Darwin" ]]; then
       record_adoption_target "bridge-env-auth-source" "skip" "$bridge_env_exists" "$BRIDGE_ENV" "bridge env missing; manual creation required before launchagent install"
     else
       record_adoption_target "bridge-env-auth-source" "skip" "$bridge_env_exists" "$BRIDGE_ENV" "bridge integration skipped by plan/platform"
@@ -728,6 +743,8 @@ generate_integration_adoption_plan() {
       else
         record_adoption_target "bridge-launchagent-plist" "skip" "$launchagent_exists" "$launchagent_plist" "bridge launchagent step skipped"
       fi
+    elif [[ "$bridge_env_exists" == "false" && "$DISCOVER_BRIDGE_LAUNCHAGENT_STATE" == "healthy" ]]; then
+      record_adoption_target "bridge-launchagent-plist" "adopt" "$launchagent_exists" "$launchagent_plist" "bridge env missing; adopt existing healthy launchagent state"
     else
       if [[ "$launchagent_exists" == "true" ]]; then
         record_adoption_target "bridge-launchagent-plist" "merge" "$launchagent_exists" "$launchagent_plist" "refresh launchagent without destructive overwrite"
@@ -1381,9 +1398,14 @@ if [[ "$SKIP_BRIDGE_LAUNCHAGENT" == "0" ]]; then
     echo "SKIP  bridge-launchagent :: not supported on $OS_NAME"
     record_step "bridge-launchagent" "skipped" "bridge LaunchAgent installer is macOS-only" "Use macOS for LaunchAgent install"
   elif [[ ! -f "$BRIDGE_ENV" ]]; then
-    echo "FAIL  bridge-launchagent :: missing bridge env file: $BRIDGE_ENV" >&2
-    record_step "bridge-launchagent" "fail" "missing bridge env file" "Create bridge env file or pass --skip-bridge-launchagent"
-    INSTALL_FAILED=1
+    if bash "$BRIDGE_INSTALL_SCRIPT" --bridge-env "$BRIDGE_ENV" --status >/dev/null 2>&1; then
+      echo "PASS  bridge-launchagent :: bridge env missing; adopted existing healthy launchagent"
+      record_step "bridge-launchagent" "pass" "bridge env missing; adopted existing healthy launchagent" "Create bridge env only when launchagent reconfiguration is required"
+    else
+      echo "FAIL  bridge-launchagent :: missing bridge env file and no healthy launchagent to adopt: $BRIDGE_ENV" >&2
+      record_step "bridge-launchagent" "fail" "missing bridge env file and no healthy launchagent to adopt" "Create bridge env file or pass --skip-bridge-launchagent"
+      INSTALL_FAILED=1
+    fi
   else
     if ! run_step "bridge-launchagent" "scripts/install-bridge-launchagent.sh" \
       bash "$BRIDGE_INSTALL_SCRIPT" --bridge-env "$BRIDGE_ENV"; then


### PR DESCRIPTION
## Summary
- treat missing `config/bridge.env` as **adoptable** when an existing bridge LaunchAgent is healthy
- add discovery + adoption plan surfacing for bridge LaunchAgent health
- make bridge step pass in this adoptable case, and still fail when no healthy LaunchAgent exists
- extend installer tests to cover both adopt-success and unhealthy-fail paths
- refresh local integration readiness doc with latest smoke evidence

## Verification
- `bash scripts/tests/test-ventureos-install.sh`
- `bash scripts/tests/test-reliability.sh`
- `npm run docs:lint`
- real-host drill evidence: `runtime/reports/issue-478-drill-20260223T064843Z`
  - `install-verify.exit = 0`
  - `revert.exit = 0`
  - cron coexistence: `preserved_after_install=true`, `restored_after_revert=true`

Closes #478
