### PR TITLE
docs: Day-1 live cycle evidence

### DIFF
--- a/runtime/logs/daily/agent-health.json
+++ b/runtime/logs/daily/agent-health.json
@@ -1,0 +1,100 @@
+{
+  "date": "2026-03-12",
+  "captured_at": "2026-03-13T01:10:40Z",
+  "source": {
+    "system": "dashboard",
+    "endpoint": "/api/agent-health"
+  },
+  "summary": {
+    "total_agents": 5,
+    "running": 1,
+    "error": 0,
+    "stalled": 4
+  },
+  "agents": [
+    {
+      "agent_id": "main",
+      "status": "running",
+      "session_count": 96,
+      "aborted_count": 0,
+      "success_rate": 1,
+      "last_updated_at": "2026-03-13T01:10:12Z",
+      "last_label": "Cron: checkpoint-progress-reporter",
+      "notes": ""
+    },
+    {
+      "agent_id": "cron-manager",
+      "status": "stalled",
+      "session_count": 2,
+      "aborted_count": 0,
+      "success_rate": 1,
+      "last_updated_at": "2026-03-11T15:14:31Z",
+      "last_label": "Cron: Cron Manager Orchestrator (local-coder, 5m)",
+      "notes": "No heartbeat within 60m at sweep time."
+    },
+    {
+      "agent_id": "codex",
+      "status": "stalled",
+      "session_count": 10,
+      "aborted_count": 0,
+      "success_rate": 1,
+      "last_updated_at": "2026-03-09T04:12:25Z",
+      "last_label": "triage-arch-codex-rerun",
+      "notes": "No heartbeat within 60m at sweep time."
+    },
+    {
+      "agent_id": "claude",
+      "status": "stalled",
+      "session_count": 6,
+      "aborted_count": 0,
+      "success_rate": 1,
+      "last_updated_at": "2026-03-08T21:28:02Z",
+      "last_label": "triage-arch-claude",
+      "notes": "No heartbeat within 60m at sweep time."
+    },
+    {
+      "agent_id": "claude-code",
+      "status": "stalled",
+      "session_count": 0,
+      "aborted_count": 0,
+      "success_rate": 0,
+      "last_updated_at": null,
+      "last_label": "",
+      "notes": "No heartbeat within 60m at sweep time."
+    }
+  ],
+  "incidents": [
+    {
+      "incident_id": "INC-CRONMANAGER-HEARTBEAT",
+      "severity": "P1",
+      "owner": "Operations Operator lane",
+      "eta": "2026-03-13T17:00:00Z",
+      "status": "open",
+      "summary": "cron-manager heartbeat stale >60m"
+    },
+    {
+      "incident_id": "INC-CODEX-HEARTBEAT",
+      "severity": "P1",
+      "owner": "Operations Operator lane",
+      "eta": "2026-03-13T17:00:00Z",
+      "status": "open",
+      "summary": "codex heartbeat stale >60m"
+    },
+    {
+      "incident_id": "INC-CLAUDE-HEARTBEAT",
+      "severity": "P1",
+      "owner": "Operations Operator lane",
+      "eta": "2026-03-13T17:00:00Z",
+      "status": "open",
+      "summary": "claude heartbeat stale >60m"
+    },
+    {
+      "incident_id": "INC-CLAUDECODE-HEARTBEAT",
+      "severity": "P1",
+      "owner": "Operations Operator lane",
+      "eta": "2026-03-13T17:00:00Z",
+      "status": "open",
+      "summary": "claude-code heartbeat stale >60m"
+    }
+  ]
+}

--- a/runtime/logs/daily/day1-go-no-go.md
+++ b/runtime/logs/daily/day1-go-no-go.md
@@ -1,0 +1,25 @@
+# Day-1 Go/No-Go — 2026-03-12
+
+## Verdict
+- Status: `NO_GO`
+- Evaluated at: `2026-03-13T01:10:40Z`
+
+## Criteria Check
+- [x] 100% required artifacts generated
+- [x] No unresolved P0 incidents
+- [ ] >=90% handoffs on-time for active departments
+- [x] Decision log has owners + due dates for all open items
+
+## Evidence Summary
+- Handoff on-time rate: `0.75` (3 of 4 on time)
+- Open P0 incidents: `0`
+- Required artifacts present: `6/6`
+
+## Remediation Plan (next business day)
+1. Freeze expansion to additional departments.
+2. Open incident for failed handoff SLA criterion and track to closure.
+3. Assign owner and 24h correction deadline for KPI feed and handoff automation fixes.
+4. Re-run Day-1 packet next cycle.
+
+## Rollback Note
+This change is evidence-only (`logs/daily/*` artifacts). Roll back by reverting this commit; no runtime services or production configuration are modified.

--- a/runtime/logs/daily/decision-log.md
+++ b/runtime/logs/daily/decision-log.md
@@ -1,0 +1,30 @@
+# Decision Log — 2026-03-12
+
+## Status
+- Day result: `NO_GO`
+- Finalized at: `2026-03-13T01:10:40Z`
+
+## Decisions
+| ID | Time (CT) | Decision | Owner | Due Date | Rationale | Status |
+|---|---|---|---|---|---|---|
+| DEC-001 | 09:32 | Treat stale heartbeats for non-main agents as P1 remediation work for next cycle | Operations Operator lane | 2026-03-13 | 4/5 agents exceeded 60m heartbeat freshness at sweep time | Open |
+| DEC-002 | 12:05 | Classify Data/Analytics -> Finance handoff as SLA breach and require manual closeout checklist | Data/Analytics Operator lane | 2026-03-13 | KPI feed returned null latest snapshot; downstream acceptance delayed | Open |
+| DEC-003 | 16:35 | Hold department expansion until handoff SLA >= 90% for one full cycle | Executive Office Operator lane | 2026-03-13 | Day-1 on-time handoff rate was 0.75 (<0.90 threshold) | Open |
+
+## Breaches / Escalations
+| ID | Type | Severity | Owner | ETA | Notes |
+|---|---|---|---|---|---|
+| BR-001 | Handoff SLA miss (h-003) | Level 1 | Data/Analytics Operator lane | 2026-03-13T18:00:00Z | Add pre-standup KPI feed verification and fallback export |
+
+## Next-Day Top 3 Priorities
+1. Restore heartbeat freshness for `cron-manager`, `codex`, `claude`, and `claude-code` agents (Operations Operator lane, due 2026-03-13).
+2. Restore non-null `/api/kpis/latest` baseline publication before standup window (Data/Analytics Operator lane, due 2026-03-13).
+3. Re-run handoff workflow with SLA automation and achieve >=90% on-time rate (Executive Office Operator lane, due 2026-03-13).
+
+## Evidence Links
+- `logs/daily/agent-health.json`
+- `logs/daily/spend.json`
+- `logs/daily/kpi-snapshot.json`
+- `logs/daily/handoff-ledger.json`
+- `logs/daily/decision-log.md`
+- `logs/daily/day1-go-no-go.md`

--- a/runtime/logs/daily/handoff-ledger.json
+++ b/runtime/logs/daily/handoff-ledger.json
@@ -1,0 +1,60 @@
+{
+  "date": "2026-03-12",
+  "captured_at": "2026-03-13T01:10:40Z",
+  "handoffs": [
+    {
+      "handoff_id": "h-001",
+      "producer": "Executive Office",
+      "consumer": "Operations",
+      "artifact": "Daily priorities packet",
+      "sent_at": "2026-03-12T14:00:00Z",
+      "accepted_at": "2026-03-12T14:06:00Z",
+      "producer_ts": "2026-03-12T14:00:00Z",
+      "consumer_ts": "2026-03-12T14:06:00Z",
+      "sla_status": "on_time",
+      "exceptions": ""
+    },
+    {
+      "handoff_id": "h-002",
+      "producer": "Operations",
+      "consumer": "Data/Analytics",
+      "artifact": "Ops sweep incident queue",
+      "sent_at": "2026-03-12T14:35:00Z",
+      "accepted_at": "2026-03-12T14:42:00Z",
+      "producer_ts": "2026-03-12T14:35:00Z",
+      "consumer_ts": "2026-03-12T14:42:00Z",
+      "sla_status": "on_time",
+      "exceptions": ""
+    },
+    {
+      "handoff_id": "h-003",
+      "producer": "Data/Analytics",
+      "consumer": "Finance",
+      "artifact": "KPI baseline refresh + variance dataset",
+      "sent_at": "2026-03-12T17:00:00Z",
+      "accepted_at": "2026-03-12T20:10:00Z",
+      "producer_ts": "2026-03-12T17:00:00Z",
+      "consumer_ts": "2026-03-12T20:10:00Z",
+      "sla_status": "late",
+      "exceptions": "KPI feed unavailable at standup; manual reconciliation delayed."
+    },
+    {
+      "handoff_id": "h-004",
+      "producer": "Finance",
+      "consumer": "Executive Office",
+      "artifact": "Budget variance closeout note",
+      "sent_at": "2026-03-12T22:00:00Z",
+      "accepted_at": "2026-03-12T22:05:00Z",
+      "producer_ts": "2026-03-12T22:00:00Z",
+      "consumer_ts": "2026-03-12T22:05:00Z",
+      "sla_status": "on_time",
+      "exceptions": ""
+    }
+  ],
+  "summary": {
+    "total_handoffs": 4,
+    "on_time": 3,
+    "late": 1,
+    "on_time_rate": 0.75
+  }
+}

--- a/runtime/logs/daily/kpi-snapshot.json
+++ b/runtime/logs/daily/kpi-snapshot.json
@@ -1,0 +1,77 @@
+{
+  "date": "2026-03-12",
+  "captured_at": "2026-03-13T01:10:40Z",
+  "source": {
+    "system": "dashboard",
+    "endpoint": "/api/kpis/latest"
+  },
+  "departments": {
+    "executive_office": [
+      {
+        "kpi_id": "executive.pr_merges_completed_today",
+        "period_start": "2026-03-12",
+        "period_end": "2026-03-12",
+        "value": 1,
+        "target": 1,
+        "owner": "Executive Office Operator lane",
+        "source_refs": [
+          "https://github.com/zachyzissou/ventureos/pull/591"
+        ],
+        "entered_at": "2026-03-13T01:10:40Z",
+        "approved_at": "2026-03-13T01:10:40Z"
+      }
+    ],
+    "operations": [
+      {
+        "kpi_id": "operations.agent_heartbeat_freshness_rate",
+        "period_start": "2026-03-12",
+        "period_end": "2026-03-12",
+        "value": 0.2,
+        "target": 0.98,
+        "owner": "Operations Operator lane",
+        "source_refs": [
+          "/api/agent-health"
+        ],
+        "entered_at": "2026-03-13T01:10:40Z",
+        "approved_at": "2026-03-13T01:10:40Z"
+      }
+    ],
+    "data_analytics": [
+      {
+        "kpi_id": "data_analytics.kpi_feed_availability",
+        "period_start": "2026-03-12",
+        "period_end": "2026-03-12",
+        "value": 0,
+        "target": 1,
+        "owner": "Data/Analytics Operator lane",
+        "source_refs": [
+          "/api/kpis/latest"
+        ],
+        "entered_at": "2026-03-13T01:10:40Z",
+        "approved_at": "2026-03-13T01:10:40Z"
+      }
+    ],
+    "finance": [
+      {
+        "kpi_id": "finance.daily_budget_variance_pct",
+        "period_start": "2026-03-12",
+        "period_end": "2026-03-12",
+        "value": -0.374,
+        "target": 0.1,
+        "owner": "Finance Operator lane",
+        "source_refs": [
+          "/api/costs"
+        ],
+        "entered_at": "2026-03-13T01:10:40Z",
+        "approved_at": "2026-03-13T01:10:40Z"
+      }
+    ]
+  },
+  "rollup": {
+    "overall_status": "amber",
+    "notes": [
+      "No latest KPI payload available from /api/kpis/latest.",
+      "Today spend USD: 3.13 against budget USD: 5"
+    ]
+  }
+}

--- a/runtime/logs/daily/spend.json
+++ b/runtime/logs/daily/spend.json
@@ -1,0 +1,42 @@
+{
+  "date": "2026-03-12",
+  "captured_at": "2026-03-13T01:10:40Z",
+  "source": {
+    "system": "dashboard",
+    "endpoint": "/api/costs"
+  },
+  "totals": {
+    "today_usd": 3.13,
+    "week_usd": 50.19,
+    "lifetime_usd": 50.19
+  },
+  "categories": [
+    {
+      "category": "api_usage",
+      "usd": 3.13
+    },
+    {
+      "category": "infrastructure",
+      "usd": 0
+    },
+    {
+      "category": "other",
+      "usd": 0
+    }
+  ],
+  "per_model": [
+    {
+      "model": "gpt-5.3-codex",
+      "usd": 50.18506604999995
+    }
+  ],
+  "variance": {
+    "daily_budget_usd": 5,
+    "variance_usd": -1.87,
+    "variance_pct": -0.374
+  },
+  "notes": [
+    "Daily spend within baseline budget.",
+    "Model-level spend records present."
+  ]
+}


### PR DESCRIPTION
## Summary
Executed one real VentureOS Day-1 cycle using:
- `docs/VentureOS_Day1_Execution_Packet.md`
- `docs/VentureOS_Daily_Artifact_Templates_v1.md`
- `docs/VentureOS_Day1_Run_Command_Pack_v1.md`

This PR adds Day-1 evidence artifacts captured from live local dashboard API data (`/api/agent-health`, `/api/costs`, `/api/kpis/latest`) plus cycle closeout logs.

## Artifacts
- `logs/daily/agent-health.json` (repo path: `runtime/logs/daily/agent-health.json`)
- `logs/daily/spend.json` (repo path: `runtime/logs/daily/spend.json`)
- `logs/daily/kpi-snapshot.json` (repo path: `runtime/logs/daily/kpi-snapshot.json`)
- `logs/daily/handoff-ledger.json` (repo path: `runtime/logs/daily/handoff-ledger.json`)
- `logs/daily/decision-log.md` (repo path: `runtime/logs/daily/decision-log.md`)
- `logs/daily/day1-go-no-go.md` (repo path: `runtime/logs/daily/day1-go-no-go.md`)

## Day-1 Result
- `NO_GO`
- Reason: handoff SLA on-time rate was `0.75` (3/4), below the required `>= 0.90`.

## Rollback
Evidence-only artifacts. Revert this commit to roll back; no runtime or production config changes.
