### PR TITLE
docs: Day-3 execution plan

### DIFF
--- a/docs/VentureOS_Day3_Execution_Plan.md
+++ b/docs/VentureOS_Day3_Execution_Plan.md
@@ -1,0 +1,56 @@
+# VentureOS Day-3 Execution Plan
+
+Date: 2026-03-15  
+Owner: Executive Office Operator lane
+
+## Basis (Day-2 GO Evidence)
+Day-2 cycle on 2026-03-14 closed `GO` with all gates passing and onboarding freeze lifted. Day-3 execution is scoped to preserve that performance while closing the residual heartbeat risk left open in Day-2.
+
+Day-2 evidence baseline:
+- Handoff on-time rate: `1.00` (4/4 on-time)
+- Critical handoff `h-003` acceptance latency: `8 minutes`
+- KPI standup probe: non-null at 08:30 CT with freshness lag `3 minutes`
+- Stale heartbeat count at checkpoint: `1`
+- Remediation start window: `4 minutes` from stale detection
+
+Source evidence:
+- `runtime/logs/daily/2026-03-14-day2-go-no-go.md`
+- `runtime/logs/daily/2026-03-14-day2-decision-log.md`
+- `runtime/logs/daily/2026-03-14-day2-handoff-ledger.json`
+- `runtime/logs/daily/2026-03-14-day2-kpi-snapshot.json`
+- `runtime/logs/daily/2026-03-14-day2-agent-health.json`
+
+## Day-3 Focused Objectives
+1. Preserve handoff reliability across the same four-link chain with no late transfers.
+2. Eliminate residual heartbeat risk by closing the open `claude-code` stale incident.
+3. Keep KPI feed continuously non-null through operating window without fallback activation.
+4. Publish Day-3 GO decision artifact within SLA and keep evidence package complete.
+
+## Owners, SLA Targets, and Deliverables
+| ID | Objective | Owner | SLA Target | Due (CT) | Deliverable / Evidence |
+|---|---|---|---|---|---|
+| D3-1 | Preserve handoff chain reliability | Operations Operator lane + department handoff owners | `on_time_rate >= 0.95`; no late handoff; `h-003 accepted_at - sent_at <= 10 min` | 2026-03-15 17:00 | `runtime/logs/daily/2026-03-15-day3-handoff-ledger.json` |
+| D3-2 | Close residual stale heartbeat incident (`claude-code`) | Operations Operator lane | Incident closed by checkpoint; `stalled = 0` at final capture; remediation starts `<= 5 min` from detection | 2026-03-15 16:00 | `runtime/logs/daily/2026-03-15-day3-agent-health.json` + closure note in decision log |
+| D3-3 | Sustain KPI feed health through standup and mid-day probe | Data/Analytics Operator lane | `/api/kpis/latest` non-null at 08:30 and 13:00 CT probes; freshness lag `<= 5 min` at both probes | 2026-03-15 13:00 | `runtime/logs/daily/2026-03-15-day3-kpi-snapshot.json` |
+| D3-4 | Keep fallback contingency bounded (only if needed) | Data/Analytics Operator lane | If primary feed turns null, fallback starts `<= 5 min` and completes `<= 15 min` | 2026-03-15 13:15 | Timestamped fallback event record in `2026-03-15-day3-decision-log.md` |
+| D3-5 | Publish explicit GO/NO_GO gate with owner sign-off | Executive Office Operator lane | Decision published `<= 30 min` after cycle close with linked evidence and freeze state | 2026-03-15 18:30 | `runtime/logs/daily/2026-03-15-day3-go-no-go.md` + decision log |
+
+## Acceptance Gates (all required)
+1. `on_time_rate >= 0.95` with zero late handoffs and `h-003 <= 10 minutes`.
+2. KPI feed is non-null at both required probes and freshness lag remains `<= 5 minutes`.
+3. Any fallback activation meets the `<= 5 minute` start and `<= 15 minute` completion SLA.
+4. `claude-code` residual stale incident is closed and final stale count is `0`.
+5. No stale heartbeat remains unresolved for more than 5 minutes without documented escalation.
+6. Day-3 GO/NO_GO artifact is published within 30 minutes of cycle close with owner sign-off and evidence links.
+
+## Verification Commands (local)
+```bash
+cat runtime/logs/daily/2026-03-15-day3-handoff-ledger.json
+cat runtime/logs/daily/2026-03-15-day3-kpi-snapshot.json
+cat runtime/logs/daily/2026-03-15-day3-agent-health.json
+cat runtime/logs/daily/2026-03-15-day3-decision-log.md
+cat runtime/logs/daily/2026-03-15-day3-go-no-go.md
+```
+
+## Rollback Note
+This is a docs-only planning artifact. Roll back by reverting the single commit that adds this file; no runtime service code or production configuration is changed.


### PR DESCRIPTION
## Summary
Add Day-3 execution plan document based on Day-2 GO evidence.

## Scope
- Add docs/VentureOS_Day3_Execution_Plan.md
- Define focused objectives, owners, SLA targets, and acceptance gates for Day-3
- Reference Day-2 GO evidence artifacts from 2026-03-14

## Validation
- Docs-only change; no code/build/test commands required.

## Rollback
- Revert this PR commit to remove the Day-3 plan document.