### PR TITLE
ops: restore unmanaged hook on uninstall

### DIFF
--- a/docs/SCRIPT_SPECS.md
+++ b/docs/SCRIPT_SPECS.md
@@ -994,6 +994,7 @@ bash scripts/install-post-merge-hook.sh --uninstall
 - Safety guardrails:
   - refuses to replace unmanaged existing hook unless `--force` is provided
   - when `--force` is used, creates backup `post-merge.pre-ventureos.<timestamp>.bak`
+  - on `--uninstall`, restores the backed-up unmanaged hook when backup metadata is available
   - `--dry-run` prints intended action without mutating hook files
 - Supports explicit path overrides for automation/testing:
   - `--repo-root`

--- a/scripts/install-post-merge-hook.sh
+++ b/scripts/install-post-merge-hook.sh
@@ -8,6 +8,7 @@ REPO_ROOT=""
 HOOK_PATH=""
 RUNNER_SCRIPT="$DEFAULT_REPO_ROOT/scripts/post-merge-cadence.sh"
 LOG_DIR="$DEFAULT_REPO_ROOT/runtime/logs/git-hooks"
+BACKUP_META_PATH=""
 
 STATUS_ONLY=0
 UNINSTALL=0
@@ -137,6 +138,7 @@ REPO_ROOT="$(resolve_repo_root)"
 HOOK_PATH="$(resolve_hook_path "$REPO_ROOT")"
 RUNNER_SCRIPT="$(resolve_path "$REPO_ROOT" "$RUNNER_SCRIPT")"
 LOG_DIR="$(resolve_path "$REPO_ROOT" "$LOG_DIR")"
+BACKUP_META_PATH="$HOOK_PATH.ventureos-backup"
 
 is_managed=0
 if [[ -f "$HOOK_PATH" ]] && grep -qF "$HOOK_MARKER_START" "$HOOK_PATH"; then
@@ -156,6 +158,9 @@ if [[ "$STATUS_ONLY" -eq 1 ]]; then
   echo "POST_MERGE_HOOK_PATH=$HOOK_PATH"
   echo "POST_MERGE_HOOK_RUNNER=$RUNNER_SCRIPT"
   echo "POST_MERGE_HOOK_LOG_DIR=$LOG_DIR"
+  if [[ -f "$BACKUP_META_PATH" ]]; then
+    echo "POST_MERGE_HOOK_BACKUP_META=$BACKUP_META_PATH"
+  fi
   exit 0
 fi
 
@@ -168,14 +173,37 @@ if [[ "$UNINSTALL" -eq 1 ]]; then
   fi
   if [[ "$DRY_RUN" -eq 1 ]]; then
     echo "DRY RUN: would remove managed hook at $HOOK_PATH"
+    restore_backup=""
+    if [[ -f "$BACKUP_META_PATH" ]]; then
+      restore_backup="$(cat "$BACKUP_META_PATH" 2>/dev/null || true)"
+    fi
+    if [[ -n "$restore_backup" ]]; then
+      echo "DRY RUN: would restore prior unmanaged hook from $restore_backup"
+    fi
     echo "POST_MERGE_HOOK_UNINSTALL=DRY_RUN"
     echo "POST_MERGE_HOOK_PATH=$HOOK_PATH"
     exit 0
   fi
-  rm -f "$HOOK_PATH"
+  restored_backup=""
+  if [[ -f "$BACKUP_META_PATH" ]]; then
+    restore_candidate="$(cat "$BACKUP_META_PATH" 2>/dev/null || true)"
+    if [[ -n "$restore_candidate" && -f "$restore_candidate" ]]; then
+      cp "$restore_candidate" "$HOOK_PATH"
+      chmod +x "$HOOK_PATH"
+      restored_backup="$restore_candidate"
+    else
+      rm -f "$HOOK_PATH"
+    fi
+    rm -f "$BACKUP_META_PATH"
+  else
+    rm -f "$HOOK_PATH"
+  fi
   echo "Removed managed VentureOS post-merge hook."
   echo "POST_MERGE_HOOK_UNINSTALL=PASS"
   echo "POST_MERGE_HOOK_PATH=$HOOK_PATH"
+  if [[ -n "$restored_backup" ]]; then
+    echo "POST_MERGE_HOOK_RESTORED_BACKUP=$restored_backup"
+  fi
   exit 0
 fi
 
@@ -244,6 +272,7 @@ fi
 mkdir -p "$(dirname "$HOOK_PATH")"
 if [[ -n "$backup_path" ]]; then
   cp "$HOOK_PATH" "$backup_path"
+  printf '%s\n' "$backup_path" > "$BACKUP_META_PATH"
 fi
 printf '%s\n' "$hook_body" > "$HOOK_PATH"
 chmod +x "$HOOK_PATH"

--- a/scripts/tests/test-install-post-merge-hook.sh
+++ b/scripts/tests/test-install-post-merge-hook.sh
@@ -53,6 +53,7 @@ LATEST_LOG="$(ls -1t "$LOG_DIR"/post-merge-cadence-*.log | head -n 1)"
 grep -q "non-blocking" "$LATEST_LOG"
 
 UNMANAGED_HOOK="$REPO/.git/hooks/post-merge"
+BACKUP_META="$UNMANAGED_HOOK.ventureos-backup"
 echo "#!/usr/bin/env bash" > "$UNMANAGED_HOOK"
 echo "echo unmanaged" >> "$UNMANAGED_HOOK"
 chmod +x "$UNMANAGED_HOOK"
@@ -72,21 +73,19 @@ grep -q "^POST_MERGE_HOOK_INSTALL=PASS" "$FORCE_OUT"
 BACKUP_PATH="$(grep -E '^POST_MERGE_HOOK_BACKUP=' "$FORCE_OUT" | tail -n 1 | cut -d= -f2-)"
 [[ -f "$BACKUP_PATH" ]]
 grep -q "unmanaged" "$BACKUP_PATH"
+[[ -f "$BACKUP_META" ]]
 
 UNINSTALL_OUT="$TMP_DIR/uninstall.out"
 bash "$SCRIPT" --repo-root "$REPO" --uninstall > "$UNINSTALL_OUT" 2>&1
 grep -q "^POST_MERGE_HOOK_UNINSTALL=PASS" "$UNINSTALL_OUT"
-if [[ -f "$UNMANAGED_HOOK" ]]; then
-  echo "managed hook should be removed after uninstall" >&2
-  exit 1
-fi
+grep -q "^POST_MERGE_HOOK_RESTORED_BACKUP=$BACKUP_PATH" "$UNINSTALL_OUT"
+[[ -f "$UNMANAGED_HOOK" ]]
+grep -q "unmanaged" "$UNMANAGED_HOOK"
+[[ ! -f "$BACKUP_META" ]]
 
 DRY_RUN_OUT="$TMP_DIR/dry-run.out"
-bash "$SCRIPT" --repo-root "$REPO" --dry-run > "$DRY_RUN_OUT" 2>&1
+bash "$SCRIPT" --repo-root "$REPO" --dry-run --force > "$DRY_RUN_OUT" 2>&1
 grep -q "^POST_MERGE_HOOK_INSTALL=DRY_RUN" "$DRY_RUN_OUT"
-if [[ -f "$UNMANAGED_HOOK" ]]; then
-  echo "dry-run should not create hook file" >&2
-  exit 1
-fi
+grep -q "unmanaged" "$UNMANAGED_HOOK"
 
 echo "INSTALL_POST_MERGE_HOOK_TEST_OK"


### PR DESCRIPTION
## Summary
- persist backup metadata when `install-post-merge-hook.sh --force` replaces unmanaged hooks
- restore backed-up unmanaged hook automatically on `--uninstall`
- expand regression coverage and docs to include restore behavior

## Validation
- `bash scripts/tests/test-install-post-merge-hook.sh`
- `bash scripts/tests/test-post-merge-cadence.sh`
- `npm run test:openclaw:post-merge:hook`
- `npm run docs:lint`

Closes #542
