### PR TITLE
Map technical incidents to handoff SLA escalation

### DIFF
--- a/docs/DOC_INDEX.md
+++ b/docs/DOC_INDEX.md
@@ -19,6 +19,7 @@
 - **docs/VentureOS_Agent_Role_Registry_v1.json** – machine-readable role registry
 - **docs/VentureOS_RBAC_Spec_v1.md** – canonical RBAC policy
 - **docs/VentureOS_Tool_Access_Matrix_v1.json** – machine-readable RBAC matrix
+- **docs/VentureOS_SLA_Framework_Map_v1.md** – canonical mapping from technical `P0-P3` incidents to department handoff breach and exception handling
 - **docs/roles/REPO_CHARTER.md** – VentureOS charter + scope boundaries
 - **docs/process/OPERATING_CONTRACT_GITLAB.md** – GitHub-first work contract (legacy filename kept for compatibility)
 - **docs/process/LABEL_PROTOCOL.md** – how workflow labels are applied/removed

--- a/docs/SLA_POLICY.md
+++ b/docs/SLA_POLICY.md
@@ -1,7 +1,7 @@
 # SLA Policy (Task Queue + Proactive Engine)
 
 ## Purpose
-Define **P0–P3 SLA tiers** for the task queue and proactive engine, including **time‑to‑ack**, **time‑to‑run**, **max retries**, and **escalation defaults**. This policy is the authoritative reference for SLA semantics used by `docs/PROACTIVE_ENGINE.md` and `docs/PROACTIVE_RULES.md`.
+Define **P0–P3 SLA tiers** for the task queue and proactive engine, including **time‑to‑ack**, **time‑to‑run**, **max retries**, and **escalation defaults**. This policy is the authoritative reference for SLA semantics used by `docs/PROACTIVE_ENGINE.md`, `docs/PROACTIVE_RULES.md`, and the VentureOS technical-to-department mapping in `docs/VentureOS_SLA_Framework_Map_v1.md`.
 
 ---
 
@@ -57,3 +57,24 @@ Escalate when any of the following occur (per tier rules above):
 4. **Consecutive failures** exceeding tier threshold
 
 Escalation routing is governed by `docs/PROACTIVE_RULES.md` and `docs/PROACTIVE_MODE.md`.
+
+---
+
+## VentureOS operating-model mapping
+
+This document governs the technical SLA plane only.
+
+When a technical incident blocks or degrades a VentureOS department handoff, the incident must also be interpreted through:
+
+- `docs/VentureOS_Department_KPI_SLA_v1.md`
+- `docs/VentureOS_SLA_Framework_Map_v1.md`
+
+Key rule:
+- technical severity does not automatically create a department handoff breach
+- a department handoff changes state only when the incident materially affects the production, acceptance, or execution window of that handoff
+
+Severity mapping summary:
+- `P0`: impacted handoffs require Executive Office exception approval or become `level_3`
+- `P1`: impacted handoffs may take an Operations-approved exception; otherwise default to `level_2`
+- `P2`: no automatic exception; missed handoffs default to `level_1`
+- `P3`: advisory only unless an actual handoff miss occurs

--- a/docs/VentureOS_30_Day_Operational_Cadence_v1.md
+++ b/docs/VentureOS_30_Day_Operational_Cadence_v1.md
@@ -7,6 +7,7 @@ Scope: Daily/weekly/monthly runbook for Phase A departments (Executive Office, O
 - `VentureOS_Department_Architecture_v1.md` — department missions and handoffs (restored to repo on 2026-03-16)
 - `VentureOS_Implementation_Plan_v1.md` — Phase 0 starts 2026-03-16; Phase A starts 2026-03-23
 - `VentureOS_Department_KPI_SLA_v1.md` — KPI targets and handoff SLAs
+- `VentureOS_SLA_Framework_Map_v1.md` — mapping from technical incident severity to handoff exception/breach handling
 - `VentureOS_Lane_Contracts_v1.md` — Director/Operator/Auditor lane obligations
 
 **Canonical evidence model:** primary artifacts live under `runtime/logs/`; validation and readiness summaries live under `runtime/reports/`.
@@ -188,9 +189,10 @@ Example: `2026-03-16-agent-health.json`
 | Agent health check fails (D-1) | Immediate → Operations Director | Operations | Acknowledge within 30 min |
 | Standup blocker unresolved >24h | Auto-escalate → Executive Chief of Staff | Operations Program Control | Directive within 4h |
 | KPI target missed 2 consecutive weeks | Flag in W-1 review; require action plan | Department Director | Action plan within 1 business day of W-1 |
-| Handoff SLA missed | Log + notify both producer and consumer Directors | Operations Program Control | Per KPI/SLA breach policy (Level 1/2/3) |
+| Handoff SLA missed | Log + notify both producer and consumer Directors | Operations Program Control | Per KPI/SLA breach policy (Level 1/2/3) and `VentureOS_SLA_Framework_Map_v1.md` when a technical incident is causal |
 | Spend variance >10% weekly | Flag in W-4; escalate to Executive if >20% | Finance Director | Corrective action within 1 business day |
 | Security incident (any severity) | Immediate → IT/Security Director + Executive | IT/Security | Containment per KPI/SLA doc: <=4h high severity |
+| Technical P0/P1 incident blocks an active handoff | Record incident-linked exception or breach routing in the handoff ledger before the handoff deadline | Operations Program Control + producer/consumer Directors | Approval route and expiry must follow `VentureOS_SLA_Framework_Map_v1.md` |
 | Daily evidence outputs missing at 17:30 CT | Operations Program Control flags; escalate to Department Director | Operations | Evidence produced or exception logged by end of next business day |
 
 ---

--- a/docs/VentureOS_Day1_Quality_Gates_v1.md
+++ b/docs/VentureOS_Day1_Quality_Gates_v1.md
@@ -2,7 +2,7 @@
 
 Date: 2026-03-12
 Owner: Claude lane (architecture/review)
-Upstream: `VentureOS_Day1_Execution_Packet.md`, `VentureOS_30_Day_Operational_Cadence_v1.md`
+Upstream: `VentureOS_Day1_Execution_Packet.md`, `VentureOS_30_Day_Operational_Cadence_v1.md`, `VentureOS_SLA_Framework_Map_v1.md`
 
 ## Purpose
 
@@ -47,7 +47,7 @@ Each gate maps to a checkpoint in the Day-1 Execution Packet. Every gate is bina
 | C2 | Timestamps present | Every handoff record has `producer_ts` and `consumer_ts` fields | Any handoff missing either timestamp |
 | C3 | SLA computed | Each current-day handoff has `compliance_status` with value `on_time`, `late`, or `exception`, plus `sla_target_minutes` and derived `latency_minutes` | Canonical compliance field missing, invalid enum, or SLA instrumentation incomplete |
 | C4 | Breach routing assigned | Every `late` handoff has canonical `breach_owner` and `breach_action` fields | Any late handoff missing owner/action, or owner uses non-canonical identifier |
-| C5 | On-time rate >= 90% | `count(on_time) / count(total) >= 0.90` for active departments, with no unresolved `level_3` breach lacking exception approval evidence | Rate below 90%, or any `level_3` breach without approval evidence |
+| C5 | On-time rate >= 90% | `count(on_time) / count(total) >= 0.90` for active departments, with no unresolved `level_3` breach lacking exception approval evidence and any incident-linked exception recorded per `VentureOS_SLA_Framework_Map_v1.md` | Rate below 90%, any `level_3` breach without approval evidence, or incident-linked exception missing technical-cause metadata |
 
 **Gate C verdict:** PASS only if C1–C5 all pass.
 
@@ -68,7 +68,7 @@ Each gate maps to a checkpoint in the Day-1 Execution Packet. Every gate is bina
 | # | Check | PASS criteria | FAIL criteria |
 |---|-------|---------------|---------------|
 | E1 | Gates A–D all passed | All four gate verdicts are PASS | Any gate verdict is FAIL |
-| E2 | No unresolved P0 incidents | Zero open P0 incidents at 17:00 CT | Any P0 incident without resolution |
+| E2 | No unresolved P0 incidents | Zero open P0 incidents at 17:00 CT | Any P0 incident without resolution, even if an impacted handoff holds approved exception status |
 | E3 | Handoff on-time rate >= 90% | Gate C5 passed | Gate C5 failed |
 | E4 | Decision log complete | Gate D3 passed | Gate D3 failed |
 

--- a/docs/VentureOS_Department_KPI_SLA_v1.md
+++ b/docs/VentureOS_Department_KPI_SLA_v1.md
@@ -74,6 +74,14 @@ Scope: KPI definitions and inter-department handoff SLAs for Company OS v1 depar
 
 - P0/P1 operational incidents override standard SLA windows.
 - Repeated Level 2/3 breaches trigger lane contract audit.
+- Technical incident severity mapping is governed by `docs/VentureOS_SLA_Framework_Map_v1.md`.
+
+### 4.1 Technical incident mapping
+
+- `P0` technical incidents may place impacted handoffs into `exception` only with `executive_office:director` approval; otherwise an impacted missed handoff is `level_3`.
+- `P1` technical incidents may place impacted handoffs into `exception` with `operations:director` approval and producer/consumer Director acknowledgement; otherwise an impacted missed handoff defaults to `level_2`.
+- `P2` and `P3` incidents do not automatically grant exceptions; any resulting missed handoff defaults to `level_1` unless separately escalated.
+- Technical severity alone does not create a handoff breach. The incident must materially affect the production, acceptance, or execution window of the handoff.
 
 ## 5) Evidence and audit requirements
 
@@ -81,6 +89,7 @@ Scope: KPI definitions and inter-department handoff SLAs for Company OS v1 depar
 - Handoff record fields: `handoff_id`, `producer`, `consumer`, `producer_binding_id`, `consumer_binding_id`, `artifact`, `sent_at`, `accepted_at`, `producer_ts`, `consumer_ts`, `sla_target_minutes`, `latency_minutes`, `compliance_status`, `breach_level`, `breach_owner`, `breach_action`, `exception_approved_by`, `exception_expires_at`, `exceptions`.
 - `sla_status` remains accepted for compatibility with historical ledgers, but `compliance_status` is the canonical field for current-day evidence and readiness evaluation.
 - Current-day ledgers must use canonical VentureOS role identifiers such as `operations:operator`, `finance:director`, or `venture_control` for binding, capability, and breach-routing fields.
+- When a technical incident affects a handoff, the handoff record must include the incident reference in `exceptions` and follow the approval/escalation rules in `docs/VentureOS_SLA_Framework_Map_v1.md`.
 - Monthly audit sample rate: 10% of KPI entries and 10% of handoffs, minimum 3 samples per department category.
 - Failed audit sample requires correction within 2 business days and re-audit.
 

--- a/docs/VentureOS_Execution_Gap_Assessment_v1.md
+++ b/docs/VentureOS_Execution_Gap_Assessment_v1.md
@@ -110,7 +110,7 @@ All four docs require evidence-first execution, and the repo now has canonical e
 
 ### C3. Two parallel SLA systems
 
-`docs/SLA_POLICY.md` defines P0-P3 SLAs for the technical task queue with response/resolution time targets. The KPI/SLA doc defines inter-department handoff SLAs with a different breach escalation model (Level 1/2/3 breach tiers based on miss count). These are parallel, unconnected SLA systems. **Resolution:** map them explicitly. Technical P0 incidents can trigger department-level SLA misses (e.g., if the task queue is down, Operations cannot meet its MTTR SLA). Document the dependency chain.
+This gap is now closed at the doc/spec layer by `docs/VentureOS_SLA_Framework_Map_v1.md`, which maps technical `P0-P3` incident severity to department handoff exception handling, breach tiers, and readiness consequences. Technical P0 incidents can now be recorded as incident-linked handoff exceptions or `level_3` breaches under explicit approval rules instead of ad hoc interpretation.
 
 ### C4. OPS_RUNBOOK scope mismatch
 
@@ -142,7 +142,7 @@ All four docs require evidence-first execution, and the repo now has canonical e
 | R2 | Evidence infrastructure is partially implemented — evidence generation coverage still needs enforcement | HIGH | Data/Analytics Director + Engineering | Keep canonical store/schema/validation in place; finish generation, retention, and query/reporting depth |
 | R3 | Cross-cutting agent contracts were missing | RESOLVED | Operations Director | Closed by `docs/VentureOS_Cross_Department_Agent_Contracts_v1.md` and `docs/VentureOS_Agent_Ownership_Matrix_v1.json` |
 | R4 | Access boundaries are defined only at the spec layer — runtime enforcement still pending | HIGH | IT/Security Director | Implement policy decisions through the named RBAC hook points and agent provisioning flow |
-| R5 | Two parallel SLA systems (P0-P3 technical vs. handoff breach tiers) still need cross-framework mapping, but handoff SLA detection is now implemented in the evidence-validation/readiness layer | MEDIUM-HIGH | Operations Director | Preserve the new handoff evidence gate; finish documenting how technical incidents cascade into department-level SLA impact |
+| R5 | Two parallel SLA systems (P0-P3 technical vs. handoff breach tiers) were previously unconnected | RESOLVED | Operations Director | Closed at the doc/spec layer by `docs/VentureOS_SLA_Framework_Map_v1.md` plus the existing handoff evidence gate |
 | R6 | No external boundary protocol for customer/vendor/regulator interactions | HIGH | Legal Director | Define boundary contracts before Sales/Legal activation in Phase B/C |
 | R7 | No inter-lane communication security model | HIGH | IT/Security Director | Define authentication/authorization for lane artifact exchange |
 | R8 | No KPI baselines — targets are aspirational until measured | MEDIUM | Data/Analytics Operator | Execute baseline measurement sprint in Phase 0 (Mar 16-25 per KPI/SLA doc §1) |
@@ -158,8 +158,7 @@ All four docs require evidence-first execution, and the repo now has canonical e
 1. **Keep Architecture doc aligned** — `VentureOS_Department_Architecture_v1.md` is restored; companion docs must continue to reference it as normative.
 2. **Complete evidence execution coverage** — The canonical store/schema/validation layer is now present. Finish generation coverage, retention policy enforcement, and query/reporting depth.
 3. **Implement RBAC enforcement hooks** — The role model and access matrix now exist; wire them into runtime policy, dashboard control surfaces, and agent provisioning.
-4. **Map SLA frameworks** — The evidence layer now computes handoff compliance, breach routing, and readiness failures. Next, document how P0-P3 technical incidents cascade into department handoff SLA impact.
-5. **Add department bootstrap checklist** — Standard activation procedure for onboarding new departments in Phase B/C.
-6. **Define external boundary protocol** — What flows out to customers/vendors/regulators, under what approvals, with what audit trail.
-7. **Add OS-level change management** — How architecture/KPI/contract changes are proposed, reviewed across affected departments, approved, and deployed.
-8. **Complete rollback procedures** — Add partial-activation rollback steps and data cleanup procedures to Implementation Plan §8.
+4. **Add department bootstrap checklist** — Standard activation procedure for onboarding new departments in Phase B/C.
+5. **Define external boundary protocol** — What flows out to customers/vendors/regulators, under what approvals, with what audit trail.
+6. **Add OS-level change management** — How architecture/KPI/contract changes are proposed, reviewed across affected departments, approved, and deployed.
+7. **Complete rollback procedures** — Add partial-activation rollback steps and data cleanup procedures to Implementation Plan §8.

--- a/docs/VentureOS_Implementation_Plan_v1.md
+++ b/docs/VentureOS_Implementation_Plan_v1.md
@@ -11,6 +11,7 @@ Normative references:
 - `docs/VentureOS_RBAC_Spec_v1.md`
 - `docs/VentureOS_Tool_Access_Matrix_v1.json`
 - `docs/VentureOS_30_Day_Operational_Cadence_v1.md`
+- `docs/VentureOS_SLA_Framework_Map_v1.md`
 - `docs/VentureOS_Phase0_Readiness_Checklist_v1.md`
 - `docs/VentureOS_Baseline_Measurement_SOP_v1.md`
 
@@ -67,6 +68,7 @@ Objective: prove repeatable execution in the core operating departments.
 In scope:
 - Run daily/weekly cadence for Executive Office, Operations, Data/Analytics, Finance.
 - Enforce SLA tracking for all handoffs among active departments.
+- Apply the technical-to-department SLA cascade map so P0-P3 incidents are recorded consistently in handoff evidence and readiness decisions.
 - Close all P0/P1 incidents within target windows.
 
 ### Phase B: Product and revenue engine (2026-04-20 to 2026-06-12)
@@ -146,6 +148,7 @@ In scope:
 - Phase C requires G3 pass and documented access-control model from IT/Security using the canonical VentureOS role model and RBAC artifacts.
 - Phase D requires G5 pass and full lane contract adoption across all active departments.
 - Any failed gate pauses downstream phase activation until remediation evidence is accepted.
+- Technical incident severity must be translated into department handoff impact using `docs/VentureOS_SLA_Framework_Map_v1.md`; teams may not invent ad hoc exception semantics during gate review.
 - GitHub epic `#603` and its successor implementation issues are the execution index for this rollout.
 
 ## 8) Rollback approach (phase-level)

--- a/docs/VentureOS_SLA_Framework_Map_v1.md
+++ b/docs/VentureOS_SLA_Framework_Map_v1.md
@@ -1,0 +1,170 @@
+# VentureOS SLA Framework Map v1
+
+Date: 2026-03-17
+Version: v1.0
+Scope: canonical mapping between technical incident severities in `docs/SLA_POLICY.md` and VentureOS department handoff breach handling in `docs/VentureOS_Department_KPI_SLA_v1.md`.
+
+Normative dependencies:
+- `docs/SLA_POLICY.md`
+- `docs/VentureOS_Department_KPI_SLA_v1.md`
+- `docs/VentureOS_Day1_Quality_Gates_v1.md`
+- `docs/VentureOS_30_Day_Operational_Cadence_v1.md`
+
+## Purpose
+
+VentureOS now has two connected but distinct SLA planes:
+
+1. Technical incident SLAs
+   Defined in `docs/SLA_POLICY.md` as `P0` through `P3` queue and proactive-engine severity bands.
+
+2. Department handoff SLAs
+   Defined in `docs/VentureOS_Department_KPI_SLA_v1.md` as inter-department handoffs with `level_1` through `level_3` breach handling.
+
+This document defines how technical incidents affect department handoffs, exception approvals, and Phase 0 readiness.
+
+## Core rule
+
+Technical severity does not automatically equal a handoff breach.
+
+A department handoff becomes impacted only when the technical incident blocks, delays, corrupts, or materially degrades a required handoff artifact or acceptance path.
+
+Three states are allowed for an impacted handoff:
+
+1. `on_time`
+   The handoff still meets the target despite the incident.
+
+2. `exception`
+   The handoff would otherwise miss SLA, but an approved incident-linked exception is recorded before the deadline.
+
+3. `late`
+   The handoff missed SLA without an active approved exception, or the exception window expired before recovery.
+
+## Dependency classes
+
+Use these dependency classes when deciding whether a technical incident affects a handoff:
+
+| Dependency class | Definition | Example |
+|---|---|---|
+| `direct_system_dependency` | The handoff artifact cannot be produced or accepted because the required system is unavailable or degraded | KPI packet blocked by data pipeline outage |
+| `decision_support_dependency` | The handoff can be produced, but quality or completeness is impaired enough that acceptance cannot proceed normally | Finance variance packet missing reconciled spend inputs |
+| `delivery_window_dependency` | The handoff itself is intact, but the downstream team cannot act inside the SLA window because a technical outage blocks execution | Engineering cannot start a launch-ready task because deployment controls are unavailable |
+
+If none of these dependency classes apply, the incident stays in the technical SLA plane only and does not alter department handoff status.
+
+## Severity-to-handoff cascade
+
+| Technical severity | Default handoff impact | Allowed exception owner | Default handoff breach level if missed without exception | Readiness impact |
+|---|---|---|---|---|
+| `P0` | Immediate incident-linked exception allowed for impacted handoffs only | `executive_office:director` | `level_3` | Phase 0 readiness fails while unresolved P0 remains open or any impacted handoff lacks active approval evidence |
+| `P1` | Exception allowed when the incident blocks a required handoff window | `operations:director` with producer/consumer Director acknowledgement | `level_2` by default; `level_3` if the missed handoff is declared critical-path or executive-facing | Readiness fails if on-time rate falls below threshold or if impacted handoff evidence lacks required routing/approval |
+| `P2` | No automatic exception; operators should reroute or recover inside normal handoff policy when possible | Producer Director lane for exceptional cases | `level_1` | Readiness impact only through normal handoff SLA degradation |
+| `P3` | Advisory only; no automatic handoff exception | none by default | `level_1` only if an actual handoff miss occurs | No direct readiness impact beyond the resulting handoff evidence |
+
+## Exception policy by technical severity
+
+### `P0`
+
+- The incident clock does not pause.
+- Any impacted handoff due during the outage window requires an explicit exception before the handoff deadline if it cannot complete on time.
+- Required fields on the handoff record:
+  - `compliance_status=exception`
+  - `breach_level=level_3`
+  - `exception_approved_by=executive_office:director`
+  - `exception_expires_at=<timestamp>`
+  - `breach_owner`
+  - `breach_action`
+  - incident reference in `exceptions`
+- If the exception expires before the handoff completes, the handoff becomes `late` and remains `level_3`.
+
+### `P1`
+
+- Exception use is allowed only when the incident creates a `direct_system_dependency`, `decision_support_dependency`, or `delivery_window_dependency`.
+- Approval route:
+  - `operations:director`
+  - acknowledgement from the producer and consumer Director lanes
+- Default classification:
+  - `exception` while approval is active
+  - `late` with `breach_level=level_2` if the handoff misses after approval expiry or without approval
+- If the handoff is marked as executive review blocking, board-facing, or launch-critical, use `level_3`.
+
+### `P2`
+
+- No automatic pause or exception.
+- Operators are expected to recover inside the normal department SLA window using fallback procedures.
+- If the miss still occurs:
+  - use `compliance_status=late`
+  - default to `breach_level=level_1`
+  - assign `breach_owner` and `breach_action`
+- A `P2` incident may justify an exception only when the producer Director explicitly records that the handoff cannot be recovered without introducing false evidence or unsafe output.
+
+### `P3`
+
+- No exception path by default.
+- Treat as advisory/degradation context.
+- Only the resulting handoff miss is recorded, not the technical severity alone.
+
+## Critical-path handoffs
+
+Treat the following handoff categories as critical-path by default:
+
+1. Executive Office incident escalation briefs
+2. Executive Office weekly KPI packet
+3. Finance variance / allocation decisions required for operating review
+4. Any handoff explicitly required by a same-day quality gate or go/no-go decision
+
+If a technical incident causes one of these handoffs to miss without active approval evidence, classify it as `level_3`.
+
+## Recording rules in evidence
+
+When a technical incident affects a handoff, the handoff ledger must record:
+
+1. the normal handoff fields from `docs/VentureOS_Department_KPI_SLA_v1.md`
+2. the canonical `breach_owner` and `breach_action`
+3. the incident reference in `exceptions`
+4. exception approval metadata if the handoff is classified as `exception`
+
+Recommended incident reference format:
+
+`exceptions: "Linked incident INC-YYYY-MM-DD-NNN (P1 queue outage); fallback reconciliation running."`
+
+## Readiness and gate effects
+
+### Day-1 / daily gate effects
+
+- Gate C fails when:
+  - a late handoff lacks breach routing
+  - on-time rate is below `0.90`
+  - a `level_3` impacted handoff lacks active approval evidence
+
+- Gate E remains fail-closed:
+  - any unresolved `P0` incident yields `NO_GO`
+  - approved `exception` handoffs do not restore `GO` if the same unresolved `P0` still exists
+
+### Phase 0 readiness effects
+
+`runtime/reports/phase0-readiness/phase0-readiness-latest.json` should be interpreted as follows:
+
+1. `handoff-sla` fails when handoff evidence is degraded, regardless of root cause.
+2. A technical incident explains the degradation only if the handoff ledger includes the incident-linked exception or breach metadata defined above.
+3. Missing technical-to-handoff linkage is treated as an evidence defect, not as a valid excuse.
+
+## Decision ownership
+
+| Decision | Owner |
+|---|---|
+| Declare whether a technical incident materially impacts a department handoff | Producer Director lane + Consumer Director lane |
+| Approve `P1` incident-linked handoff exception | `operations:director` |
+| Approve `P0` incident-linked handoff exception | `executive_office:director` |
+| Approve exception extensions beyond the original expiry | same approver as original exception |
+| Certify the resulting evidence for audit/readiness | Evidence/QA Auditor lane |
+
+## Non-goals
+
+- This document does not change the technical queue SLA timers in `docs/SLA_POLICY.md`.
+- This document does not replace the handoff breach policy in `docs/VentureOS_Department_KPI_SLA_v1.md`; it maps technical incidents into that policy.
+- This document does not define degraded-mode SOPs for lane outages. That remains separate work.
+
+## Change control
+
+- Any change to technical severity semantics must update `docs/SLA_POLICY.md` and this document in the same PR.
+- Any change to handoff breach levels or exception approval routes must update `docs/VentureOS_Department_KPI_SLA_v1.md`, this document, and any affected quality gates in the same PR.


### PR DESCRIPTION
## Summary
- add a canonical SLA framework map that defines how technical `P0-P3` incidents cascade into VentureOS department handoff exceptions, breach tiers, and readiness outcomes
- update the technical SLA, KPI/SLA, quality gate, cadence, implementation, and gap docs so the operating model uses one explicit severity-to-breach mapping
- close the remaining doc/spec gap around the previously parallel technical and department SLA systems

Closes #615
Relates to #603
Updates #138

## Validation
- `npm run docs:lint`

## Evidence Artifacts
- `docs/VentureOS_SLA_Framework_Map_v1.md`

## Residual Risks
- this PR closes the mapping gap at the doc/spec layer; it does not add new runtime enforcement beyond the handoff evidence/readiness layer already implemented in `#610`
- degraded-mode lane SOPs, department bootstrap checklists, and external boundary protocol work remain separate follow-on slices
