### PR TITLE
docs: Day-1 remediation plan

### DIFF
--- a/docs/VentureOS_Day1_Remediation_Plan.md
+++ b/docs/VentureOS_Day1_Remediation_Plan.md
@@ -1,0 +1,44 @@
+# VentureOS Day-1 Remediation Plan
+
+Date: 2026-03-13  
+Owner: Executive Office Operator lane
+
+## Trigger
+Day-1 cycle on 2026-03-12 closed as `NO_GO` because handoff on-time rate was `0.75` (3/4), below the `0.90` GO threshold. The failed handoff was `h-003` (Data/Analytics -> Finance), delayed by KPI feed unavailability and manual reconciliation lag.
+
+## Remediation Objective (next cycle)
+Achieve `GO` by delivering handoff on-time rate `>= 0.90` in the next full Day-1 cycle, with no late handoff in the critical chain.
+
+## Scope
+In-scope chain for this remediation cycle:
+1. Executive Office -> Operations (`h-001`)
+2. Operations -> Data/Analytics (`h-002`)
+3. Data/Analytics -> Finance (`h-003`, primary breach)
+4. Finance -> Executive Office (`h-004`)
+
+## Owners, Actions, and SLAs
+| ID | Action | Owner | SLA | Due (CT) | Evidence |
+|---|---|---|---|---|---|
+| R1 | Add pre-standup KPI readiness probe for `/api/kpis/latest`; if latest payload is null, auto-run fallback export before handoff window opens. | Data/Analytics Operator lane | Probe executes by 08:30; fallback completes within 15 min of null detection. | 2026-03-13 09:00 | Probe log + export artifact path recorded in decision log |
+| R2 | Timebox `h-003` handoff using explicit send/accept checkpoints and automated timer alerts. | Data/Analytics Operator lane (producer), Finance Operator lane (consumer) | Acceptance occurs within 10 min of send time. | 2026-03-13 17:00 | `handoff-ledger.json` entry shows `sla_status=on_time` and timestamps within SLA |
+| R3 | Add escalation policy for `h-003` delay risk: notify Executive Office and Operations when 5 min remains in acceptance budget. | Operations Operator lane | Alert emitted within 1 min after threshold breach risk. | 2026-03-13 16:00 | Alert event logged with timestamp and recipients |
+| R4 | Freeze additional department onboarding until remediation acceptance criteria pass once. | Executive Office Operator lane | No new departments added before GO evidence is complete. | Immediate through cycle close | Decision log entry confirming freeze maintained |
+| R5 | Run end-of-day GO gate review with explicit sign-off checklist for handoff SLA and KPI availability. | Executive Office Operator lane | Review completed within 30 min of cycle close. | 2026-03-13 18:30 | Updated `day1-go-no-go.md` with checklist outcomes |
+
+## Next-Cycle Acceptance Criteria (must all pass)
+1. `runtime/logs/daily/handoff-ledger.json` reports `on_time_rate >= 0.90`.
+2. Critical handoff `h-003` is `on_time` with `accepted_at - sent_at <= 10 minutes`.
+3. `/api/kpis/latest` has a non-null latest payload before `h-003` send time, or fallback export evidence exists with completion within SLA.
+4. `runtime/logs/daily/decision-log.md` records closure status for SLA-breach follow-up items with owners and timestamps.
+5. `runtime/logs/daily/day1-go-no-go.md` verdict is `GO` for the next cycle.
+
+## Verification Commands (local)
+```bash
+cat runtime/logs/daily/handoff-ledger.json
+cat runtime/logs/daily/kpi-snapshot.json
+cat runtime/logs/daily/decision-log.md
+cat runtime/logs/daily/day1-go-no-go.md
+```
+
+## Rollback Note
+This is a docs-only planning artifact. Roll back by reverting the commit that adds this file; no runtime service code or production configuration is changed.


### PR DESCRIPTION
## Summary
- add Day-1 remediation plan for NO_GO cause: handoff on-time 0.75 < 0.90
- define concrete owners, actions, SLAs, and acceptance criteria to reach GO next cycle

## Scope
- docs-only change

## Validation
- docs-only: no lint/test/build run