### PR TITLE
Improve local readiness diagnostics for dashboard URL collisions

### DIFF
--- a/docs/CRON_SPECS.md
+++ b/docs/CRON_SPECS.md
@@ -76,7 +76,7 @@
 - **Session:** isolated
 - **Agent:** nexus
 - **Payload:** run `scripts/openclaw-local-ready-cron.sh`
-- **Default dashboard URL in managed cron:** `http://127.0.0.1:7000` via `OPENCLAW_LOCAL_READY_DASHBOARD_URL`
+- **Dashboard URL in managed cron:** resolved at install time via `openclaw_local_resolve_dashboard_url` (honors `OPENCLAW_LOCAL_READY_DASHBOARD_URL`, then `DASHBOARD_URL`, then `DASHBOARD_PORT`)
 - **Output:** refreshed `docs/LOCAL_INTEGRATION_READY.md` and paired JSON/MD/SVG artifacts
 - **Status artifact:** `runtime/reports/openclaw-local-smoke/openclaw-local-ready-latest.json`
 - **Retention:** defaults to keep newest 14 artifact sets (configurable via env)

--- a/docs/LOCAL_INTEGRATION_READY.md
+++ b/docs/LOCAL_INTEGRATION_READY.md
@@ -7,34 +7,32 @@ Owner: automated refresh via `scripts/refresh-local-integration-ready.sh`
 - Verdict: `BLOCKED`
 - Readiness score: `30`
 - Confidence: `low`
-- Profile: `full`
+- Profile: `quick`
 - Dashboard URL: `http://127.0.0.1:7000`
 - Token source: `token-file`
 - Token health: `ok`
 - Token repair action: `none`
-- Required failures: `6`
-- Required skipped: `0`
-- Warnings: `2`
+- Required failures: `1`
+- Required skipped: `5`
+- Warnings: `0`
 
 ## Latest Evidence Artifacts
-- JSON: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260224T181509Z.json`
-- Markdown: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260224T181509Z.md`
-- Status strip SVG: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260224T181509Z.svg`
+- JSON: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260224T193634Z.json`
+- Markdown: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260224T193634Z.md`
+- Status strip SVG: `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260224T193634Z.svg`
 - Status summary JSON: `runtime/reports/openclaw-local-smoke/openclaw-local-ready-latest.json`
 - Status summary Markdown: `runtime/reports/openclaw-local-smoke/openclaw-local-ready-latest.md`
 
 ## Top 3 Blockers
-- `dashboard-agent-health` owner=`Dashboard Ops`; cause: Agent health endpoint is unavailable or response format changed.; next: `curl -sS -H 'Authorization: Bearer <token>' http://127.0.0.1:7000/api/agent-health`
-- `dashboard-config-auth` owner=`Dashboard Ops`; cause: Dashboard auth token is invalid or auth middleware blocked access.; next: `curl -sS -H 'Authorization: Bearer <token>' http://127.0.0.1:7000/api/config`
-- `dashboard-health` owner=`Dashboard Ops`; cause: Dashboard process is not healthy or not reachable.; next: `curl -sS http://127.0.0.1:7000/api/health`
+- `dashboard-health` owner=`Dashboard Ops`; cause: Dashboard URL points to a different local service (port collision or stale URL).; next: `export OPENCLAW_LOCAL_READY_DASHBOARD_URL=http://127.0.0.1:<dashboard-port> && bash scripts/openclaw-local-smoke.sh --profile quick`
 
 ## Required Check Status Map
-- `dashboard-agent-health`: `fail`
-- `dashboard-config-auth`: `fail`
+- `dashboard-agent-health`: `skipped`
+- `dashboard-config-auth`: `skipped`
 - `dashboard-health`: `fail`
-- `dashboard-live-telemetry-sse`: `fail`
-- `dashboard-scheduler-jobs`: `fail`
-- `dashboard-services`: `fail`
+- `dashboard-live-telemetry-sse`: `skipped`
+- `dashboard-scheduler-jobs`: `skipped`
+- `dashboard-services`: `skipped`
 - `dashboard-token`: `pass`
 - `openclaw-cli`: `pass`
 - `openclaw-gateway-status`: `pass`
@@ -42,45 +40,40 @@ Owner: automated refresh via `scripts/refresh-local-integration-ready.sh`
 ## Trend (Last 7 Runs)
 | Timestamp | Verdict | Score | Required Failures | Warnings | Bridge |
 |---|---|---:|---:|---:|---|
-| `20260223T181511Z` | `GO` | 100 | 0 | 0 | `pass` |
 | `20260223T221510Z` | `BLOCKED` | 30 | 6 | 2 | `fail` |
 | `20260224T021511Z` | `BLOCKED` | 30 | 6 | 2 | `fail` |
 | `20260224T061509Z` | `BLOCKED` | 30 | 6 | 2 | `fail` |
 | `20260224T101509Z` | `BLOCKED` | 30 | 6 | 2 | `fail` |
 | `20260224T141509Z` | `BLOCKED` | 30 | 6 | 2 | `fail` |
 | `20260224T181509Z` | `BLOCKED` | 30 | 6 | 2 | `fail` |
+| `20260224T193634Z` | `BLOCKED` | 30 | 1 | 0 | `skipped` |
 
 ## Required Checks
 - [x] `openclaw-cli` — `pass` group=`core` severity=`critical` (openclaw CLI found)
 - [x] `openclaw-gateway-status` — `pass` group=`core` severity=`critical` (Service: LaunchAgent (loaded))
 - [x] `dashboard-token` — `pass` group=`core` severity=`critical` (dashboard token loaded from token file)
-- [ ] `dashboard-health` — `fail` group=`apis` severity=`critical` (expected 200, got 403); cause: Dashboard process is not healthy or not reachable.; next: `curl -sS http://127.0.0.1:7000/api/health`
-- [ ] `dashboard-config-auth` — `fail` group=`apis` severity=`critical` (expected 200, got 403); cause: Dashboard auth token is invalid or auth middleware blocked access.; next: `curl -sS -H 'Authorization: Bearer <token>' http://127.0.0.1:7000/api/config`
-- [ ] `dashboard-services` — `fail` group=`apis` severity=`critical` (expected 200, got 403); cause: Service aggregation is incomplete or API contract changed.; next: `curl -sS -H 'Authorization: Bearer <token>' http://127.0.0.1:7000/api/services`
-- [ ] `dashboard-scheduler-jobs` — `fail` group=`apis` severity=`critical` (expected 200, got 403); cause: Scheduler jobs API is unavailable or returning invalid payload.; next: `curl -sS -H 'Authorization: Bearer <token>' http://127.0.0.1:7000/api/scheduler-jobs`
-- [ ] `dashboard-agent-health` — `fail` group=`apis` severity=`critical` (expected 200, got 403); cause: Agent health endpoint is unavailable or response format changed.; next: `curl -sS -H 'Authorization: Bearer <token>' http://127.0.0.1:7000/api/agent-health`
-- [ ] `dashboard-live-telemetry-sse` — `fail` group=`realtime` severity=`critical` (missing SSE 200/text-event-stream headers); cause: SSE channel is blocked or headers are incorrect.; next: `curl -N -H 'Authorization: Bearer <token>' http://127.0.0.1:7000/api/live-telemetry`
+- [ ] `dashboard-health` — `fail` group=`apis` severity=`critical` (non-dashboard target detected (server: AirTunes/935.7.1, status: 403)); cause: Dashboard URL points to a different local service (port collision or stale URL).; next: `export OPENCLAW_LOCAL_READY_DASHBOARD_URL=http://127.0.0.1:<dashboard-port> && bash scripts/openclaw-local-smoke.sh --profile quick`
+- [-] `dashboard-config-auth` — `skipped` group=`apis` severity=`critical` (skipped due to dashboard-health failure)
+- [-] `dashboard-services` — `skipped` group=`apis` severity=`critical` (skipped due to dashboard-health failure)
+- [-] `dashboard-scheduler-jobs` — `skipped` group=`apis` severity=`critical` (skipped due to dashboard-health failure)
+- [-] `dashboard-agent-health` — `skipped` group=`apis` severity=`critical` (skipped due to dashboard-health failure)
+- [-] `dashboard-live-telemetry-sse` — `skipped` group=`realtime` severity=`critical` (skipped due to dashboard-health failure)
 
 ## Optional Checks
-- [ ] `dashboard-map-route` — `fail` group=`apis` severity=`info` (expected 200, got 403); cause: Map route assets or auth path is misconfigured.; next: `curl -I -H 'Authorization: Bearer <token>' http://127.0.0.1:7000/map/`
-- [ ] `bridge-scheduler-jobs` — `fail` group=`bridge` severity=`warn` (bridge request failed); cause: Bridge token/source is not configured or bridge API is unreachable.; next: `export BRIDGE_TOKEN_FILE=~/.openclaw/bridge/bridge-token && bash scripts/openclaw-local-smoke.sh --profile bridge`
+- [-] `dashboard-map-route` — `skipped` group=`apis` severity=`info` (skipped due to dashboard-health failure)
+- [-] `bridge-scheduler-jobs` — `skipped` group=`bridge` severity=`warn` (skipped by profile/flag)
 
 ## Bridge Token Setup Note
 - Direct bridge checks support `--bridge-token-file`, `BRIDGE_TOKEN`, `BRIDGE_TOKEN_FILE`, or default `OPENCLAW_DIR/bridge/bridge-token`.
-- Latest bridge check: `fail: bridge request failed`
+- Latest bridge check: `skipped: skipped by profile/flag`
 
 ## Current Next Steps
 1. Install or refresh managed cron entries: `bash scripts/install-cron.sh --force`
 2. Run one manual cadence cycle and verify artifact generation: `bash scripts/openclaw-local-ready-cron.sh`
 3. Resolve required check failures before relying on automated readiness cadence.
-4. If bridge coverage is expected, configure bridge token and rerun bridge profile: `export BRIDGE_TOKEN_FILE=~/.openclaw/bridge/bridge-token && bash scripts/openclaw-local-smoke.sh --profile bridge`
-5. Confirm Mission Control shows the latest readiness payload from `/api/openclaw-local-readiness`.
-6. Capture PR queue status before merge windows: `bash scripts/pr-queue-sweep.sh --json-out runtime/reports/pr-queue/queue-latest.json`
+4. Confirm Mission Control shows the latest readiness payload from `/api/openclaw-local-readiness`.
 
 ## Refresh Command
 ```bash
 bash scripts/refresh-local-integration-ready.sh
 ```
-
-## Run Exit Note
-- The smoke command exited non-zero (`2`). This document still reflects the latest generated report.

--- a/docs/OPENCLAW_LOCAL_INTEGRATION_SMOKE.md
+++ b/docs/OPENCLAW_LOCAL_INTEGRATION_SMOKE.md
@@ -117,6 +117,7 @@ The JSON report includes machine-readable check metadata and readiness summary f
 - `auth.tokenSource|tokenHealth|tokenRepairAction`: non-secret auth readiness diagnostics
 - Per-check metadata: `group`, `severity`, `likelyCause`, `nextCommand`
 - If a check fails with HTTP `429`, smoke classifies it as rate-limit pressure and emits a `sleep 60 && bash scripts/openclaw-local-smoke.sh --profile <profile>` next-command hint.
+- If `/api/health` indicates the URL is targeting a non-dashboard service (for example `Server: AirTunes/...`), smoke emits an explicit non-dashboard collision detail and skips dependent dashboard API checks.
 
 `scripts/refresh-local-integration-ready.sh` now enforces strict latest JSON/MD/SVG timestamp pairing and schema validation before regenerating `docs/LOCAL_INTEGRATION_READY.md`.
 Use `--prune-keep <n>` if you want refresh to keep only the newest `n` timestamp groups of smoke artifacts after regeneration.
@@ -138,6 +139,12 @@ Mission Control API note (dashboard route):
   - `OPENCLAW_LOCAL_READINESS_REPORT_DIR` when set
   - otherwise `VENTUREOS_ROOT/runtime/reports/openclaw-local-smoke`
 - In hybrid Docker mode, ensure the report directory is bind-mounted into the dashboard container and wired via `OPENCLAW_LOCAL_READINESS_REPORT_DIR`.
+
+Managed cron note:
+- `scripts/install-cron.sh` now resolves and pins `OPENCLAW_LOCAL_READY_DASHBOARD_URL` during install using this precedence:
+  1. `OPENCLAW_LOCAL_READY_DASHBOARD_URL`
+  2. `DASHBOARD_URL` (legacy)
+  3. `http://127.0.0.1:${DASHBOARD_PORT:-7000}`
 
 ## Current Next Steps (February 22, 2026)
 1. Run installer preflight evidence bundle after onboarding/install execution changes:

--- a/docs/SCRIPT_SPECS.md
+++ b/docs/SCRIPT_SPECS.md
@@ -242,6 +242,8 @@ bash scripts/openclaw-local-smoke.sh \
   - Retries HTTP `429` responses (dashboard + bridge checks) using `Retry-After` when present.
   - Retry controls: `SMOKE_HTTP_RETRY_MAX` (default `2`), `SMOKE_HTTP_RETRY_BASE_SEC` (default `1`), `SMOKE_HTTP_RETRY_MAX_DELAY_SEC` (default `60`).
 - Gateway status check requires a healthy runtime signal (`RPC probe: ok` or `Listening:`) to pass.
+- Detects non-dashboard target collisions on `/api/health` (for example AirTunes on port `7000`) and emits explicit root-cause detail instead of generic auth failure noise.
+- If `dashboard-health` fails, dependent dashboard API checks are marked `skipped` to keep blocker output actionable.
 - Emits timestamped JSON + markdown + SVG reports to `runtime/reports/openclaw-local-smoke/`.
 - Uses canonical dashboard URL resolution policy:
   - `--dashboard-url`
@@ -322,6 +324,7 @@ bash scripts/openclaw-local-ready-cron.sh
   - `OPENCLAW_LOCAL_READY_DASHBOARD_URL` (must start with `http://` or `https://`)
 - Validates env inputs and exits `2` on invalid values before running refresh.
 - Forwards any additional CLI flags to the underlying refresh script (last flag wins).
+- Managed cron installation now resolves and persists the local readiness dashboard URL at install time (`scripts/install-cron.sh`) rather than hardcoding port `7000`.
 
 **Regression test:**
 ```bash

--- a/scripts/install-cron.sh
+++ b/scripts/install-cron.sh
@@ -16,6 +16,7 @@ set -euo pipefail
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+source "$SCRIPT_DIR/lib/openclaw-local-defaults.sh"
 RUNNER="$SCRIPT_DIR/cron-runner.sh"
 LOG_BASE="$HOME/.openclaw/logs"
 
@@ -41,6 +42,12 @@ if [[ "$LIST_ONLY" == "true" ]]; then
   echo "Current crontab:"
   crontab -l 2>/dev/null || echo "(empty)"
   exit 0
+fi
+
+LOCAL_READY_DASHBOARD_URL="$(openclaw_local_resolve_dashboard_url "" "${OPENCLAW_LOCAL_READY_DASHBOARD_URL:-}" "${DASHBOARD_URL:-}" "${DASHBOARD_PORT:-7000}")"
+if ! openclaw_local_validate_dashboard_url "$LOCAL_READY_DASHBOARD_URL"; then
+  echo "Invalid local readiness dashboard URL: $LOCAL_READY_DASHBOARD_URL" >&2
+  exit 1
 fi
 
 # Check for existing installation
@@ -101,7 +108,7 @@ NEW_CRON=$(cat <<EOF
 */30 * * * * $RUNNER routing-healthcheck >> $LOG_BASE/cron-routing-healthcheck.log 2>&1
 
 # 12) Local OpenClaw readiness refresh — every 4 hours
-15 */4 * * * OPENCLAW_LOCAL_READY_DASHBOARD_URL=http://127.0.0.1:7000 $RUNNER openclaw-local-ready >> $LOG_BASE/cron-openclaw-local-ready.log 2>&1
+15 */4 * * * OPENCLAW_LOCAL_READY_DASHBOARD_URL=$LOCAL_READY_DASHBOARD_URL $RUNNER openclaw-local-ready >> $LOG_BASE/cron-openclaw-local-ready.log 2>&1
 
 # 13) VB-003 telemetry synthesis — every 6 hours
 30 */6 * * * $RUNNER vb003-telemetry-synthesis >> $LOG_BASE/cron-vb003-telemetry.log 2>&1
@@ -130,3 +137,4 @@ echo ""
 echo "Configuration: $REPO_ROOT/config/reliability.json"
 echo "Runner: $RUNNER"
 echo "Logs: $LOG_BASE/cron-*.log"
+echo "Local readiness dashboard URL: $LOCAL_READY_DASHBOARD_URL"

--- a/scripts/openclaw-local-smoke.sh
+++ b/scripts/openclaw-local-smoke.sh
@@ -403,6 +403,72 @@ HTTP_STATUS=""
 HTTP_BODY_FILE=""
 HTTP_HEADER_FILE=""
 
+extract_header_value() {
+  local header_file="$1"
+  local header_name="$2"
+  python3 - "$header_file" "$header_name" <<'PY'
+import pathlib
+import sys
+
+header_file = pathlib.Path(sys.argv[1])
+needle = sys.argv[2].strip().lower()
+value = ''
+
+for raw in header_file.read_text(encoding='utf-8', errors='ignore').splitlines():
+    if ':' not in raw:
+        continue
+    name, remainder = raw.split(':', 1)
+    if name.strip().lower() != needle:
+        continue
+    value = remainder.strip()
+    break
+
+print(value)
+PY
+}
+
+dashboard_health_failure_detail() {
+  local status="$1"
+  local header_file="$2"
+  local body_file="$3"
+  local server_header content_type server_lc
+  local body_preview
+
+  server_header="$(extract_header_value "$header_file" "server")"
+  content_type="$(extract_header_value "$header_file" "content-type")"
+  server_lc="$(printf '%s' "$server_header" | tr '[:upper:]' '[:lower:]')"
+
+  body_preview="$(python3 - "$body_file" <<'PY'
+import pathlib
+import sys
+
+body = pathlib.Path(sys.argv[1]).read_text(encoding='utf-8', errors='ignore').strip()
+if len(body) > 80:
+    body = body[:80]
+print(body.replace('\n', ' ').replace('\r', ' ').replace('\t', ' '))
+PY
+)"
+
+  if [[ -n "$server_lc" ]] && [[ "$server_lc" == *"airtunes"* || "$server_lc" == *"airplay"* ]]; then
+    echo "non-dashboard target detected (server: ${server_header}, status: ${status})"
+    return 0
+  fi
+
+  if [[ "$status" =~ ^(401|403|404)$ ]] && [[ -n "$server_header" ]] && [[ "$server_lc" != *"openclaw"* ]] && [[ "$server_lc" != *"ventureos"* ]] && [[ "$server_lc" != *"node"* ]]; then
+    echo "possible non-dashboard target (server: ${server_header}, status: ${status})"
+    return 0
+  fi
+
+  if [[ -n "$content_type" ]] && [[ "$status" != "200" ]]; then
+    if [[ -n "$body_preview" ]]; then
+      echo "expected 200, got ${status} (content-type: ${content_type})"
+      return 0
+    fi
+  fi
+
+  echo "expected 200, got ${status}"
+}
+
 extract_retry_after_seconds() {
   local header_file="$1"
   python3 - "$header_file" <<'PY'
@@ -506,7 +572,7 @@ check_dashboard_health() {
     return 1
   fi
   if [[ "$HTTP_STATUS" != "200" ]]; then
-    CHECK_DETAIL="expected 200, got $HTTP_STATUS"
+    CHECK_DETAIL="$(dashboard_health_failure_detail "$HTTP_STATUS" "$HTTP_HEADER_FILE" "$HTTP_BODY_FILE")"
     return 1
   fi
   if ! python3 - "$HTTP_BODY_FILE" <<'PY'
@@ -816,18 +882,27 @@ fi
 run_check "dashboard-token" "true" "Dashboard token is available" check_dashboard_token
 if [[ "$required_failures" -eq 0 ]]; then
   run_check "dashboard-health" "true" "Dashboard /api/health responds with ok=true" check_dashboard_health
-  run_check "dashboard-config-auth" "true" "Dashboard /api/config is reachable with auth" check_dashboard_config_auth
-  run_check "dashboard-services" "true" "Dashboard /api/services returns required service rows" check_dashboard_services
-  run_check "dashboard-scheduler-jobs" "true" "Dashboard /api/scheduler-jobs is reachable" check_dashboard_scheduler_jobs
-  run_check "dashboard-agent-health" "true" "Dashboard /api/agent-health is reachable" check_dashboard_agent_health
+  if [[ "$required_failures" -eq 0 ]]; then
+    run_check "dashboard-config-auth" "true" "Dashboard /api/config is reachable with auth" check_dashboard_config_auth
+    run_check "dashboard-services" "true" "Dashboard /api/services returns required service rows" check_dashboard_services
+    run_check "dashboard-scheduler-jobs" "true" "Dashboard /api/scheduler-jobs is reachable" check_dashboard_scheduler_jobs
+    run_check "dashboard-agent-health" "true" "Dashboard /api/agent-health is reachable" check_dashboard_agent_health
 
-  if [[ "$SKIP_MAP" == "1" ]]; then
-    run_skipped "dashboard-map-route" "false" "Dashboard /map route is reachable" "skipped by profile/flag"
+    if [[ "$SKIP_MAP" == "1" ]]; then
+      run_skipped "dashboard-map-route" "false" "Dashboard /map route is reachable" "skipped by profile/flag"
+    else
+      run_check "dashboard-map-route" "false" "Dashboard /map route is reachable" check_tactical_map_route
+    fi
+
+    run_check "dashboard-live-telemetry-sse" "true" "Dashboard /api/live-telemetry SSE handshake succeeds" check_live_telemetry_handshake
   else
-    run_check "dashboard-map-route" "false" "Dashboard /map route is reachable" check_tactical_map_route
+    run_skipped "dashboard-config-auth" "true" "Dashboard /api/config is reachable with auth" "skipped due to dashboard-health failure"
+    run_skipped "dashboard-services" "true" "Dashboard /api/services returns required service rows" "skipped due to dashboard-health failure"
+    run_skipped "dashboard-scheduler-jobs" "true" "Dashboard /api/scheduler-jobs is reachable" "skipped due to dashboard-health failure"
+    run_skipped "dashboard-agent-health" "true" "Dashboard /api/agent-health is reachable" "skipped due to dashboard-health failure"
+    run_skipped "dashboard-map-route" "false" "Dashboard /map route is reachable" "skipped due to dashboard-health failure"
+    run_skipped "dashboard-live-telemetry-sse" "true" "Dashboard /api/live-telemetry SSE handshake succeeds" "skipped due to dashboard-health failure"
   fi
-
-  run_check "dashboard-live-telemetry-sse" "true" "Dashboard /api/live-telemetry SSE handshake succeeds" check_live_telemetry_handshake
 else
   run_skipped "dashboard-health" "true" "Dashboard /api/health responds with ok=true" "skipped due to prior required failure"
   run_skipped "dashboard-config-auth" "true" "Dashboard /api/config is reachable with auth" "skipped due to prior required failure"
@@ -987,6 +1062,14 @@ for check in checks:
     detail = str(check.get('detail', '')).lower()
     if check.get('status') != 'fail':
         continue
+    if check.get('id') == 'dashboard-health':
+        if 'non-dashboard target detected' in detail or 'possible non-dashboard target' in detail:
+            check['likelyCause'] = 'Dashboard URL points to a different local service (port collision or stale URL).'
+            check['nextCommand'] = (
+                "export OPENCLAW_LOCAL_READY_DASHBOARD_URL=http://127.0.0.1:<dashboard-port> && "
+                "bash scripts/openclaw-local-smoke.sh --profile quick"
+            )
+            continue
     if 'got 429' not in detail:
         continue
     check['likelyCause'] = 'API rate limit window was exhausted by concurrent local requests.'

--- a/scripts/tests/test-openclaw-local-smoke.sh
+++ b/scripts/tests/test-openclaw-local-smoke.sh
@@ -7,6 +7,7 @@ TMP_DIR="$(mktemp -d)"
 SERVER_PID=""
 BRIDGE_SERVER_PID=""
 RATE_LIMIT_SERVER_PID=""
+NON_DASHBOARD_SERVER_PID=""
 
 cleanup() {
   if [[ -n "$SERVER_PID" ]]; then
@@ -20,6 +21,10 @@ cleanup() {
   if [[ -n "$RATE_LIMIT_SERVER_PID" ]]; then
     kill "$RATE_LIMIT_SERVER_PID" 2>/dev/null || true
     wait "$RATE_LIMIT_SERVER_PID" 2>/dev/null || true
+  fi
+  if [[ -n "$NON_DASHBOARD_SERVER_PID" ]]; then
+    kill "$NON_DASHBOARD_SERVER_PID" 2>/dev/null || true
+    wait "$NON_DASHBOARD_SERVER_PID" 2>/dev/null || true
   fi
   rm -rf "$TMP_DIR"
 }
@@ -224,12 +229,44 @@ s.close()
 PY
 )"
 
+NON_DASHBOARD_PORT="$(python3 - <<'PY'
+import socket
+s = socket.socket()
+s.bind(('127.0.0.1', 0))
+print(s.getsockname()[1])
+s.close()
+PY
+)"
+
+cat > "$TMP_DIR/mock-non-dashboard.py" <<'PY'
+from http.server import BaseHTTPRequestHandler, HTTPServer
+import sys
+
+PORT = int(sys.argv[1])
+
+class Handler(BaseHTTPRequestHandler):
+    server_version = "AirTunes/935.7.1"
+    sys_version = ""
+
+    def log_message(self, format, *args):
+        pass
+
+    def do_GET(self):
+        self.send_response(403)
+        self.send_header("Content-Length", "0")
+        self.end_headers()
+
+HTTPServer(("127.0.0.1", PORT), Handler).serve_forever()
+PY
+
 python3 "$TMP_DIR/mock-dashboard.py" "$PORT" >/dev/null 2>&1 &
 SERVER_PID=$!
 python3 "$TMP_DIR/mock-bridge.py" "$BRIDGE_PORT" >/dev/null 2>&1 &
 BRIDGE_SERVER_PID=$!
 python3 "$TMP_DIR/mock-dashboard.py" "$RATE_LIMIT_PORT" "/api/services" >/dev/null 2>&1 &
 RATE_LIMIT_SERVER_PID=$!
+python3 "$TMP_DIR/mock-non-dashboard.py" "$NON_DASHBOARD_PORT" >/dev/null 2>&1 &
+NON_DASHBOARD_SERVER_PID=$!
 sleep 0.3
 
 REPORT_DIR_BASELINE="$TMP_DIR/reports-baseline"
@@ -444,6 +481,41 @@ assert summary.get("status") == "pass", summary
 checks = {c["id"]: c for c in payload.get("checks", [])}
 assert checks["dashboard-services"]["status"] == "pass", checks["dashboard-services"]
 print("OPENCLAW_LOCAL_SMOKE_RETRY_429_OK")
+PY
+
+REPORT_DIR_NON_DASHBOARD="$TMP_DIR/reports-non-dashboard"
+set +e
+bash "$SMOKE_SCRIPT" \
+  --dashboard-url "http://127.0.0.1:$NON_DASHBOARD_PORT" \
+  --token-file "$TOKEN_FILE" \
+  --report-dir "$REPORT_DIR_NON_DASHBOARD" \
+  --profile quick \
+  --skip-openclaw-cli \
+  --skip-bridge \
+  --timeout-sec 3 >/tmp/openclaw-local-smoke-test-non-dashboard.out
+NON_DASHBOARD_RC=$?
+set -e
+
+if [[ "$NON_DASHBOARD_RC" -ne 2 ]]; then
+  echo "Expected non-dashboard smoke run to fail with exit 2, got $NON_DASHBOARD_RC" >&2
+  exit 1
+fi
+
+python3 - "$REPORT_DIR_NON_DASHBOARD" <<'PY'
+import json
+from pathlib import Path
+import sys
+
+report_dir = Path(sys.argv[1])
+json_reports = sorted(report_dir.glob("openclaw-local-smoke-*.json"))
+assert json_reports, "missing non-dashboard json report"
+payload = json.loads(json_reports[-1].read_text())
+checks = {c["id"]: c for c in payload.get("checks", [])}
+health = checks["dashboard-health"]
+assert health["status"] == "fail", health
+assert "non-dashboard target detected" in health.get("detail", "").lower(), health
+assert checks["dashboard-config-auth"]["status"] == "skipped", checks["dashboard-config-auth"]
+print("OPENCLAW_LOCAL_SMOKE_NON_DASHBOARD_DETECTION_OK")
 PY
 
 REPORT_DIR_URL_POLICY="$TMP_DIR/reports-url-policy"


### PR DESCRIPTION
## Summary
- fixes local readiness smoke signaling when the dashboard URL points to a non-dashboard service (for example AirTunes on port 7000)
- updates `openclaw-local-smoke.sh` to emit explicit non-dashboard root-cause detail and skip dependent dashboard API checks after `dashboard-health` fails
- updates `install-cron.sh` so the managed readiness job persists a resolved dashboard URL instead of hardcoding `127.0.0.1:7000`
- adds regression coverage for the non-dashboard collision case and updates integration docs
- refreshes local readiness evidence doc using a real local run (`openclaw-local-smoke-20260224T193634Z`)

## Verification
- `bash scripts/tests/test-openclaw-local-smoke.sh`
- `bash scripts/tests/test-refresh-local-integration-ready.sh`
- `npm run docs:lint`
- `bash scripts/openclaw-local-smoke.sh --profile quick` (real host, expected blocked due local 7000 AirTunes collision)
- `bash scripts/refresh-local-integration-ready.sh --skip-smoke`

## Evidence
- `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260224T193634Z.json`
- `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260224T193634Z.md`
- `runtime/reports/openclaw-local-smoke/openclaw-local-smoke-20260224T193634Z.svg`
- `docs/LOCAL_INTEGRATION_READY.md`

Closes #511
