### PR TITLE
Installer onboarding UX: add interactive phase progress meter

### DIFF
--- a/scripts/tests/test-ventureos-install.sh
+++ b/scripts/tests/test-ventureos-install.sh
@@ -456,6 +456,7 @@ run_install_interactive interactive_apply \
 grep -q "VENTUREOS_INSTALL_RESULT=PASS" "$OUT_DIR/interactive_apply.out"
 grep -q "\\[Phase 2/6\\] Preference selection" "$OUT_DIR/interactive_apply.out"
 grep -q "\\[Phase 5/6\\] Installer execution" "$OUT_DIR/interactive_apply.out"
+grep -q "Phase progress \\[" "$OUT_DIR/interactive_apply.out"
 grep -q "RUN   dashboard-install :: dashboard/scripts/install-macos.sh" "$OUT_DIR/interactive_apply.out"
 grep -q "dashboard-macos|" "$CALL_LOG"
 grep -q "cron|--force" "$CALL_LOG"
@@ -482,6 +483,7 @@ run_install_interactive interactive_abort \
 
 grep -q "VENTUREOS_INSTALL_RESULT=CANCELLED" "$OUT_DIR/interactive_abort.out"
 grep -q "\\[Phase 3/6\\] Plan + compatibility review" "$OUT_DIR/interactive_abort.out"
+grep -q "Phase progress \\[" "$OUT_DIR/interactive_abort.out"
 if grep -E -q '^(dashboard-macos|dashboard-linux|cron\||ready\|)' "$CALL_LOG"; then
   echo "Interactive cancel should not execute installer primitives" >&2
   exit 1

--- a/scripts/ventureos-install.sh
+++ b/scripts/ventureos-install.sh
@@ -166,6 +166,61 @@ ui_section() {
   fi
 }
 
+ui_progress_bar() {
+  local index="$1"
+  local total="$2"
+  local width="${3:-18}"
+  local filled=0
+  local i=0
+  local bar=""
+
+  if ! [[ "$index" =~ ^[0-9]+$ && "$total" =~ ^[0-9]+$ && "$width" =~ ^[0-9]+$ ]]; then
+    printf '%s' "------------------"
+    return 0
+  fi
+  if [[ "$total" -le 0 ]]; then
+    total=1
+  fi
+
+  filled=$((index * width / total))
+  if [[ "$filled" -lt 0 ]]; then
+    filled=0
+  elif [[ "$filled" -gt "$width" ]]; then
+    filled="$width"
+  fi
+
+  for ((i = 0; i < width; i++)); do
+    if [[ "$i" -lt "$filled" ]]; then
+      bar+="#"
+    else
+      bar+="-"
+    fi
+  done
+  printf '%s' "$bar"
+}
+
+ui_phase_progress() {
+  local index="$1"
+  local total="$2"
+  local width=18
+  local percent=0
+  local bar
+  bar="$(ui_progress_bar "$index" "$total" "$width")"
+  if [[ "$total" -gt 0 ]]; then
+    percent=$((index * 100 / total))
+  fi
+
+  if [[ "$UI_ENABLED" == "1" && "$NO_ANIMATION" != "1" ]]; then
+    local pulse=""
+    for pulse in "." ".." "..."; do
+      printf '\r\033[2K  Phase progress [%s] %s%%%s' "$bar" "$percent" "$pulse"
+      sleep 0.04
+    done
+    printf '\r\033[2K'
+  fi
+  printf '  Phase progress [%s] %s%%\n' "$bar" "$percent"
+}
+
 ui_phase() {
   local index="$1"
   local total="$2"
@@ -178,6 +233,7 @@ ui_phase() {
   else
     printf '\n[Phase %s/%s] %s\n' "$index" "$total" "$title"
   fi
+  ui_phase_progress "$index" "$total"
   ui_sleep 0.05
 }
 


### PR DESCRIPTION
## Summary
- add `ui_progress_bar` + `ui_phase_progress` helpers in `scripts/ventureos-install.sh`
- render a per-phase progress line (`Phase progress [...] <percent>%`) during interactive onboarding
- keep non-interactive behavior unchanged and honor existing `VENTUREOS_INSTALL_NO_ANIMATION=1`
- extend installer onboarding tests to assert the new phase-progress marker in apply/cancel interactive flows

## Validation
- `bash -n scripts/ventureos-install.sh scripts/tests/test-ventureos-install.sh`
- `bash scripts/tests/test-ventureos-install.sh`

Closes #552
