### PR TITLE
Implement #489: local integration checklist + drill evidence

### DIFF
--- a/docs/LOCAL_INTEGRATION_CHECKLIST.md
+++ b/docs/LOCAL_INTEGRATION_CHECKLIST.md
@@ -1,0 +1,53 @@
+# Local Integration Checklist (Installer + OpenClaw)
+
+Last verified: 2026-02-23
+Owner: VentureOS installer execution
+
+## Checklist
+
+- [x] Real-host installer adoption drill completed (non-destructive skip profile)
+- [x] Integration adoption matrix generated (`adopt|merge|create|skip` targets)
+- [x] Pre-install restore point captured and manifest validated
+- [x] Revert command executed from generated restore point
+- [x] Revert summary reports `errors=0`
+- [x] Current readiness doc reflects latest local evidence
+
+## Latest Result
+
+- Date (UTC): `2026-02-23`
+- Installer run start: `20260223T212912Z`
+- Installer status: `PASS`
+- Revert run start: `20260223T212918Z`
+- Revert status: `REVERTED`
+- Revert summary: `restored=5 removed=0 skipped=1 errors=0`
+
+## Commands Executed
+
+```bash
+bash scripts/ventureos-install.sh \
+  --non-interactive \
+  --verify \
+  --skip-dashboard-install \
+  --skip-bridge-launchagent \
+  --skip-cron \
+  --skip-readiness \
+  --openclaw-dir "$HOME/.openclaw" \
+  --bridge-env "$PWD/config/bridge.env"
+
+bash scripts/ventureos-install.sh --non-interactive --revert <restore-point-dir>
+```
+
+## Evidence Artifacts
+
+- Installer drill log: `runtime/reports/ventureos-install/issue-489-drill-20260223T212912Z.log`
+- Revert drill log: `runtime/reports/ventureos-install/issue-489-revert-20260223T212918Z.log`
+- Installer report: `runtime/reports/ventureos-install/ventureos-install-20260223T212913Z.md`
+- Adoption evidence JSON: `runtime/reports/ventureos-install/ventureos-install-adoption-20260223T212913Z.json`
+- Onboarding transcript: `runtime/reports/ventureos-install/ventureos-onboarding-20260223T212913Z.md`
+- Restore point: `runtime/backups/ventureos-install/20260223T212913Z-52358`
+
+## Tracking
+
+- Issue: `#489`
+- Related hygiene issue: `#490`
+- Related PR: `#491`

--- a/docs/LOCAL_INTEGRATION_READY.md
+++ b/docs/LOCAL_INTEGRATION_READY.md
@@ -7,7 +7,7 @@ Owner: automated refresh via `scripts/refresh-local-integration-ready.sh`
 - Verdict: `GO`
 - Readiness score: `100`
 - Confidence: `high`
-- Profile: `bridge`
+- Profile: `full`
 - Dashboard URL: `http://127.0.0.1:7000`
 - Token source: `token-file`
 - Token health: `ok`
@@ -17,9 +17,9 @@ Owner: automated refresh via `scripts/refresh-local-integration-ready.sh`
 - Warnings: `0`
 
 ## Latest Evidence Artifacts
-- JSON: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260223T070058Z.json`
-- Markdown: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260223T070058Z.md`
-- Status strip SVG: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260223T070058Z.svg`
+- JSON: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260223T181511Z.json`
+- Markdown: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260223T181511Z.md`
+- Status strip SVG: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260223T181511Z.svg`
 - Status summary JSON: `runtime/reports/openclaw-local-smoke/openclaw-local-ready-latest.json`
 - Status summary Markdown: `runtime/reports/openclaw-local-smoke/openclaw-local-ready-latest.md`
 
@@ -37,13 +37,16 @@ Owner: automated refresh via `scripts/refresh-local-integration-ready.sh`
 - `openclaw-cli`: `pass`
 - `openclaw-gateway-status`: `pass`
 
-## Trend (Last 4 Runs)
+## Trend (Last 7 Runs)
 | Timestamp | Verdict | Score | Required Failures | Warnings | Bridge |
 |---|---|---:|---:|---:|---|
 | `20260223T061513Z` | `GO` | 100 | 0 | 0 | `pass` |
 | `20260223T064406Z` | `GO` | 100 | 0 | 0 | `pass` |
 | `20260223T065224Z` | `GO` | 100 | 0 | 0 | `pass` |
 | `20260223T070058Z` | `GO` | 100 | 0 | 0 | `pass` |
+| `20260223T101512Z` | `GO` | 100 | 0 | 0 | `pass` |
+| `20260223T141510Z` | `GO` | 100 | 0 | 0 | `pass` |
+| `20260223T181511Z` | `GO` | 100 | 0 | 0 | `pass` |
 
 ## Required Checks
 - [x] `openclaw-cli` — `pass` group=`core` severity=`critical` (openclaw CLI found)
@@ -58,7 +61,7 @@ Owner: automated refresh via `scripts/refresh-local-integration-ready.sh`
 
 ## Optional Checks
 - [x] `dashboard-map-route` — `pass` group=`apis` severity=`info` (map route reachable)
-- [x] `bridge-scheduler-jobs` — `pass` group=`bridge` severity=`critical-optional` (bridge scheduler endpoint reachable)
+- [x] `bridge-scheduler-jobs` — `pass` group=`bridge` severity=`warn` (bridge scheduler endpoint reachable)
 
 ## Bridge Token Setup Note
 - Direct bridge checks support `--bridge-token-file`, `BRIDGE_TOKEN`, `BRIDGE_TOKEN_FILE`, or default `OPENCLAW_DIR/bridge/bridge-token`.


### PR DESCRIPTION
## Summary
- add a short auditable local integration checklist doc with latest installer adoption + rollback drill evidence
- refresh `docs/LOCAL_INTEGRATION_READY.md` to latest full-profile local smoke evidence window

## What was executed on this host
- installer drill (non-destructive execution profile):
  - `bash scripts/ventureos-install.sh --non-interactive --verify --skip-dashboard-install --skip-bridge-launchagent --skip-cron --skip-readiness --openclaw-dir "$HOME/.openclaw" --bridge-env "$PWD/config/bridge.env"`
- rollback validation:
  - `bash scripts/ventureos-install.sh --non-interactive --revert <restore-point-dir>`

## Evidence
- `runtime/reports/ventureos-install/issue-489-drill-20260223T212912Z.log`
- `runtime/reports/ventureos-install/issue-489-revert-20260223T212918Z.log`
- `runtime/reports/ventureos-install/ventureos-install-20260223T212913Z.md`
- `runtime/reports/ventureos-install/ventureos-install-adoption-20260223T212913Z.json`
- `runtime/reports/ventureos-install/ventureos-onboarding-20260223T212913Z.md`
- `runtime/backups/ventureos-install/20260223T212913Z-52358`

## Verification
- `npm run docs:lint`

Closes #489
