### PR TITLE
Installer UX: add interactive safety posture summary

### DIFF
--- a/scripts/tests/test-ventureos-install.sh
+++ b/scripts/tests/test-ventureos-install.sh
@@ -461,6 +461,9 @@ grep -q "VENTUREOS_INSTALL_RESULT=PASS" "$OUT_DIR/interactive_apply.out"
 grep -q "\\[Phase 2/6\\] Preference selection" "$OUT_DIR/interactive_apply.out"
 grep -q "\\[Phase 5/6\\] Installer execution" "$OUT_DIR/interactive_apply.out"
 grep -q "Phase progress \\[" "$OUT_DIR/interactive_apply.out"
+grep -q "Safety posture" "$OUT_DIR/interactive_apply.out"
+grep -q "execution mode: apply" "$OUT_DIR/interactive_apply.out"
+grep -q "restore point: enabled" "$OUT_DIR/interactive_apply.out"
 grep -q "RUN   dashboard-install :: dashboard/scripts/install-macos.sh" "$OUT_DIR/interactive_apply.out"
 grep -q "dashboard-macos|" "$CALL_LOG"
 grep -q "cron|--force" "$CALL_LOG"
@@ -502,6 +505,7 @@ run_install_interactive interactive_abort \
 grep -q "VENTUREOS_INSTALL_RESULT=CANCELLED" "$OUT_DIR/interactive_abort.out"
 grep -q "\\[Phase 3/6\\] Plan + compatibility review" "$OUT_DIR/interactive_abort.out"
 grep -q "Phase progress \\[" "$OUT_DIR/interactive_abort.out"
+grep -q "Safety posture" "$OUT_DIR/interactive_abort.out"
 if grep -E -q '^(dashboard-macos|dashboard-linux|cron\||ready\|)' "$CALL_LOG"; then
   echo "Interactive cancel should not execute installer primitives" >&2
   exit 1

--- a/scripts/ventureos-install.sh
+++ b/scripts/ventureos-install.sh
@@ -1905,6 +1905,19 @@ else
 fi
 
 if [[ "$ONBOARDING_MODE" == "interactive" ]]; then
+  execution_mode="apply"
+  if [[ "$DRY_RUN" == "1" ]]; then
+    execution_mode="dry-run"
+  elif [[ "$PREFLIGHT_ONLY" == "1" ]]; then
+    execution_mode="preflight-only"
+  fi
+  ui_section "Safety posture"
+  echo "  execution mode: $execution_mode"
+  echo "  restore point: $([[ "$CAPTURE_RESTORE_POINT" == "1" ]] && echo enabled || echo disabled)"
+  echo "  post-install verify: $([[ "$VERIFY_POST_INSTALL" == "1" ]] && echo enabled || echo disabled)"
+  echo "  animation: $([[ "$NO_ANIMATION" == "1" ]] && echo disabled || echo enabled)"
+  echo "  approval gates: OpenClaw config reconciliation + action matrix confirmation"
+
   ui_section "OpenClaw Config Reconciliation"
   render_openclaw_config_reconciliation_preview
   if [[ "$(prompt_yes_no "Approve OpenClaw config reconciliation plan?" "y")" != "y" ]]; then


### PR DESCRIPTION
## Summary
- add interactive `Safety posture` section in installer onboarding before approval gates
- summarize execution mode, restore-point state, verify state, animation state, and approval gates
- extend interactive onboarding tests to assert the safety posture summary appears in apply/cancel flows

## Validation
- `bash -n scripts/ventureos-install.sh scripts/tests/test-ventureos-install.sh`
- `bash scripts/tests/test-ventureos-install.sh`

Closes #563
