### PR TITLE
docs: CompanyOS Day-1 execution packet

### DIFF
--- a/docs/VentureOS_Day1_Execution_Packet.md
+++ b/docs/VentureOS_Day1_Execution_Packet.md
@@ -1,0 +1,68 @@
+# VentureOS Day-1 Execution Packet
+
+Date: 2026-03-12
+Owner: Executive Office (Director lane)
+
+## Objective
+Start the first live CompanyOS operating cycle with evidence-first outputs.
+
+## Day-1 Scope
+Activate and run these departments for one full cycle:
+1. Executive Office
+2. Operations
+3. Data/Analytics
+4. Finance
+
+## Must-produce artifacts (today)
+- `logs/daily/YYYY-MM-DD-agent-health.json`
+- `logs/daily/YYYY-MM-DD-spend.json`
+- `logs/daily/YYYY-MM-DD-kpi-snapshot.json`
+- `logs/daily/YYYY-MM-DD-handoff-ledger.json`
+- `logs/daily/YYYY-MM-DD-decision-log.md`
+
+## Execution checklist
+
+### A) 09:00 Ops Sweep
+- [ ] Validate lane health (running/error/stalled)
+- [ ] Triage overnight incidents
+- [ ] Confirm data freshness (<24h)
+- [ ] Capture daily spend snapshot
+
+### B) 09:30 Department Standup Update
+- [ ] Executive Office priorities published
+- [ ] Operations blockers + owners assigned
+- [ ] Data/Analytics KPI baseline refresh status posted
+- [ ] Finance variance summary posted
+
+### C) 12:00 Handoff SLA check
+- [ ] Handoffs logged with producer/consumer timestamps
+- [ ] SLA status computed (on-time/late)
+- [ ] Breach actions assigned if needed
+
+### D) 16:30 Evidence Closeout
+- [ ] Daily artifacts complete + linked
+- [ ] Missing evidence list = empty
+- [ ] Decision log finalized
+- [ ] Next-day top 3 priorities posted
+
+## Go/No-Go criteria (end of day)
+GO only if all are true:
+- 100% required artifacts generated
+- No unresolved P0 incidents
+- >=90% handoffs on-time for active departments
+- Decision log has owners + due dates for all open items
+
+If any fail: status = NO_GO and run remediation plan next business day.
+
+## Remediation plan (if NO_GO)
+1. Freeze expansion to additional departments.
+2. Open incident for each failed criterion.
+3. Assign owner and 24h correction deadline.
+4. Re-run Day-1 packet next cycle.
+
+## Reporting format
+At end of cycle, publish:
+- Status: GO/NO_GO
+- Evidence links
+- Breaches + owners + ETA
+- Next cycle priorities (top 3)


### PR DESCRIPTION
Adds a concrete day-1 live-cycle kickoff packet for Executive/Operations/Data/Finance with artifact requirements, SLA checks, GO/NO_GO criteria, and remediation path.