### PR TITLE
docs: Day-2 execution plan

### DIFF
--- a/docs/VentureOS_Day2_Execution_Plan.md
+++ b/docs/VentureOS_Day2_Execution_Plan.md
@@ -1,0 +1,55 @@
+# VentureOS Day-2 Execution Plan
+
+Date: 2026-03-13  
+Owner: Executive Office Operator lane
+
+## Basis (Cycle 2 GO Outcome)
+Day-1 Cycle 2 on 2026-03-13 closed `GO` with handoff SLA score `1.00` (4/4 on-time), no open P0 incidents, and all required evidence artifacts present. Day-2 execution focuses on converting that recovery into stable operating performance.
+
+Source evidence:
+- `runtime/logs/daily/2026-03-13-day1-go-no-go-cycle2.md`
+- `runtime/logs/daily/2026-03-13-decision-log-cycle2.md`
+
+## Day-2 Objectives
+1. Sustain handoff reliability for one additional full cycle before lifting onboarding freeze.
+2. Remove KPI fallback dependency by restoring primary non-null KPI feed before standup.
+3. Reduce stale agent heartbeat risk to near-zero and keep monitoring within deterministic response windows.
+
+## Scope
+In-scope handoff chain:
+1. Executive Office -> Operations (`h-001`)
+2. Operations -> Data/Analytics (`h-002`)
+3. Data/Analytics -> Finance (`h-003`)
+4. Finance -> Executive Office (`h-004`)
+
+Out of scope:
+- New department onboarding prior to Day-2 acceptance sign-off.
+
+## Owners, SLA Targets, and Deliverables
+| ID | Objective | Owner | SLA Target | Due (CT) | Deliverable / Evidence |
+|---|---|---|---|---|---|
+| D2-1 | Preserve handoff chain on-time performance | Operations Operator lane + department handoff owners | `on_time_rate >= 0.95` across required handoffs; `h-003 accepted_at - sent_at <= 10 min` | 2026-03-14 17:00 | `runtime/logs/daily/handoff-ledger.json` (or cycle artifact) with on-time entries and timestamps |
+| D2-2 | Restore primary KPI feed | Data/Analytics Operator lane | `/api/kpis/latest` returns non-null payload by 08:30; freshness lag <= 5 min at first probe | 2026-03-14 08:30 | KPI probe output + `runtime/logs/daily/kpi-snapshot.json` (or cycle artifact) |
+| D2-3 | Keep KPI fallback as bounded contingency | Data/Analytics Operator lane | If primary feed is null, fallback export starts <= 5 min and completes <= 15 min from detection | 2026-03-14 09:00 | Decision log entry with timestamps and fallback artifact path |
+| D2-4 | Reduce stale heartbeat footprint | Operations Operator lane | Stale agents reduced from 4 to <= 1; remediation starts <= 5 min after stale detection | 2026-03-14 10:00 | Agent health artifact + remediation event record |
+| D2-5 | Govern freeze-lift decision with explicit gate | Executive Office Operator lane | GO/NO_GO decision published <= 30 min after cycle close with evidence links and owner sign-off | 2026-03-14 18:30 | `runtime/logs/daily/day1-go-no-go.md` (or cycle artifact) + decision log entry |
+
+## Acceptance Criteria (all required)
+1. Handoff on-time rate is `>= 0.95` and critical handoff `h-003` remains within 10 minutes acceptance latency.
+2. Primary KPI feed is non-null by standup probe and remains available for handoff planning.
+3. Any KPI fallback activation meets the 5-minute start and 15-minute completion SLA.
+4. Stale heartbeat count is `<= 1` by checkpoint and no stale agent remains unresolved past 5 minutes without escalation.
+5. End-of-day decision artifact records explicit `GO`/`NO_GO`, owners, timestamps, and evidence links.
+6. Department onboarding freeze is lifted only if Criteria 1-5 pass for Day-2.
+
+## Verification Commands (local)
+```bash
+cat runtime/logs/daily/handoff-ledger.json
+cat runtime/logs/daily/kpi-snapshot.json
+cat runtime/logs/daily/agent-health.json
+cat runtime/logs/daily/decision-log.md
+cat runtime/logs/daily/day1-go-no-go.md
+```
+
+## Rollback Note
+This is a docs-only planning artifact. Roll back by reverting the commit that adds this file; no runtime service code or production configuration is changed.


### PR DESCRIPTION
## Summary
Add Day-2 execution plan based on Cycle 2 GO outcome with concrete objectives, owners, SLA targets, and acceptance criteria.

## Scope
- Add docs/VentureOS_Day2_Execution_Plan.md
- Docs-only change

## Validation
- No code/build/test changes required (docs-only).