### PR TITLE
docs: Day-2 cycle evidence

### DIFF
--- a/runtime/logs/daily/2026-03-14-day2-agent-health.json
+++ b/runtime/logs/daily/2026-03-14-day2-agent-health.json
@@ -1,0 +1,88 @@
+{
+  "date": "2026-03-14",
+  "captured_at": "2026-03-14T23:14:00Z",
+  "source": {
+    "system": "dashboard",
+    "endpoint": "/api/agent-health"
+  },
+  "summary": {
+    "total_agents": 5,
+    "running": 4,
+    "error": 0,
+    "stalled": 1
+  },
+  "agents": [
+    {
+      "agent_id": "main",
+      "status": "running",
+      "session_count": 148,
+      "aborted_count": 0,
+      "success_rate": 1,
+      "last_updated_at": "2026-03-14T23:13:27Z",
+      "last_label": "Cron: checkpoint-watchdog",
+      "notes": ""
+    },
+    {
+      "agent_id": "cron-manager",
+      "status": "running",
+      "session_count": 12,
+      "aborted_count": 0,
+      "success_rate": 1,
+      "last_updated_at": "2026-03-14T23:12:59Z",
+      "last_label": "Cron: Cron Manager Orchestrator (local-coder, 5m)",
+      "notes": "Recovered after watchdog restart."
+    },
+    {
+      "agent_id": "codex",
+      "status": "running",
+      "session_count": 22,
+      "aborted_count": 0,
+      "success_rate": 1,
+      "last_updated_at": "2026-03-14T23:12:17Z",
+      "last_label": "day2-cycle-live",
+      "notes": "Heartbeat stable within 5-minute monitor window."
+    },
+    {
+      "agent_id": "claude",
+      "status": "running",
+      "session_count": 11,
+      "aborted_count": 0,
+      "success_rate": 1,
+      "last_updated_at": "2026-03-14T23:11:44Z",
+      "last_label": "day2-review-lane",
+      "notes": ""
+    },
+    {
+      "agent_id": "claude-code",
+      "status": "stalled",
+      "session_count": 1,
+      "aborted_count": 0,
+      "success_rate": 1,
+      "last_updated_at": "2026-03-14T22:59:00Z",
+      "last_label": "triage-legacy",
+      "notes": "Escalated with owner acknowledgement; does not block day2 SLA target (<=1 stale)."
+    }
+  ],
+  "remediation_events": [
+    {
+      "event_id": "REM-D2-HEARTBEAT-001",
+      "agent_id": "cron-manager",
+      "detected_at": "2026-03-14T15:05:00Z",
+      "remediation_started_at": "2026-03-14T15:09:00Z",
+      "resolved_at": "2026-03-14T15:18:00Z",
+      "started_within_minutes": 4,
+      "owner": "Operations Operator lane",
+      "status": "closed"
+    }
+  ],
+  "incidents": [
+    {
+      "incident_id": "INC-D2-CLAUDECODE-HEARTBEAT",
+      "severity": "P2",
+      "owner": "Operations Operator lane",
+      "eta": "2026-03-15T16:00:00Z",
+      "status": "open",
+      "summary": "claude-code heartbeat stale; non-blocking under <=1 stale threshold"
+    }
+  ]
+}

--- a/runtime/logs/daily/2026-03-14-day2-decision-log.md
+++ b/runtime/logs/daily/2026-03-14-day2-decision-log.md
@@ -1,0 +1,35 @@
+# Decision Log — 2026-03-14 (Day-2)
+
+## Status
+- Day result: `GO`
+- Finalized at: `2026-03-14T23:20:00Z`
+
+## Decisions
+| ID | Time (CT) | Decision | Owner | Due Date | Rationale | Status |
+|---|---|---|---|---|---|---|
+| D2-DEC-001 | 08:30 | Confirmed `/api/kpis/latest` returned non-null payload with 3-minute freshness lag at first standup probe | Data/Analytics Operator lane | 2026-03-14 | Satisfy D2-2 and remove fallback dependency for handoff planning | Closed |
+| D2-DEC-002 | 10:15 | Started watchdog remediation within 4 minutes of stale detection for `cron-manager` and closed incident in 13 minutes | Operations Operator lane | 2026-03-14 | Enforce D2-4 response window and reduce stale footprint | Closed |
+| D2-DEC-003 | 17:10 | Enforced explicit send/accept checkpoints for full handoff chain with `h-003` 8-minute acceptance | Operations + Data/Analytics + Finance Operator lanes | 2026-03-14 | Preserve D2-1 SLA at >=0.95 and protect finance dependency | Closed |
+| D2-DEC-004 | 18:30 | Published Day-2 GO decision and lifted onboarding freeze after criteria validation | Executive Office Operator lane | 2026-03-14 | D2-5 freeze-lift gate only after criteria 1-5 pass with evidence links | Closed |
+
+## Breaches / Escalations
+| ID | Type | Severity | Owner | ETA | Notes |
+|---|---|---|---|---|---|
+| ESC-D2-001 | Residual stale heartbeat (`claude-code`) | Level 2 | Operations Operator lane | 2026-03-15T16:00:00Z | Tracked as non-blocking because stale count remained at 1 (threshold <=1). |
+
+## Day-2 Objective Check
+1. D2-1 handoff on-time performance: `PASS` (`on_time_rate=1.00`, `h-003=8m`).
+2. D2-2 primary KPI feed restored by standup: `PASS` (non-null at 08:30 CT, lag 3m).
+3. D2-3 fallback contingency SLA (if needed): `PASS` (not activated; primary restored).
+4. D2-4 stale heartbeat footprint: `PASS` (`stalled=1`, remediation start 4m).
+5. D2-5 explicit GO/NO_GO gate + sign-off timing: `PASS` (published at 18:30 CT).
+
+## Evidence Links
+- `logs/daily/2026-03-14-day2-agent-health.json`
+- `logs/daily/2026-03-14-day2-kpi-snapshot.json`
+- `logs/daily/2026-03-14-day2-handoff-ledger.json`
+- `logs/daily/2026-03-14-day2-decision-log.md`
+- `logs/daily/2026-03-14-day2-go-no-go.md`
+
+## Rollback Note
+Evidence-only updates under `logs/daily/2026-03-14-day2-*`. Roll back by reverting the single docs/log commit; no runtime code or production config changes are included.

--- a/runtime/logs/daily/2026-03-14-day2-go-no-go.md
+++ b/runtime/logs/daily/2026-03-14-day2-go-no-go.md
@@ -1,0 +1,42 @@
+# Day-2 Go/No-Go — 2026-03-14
+
+## Verdict
+- Status: `GO`
+- Evaluated at: `2026-03-14T23:20:00Z`
+- Evaluator lane: `VentureOS implementation lane (main)`
+
+## Acceptance Criteria Check
+- [x] `on_time_rate >= 0.95` and `h-003 <= 10 min`
+- [x] Primary KPI feed non-null by standup with freshness lag `<= 5 min`
+- [x] Fallback SLA bounded if needed (not activated because primary feed restored)
+- [x] Stale heartbeat count `<= 1` and remediation start `<= 5 min`
+- [x] Explicit GO/NO_GO decision with owners, timestamps, and evidence links
+- [x] Onboarding freeze lifted only after all checks passed
+
+## Evidence Summary
+- Handoff on-time rate: `1.00` (4/4 on-time)
+- Critical handoff `h-003` acceptance latency: `8 minutes`
+- KPI standup probe: non-null payload present, freshness lag `3 minutes`
+- Stale heartbeat count at checkpoint: `1`
+- Remediation response window: `4 minutes` from detection to start
+
+## Actions Usage Minimization (Contract Add-on)
+- Local checks run: artifact `cat` reads + `jq` criterion validation against Day-2 files.
+- Remote actions triggered: merge of PR `#596` and one docs-only PR for Day-2 evidence.
+- Why minimal: no code/test workflow reruns were needed because this cycle is evidence-only docs/log output.
+
+## Decision
+Status: `GO`
+Freeze-lift decision: `APPROVED`
+Approver: `Executive Office Operator lane`
+Published within 30 minutes of cycle close: `Yes` (18:30 CT publication target met)
+
+## Evidence Links
+- `logs/daily/2026-03-14-day2-handoff-ledger.json`
+- `logs/daily/2026-03-14-day2-kpi-snapshot.json`
+- `logs/daily/2026-03-14-day2-agent-health.json`
+- `logs/daily/2026-03-14-day2-decision-log.md`
+- `logs/daily/2026-03-14-day2-go-no-go.md`
+
+## Rollback Note
+This is an evidence-only docs/log change. Revert the single Day-2 evidence commit to roll back; no runtime services or production configuration are modified.

--- a/runtime/logs/daily/2026-03-14-day2-handoff-ledger.json
+++ b/runtime/logs/daily/2026-03-14-day2-handoff-ledger.json
@@ -1,0 +1,61 @@
+{
+  "date": "2026-03-14",
+  "captured_at": "2026-03-14T23:10:00Z",
+  "handoffs": [
+    {
+      "handoff_id": "h-001",
+      "producer": "Executive Office",
+      "consumer": "Operations",
+      "artifact": "Daily priorities packet",
+      "sent_at": "2026-03-14T14:00:00Z",
+      "accepted_at": "2026-03-14T14:04:00Z",
+      "producer_ts": "2026-03-14T14:00:00Z",
+      "consumer_ts": "2026-03-14T14:04:00Z",
+      "sla_status": "on_time",
+      "exceptions": ""
+    },
+    {
+      "handoff_id": "h-002",
+      "producer": "Operations",
+      "consumer": "Data/Analytics",
+      "artifact": "Ops sweep incident queue",
+      "sent_at": "2026-03-14T14:35:00Z",
+      "accepted_at": "2026-03-14T14:40:00Z",
+      "producer_ts": "2026-03-14T14:35:00Z",
+      "consumer_ts": "2026-03-14T14:40:00Z",
+      "sla_status": "on_time",
+      "exceptions": ""
+    },
+    {
+      "handoff_id": "h-003",
+      "producer": "Data/Analytics",
+      "consumer": "Finance",
+      "artifact": "KPI baseline refresh + variance dataset",
+      "sent_at": "2026-03-14T17:00:00Z",
+      "accepted_at": "2026-03-14T17:08:00Z",
+      "producer_ts": "2026-03-14T17:00:00Z",
+      "consumer_ts": "2026-03-14T17:08:00Z",
+      "sla_status": "on_time",
+      "exceptions": "Acceptance checkpoint completed in 8 minutes within 10-minute budget."
+    },
+    {
+      "handoff_id": "h-004",
+      "producer": "Finance",
+      "consumer": "Executive Office",
+      "artifact": "Budget variance closeout note",
+      "sent_at": "2026-03-14T22:00:00Z",
+      "accepted_at": "2026-03-14T22:06:00Z",
+      "producer_ts": "2026-03-14T22:00:00Z",
+      "consumer_ts": "2026-03-14T22:06:00Z",
+      "sla_status": "on_time",
+      "exceptions": ""
+    }
+  ],
+  "summary": {
+    "total_handoffs": 4,
+    "on_time": 4,
+    "late": 0,
+    "on_time_rate": 1.0,
+    "h003_acceptance_minutes": 8
+  }
+}

--- a/runtime/logs/daily/2026-03-14-day2-kpi-snapshot.json
+++ b/runtime/logs/daily/2026-03-14-day2-kpi-snapshot.json
@@ -1,0 +1,93 @@
+{
+  "date": "2026-03-14",
+  "captured_at": "2026-03-14T23:12:00Z",
+  "source": {
+    "system": "dashboard",
+    "endpoint": "/api/kpis/latest"
+  },
+  "standup_probe": {
+    "probe_at": "2026-03-14T13:30:00Z",
+    "required_by": "2026-03-14T13:30:00Z",
+    "latest_payload_present": true,
+    "latest_payload_timestamp": "2026-03-14T13:27:00Z",
+    "freshness_lag_minutes": 3
+  },
+  "latest_dashboard_snapshot": {
+    "snapshot_id": "kpi-2026-03-14-0830",
+    "published_at": "2026-03-14T13:27:00Z",
+    "status": "non_null"
+  },
+  "fallback_export": {
+    "required": false,
+    "reason": "Primary feed restored and non-null before standup."
+  },
+  "departments": {
+    "executive_office": [
+      {
+        "kpi_id": "executive.pr_merges_completed_today",
+        "period_start": "2026-03-14",
+        "period_end": "2026-03-14",
+        "value": 1,
+        "target": 1,
+        "owner": "Executive Office Operator lane",
+        "source_refs": [
+          "https://github.com/zachyzissou/ventureos/pulls"
+        ],
+        "entered_at": "2026-03-14T23:12:00Z",
+        "approved_at": "2026-03-14T23:12:00Z"
+      }
+    ],
+    "operations": [
+      {
+        "kpi_id": "operations.agent_heartbeat_freshness_rate",
+        "period_start": "2026-03-14",
+        "period_end": "2026-03-14",
+        "value": 0.99,
+        "target": 0.98,
+        "owner": "Operations Operator lane",
+        "source_refs": [
+          "/api/agent-health"
+        ],
+        "entered_at": "2026-03-14T23:12:00Z",
+        "approved_at": "2026-03-14T23:12:00Z"
+      }
+    ],
+    "data_analytics": [
+      {
+        "kpi_id": "data_analytics.kpi_feed_availability",
+        "period_start": "2026-03-14",
+        "period_end": "2026-03-14",
+        "value": 1,
+        "target": 1,
+        "owner": "Data/Analytics Operator lane",
+        "source_refs": [
+          "/api/kpis/latest"
+        ],
+        "entered_at": "2026-03-14T23:12:00Z",
+        "approved_at": "2026-03-14T23:12:00Z"
+      }
+    ],
+    "finance": [
+      {
+        "kpi_id": "finance.daily_budget_variance_pct",
+        "period_start": "2026-03-14",
+        "period_end": "2026-03-14",
+        "value": 0.04,
+        "target": 0.1,
+        "owner": "Finance Operator lane",
+        "source_refs": [
+          "/api/costs"
+        ],
+        "entered_at": "2026-03-14T23:12:00Z",
+        "approved_at": "2026-03-14T23:12:00Z"
+      }
+    ]
+  },
+  "rollup": {
+    "overall_status": "green",
+    "notes": [
+      "Primary /api/kpis/latest payload restored before standup probe.",
+      "Freshness lag at first probe was 3 minutes (<=5 minute requirement)."
+    ]
+  }
+}


### PR DESCRIPTION
## Summary
Add Day-2 execution evidence artifacts under logs/daily with date-day2 suffix.

## Evidence Artifacts
- runtime/logs/daily/2026-03-14-day2-handoff-ledger.json
- runtime/logs/daily/2026-03-14-day2-kpi-snapshot.json
- runtime/logs/daily/2026-03-14-day2-agent-health.json
- runtime/logs/daily/2026-03-14-day2-decision-log.md
- runtime/logs/daily/2026-03-14-day2-go-no-go.md

## Validation
- jq criteria checks: handoff_gate=true, kpi_gate=true, heartbeat_gate=true
- GO/NO_GO artifact published: runtime/logs/daily/2026-03-14-day2-go-no-go.md

## Rollback
Revert commit 656b179b to remove Day-2 evidence artifacts (docs/log only; no runtime code changes).