### PR TITLE
feat(pr): enforce queue merge evidence gates and status reporting

### DIFF
--- a/docs/LOCAL_INTEGRATION_CHECKLIST.md
+++ b/docs/LOCAL_INTEGRATION_CHECKLIST.md
@@ -42,6 +42,25 @@ Cadence checklist:
 - [ ] Installer report + adoption evidence paths included in evidence bundle
 - [ ] Readiness status JSON reference present in evidence bundle
 
+## PR Queue Execution Cadence (Issue #504)
+
+Queue status command (single-command health snapshot):
+
+```bash
+bash scripts/pr-queue-sweep.sh --json-out runtime/reports/pr-queue/queue-latest.json
+```
+
+Optional merge execution (with automatic readiness evidence capture):
+
+```bash
+bash scripts/pr-queue-sweep.sh --merge-approved --report-dir runtime/reports/pr-queue
+```
+
+Queue cadence checklist:
+- [ ] Queue status JSON captured after approvals land
+- [ ] Merge mode output linked when merges are executed
+- [ ] Candidate PRs have readiness + required-check evidence artifacts before merge
+
 ## Latest Result
 
 - Date (UTC): `2026-02-23`

--- a/docs/LOCAL_INTEGRATION_READY.md
+++ b/docs/LOCAL_INTEGRATION_READY.md
@@ -1,6 +1,6 @@
 # Local Integration Ready Checklist
 
-Date: 2026-02-23 (UTC)
+Date: 2026-02-24 (UTC)
 Owner: automated refresh via `scripts/refresh-local-integration-ready.sh`
 
 ## Mission Control Card
@@ -17,9 +17,9 @@ Owner: automated refresh via `scripts/refresh-local-integration-ready.sh`
 - Warnings: `2`
 
 ## Latest Evidence Artifacts
-- JSON: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260223T221510Z.json`
-- Markdown: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260223T221510Z.md`
-- Status strip SVG: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260223T221510Z.svg`
+- JSON: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260224T181509Z.json`
+- Markdown: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260224T181509Z.md`
+- Status strip SVG: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260224T181509Z.svg`
 - Status summary JSON: `runtime/reports/openclaw-local-smoke/openclaw-local-ready-latest.json`
 - Status summary Markdown: `runtime/reports/openclaw-local-smoke/openclaw-local-ready-latest.md`
 
@@ -42,13 +42,13 @@ Owner: automated refresh via `scripts/refresh-local-integration-ready.sh`
 ## Trend (Last 7 Runs)
 | Timestamp | Verdict | Score | Required Failures | Warnings | Bridge |
 |---|---|---:|---:|---:|---|
-| `20260223T064406Z` | `GO` | 100 | 0 | 0 | `pass` |
-| `20260223T065224Z` | `GO` | 100 | 0 | 0 | `pass` |
-| `20260223T070058Z` | `GO` | 100 | 0 | 0 | `pass` |
-| `20260223T101512Z` | `GO` | 100 | 0 | 0 | `pass` |
-| `20260223T141510Z` | `GO` | 100 | 0 | 0 | `pass` |
 | `20260223T181511Z` | `GO` | 100 | 0 | 0 | `pass` |
 | `20260223T221510Z` | `BLOCKED` | 30 | 6 | 2 | `fail` |
+| `20260224T021511Z` | `BLOCKED` | 30 | 6 | 2 | `fail` |
+| `20260224T061509Z` | `BLOCKED` | 30 | 6 | 2 | `fail` |
+| `20260224T101509Z` | `BLOCKED` | 30 | 6 | 2 | `fail` |
+| `20260224T141509Z` | `BLOCKED` | 30 | 6 | 2 | `fail` |
+| `20260224T181509Z` | `BLOCKED` | 30 | 6 | 2 | `fail` |
 
 ## Required Checks
 - [x] `openclaw-cli` — `pass` group=`core` severity=`critical` (openclaw CLI found)
@@ -75,6 +75,7 @@ Owner: automated refresh via `scripts/refresh-local-integration-ready.sh`
 3. Resolve required check failures before relying on automated readiness cadence.
 4. If bridge coverage is expected, configure bridge token and rerun bridge profile: `export BRIDGE_TOKEN_FILE=~/.openclaw/bridge/bridge-token && bash scripts/openclaw-local-smoke.sh --profile bridge`
 5. Confirm Mission Control shows the latest readiness payload from `/api/openclaw-local-readiness`.
+6. Capture PR queue status before merge windows: `bash scripts/pr-queue-sweep.sh --json-out runtime/reports/pr-queue/queue-latest.json`
 
 ## Refresh Command
 ```bash

--- a/docs/PR_MERGE_RUNBOOK.md
+++ b/docs/PR_MERGE_RUNBOOK.md
@@ -2,6 +2,22 @@
 
 Use this runbook to keep merge execution predictable and auditable.
 
+## Merge Cadence (Solo Maintainer)
+Run this cadence whenever approvals land or at least once per working session:
+1. Capture queue status in one command:
+```bash
+bash scripts/pr-queue-sweep.sh --json-out runtime/reports/pr-queue/queue-latest.json
+```
+2. If queue status is `merge-ready`, perform an evidence-backed dry-run:
+```bash
+bash scripts/pr-queue-sweep.sh --merge-approved --dry-run --report-dir runtime/reports/pr-queue
+```
+3. If dry-run output has no blocked candidates, execute merge sweep:
+```bash
+bash scripts/pr-queue-sweep.sh --merge-approved --report-dir runtime/reports/pr-queue
+```
+4. Link `queue-latest.json` and the merge evidence directory in the tracking issue/PR notes.
+
 ## Standard Path
 1. Run merge-readiness check:
 ```bash
@@ -16,6 +32,13 @@ bash scripts/required-check-contexts.sh --pr <PR_NUMBER>
 gh pr merge <PR_NUMBER> --merge --delete-branch
 ```
 4. If status is `blocked`, follow the first `Recommended Next Action` from the readiness output.
+
+## Merge Evidence Requirement
+When using queue merge mode (`--merge-approved`), `pr-queue-sweep.sh` captures before-merge evidence per candidate PR:
+- readiness report (`scripts/pr-merge-readiness.sh --json-out ...`)
+- required-context audit (`scripts/required-check-contexts.sh --json-out ...`)
+
+Candidates are merged only when both evidence checks return ready/aligned exit codes. Blocked candidates are skipped and recorded in queue merge output.
 
 ## Solo-Maintainer Fallback
 When PRs are blocked by branch-protection requirements that cannot be satisfied in a single-operator window:
@@ -52,6 +75,10 @@ The JSON report includes:
 - Queue classification:
 ```bash
 bash scripts/pr-queue-sweep.sh
+```
+- Queue classification + evidence JSON:
+```bash
+bash scripts/pr-queue-sweep.sh --json-out runtime/reports/pr-queue/queue-latest.json
 ```
 - NPM shortcuts:
 ```bash

--- a/docs/SCRIPT_SPECS.md
+++ b/docs/SCRIPT_SPECS.md
@@ -607,6 +607,11 @@ Dry-run merge simulation:
 bash scripts/pr-queue-sweep.sh --merge-approved --dry-run
 ```
 
+Queue status report output:
+```bash
+bash scripts/pr-queue-sweep.sh --json-out runtime/reports/pr-queue/queue-latest.json
+```
+
 **Behavior:**
 - Reads open PRs from `gh pr list` and classifies each as:
   - `draft`
@@ -614,9 +619,21 @@ bash scripts/pr-queue-sweep.sh --merge-approved --dry-run
   - `approved-merge-ready`
   - `approved-blocked`
 - Prints queue summary + per-PR rows.
+- Emits machine-readable status marker:
+  - `PR_QUEUE_STATUS=empty|quiet|review-needed|blocked|merge-ready`
 - Optionally writes JSON report with `--json-out <path>`.
-- Optional merge mode (`--merge-approved`) merges only `approved-merge-ready` PRs.
+- Supports `--report-dir <path>` to store merge-evidence artifacts.
+- Optional merge mode (`--merge-approved`) now:
+  - captures readiness evidence for each merge candidate via:
+    - `scripts/pr-merge-readiness.sh --json-out ...`
+    - `scripts/required-check-contexts.sh --json-out ...`
+  - skips candidates with non-ready evidence status
+  - merges only candidates with both checks ready/aligned
+  - emits `PR_QUEUE_MERGE_EXECUTION_STATUS=ready-executed|blocked|no-candidates`
 - Supports deterministic fixture mode for tests via `PR_QUEUE_FIXTURE_JSON`.
+  - Readiness/required-check scripts can be overridden for tests via:
+    - `PR_QUEUE_READINESS_SCRIPT`
+    - `PR_QUEUE_REQUIRED_CHECKS_SCRIPT`
 
 **Regression test:**
 ```bash

--- a/scripts/pr-queue-sweep.sh
+++ b/scripts/pr-queue-sweep.sh
@@ -1,10 +1,16 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
 LIMIT=30
 MERGE_APPROVED=0
 DRY_RUN=0
 JSON_OUT=""
+REPORT_DIR="${PR_QUEUE_REPORT_DIR:-$REPO_ROOT/runtime/reports/pr-queue}"
+READINESS_SCRIPT="${PR_QUEUE_READINESS_SCRIPT:-$REPO_ROOT/scripts/pr-merge-readiness.sh}"
+REQUIRED_CHECKS_SCRIPT="${PR_QUEUE_REQUIRED_CHECKS_SCRIPT:-$REPO_ROOT/scripts/required-check-contexts.sh}"
 
 usage() {
   cat <<'EOF_USAGE'
@@ -17,6 +23,7 @@ Options:
   --limit <n>          Number of open PRs to inspect (default: 30)
   --merge-approved     Merge PRs that are approved + merge-ready
   --dry-run            Print merge actions without executing
+  --report-dir <path>  Evidence/report directory (default: runtime/reports/pr-queue)
   --json-out <path>    Write queue classification JSON report
   -h, --help           Show help
 
@@ -24,6 +31,10 @@ Environment:
   PR_QUEUE_FIXTURE_JSON
     Optional path to JSON payload (same shape as gh pr list --json output)
     for deterministic testing.
+  PR_QUEUE_READINESS_SCRIPT
+    Optional override path for readiness script (default: scripts/pr-merge-readiness.sh).
+  PR_QUEUE_REQUIRED_CHECKS_SCRIPT
+    Optional override path for required-check audit script (default: scripts/required-check-contexts.sh).
 EOF_USAGE
 }
 
@@ -54,6 +65,11 @@ while [[ $# -gt 0 ]]; do
       JSON_OUT="$2"
       shift 2
       ;;
+    --report-dir)
+      need_value "$@"
+      REPORT_DIR="$2"
+      shift 2
+      ;;
     -h|--help)
       usage
       exit 0
@@ -76,6 +92,9 @@ trap 'rm -rf "$TMP_DIR"' EXIT
 RAW_JSON="$TMP_DIR/prs.json"
 CLASSIFIED_JSON="$TMP_DIR/classified.json"
 MERGE_LIST="$TMP_DIR/merge-ready.txt"
+MERGE_RESULTS_TSV="$TMP_DIR/merge-results.tsv"
+MERGE_RESULTS_JSON="$TMP_DIR/merge-results.json"
+FINAL_JSON="$TMP_DIR/final.json"
 
 if [[ -n "${PR_QUEUE_FIXTURE_JSON:-}" ]]; then
   cp "$PR_QUEUE_FIXTURE_JSON" "$RAW_JSON"
@@ -126,6 +145,25 @@ const summary = {
   approvedBlocked: classified.filter((r) => r.queueState === "approved-blocked").length,
 };
 
+let queueStatus = "quiet";
+let recommendedAction = "No immediate queue action required.";
+if (summary.totalOpen === 0) {
+  queueStatus = "empty";
+  recommendedAction = "No open PRs in queue.";
+} else if (summary.approvedMergeReady > 0) {
+  queueStatus = "merge-ready";
+  recommendedAction = "Run queue merge sweep to merge approved + green PRs.";
+} else if (summary.approvedBlocked > 0) {
+  queueStatus = "blocked";
+  recommendedAction = "Resolve blocker conditions on approved PRs.";
+} else if (summary.reviewNeeded > 0) {
+  queueStatus = "review-needed";
+  recommendedAction = "Request/complete reviews for queued PRs.";
+}
+
+summary.queueStatus = queueStatus;
+summary.recommendedAction = recommendedAction;
+
 const payload = { summary, prs: classified };
 fs.writeFileSync(outPath, JSON.stringify(payload, null, 2) + "\n", "utf8");
 
@@ -136,34 +174,135 @@ const mergeReady = classified
 fs.writeFileSync(mergePath, mergeReady.join("\n"), "utf8");
 NODE
 
+cp "$CLASSIFIED_JSON" "$FINAL_JSON"
+
 echo "PR Queue Summary"
 echo "  total_open:          $(jq -r '.summary.totalOpen' "$CLASSIFIED_JSON")"
 echo "  draft:               $(jq -r '.summary.draft' "$CLASSIFIED_JSON")"
 echo "  review_needed:       $(jq -r '.summary.reviewNeeded' "$CLASSIFIED_JSON")"
 echo "  approved_merge_ready:$(jq -r '.summary.approvedMergeReady' "$CLASSIFIED_JSON")"
 echo "  approved_blocked:    $(jq -r '.summary.approvedBlocked' "$CLASSIFIED_JSON")"
+echo "  queue_status:        $(jq -r '.summary.queueStatus' "$CLASSIFIED_JSON")"
+echo "  next_action:         $(jq -r '.summary.recommendedAction' "$CLASSIFIED_JSON")"
 
 echo ""
 echo "PR Queue Detail"
 jq -r '.prs[] | "#\(.number)\t\(.queueState)\t\(.mergeStateStatus)\t\(.reviewDecision)\t\(.title)"' "$CLASSIFIED_JSON"
 
-if [[ -n "$JSON_OUT" ]]; then
-  mkdir -p "$(dirname "$JSON_OUT")"
-  cp "$CLASSIFIED_JSON" "$JSON_OUT"
-  echo ""
-  echo "JSON report: $JSON_OUT"
-fi
-
 if [[ "$MERGE_APPROVED" == "1" ]]; then
+  timestamp_utc="$(date -u +%Y%m%dT%H%M%SZ)"
+  merge_report_dir="$REPORT_DIR/$timestamp_utc"
+  readiness_out_dir="$merge_report_dir/pr-merge-readiness"
+  required_out_dir="$merge_report_dir/pr-required-checks"
+  mkdir -p "$readiness_out_dir" "$required_out_dir"
+  : > "$MERGE_RESULTS_TSV"
+
   while IFS= read -r pr_number || [[ -n "$pr_number" ]]; do
     [[ -z "$pr_number" ]] && continue
+
+    readiness_json="$readiness_out_dir/pr-$pr_number.json"
+    required_json="$required_out_dir/pr-$pr_number.json"
+
+    readiness_rc=0
+    required_rc=0
+    if bash "$READINESS_SCRIPT" --pr "$pr_number" --json-out "$readiness_json" >/tmp/pr-queue-readiness-"$pr_number".out 2>&1; then
+      readiness_rc=0
+    else
+      readiness_rc=$?
+    fi
+    if bash "$REQUIRED_CHECKS_SCRIPT" --pr "$pr_number" --json-out "$required_json" >/tmp/pr-queue-required-"$pr_number".out 2>&1; then
+      required_rc=0
+    else
+      required_rc=$?
+    fi
+
+    if [[ "$readiness_rc" -ne 0 || "$required_rc" -ne 0 ]]; then
+      echo "SKIP merge PR #$pr_number :: readiness evidence not green (readiness_rc=$readiness_rc required_rc=$required_rc)"
+      printf '%s\t%s\t%s\t%s\t%s\n' "$pr_number" "$readiness_rc" "$required_rc" "blocked" "$readiness_json" >> "$MERGE_RESULTS_TSV"
+      continue
+    fi
+
     if [[ "$DRY_RUN" == "1" ]]; then
       echo "[dry-run] would merge PR #$pr_number"
+      printf '%s\t%s\t%s\t%s\t%s\n' "$pr_number" "$readiness_rc" "$required_rc" "dry-run" "$readiness_json" >> "$MERGE_RESULTS_TSV"
       continue
     fi
     echo "Merging PR #$pr_number ..."
     gh pr merge "$pr_number" --merge --delete-branch
+    printf '%s\t%s\t%s\t%s\t%s\n' "$pr_number" "$readiness_rc" "$required_rc" "merged" "$readiness_json" >> "$MERGE_RESULTS_TSV"
   done < "$MERGE_LIST"
+
+  python3 - "$MERGE_RESULTS_TSV" "$MERGE_RESULTS_JSON" "$merge_report_dir" "$DRY_RUN" <<'PY'
+import csv
+import json
+import pathlib
+import sys
+from datetime import datetime, timezone
+
+rows_path = pathlib.Path(sys.argv[1])
+out_path = pathlib.Path(sys.argv[2])
+report_dir = pathlib.Path(sys.argv[3])
+dry_run = sys.argv[4] == "1"
+
+rows = []
+if rows_path.exists():
+    with rows_path.open("r", encoding="utf-8") as fh:
+        reader = csv.reader(fh, delimiter="\t")
+        for row in reader:
+            if len(row) != 5:
+                continue
+            rows.append({
+                "number": int(row[0]),
+                "readinessExitCode": int(row[1]),
+                "requiredChecksExitCode": int(row[2]),
+                "action": row[3],
+                "readinessJson": row[4],
+            })
+
+summary = {
+    "totalCandidates": len(rows),
+    "merged": sum(1 for row in rows if row["action"] == "merged"),
+    "dryRun": sum(1 for row in rows if row["action"] == "dry-run"),
+    "blocked": sum(1 for row in rows if row["action"] == "blocked"),
+}
+if summary["blocked"] > 0:
+    status = "blocked"
+elif summary["merged"] > 0 or summary["dryRun"] > 0:
+    status = "ready-executed"
+else:
+    status = "no-candidates"
+
+payload = {
+    "generatedAtUtc": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "status": status,
+    "dryRun": dry_run,
+    "reportDir": str(report_dir),
+    "summary": summary,
+    "results": rows,
+}
+out_path.write_text(json.dumps(payload, indent=2) + "\n", encoding="utf-8")
+PY
+
+  jq --slurpfile mergeExec "$MERGE_RESULTS_JSON" '. + { mergeExecution: $mergeExec[0] }' "$FINAL_JSON" > "$TMP_DIR/final-merged.json"
+  mv "$TMP_DIR/final-merged.json" "$FINAL_JSON"
+
+  if [[ "$DRY_RUN" == "1" ]]; then
+    echo "Merge mode: dry-run with readiness evidence capture."
+  else
+    echo "Merge mode: executed with readiness evidence capture."
+  fi
+  echo "Merge evidence dir: $merge_report_dir"
 fi
 
+if [[ -n "$JSON_OUT" ]]; then
+  mkdir -p "$(dirname "$JSON_OUT")"
+  cp "$FINAL_JSON" "$JSON_OUT"
+  echo ""
+  echo "JSON report: $JSON_OUT"
+fi
+
+echo "PR_QUEUE_STATUS=$(jq -r '.summary.queueStatus' "$FINAL_JSON")"
+if [[ "$MERGE_APPROVED" == "1" ]]; then
+  echo "PR_QUEUE_MERGE_EXECUTION_STATUS=$(jq -r '.mergeExecution.status' "$FINAL_JSON")"
+fi
 echo "PR_QUEUE_SWEEP_DONE"

--- a/scripts/tests/test-pr-queue-sweep.sh
+++ b/scripts/tests/test-pr-queue-sweep.sh
@@ -12,6 +12,12 @@ trap cleanup EXIT
 
 FIXTURE="$TMP_DIR/prs.json"
 REPORT="$TMP_DIR/report.json"
+MERGE_REPORT="$TMP_DIR/merge-report.json"
+BLOCKED_REPORT="$TMP_DIR/blocked-report.json"
+QUEUE_REPORT_DIR="$TMP_DIR/queue-reports"
+CALL_LOG="$TMP_DIR/calls.log"
+FAKE_READINESS="$TMP_DIR/fake-pr-merge-readiness.sh"
+FAKE_REQUIRED="$TMP_DIR/fake-required-checks.sh"
 
 cat > "$FIXTURE" <<'EOF_JSON'
 [
@@ -71,8 +77,102 @@ jq -e '.summary.approvedMergeReady == 1' "$REPORT" >/dev/null
 jq -e '.summary.approvedBlocked == 1' "$REPORT" >/dev/null
 
 grep -q $'#102\tapproved-merge-ready' /tmp/test-pr-queue-sweep.out
+grep -q "PR_QUEUE_STATUS=merge-ready" /tmp/test-pr-queue-sweep.out
 echo "PR_QUEUE_SWEEP_CLASSIFY_OK"
 
-PR_QUEUE_FIXTURE_JSON="$FIXTURE" bash "$SCRIPT" --merge-approved --dry-run >/tmp/test-pr-queue-sweep-merge.out
+cat > "$FAKE_READINESS" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+pr=""
+json_out=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr)
+      pr="${2:-}"
+      shift 2
+      ;;
+    --json-out)
+      json_out="${2:-}"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+echo "readiness:$pr" >> "$CALL_LOG"
+if [[ "${FAIL_READY_PR:-}" == "$pr" ]]; then
+  exit 3
+fi
+
+mkdir -p "$(dirname "$json_out")"
+cat > "$json_out" <<JSON
+{"status":"merge-ready","number":$pr}
+JSON
+exit 0
+SH
+
+cat > "$FAKE_REQUIRED" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+pr=""
+json_out=""
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --pr)
+      pr="${2:-}"
+      shift 2
+      ;;
+    --json-out)
+      json_out="${2:-}"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+echo "required:$pr" >> "$CALL_LOG"
+if [[ "${FAIL_REQUIRED_PR:-}" == "$pr" ]]; then
+  exit 4
+fi
+
+mkdir -p "$(dirname "$json_out")"
+cat > "$json_out" <<JSON
+{"status":"aligned-ready","number":$pr}
+JSON
+exit 0
+SH
+
+chmod +x "$FAKE_READINESS" "$FAKE_REQUIRED"
+export CALL_LOG
+
+PR_QUEUE_FIXTURE_JSON="$FIXTURE" \
+PR_QUEUE_READINESS_SCRIPT="$FAKE_READINESS" \
+PR_QUEUE_REQUIRED_CHECKS_SCRIPT="$FAKE_REQUIRED" \
+bash "$SCRIPT" --merge-approved --dry-run --report-dir "$QUEUE_REPORT_DIR" --json-out "$MERGE_REPORT" >/tmp/test-pr-queue-sweep-merge.out
+
 grep -q "\[dry-run\] would merge PR #102" /tmp/test-pr-queue-sweep-merge.out
+grep -q "PR_QUEUE_MERGE_EXECUTION_STATUS=ready-executed" /tmp/test-pr-queue-sweep-merge.out
+grep -q "readiness:102" "$CALL_LOG"
+grep -q "required:102" "$CALL_LOG"
+jq -e '.mergeExecution.summary.dryRun == 1' "$MERGE_REPORT" >/dev/null
+jq -e '.mergeExecution.summary.blocked == 0' "$MERGE_REPORT" >/dev/null
 echo "PR_QUEUE_SWEEP_DRY_MERGE_OK"
+
+: > "$CALL_LOG"
+PR_QUEUE_FIXTURE_JSON="$FIXTURE" \
+PR_QUEUE_READINESS_SCRIPT="$FAKE_READINESS" \
+PR_QUEUE_REQUIRED_CHECKS_SCRIPT="$FAKE_REQUIRED" \
+FAIL_READY_PR=102 \
+bash "$SCRIPT" --merge-approved --dry-run --report-dir "$QUEUE_REPORT_DIR" --json-out "$BLOCKED_REPORT" >/tmp/test-pr-queue-sweep-blocked.out
+
+grep -q "SKIP merge PR #102" /tmp/test-pr-queue-sweep-blocked.out
+grep -q "PR_QUEUE_MERGE_EXECUTION_STATUS=blocked" /tmp/test-pr-queue-sweep-blocked.out
+jq -e '.mergeExecution.summary.blocked == 1' "$BLOCKED_REPORT" >/dev/null
+jq -e '.mergeExecution.summary.dryRun == 0' "$BLOCKED_REPORT" >/dev/null
+echo "PR_QUEUE_SWEEP_BLOCKED_OK"


### PR DESCRIPTION
## Summary
- harden `scripts/pr-queue-sweep.sh` with explicit queue status markers and merge-evidence gating
- in merge mode, capture readiness + required-check artifacts per candidate PR before merge
- skip blocked candidates and emit machine-readable merge execution status
- expand queue sweep regression coverage for dry-run evidence and blocked candidate behavior
- document merge cadence/owner flow and queue status reporting in runbook/checklists/specs
- include latest local readiness doc refresh with queue-status next step

## Verification
- `npm run test:pr:queue:sweep`
- `npm run test:pr:merge:readiness`
- `npm run docs:lint`

Closes #504
