### PR TITLE
Define inter-lane communication security model

### DIFF
--- a/docs/DOC_INDEX.md
+++ b/docs/DOC_INDEX.md
@@ -19,6 +19,7 @@
 - **docs/VentureOS_Agent_Role_Registry_v1.json** – machine-readable role registry
 - **docs/VentureOS_RBAC_Spec_v1.md** – canonical RBAC policy
 - **docs/VentureOS_Tool_Access_Matrix_v1.json** – machine-readable RBAC matrix
+- **docs/VentureOS_Inter_Lane_Security_Model_v1.md** – canonical security model for lane-to-lane artifact exchange, provenance, integrity, and replay protection
 - **docs/VentureOS_SLA_Framework_Map_v1.md** – canonical mapping from technical `P0-P3` incidents to department handoff breach and exception handling
 - **docs/roles/REPO_CHARTER.md** – VentureOS charter + scope boundaries
 - **docs/process/OPERATING_CONTRACT_GITLAB.md** – GitHub-first work contract (legacy filename kept for compatibility)

--- a/docs/VentureOS_Cross_Department_Agent_Contracts_v1.md
+++ b/docs/VentureOS_Cross_Department_Agent_Contracts_v1.md
@@ -20,6 +20,7 @@ These roles are not department-local variants of the Director, Operator, and Aud
 - `docs/VentureOS_Role_Model_v1.md` remains the normative source for canonical lane bindings, capability overlays, and authority classes.
 - `docs/VentureOS_Agent_Role_Registry_v1.json` is the machine-readable role registry for those canonical identifiers.
 - `docs/VentureOS_RBAC_Spec_v1.md` and `docs/VentureOS_Tool_Access_Matrix_v1.json` remain the normative access-control sources.
+- `docs/VentureOS_Inter_Lane_Security_Model_v1.md` remains the normative security model for cross-lane artifact exchange, integrity, provenance, and replay handling.
 - This document is the normative source for cross-cutting agent mission, I/O, authority limits, and escalation obligations.
 - `docs/VentureOS_Agent_Ownership_Matrix_v1.json` is the machine-readable ownership companion for future enforcement and reporting.
 
@@ -30,6 +31,7 @@ These roles are not department-local variants of the Director, Operator, and Aud
 - No cross-cutting agent may unilaterally approve budget, legal, security, or irreversible production-risk exceptions.
 - Every cross-cutting output must include timestamps, linked evidence, and an accountable lane owner.
 - Every cross-cutting handoff must use the envelope standard defined in `docs/VentureOS_Lane_Contracts_v1.md`.
+- Every cross-cutting handoff that crosses a lane boundary must satisfy the security expectations in `docs/VentureOS_Inter_Lane_Security_Model_v1.md`.
 - Cross-cutting directives that alter department scope or priority must be logged in `runtime/logs/daily/YYYY-MM-DD-decision-log.md`.
 
 ## 4) Contract summary matrix

--- a/docs/VentureOS_Execution_Gap_Assessment_v1.md
+++ b/docs/VentureOS_Execution_Gap_Assessment_v1.md
@@ -130,7 +130,7 @@ This gap is now closed at the doc/spec layer by `docs/VentureOS_SLA_Framework_Ma
 
 **MC5. No external boundary protocol.** No specification for how the OS interfaces with external parties (customers, vendors, partners, regulators). Sales, CS, Legal, and Marketing all reference external entities, but no boundary contract defines what information can flow out, what approvals are needed, and what audit trail is required for external interactions. **Priority: HIGH — especially for Legal and Sales workflows.**
 
-**MC6. No security model for inter-lane communication.** Lanes exchange artifacts and approvals, but no authentication, authorization, or integrity verification is specified for these exchanges. In an agent-operated system, this means any agent could potentially forge a handoff or approval. **Priority: HIGH — must be addressed before production-grade operation.**
+**MC6. Inter-lane communication security model is now defined at the doc/spec layer.** `docs/VentureOS_Inter_Lane_Security_Model_v1.md` now specifies trust boundaries, authentication, authorization, integrity, provenance, replay protection, and exception handling for lane artifact exchange. The remaining gap is runtime enforcement. **Priority: MEDIUM-HIGH — model defined, enforcement still required before production-grade operation.**
 
 ---
 
@@ -144,7 +144,7 @@ This gap is now closed at the doc/spec layer by `docs/VentureOS_SLA_Framework_Ma
 | R4 | Access boundaries are partially enforced at runtime — shared authority-plane and tactical-map hooks now use canonical VentureOS metadata, but dashboard control surfaces and provisioning flow still need coverage | MEDIUM-HIGH | IT/Security Director | Expand enforcement beyond `lib/authority-map.ts`, `lib/policy-gate.ts`, `lib/nexus-arbiter.ts`, and `tactical-map/src/interaction/permissions.ts` into remaining hook points and agent provisioning flow |
 | R5 | Two parallel SLA systems (P0-P3 technical vs. handoff breach tiers) were previously unconnected | RESOLVED | Operations Director | Closed at the doc/spec layer by `docs/VentureOS_SLA_Framework_Map_v1.md` plus the existing handoff evidence gate |
 | R6 | No external boundary protocol for customer/vendor/regulator interactions | HIGH | Legal Director | Define boundary contracts before Sales/Legal activation in Phase B/C |
-| R7 | No inter-lane communication security model | HIGH | IT/Security Director | Define authentication/authorization for lane artifact exchange |
+| R7 | Inter-lane communication security model is defined at the doc/spec layer, but runtime enforcement is still pending | MEDIUM-HIGH | IT/Security Director | Implement the model in exchange envelopes, auth boundaries, and evidence validation |
 | R8 | No KPI baselines — targets are aspirational until measured | MEDIUM | Data/Analytics Operator | Execute baseline measurement sprint in Phase 0 (Mar 16-25 per KPI/SLA doc §1) |
 | R9 | Rollback procedures incomplete for partial-activation scenarios | MEDIUM | Operations Director | Add partial-activation rollback steps to Implementation Plan §8 |
 | R10 | No degraded-mode procedures for organizational lane failures | MEDIUM | Operations Director | Define temporary fallback authority and restoration SOPs |

--- a/docs/VentureOS_Implementation_Plan_v1.md
+++ b/docs/VentureOS_Implementation_Plan_v1.md
@@ -10,6 +10,7 @@ Normative references:
 - `docs/VentureOS_Agent_Role_Registry_v1.json`
 - `docs/VentureOS_RBAC_Spec_v1.md`
 - `docs/VentureOS_Tool_Access_Matrix_v1.json`
+- `docs/VentureOS_Inter_Lane_Security_Model_v1.md`
 - `docs/VentureOS_30_Day_Operational_Cadence_v1.md`
 - `docs/VentureOS_SLA_Framework_Map_v1.md`
 - `docs/VentureOS_Phase0_Readiness_Checklist_v1.md`
@@ -146,6 +147,7 @@ In scope:
 
 - Phase B requires G1 pass and verified KPI data quality from Data/Analytics.
 - Phase C requires G3 pass and documented access-control model from IT/Security using the canonical VentureOS role model and RBAC artifacts.
+- Phase C also requires the inter-lane communication security model to be defined for artifact exchange, approvals, and handoff evidence.
 - Phase D requires G5 pass and full lane contract adoption across all active departments.
 - Any failed gate pauses downstream phase activation until remediation evidence is accepted.
 - Technical incident severity must be translated into department handoff impact using `docs/VentureOS_SLA_Framework_Map_v1.md`; teams may not invent ad hoc exception semantics during gate review.

--- a/docs/VentureOS_Inter_Lane_Security_Model_v1.md
+++ b/docs/VentureOS_Inter_Lane_Security_Model_v1.md
@@ -1,0 +1,174 @@
+# VentureOS Inter-Lane Security Model v1
+
+Date: 2026-03-16
+Version: v1.0
+Scope: normative security model for artifact exchange, approval transport, and handoff evidence across VentureOS lanes.
+
+## 1) Purpose
+
+This document defines the minimum security controls for any artifact, approval, or handoff exchanged between VentureOS lanes.
+
+Without this model, a lane-to-lane handoff is only operationally structured, not security-qualified. That leaves VentureOS exposed to forged approvals, replayed artifacts, ambiguous producer identity, and unverifiable downstream acceptance.
+
+## 2) Normative relationship to other docs
+
+- `docs/VentureOS_Role_Model_v1.md` remains the normative source for canonical lane bindings and authority classes.
+- `docs/VentureOS_RBAC_Spec_v1.md` remains the normative source for who may access which resource classes.
+- `docs/VentureOS_Cross_Department_Agent_Contracts_v1.md` remains the normative source for cross-cutting mission, SLA, and escalation obligations.
+- `docs/VentureOS_Department_KPI_SLA_v1.md` remains the normative source for handoff SLA behavior and breach handling.
+- This document is the normative source for lane-to-lane trust boundaries, authentication, authorization, integrity, provenance, replay protection, and exception handling.
+
+## 3) Trust boundaries
+
+The following trust boundaries are normative:
+
+1. Lane instance boundary
+   A producer lane instance is not implicitly trusted by a consumer lane instance, even when both belong to the same department.
+
+2. Department boundary
+   Cross-department artifacts must always be treated as external to the receiving department until validated.
+
+3. Control-plane boundary
+   Cross-cutting functions may route or certify exchange state, but they do not replace producer identity or consumer acceptance.
+
+4. Human override boundary
+   Human override may waive or escalate an exchange rule, but it must be explicit, timestamped, and evidenced.
+
+## 4) Security goals
+
+Every inter-lane exchange must provide:
+
+1. authenticated producer identity
+2. authorized producer scope
+3. authorized consumer scope
+4. artifact integrity verification
+5. provenance traceability
+6. replay resistance
+7. auditable exception handling
+
+## 5) Canonical exchange envelope
+
+Every inter-lane artifact exchange must be representable with this minimum envelope:
+
+- `exchange_id`
+- `artifact_type`
+- `producer_binding_id`
+- `producer_capability_id`
+- `consumer_binding_id`
+- `issued_at`
+- `expires_at`
+- `classification`
+- `integrity_hash`
+- `evidence_ref`
+- `transport_auth_class`
+- `approval_chain`
+- `nonce`
+
+These fields may be implemented in existing handoff or evidence payloads without changing user-facing operator commands, but the security model requires that they exist logically even if runtime surfaces still serialize them differently during transition.
+
+## 6) Authentication rules
+
+### Producer authentication
+
+- Every exchange must identify the producer using canonical `producer_binding_id`.
+- Automated exchange transport may use `S1_runtime_token` or `S2_service_secret`, depending on the transport boundary.
+- `S3_production_credential` must never be used as a routine inter-lane exchange token.
+- Raw secret disclosure is prohibited; transport auth must prove identity, not expose secret material.
+
+### Consumer authentication
+
+- Any system accepting an exchange must authenticate the receiving lane or service boundary before processing or acknowledging the artifact.
+- Acknowledgement without authenticated consumer identity is invalid for SLA and audit purposes.
+
+## 7) Authorization rules
+
+- Producer and consumer bindings must be canonical VentureOS bindings.
+- A valid producer identity is not sufficient on its own; the producer must also be authorized to emit the artifact class.
+- Consumer acceptance is valid only if the consumer is authorized to receive the artifact class.
+- Cross-cutting agents may route or validate exchanges only within the authority limits already defined in `docs/VentureOS_Cross_Department_Agent_Contracts_v1.md`.
+- Security-sensitive artifacts require `it_security:director` escalation when the exchange crosses into higher-risk policy domains or secret classes.
+
+## 8) Integrity and provenance rules
+
+- Every exchangeable artifact must carry or derive an `integrity_hash`.
+- The producer must bind that hash to the issued exchange envelope.
+- Downstream mutation after issuance requires a new envelope or explicit revision record.
+- `evidence_ref` must point to the canonical evidence location used to reconstruct the exchange.
+- Approvals must be attributable to the approving binding, not just a display label or free-text owner string.
+
+## 9) Replay and expiry controls
+
+- `exchange_id` must be unique per issued envelope.
+- `nonce` must be unique within the active replay-protection window.
+- `expires_at` must be present for time-sensitive approval or handoff envelopes.
+- Consumer systems must reject expired or duplicate envelopes unless an explicit exception record exists.
+- Replayed approvals are invalid unless reissued through a fresh, auditable exchange envelope.
+
+## 10) Classification model
+
+Every inter-lane exchange must carry one of these classifications:
+
+- `public_operational`
+- `internal_operational`
+- `restricted_control`
+- `security_sensitive`
+
+Required handling:
+
+- `public_operational`: standard authenticated exchange, integrity required
+- `internal_operational`: authenticated exchange plus consumer authorization check
+- `restricted_control`: authenticated exchange, authorization check, provenance evidence, and explicit approval chain
+- `security_sensitive`: authenticated exchange, authorization check, provenance evidence, explicit approval chain, and security escalation rules when required
+
+## 11) Exception handling
+
+- Exceptions may not be implicit.
+- Any bypass of expiry, replay protection, provenance completeness, or authorization path must be logged in the daily decision log.
+- The exception record must identify:
+  - approving binding
+  - reason
+  - affected exchange scope
+  - expiry time
+  - remediation requirement
+- Critical exceptions require `executive_office:director` approval plus `it_security:director` acknowledgement when the exception changes security exposure.
+
+## 12) Evidence requirements
+
+The following evidence is required for any security-relevant inter-lane exchange:
+
+- producer binding
+- consumer binding
+- issued timestamp
+- acceptance timestamp when accepted
+- integrity hash or equivalent immutable content fingerprint
+- evidence reference path
+- exception record when normal controls are bypassed
+
+Canonical evidence locations remain under `runtime/logs/` and `runtime/reports/`.
+
+## 13) Minimum enforcement expectations
+
+This document defines the model now. Runtime enforcement should follow this order:
+
+1. validate canonical producer and consumer bindings
+2. validate transport authentication class
+3. validate authorization against the RBAC model
+4. validate integrity hash and evidence reference
+5. reject replayed or expired envelopes
+6. record acceptance or denial into evidence outputs
+
+## 14) Implementation hook targets
+
+The initial enforcement hooks for this model should align with:
+
+- `lib/policy-gate.ts`
+- `lib/evidence.ts`
+- `dashboard/server/middleware/auth.ts`
+- task-board and handoff transport surfaces
+- future inter-lane envelope validation utilities
+
+## 15) Current status
+
+This security model is now defined at the doc/spec layer.
+
+Runtime enforcement is still follow-on work. Until enforcement lands, any inter-lane exchange should be treated as operationally structured but not fully security-enforced.

--- a/docs/VentureOS_RBAC_Spec_v1.md
+++ b/docs/VentureOS_RBAC_Spec_v1.md
@@ -16,6 +16,7 @@ RBAC subjects in VentureOS are evaluated in this order:
 RBAC subjects must be expressed using canonical identifiers from:
 - `docs/VentureOS_Role_Model_v1.md`
 - `docs/VentureOS_Agent_Role_Registry_v1.json`
+- `docs/VentureOS_Inter_Lane_Security_Model_v1.md`
 
 ## 2) Resource classes
 
@@ -161,6 +162,14 @@ The following repo paths are the intended integration points for future runtime 
 - No runtime permission behavior changes in this PR
 - No removal of compatibility aliases required for existing runtime data
 
-## 11) Change control
+## 11) Inter-lane exchange relationship
+
+The RBAC model determines who may emit, receive, approve, or waive a protected exchange. The transport and evidence protections for that exchange are governed by `docs/VentureOS_Inter_Lane_Security_Model_v1.md`.
+
+In other words:
+- RBAC answers whether a subject may act
+- the inter-lane security model answers how that action must be authenticated, validated, and evidenced
+
+## 12) Change control
 
 Any change to the RBAC model must update `docs/VentureOS_Tool_Access_Matrix_v1.json` in the same change.


### PR DESCRIPTION
Closes #619
Relates to #603
Updates #138

## Summary
- add the normative VentureOS inter-lane communication security model covering trust boundaries, authentication, authorization, integrity, provenance, replay protection, and exception handling
- thread that model into the cross-department contracts, RBAC spec, implementation plan, and gap assessment
- move the March `R7` gap from undefined to defined-at-spec-layer with runtime enforcement clearly called out as follow-on work

## Validation
- `npm run docs:lint`

## Evidence
- `docs/VentureOS_Inter_Lane_Security_Model_v1.md`
- updated references in:
  - `docs/VentureOS_Cross_Department_Agent_Contracts_v1.md`
  - `docs/VentureOS_RBAC_Spec_v1.md`
  - `docs/VentureOS_Implementation_Plan_v1.md`
  - `docs/VentureOS_Execution_Gap_Assessment_v1.md`
  - `docs/DOC_INDEX.md`

## Residual risks
- this PR defines the model; it does not yet implement runtime exchange-envelope enforcement
- repo-wide legacy identifier cleanup is still separate follow-on work
