### PR TITLE
fix: stabilize dashboard next task board auth base

### DIFF
--- a/dashboard-next/README.md
+++ b/dashboard-next/README.md
@@ -47,6 +47,12 @@ npm run dashboard:next:smoke
 
 This validates task-board write auth forwarding and success/failure behavior through Next API parity routes.
 
+## API base behavior
+
+- `/readiness`, `/overview`, and `/logs` call the configured dashboard API base directly from the browser session context.
+- `/task-board` goes through Next API parity routes, but now forwards the same session-selected API base via request header so the proxy and shell stay aligned.
+- If no session-selected API base is provided, task-board proxy routes fall back to `DASHBOARD_API_BASE`, then `NEXT_PUBLIC_DASHBOARD_API_BASE`, then `http://localhost:7000`.
+
 ## Migration Notes
 
 See `dashboard-next/docs/MIGRATION_CHECKLIST.md` for route parity and rollback.

--- a/dashboard-next/app/globals.css
+++ b/dashboard-next/app/globals.css
@@ -159,11 +159,32 @@ a {
   gap: 10px;
 }
 
+.field-group {
+  display: grid;
+  gap: 6px;
+  min-width: min(420px, 100%);
+  flex: 1 1 320px;
+}
+
+.field-label {
+  color: var(--text);
+  font-size: 0.9rem;
+  font-weight: 600;
+}
+
+.field-help {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.84rem;
+  line-height: 1.4;
+}
+
 .compact-actions {
   margin-top: 0;
 }
 
-input[type="text"] {
+input[type="text"],
+input[type="password"] {
   width: min(420px, 100%);
   background: #0a202a;
   color: var(--text);

--- a/dashboard-next/app/task-board/page.js
+++ b/dashboard-next/app/task-board/page.js
@@ -22,6 +22,7 @@ function formatTs(epochMs) {
 
 export default function TaskBoardPage() {
   const {
+    normalizedApiBase,
     token,
     authenticateIfNeeded,
   } = useDashboardSession();
@@ -54,8 +55,8 @@ export default function TaskBoardPage() {
       if (!normalizedApiBase) throw new Error("API base URL is required");
       if (includeLogin) await authenticateIfNeeded();
       const [listPayload, summaryPayload] = await Promise.all([
-        requestLocalJson("/api/task-board", { token }),
-        requestLocalJson("/api/task-board/summary", { token }),
+        requestLocalJson("/api/task-board", { token, apiBase: normalizedApiBase }),
+        requestLocalJson("/api/task-board/summary", { token, apiBase: normalizedApiBase }),
       ]);
       const normalized = normalizeTaskBoardPayload(listPayload, summaryPayload);
       const nextTargets = {};
@@ -83,6 +84,7 @@ export default function TaskBoardPage() {
       await requestLocalJson("/api/task-board", {
         method: "POST",
         token,
+        apiBase: normalizedApiBase,
         body: {
           title: draft.title.trim(),
           description: draft.description.trim(),
@@ -115,6 +117,7 @@ export default function TaskBoardPage() {
       await requestLocalJson(`/api/task-board/${taskId}`, {
         method: "PATCH",
         token,
+        apiBase: normalizedApiBase,
         body: { status: target },
       });
       await loadBoard({ includeLogin: false });

--- a/dashboard-next/components/dashboard-shell.js
+++ b/dashboard-next/components/dashboard-shell.js
@@ -37,6 +37,7 @@ export function DashboardShell({
   const {
     apiBase,
     setApiBase,
+    normalizedApiBase,
     token,
     setToken,
     authState,
@@ -75,18 +76,47 @@ export function DashboardShell({
           ))}
         </div>
         <div className="actions">
-          <input
-            type="text"
-            value={apiBase}
-            onChange={(e) => setApiBase(e.target.value)}
-            placeholder="Dashboard API base URL"
-          />
-          <input
-            type="text"
-            value={token}
-            onChange={(e) => setToken(e.target.value)}
-            placeholder="Token for /api/login and Authorization header"
-          />
+          <div className="field-group">
+            <label className="field-label" htmlFor="dashboard-api-base">
+              Dashboard API base URL
+            </label>
+            <input
+              id="dashboard-api-base"
+              type="text"
+              value={apiBase}
+              onChange={(e) => setApiBase(e.target.value)}
+              placeholder="http://localhost:7000"
+              aria-describedby="dashboard-api-base-help"
+            />
+            <p id="dashboard-api-base-help" className="field-help">
+              Read-only pages call this base directly. Task Board proxies use this same value
+              when forwarding requests through Next API routes.
+            </p>
+            {normalizedApiBase ? (
+              <p className="field-help">Normalized base: {normalizedApiBase}</p>
+            ) : (
+              <p className="field-help">Enter a valid dashboard API base URL to enable requests.</p>
+            )}
+          </div>
+          <div className="field-group">
+            <label className="field-label" htmlFor="dashboard-token">
+              Session token
+            </label>
+            <input
+              id="dashboard-token"
+              type="password"
+              value={token}
+              onChange={(e) => setToken(e.target.value)}
+              placeholder="Token for /api/login and Authorization header"
+              autoComplete="current-password"
+              spellCheck="false"
+              aria-describedby="dashboard-token-help"
+            />
+            <p id="dashboard-token-help" className="field-help">
+              Stored only in this browser session storage. The token is masked in the UI and sent
+              to authenticate or forward authorized requests.
+            </p>
+          </div>
           <button
             disabled={authState === "authenticating"}
             onClick={onAuthenticate}

--- a/dashboard-next/lib/dashboard-api.js
+++ b/dashboard-next/lib/dashboard-api.js
@@ -73,9 +73,11 @@ export async function fetchDashboardJson(apiBase, path, token = "") {
 
 export async function requestLocalJson(
   path,
-  { method = "GET", token = "", body = undefined } = {},
+  { method = "GET", token = "", body = undefined, apiBase = "" } = {},
 ) {
   const headers = buildAuthHeaders(token);
+  const normalizedBase = normalizeApiBase(apiBase);
+  if (normalizedBase) headers["x-dashboard-api-base"] = normalizedBase;
   const init = {
     method,
     credentials: "include",

--- a/dashboard-next/lib/task-board-proxy.js
+++ b/dashboard-next/lib/task-board-proxy.js
@@ -1,11 +1,11 @@
-function normalizeApiBase(rawBase) {
-  const value = String(rawBase ?? "").trim();
-  return value.replace(/\/+$/, "");
-}
+import { normalizeApiBase } from "./dashboard-api.js";
 
-function resolveDashboardApiBase() {
+const DASHBOARD_API_BASE_HEADER = "x-dashboard-api-base";
+
+function resolveDashboardApiBase(request) {
   return normalizeApiBase(
-    process.env.DASHBOARD_API_BASE
+    request.headers.get(DASHBOARD_API_BASE_HEADER)
+      ?? process.env.DASHBOARD_API_BASE
       ?? process.env.NEXT_PUBLIC_DASHBOARD_API_BASE
       ?? "http://localhost:7000",
   );
@@ -48,7 +48,7 @@ function resolveUpstreamPath(request, path) {
 }
 
 export async function proxyTaskBoardRequest(request, path) {
-  const base = resolveDashboardApiBase();
+  const base = resolveDashboardApiBase(request);
   if (!base) return jsonError(500, "Dashboard API base URL is not configured");
 
   const method = request.method.toUpperCase();

--- a/dashboard-next/scripts/smoke-check-task-board-write.mjs
+++ b/dashboard-next/scripts/smoke-check-task-board-write.mjs
@@ -72,13 +72,27 @@ const address = server.address();
 if (!address || typeof address === "string") {
   throw new Error("Failed to bind test server");
 }
-process.env.DASHBOARD_API_BASE = `http://127.0.0.1:${address.port}`;
+const upstreamBase = `http://127.0.0.1:${address.port}`;
+process.env.DASHBOARD_API_BASE = "http://127.0.0.1:9";
 
 try {
-  const readResponse = await getBoard(
+  const failedWithoutOverride = await getBoard(
     new Request("http://localhost:7001/api/task-board?limit=20", {
       method: "GET",
       headers: { authorization: "Bearer token-read" },
+    }),
+  );
+  assert.equal(failedWithoutOverride.status, 502);
+  const failedPayload = await failedWithoutOverride.json();
+  assert.equal(failedPayload.error, "Upstream dashboard request failed");
+
+  const readResponse = await getBoard(
+    new Request("http://localhost:7001/api/task-board?limit=20", {
+      method: "GET",
+      headers: {
+        authorization: "Bearer token-read",
+        "x-dashboard-api-base": upstreamBase,
+      },
     }),
   );
   assert.equal(readResponse.status, 200);
@@ -90,6 +104,7 @@ try {
         authorization: "Bearer token-write",
         cookie: "openclaw_dashboard_token=session-cookie",
         "content-type": "application/json",
+        "x-dashboard-api-base": upstreamBase,
       },
       body: JSON.stringify({ title: "Create from smoke" }),
     }),
@@ -101,7 +116,10 @@ try {
   const patchUnauthorized = await patchTask(
     new Request("http://localhost:7001/api/task-board/task-001", {
       method: "PATCH",
-      headers: { "content-type": "application/json" },
+      headers: {
+        "content-type": "application/json",
+        "x-dashboard-api-base": upstreamBase,
+      },
       body: JSON.stringify({ status: "running" }),
     }),
     { params: { taskId: "task-001" } },
@@ -114,6 +132,7 @@ try {
       headers: {
         authorization: "Bearer token-write",
         "content-type": "application/json",
+        "x-dashboard-api-base": upstreamBase,
       },
       body: JSON.stringify({ status: "running" }),
     }),
@@ -127,6 +146,7 @@ try {
       headers: {
         authorization: "Bearer token-write",
         "content-type": "application/json",
+        "x-dashboard-api-base": upstreamBase,
       },
       body: "{invalid",
     }),
@@ -147,6 +167,7 @@ try {
     (entry) => entry.method === "GET" && entry.url === "/api/task-board?limit=20",
   );
   assert.ok(readUpstream, "expected upstream GET query passthrough");
+  assert.equal(readUpstream.headers["x-dashboard-api-base"], undefined);
 
   console.log("DASHBOARD_NEXT_TASK_BOARD_WRITE_SMOKE_OK");
 } finally {


### PR DESCRIPTION
## Summary
- fix the `task-board` runtime path by wiring `normalizedApiBase` from session context into local Next task-board requests
- make Next task-board proxy routes honor the session-selected API base via request header so shell and proxy stay aligned
- mask token input and add explicit labels/help text for dashboard auth controls
- document the task-board API base behavior and strengthen the task-board smoke check for override + failure paths

## Validation
- `npm run build --workspace=dashboard-next`
- `npm run parity:task-board --workspace=dashboard-next`
- `npm run smoke:task-board-write --workspace=dashboard-next`
- `npm run docs:lint`

## Notes
- `dashboard-next` build completed successfully, but Next emitted existing lockfile/SWC patch warnings because this repo is workspace-managed.

Closes #582
