### PR TITLE
Cross-department agent contracts and ownership matrix

### DIFF
--- a/docs/VentureOS_Agent_Ownership_Matrix_v1.json
+++ b/docs/VentureOS_Agent_Ownership_Matrix_v1.json
@@ -1,0 +1,163 @@
+{
+  "version": "v1.0",
+  "updated_at": "2026-03-16T22:20:00Z",
+  "scope": "Cross-department ownership matrix for Company OS v1 control functions.",
+  "functions": [
+    {
+      "function_id": "portfolio_priorities",
+      "function": "Portfolio priorities and sequencing",
+      "accountable_owner": "Executive Office Director lane",
+      "execution_owner": "Chief of Staff Agent",
+      "gate_owner": "Executive Office Auditor lane",
+      "supporting_lanes": [
+        "Program Control Agent",
+        "Finance Director lane"
+      ],
+      "departments_served": [
+        "All active departments"
+      ],
+      "primary_artifacts": [
+        "runtime/logs/weekly/YYYY-Www-ops-review.md",
+        "runtime/logs/daily/YYYY-MM-DD-decision-log.md"
+      ]
+    },
+    {
+      "function_id": "blocker_routing",
+      "function": "Cross-department blocker routing and directive issuance",
+      "accountable_owner": "Operations Director lane",
+      "execution_owner": "Program Control Agent",
+      "gate_owner": "Executive Office Director lane",
+      "supporting_lanes": [
+        "Chief of Staff Agent",
+        "Department Director lanes"
+      ],
+      "departments_served": [
+        "All active departments"
+      ],
+      "primary_artifacts": [
+        "runtime/logs/weekly/YYYY-Www-risk-register.md",
+        "runtime/logs/daily/YYYY-MM-DD-decision-log.md"
+      ]
+    },
+    {
+      "function_id": "sla_monitoring",
+      "function": "Inter-department handoff SLA monitoring and breach routing",
+      "accountable_owner": "Operations Director lane",
+      "execution_owner": "Program Control Agent",
+      "gate_owner": "Evidence/QA Agent",
+      "supporting_lanes": [
+        "Producer Director lane",
+        "Consumer Director lane"
+      ],
+      "departments_served": [
+        "Executive Office",
+        "Operations",
+        "Data/Analytics",
+        "Finance",
+        "Product",
+        "Engineering",
+        "Design",
+        "Marketing",
+        "Sales",
+        "Customer Success",
+        "Legal",
+        "IT/Security",
+        "HR"
+      ],
+      "primary_artifacts": [
+        "runtime/logs/daily/YYYY-MM-DD-handoff-ledger.json",
+        "runtime/logs/weekly/YYYY-Www-risk-register.md"
+      ]
+    },
+    {
+      "function_id": "evidence_validation",
+      "function": "Evidence bundle validation and freshness certification",
+      "accountable_owner": "Trust Director lane",
+      "execution_owner": "Evidence/QA Agent",
+      "gate_owner": "Evidence/QA Agent",
+      "supporting_lanes": [
+        "Department Auditor lanes",
+        "Program Control Agent"
+      ],
+      "departments_served": [
+        "All active departments"
+      ],
+      "primary_artifacts": [
+        "runtime/reports/evidence/evidence-validate-latest.json",
+        "runtime/reports/evidence/evidence-validate-latest.md"
+      ]
+    },
+    {
+      "function_id": "phase_gate_readiness",
+      "function": "Phase gate readiness packet preparation and certification",
+      "accountable_owner": "Executive Office Director lane",
+      "execution_owner": "Program Control Agent",
+      "gate_owner": "Evidence/QA Agent",
+      "supporting_lanes": [
+        "Chief of Staff Agent",
+        "Department Director lanes"
+      ],
+      "departments_served": [
+        "All active departments"
+      ],
+      "primary_artifacts": [
+        "runtime/reports/phase0-readiness/phase0-readiness-latest.json",
+        "runtime/reports/phase0-readiness/phase0-readiness-latest.md"
+      ]
+    },
+    {
+      "function_id": "kpi_quality_assurance",
+      "function": "Cross-cutting KPI quality assurance and baseline integrity",
+      "accountable_owner": "Data/Analytics Director lane",
+      "execution_owner": "Data/Analytics Operator lane",
+      "gate_owner": "Evidence/QA Agent",
+      "supporting_lanes": [
+        "Department Operator lanes",
+        "Department Auditor lanes"
+      ],
+      "departments_served": [
+        "All active departments"
+      ],
+      "primary_artifacts": [
+        "runtime/logs/daily/YYYY-MM-DD-kpi-snapshot.json",
+        "runtime/logs/weekly/YYYY-Www-kpi-rollup.json"
+      ]
+    },
+    {
+      "function_id": "department_activation_readiness",
+      "function": "Department activation readiness and dependency verification",
+      "accountable_owner": "Executive Office Director lane",
+      "execution_owner": "Chief of Staff Agent",
+      "gate_owner": "Evidence/QA Agent",
+      "supporting_lanes": [
+        "Program Control Agent",
+        "Department Director lanes"
+      ],
+      "departments_served": [
+        "Departments scheduled for activation"
+      ],
+      "primary_artifacts": [
+        "docs/VentureOS_Phase0_Readiness_Checklist_v1.md",
+        "runtime/reports/phase0-readiness/phase0-readiness-latest.json"
+      ]
+    },
+    {
+      "function_id": "operating_model_change_intake",
+      "function": "Operating model change intake, triage, and routing",
+      "accountable_owner": "Executive Office Director lane",
+      "execution_owner": "Chief of Staff Agent",
+      "gate_owner": "Operations Director lane",
+      "supporting_lanes": [
+        "Program Control Agent",
+        "Evidence/QA Agent"
+      ],
+      "departments_served": [
+        "All active departments"
+      ],
+      "primary_artifacts": [
+        "runtime/logs/daily/YYYY-MM-DD-decision-log.md",
+        "runtime/logs/weekly/YYYY-Www-risk-register.md"
+      ]
+    }
+  ]
+}

--- a/docs/VentureOS_Cross_Department_Agent_Contracts_v1.md
+++ b/docs/VentureOS_Cross_Department_Agent_Contracts_v1.md
@@ -1,0 +1,182 @@
+# VentureOS Cross-Department Agent Contracts v1
+
+Date: 2026-03-16
+Version: v1.0
+Scope: normative contract definitions for the three cross-cutting agents that operate across Company OS v1 departments.
+
+## 1) Purpose
+
+This document closes the Phase 0 contract gap for the three cross-cutting agents named in `docs/VentureOS_Department_Architecture_v1.md`:
+- Chief of Staff Agent
+- Program Control Agent
+- Evidence/QA Agent
+
+These roles are not department-local variants of the Director, Operator, and Auditor lane contracts. They are cross-department control surfaces that coordinate priorities, enforce operating cadence, and certify evidence quality across all active departments.
+
+## 2) Normative relationship to other docs
+
+- `docs/VentureOS_Department_Architecture_v1.md` remains the normative source for department topology and decision rights.
+- `docs/VentureOS_Lane_Contracts_v1.md` remains the normative source for baseline lane obligations and separation of duties.
+- This document is the normative source for cross-cutting agent mission, I/O, authority limits, and escalation obligations.
+- `docs/VentureOS_Agent_Ownership_Matrix_v1.json` is the machine-readable ownership companion for future enforcement and reporting.
+
+## 3) Global rules for cross-cutting agents
+
+- Cross-cutting agents may coordinate or certify work across departments, but they do not replace department Directors, Operators, or Auditors.
+- No cross-cutting agent may unilaterally approve budget, legal, security, or irreversible production-risk exceptions.
+- Every cross-cutting output must include timestamps, linked evidence, and an accountable lane owner.
+- Every cross-cutting handoff must use the envelope standard defined in `docs/VentureOS_Lane_Contracts_v1.md`.
+- Cross-cutting directives that alter department scope or priority must be logged in `runtime/logs/daily/YYYY-MM-DD-decision-log.md`.
+
+## 4) Contract summary matrix
+
+| Agent | Home department | Mission | Primary consumers | Core outputs | Primary SLA |
+|---|---|---|---|---|---|
+| Chief of Staff Agent | Executive Office | Coordinate inter-department priorities, unblock dependencies, and route executive decisions into executable directives | Department Directors, Program Control, Finance, Data/Analytics | priorities packets, dependency directives, decision packets, escalation summaries | Blocking cross-department directive within 4h of executive decision or blocker escalation |
+| Program Control Agent | Operations | Enforce operating cadence, track blockers, monitor SLA health, and route operational escalations | Department Directors, Chief of Staff, Operators, Auditors | blocker ledger, SLA compliance summary, gate readiness packets, escalation notices | P0/P1 operational escalation packet within 30 minutes; missed-handoff notice same business cycle |
+| Evidence/QA Agent | Trust / Evidence | Verify evidence completeness, certify gate readiness, and audit cross-cutting metrics and claims | Department Auditors, Executive Office, Program Control, Data/Analytics | gate decisions, audit findings, evidence validation summaries, re-audit requests | Critical evidence finding escalation within 30 minutes; standard gate decision within 1 business day |
+
+## 5) Chief of Staff Agent contract
+
+### Mission
+Convert executive intent into coherent cross-department execution and keep dependency routing from fragmenting across department boundaries.
+
+### Required inputs
+- Executive Office strategy, priorities, and decision packets.
+- Program Control blocker summaries and escalation notices.
+- Department Director dependency requests.
+- Finance allocation constraints and Data/Analytics KPI summaries when decisions depend on them.
+
+### Required outputs
+- Weekly priorities packet to Operations and active department Directors.
+- Dependency directives with owner, due date, and escalation path.
+- Executive decision briefs that translate policy or priority changes into department actions.
+- Architecture or cadence review trigger when recurring cross-department failure patterns emerge.
+
+### Service-level obligations
+- Weekly priorities packet delivered by Monday 09:00 CT.
+- Blocking cross-department directive issued within 4 hours of executive decision or confirmed blocker escalation.
+- Director decision latency >72 hours escalated to Executive Office Director within the same business cycle.
+- Cross-department action distribution acknowledged by all receiving Directors within 1 business day.
+
+### Hard constraints
+- Cannot reallocate budget without Executive Office Director approval.
+- Cannot waive legal, compliance, or security controls.
+- Cannot mark a dependency resolved without confirming owner and acceptance state from affected departments.
+- Cannot close audit findings owned by Evidence/QA or department Auditors.
+
+### Acceptance signals
+- Every directive includes owner, due date, rationale, and evidence link.
+- Every escalated blocker has a current status and next action.
+- Weekly priorities packet aligns to the active operating review and department plans.
+
+### Evidence outputs
+- `runtime/logs/daily/YYYY-MM-DD-decision-log.md`
+- `runtime/logs/weekly/YYYY-Www-ops-review.md`
+
+## 6) Program Control Agent contract
+
+### Mission
+Run the Company OS control loop by enforcing cadence, surfacing dependency risk, and keeping inter-department SLAs measurable and actionable.
+
+### Required inputs
+- Daily status from department Operators.
+- Handoff ledger entries and incident updates.
+- Chief of Staff directives and active risk register items.
+- Phase gate criteria from implementation and readiness docs.
+
+### Required outputs
+- Daily blocker ledger with escalation state.
+- Weekly SLA compliance summary and miss-count rollups.
+- Phase gate readiness packet for executive review.
+- Operational escalation briefs for P0/P1 incidents or repeated SLA misses.
+
+### Service-level obligations
+- New P0/P1 operational escalation packet delivered within 30 minutes.
+- Standup blocker unresolved for more than 24 hours escalated to Chief of Staff within 4 hours of threshold breach.
+- Missed handoff logged and routed to producer and consumer Directors in the same business cycle.
+- Weekly SLA compliance summary published before executive operating review.
+
+### Hard constraints
+- Cannot change SLA targets or breach policy without the approvals defined in `docs/VentureOS_Department_KPI_SLA_v1.md`.
+- Cannot suppress blocker visibility to preserve cosmetic status.
+- Cannot downgrade incident severity without evidence and Director approval from the owning function.
+- Cannot certify a phase gate without Evidence/QA confirmation on required evidence artifacts.
+
+### Acceptance signals
+- Every blocker has owner, target resolution time, and current escalation state.
+- Every tracked handoff has met/missed status and breach level when applicable.
+- Every phase gate packet references current evidence and explicit pass/fail criteria.
+
+### Evidence outputs
+- `runtime/logs/daily/YYYY-MM-DD-handoff-ledger.json`
+- `runtime/logs/weekly/YYYY-Www-risk-register.md`
+- `runtime/reports/phase0-readiness/phase0-readiness-latest.json`
+
+## 7) Evidence/QA Agent contract
+
+### Mission
+Independently verify that Company OS claims are backed by current, complete, and reproducible evidence before gates are passed or work is treated as complete.
+
+### Required inputs
+- Daily, weekly, and monthly evidence bundles.
+- Gate criteria from readiness, quality-gate, and KPI/SLA docs.
+- Audit history, prior findings, and re-test evidence.
+- KPI and handoff records requiring cross-cutting audit coverage.
+
+### Required outputs
+- Pass/fail gate certification with findings and remediation steps.
+- Evidence validation summary for required bundles.
+- Cross-cutting audit findings for KPI quality, handoff compliance, and evidence freshness.
+- Re-audit requests and closure notes after remediation.
+
+### Service-level obligations
+- Standard gate decision within 1 business day.
+- Critical evidence or compliance finding escalated within 30 minutes.
+- Re-audit completed within 1 business day of remediation evidence landing.
+- Monthly cross-cutting audit coverage meets or exceeds the sampling minimums defined in `docs/VentureOS_Department_KPI_SLA_v1.md`.
+
+### Hard constraints
+- Cannot certify evidence produced by the same lane instance.
+- Cannot waive Critical findings without Executive Office Director approval and explicit expiry.
+- Cannot close findings without objective remediation evidence.
+- Cannot substitute stale evidence for required current evidence without an exception recorded in the decision log.
+
+### Acceptance signals
+- Every gate decision identifies the exact artifacts reviewed.
+- Every finding includes severity, owner, due date, and re-audit trigger.
+- Every pass decision is reproducible from linked evidence artifacts and timestamps.
+
+### Evidence outputs
+- `runtime/reports/evidence/evidence-validate-latest.json`
+- `runtime/reports/evidence/evidence-validate-latest.md`
+- `runtime/reports/phase0-readiness/phase0-readiness-latest.md`
+
+## 8) Cross-department ownership matrix
+
+The machine-readable ownership matrix lives in `docs/VentureOS_Agent_Ownership_Matrix_v1.json`.
+
+The matrix assigns accountable owner, execution owner, gate owner, supporting lanes, and primary artifacts for the cross-department functions that the three agents jointly control, including:
+- portfolio priorities and sequencing
+- blocker routing
+- SLA monitoring
+- gate readiness and certification
+- KPI quality assurance
+- department activation readiness
+- operating model change intake
+
+## 9) Escalation boundaries between cross-cutting agents
+
+| Condition | Initial owner | Required partner | Escalation target |
+|---|---|---|---|
+| Cross-department blocker unresolved >24h | Program Control Agent | Chief of Staff Agent | Executive Office Director |
+| Scope or priority conflict across departments | Chief of Staff Agent | Program Control Agent | Executive Office Director |
+| Evidence bundle missing for gate-bound deliverable | Evidence/QA Agent | Program Control Agent | Owning Department Director |
+| Repeated SLA breach with downstream freeze risk | Program Control Agent | Chief of Staff Agent | Executive Office Director |
+| Cross-cutting metric dispute or audit challenge | Evidence/QA Agent | Data/Analytics Director | Executive Office Director |
+
+## 10) Change control
+
+- Changes to this document require Executive Office Director approval and review from the affected home department Director.
+- Changes that alter measurable SLAs or approval boundaries must also update `docs/VentureOS_Agent_Ownership_Matrix_v1.json` in the same change.
+- Contract changes that introduce new access rights must not be merged until the RBAC workstream in `#609` is updated.

--- a/docs/VentureOS_Department_Architecture_v1.md
+++ b/docs/VentureOS_Department_Architecture_v1.md
@@ -183,6 +183,8 @@ Cross-cutting agents:
 - **Program Control Agent** (Operations): enforces SLAs, tracks blockers, escalation routing.
 - **Evidence/QA Agent** (Trust): validates “done” claims with artifacts.
 
+Normative cross-cutting contract definitions live in `docs/VentureOS_Cross_Department_Agent_Contracts_v1.md`, with machine-readable ownership mappings in `docs/VentureOS_Agent_Ownership_Matrix_v1.json`.
+
 ---
 
 ## 6) Governance and decision rights

--- a/docs/VentureOS_Execution_Gap_Assessment_v1.md
+++ b/docs/VentureOS_Execution_Gap_Assessment_v1.md
@@ -24,7 +24,11 @@ The Architecture doc (§3) uses qualitative SLAs ("before sprint lock", "T-7 day
 
 ### CF2. Cross-cutting agent contracts are missing
 
-Architecture §5 defines Director/Operator/Auditor per department (13 × 3 = 39 roles) plus 3 cross-cutting agents (Chief of Staff, Program Control, Evidence/QA) = 42 roles total. The Lane Contracts doc specifies contracts for the 3 lane types but does not cover cross-cutting agents. These agents appear in the Implementation Plan as phase owners and in the Cadence doc as daily/weekly operators, but their I/O obligations, authority limits, and escalation paths are undefined. **Fix:** extend Lane Contracts doc with explicit contracts for each cross-cutting role.
+Architecture §5 defines Director/Operator/Auditor per department (13 × 3 = 39 roles) plus 3 cross-cutting agents (Chief of Staff, Program Control, Evidence/QA) = 42 roles total. This gap was closed on 2026-03-16 by adding explicit cross-cutting contracts and a machine-readable ownership matrix:
+- `docs/VentureOS_Cross_Department_Agent_Contracts_v1.md`
+- `docs/VentureOS_Agent_Ownership_Matrix_v1.json`
+
+These artifacts define mission, required inputs/outputs, authority limits, escalation rules, and accountable/execution/gate ownership for the cross-department control functions.
 
 ### CF3. Implementation Plan dates vs. Cadence doc
 
@@ -137,11 +141,9 @@ All four docs require evidence-first execution, and the repo now has canonical e
 
 1. **Keep Architecture doc aligned** — `VentureOS_Department_Architecture_v1.md` is restored; companion docs must continue to reference it as normative.
 2. **Complete evidence execution coverage** — The canonical store/schema/validation layer is now present. Finish generation coverage, retention policy enforcement, and query/reporting depth.
-3. **Add cross-cutting agent contracts** — Extend Lane Contracts with Chief of Staff, Program Control, and Evidence/QA agent contracts: mission, required I/O, authority limits, SLAs.
-4. **Define tool access / RBAC per lane** — Map each lane type to specific system permissions (git repos, evidence stores, dashboards, approval workflows).
-5. **Map SLA frameworks** — Document the relationship between P0-P3 technical SLAs and department handoff SLA tiers. Define how a technical incident cascades to department-level SLA impact.
-6. **Add Phase 0 readiness checklist** — Pre-mobilization gate by Mar 14: evidence infra confirmed, stakeholder alignment documented, baseline measurement plan approved, agent provisioning verified.
-7. **Add department bootstrap checklist** — Standard activation procedure for onboarding new departments in Phase B/C.
-8. **Define external boundary protocol** — What flows out to customers/vendors/regulators, under what approvals, with what audit trail.
-9. **Add OS-level change management** — How architecture/KPI/contract changes are proposed, reviewed across affected departments, approved, and deployed.
+3. **Define tool access / RBAC per lane** — Map each lane type to specific system permissions (git repos, evidence stores, dashboards, approval workflows).
+4. **Map SLA frameworks** — Document the relationship between P0-P3 technical SLAs and department handoff SLA tiers. Define how a technical incident cascades to department-level SLA impact.
+5. **Add department bootstrap checklist** — Standard activation procedure for onboarding new departments in Phase B/C.
+6. **Define external boundary protocol** — What flows out to customers/vendors/regulators, under what approvals, with what audit trail.
+7. **Add OS-level change management** — How architecture/KPI/contract changes are proposed, reviewed across affected departments, approved, and deployed.
 10. **Complete rollback procedures** — Add partial-activation rollback steps and data cleanup procedures to Implementation Plan §8.

--- a/docs/VentureOS_Implementation_Plan_v1.md
+++ b/docs/VentureOS_Implementation_Plan_v1.md
@@ -33,6 +33,10 @@ Derived validation and readiness reports: `runtime/reports/`
 | Portfolio priorities and sequencing | Executive Office Director lane | Chief of Staff Operator lane | Executive Office Auditor lane |
 | Process reliability and dependency tracking | Operations Director lane | Program Control Operator lane | Operations Auditor lane |
 | KPI system and reporting data quality | Data/Analytics Director lane | Data/Analytics Operator lane | Evidence/QA Auditor lane |
+
+Cross-department contract details and ownership mappings for the Chief of Staff, Program Control, and Evidence/QA roles are defined in:
+- `docs/VentureOS_Cross_Department_Agent_Contracts_v1.md`
+- `docs/VentureOS_Agent_Ownership_Matrix_v1.json`
 | Budget and runway control | Finance Director lane | Finance Operator lane | Finance Auditor lane |
 | Department delivery (each department) | Department Director lane | Department Operator lane | Department Auditor lane |
 

--- a/docs/VentureOS_Lane_Contracts_v1.md
+++ b/docs/VentureOS_Lane_Contracts_v1.md
@@ -145,3 +145,18 @@ Thresholds:
 - Proposed changes must include rationale, expected impact, and migration date.
 - Approval requires Director + Auditor sign-off for affected departments.
 - Cross-department contract changes also require Operations Director approval.
+
+## 11) Cross-cutting agent contracts
+
+The baseline lane contracts above apply to all department Director, Operator, and Auditor lanes.
+
+Three cross-cutting agents require additional contract definitions because they coordinate or certify work across department boundaries:
+- Chief of Staff Agent
+- Program Control Agent
+- Evidence/QA Agent
+
+Their mission, required I/O, authority limits, escalation rules, and ownership mappings are defined in:
+- `docs/VentureOS_Cross_Department_Agent_Contracts_v1.md`
+- `docs/VentureOS_Agent_Ownership_Matrix_v1.json`
+
+These companion artifacts are normative for cross-department coordination and must be updated alongside this document when cross-cutting contract boundaries change.


### PR DESCRIPTION
## Summary
- add a normative cross-department agent contracts doc for the Chief of Staff, Program Control, and Evidence/QA roles
- add a machine-readable ownership matrix for cross-department Company OS control functions
- link the new contract artifacts from the lane contracts, architecture, implementation plan, and gap assessment docs

## Linked Issue
Closes #608
Relates to #603
Updates #138

## Validation
- `npm run docs:lint`
- `python3 -m json.tool docs/VentureOS_Agent_Ownership_Matrix_v1.json >/dev/null`

## Artifact Paths
- `docs/VentureOS_Cross_Department_Agent_Contracts_v1.md`
- `docs/VentureOS_Agent_Ownership_Matrix_v1.json`

## Residual Risks
- RBAC and tool-access enforcement is still tracked separately in #609
- SLA framework mapping is still tracked separately in #610
