### PR TITLE
docs: single lane execution plan v1

### DIFF
--- a/docs/VentureOS_Single_Lane_Execution_Plan.md
+++ b/docs/VentureOS_Single_Lane_Execution_Plan.md
@@ -1,0 +1,39 @@
+# VentureOS Single Lane Execution Plan
+
+## Lane Scope
+- Execute one clean implementation lane on branch `ventureos-single-lane-v1`.
+- Deliver docs-only process governance for retiring auto checkpoint PR loops.
+- Exclude product code, infra code, and non-doc assets from this lane.
+
+## Branch Policy
+- Source branch: `main` (fast-forward updated before branching).
+- Active implementation branch: `ventureos-single-lane-v1`.
+- One active lane branch at a time for this objective; no checkpoint branches.
+- All work merges into `main` via a single PR.
+
+## Commit Policy
+- Maximum one commit for this lane.
+- Commit scope must remain docs-only.
+- No empty/noop commits and no commit loops for status signaling.
+- Commit message should clearly describe adoption of single-lane policy.
+
+## Quality and Evidence Gates
+- Scope gate: objective and deliverables are explicitly documented in this file and PR description.
+- Evidence gate:
+  - changed-file list from `git status`/`git diff --name-only`
+  - diff summary from `git diff --stat`
+  - explicit validation waiver: docs-only change, so no test/lint/build run required
+  - rollback note included in this plan and PR
+- Verification gate: confirm repo state with `git status -sb`, `git log --oneline -1`, and PR metadata.
+- Fail-closed gate: if any required artifact is missing, status is `BLOCKED/INCOMPLETE`.
+
+## Merge Criteria
+- PR targets `main` from `ventureos-single-lane-v1`.
+- Diff contains only `docs/VentureOS_Single_Lane_Execution_Plan.md`.
+- Exactly one commit exists on the branch for this objective.
+- PR records retirement of auto checkpoint loop (PR #590 closure).
+
+## Rollback Policy
+- If this change needs to be reverted, revert the single commit from this lane.
+- If the PR is not merged yet, close the PR and delete `ventureos-single-lane-v1`.
+- If merged, create a revert PR to `main` restoring prior lane policy state.


### PR DESCRIPTION
## Summary
- add `docs/VentureOS_Single_Lane_Execution_Plan.md`
- define single-lane scope, branch/commit policy, quality/evidence gates, merge criteria, and rollback policy
- retire auto checkpoint PR loop by consolidating execution into one clean implementation lane

## Validation
- docs-only change; no test/lint/build run required
- verified branch contains one commit and one docs file change

## Policy Note
- supersedes auto checkpoint PR loop behavior
