### PR TITLE
Harden benchmark workflow PR comment handling

### DIFF
--- a/.github/workflows/performance.yml
+++ b/.github/workflows/performance.yml
@@ -13,6 +13,11 @@
 
 name: Performance Benchmarks
 
+permissions:
+  contents: read
+  issues: write
+  pull-requests: write
+
 on:
   push:
     branches: [main]
@@ -142,32 +147,36 @@ jobs:
               console.log('No summary file found');
             }
 
-            // Find existing comment
-            const { data: comments } = await github.rest.issues.listComments({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              issue_number: context.issue.number,
-            });
-
-            const botComment = comments.find(c =>
-              c.body.includes('🏎️ Performance Benchmark') &&
-              c.user.type === 'Bot'
-            );
-
-            if (botComment) {
-              await github.rest.issues.updateComment({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                comment_id: botComment.id,
-                body,
-              });
-            } else {
-              await github.rest.issues.createComment({
+            try {
+              const { data: comments } = await github.rest.issues.listComments({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: context.issue.number,
-                body,
               });
+
+              const botComment = comments.find(c =>
+                c.body.includes('🏎️ Performance Benchmark') &&
+                c.user.type === 'Bot'
+              );
+
+              if (botComment) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: botComment.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body,
+                });
+              }
+            } catch (error) {
+              const status = error?.status ?? 'unknown';
+              core.warning(`Unable to publish performance comment (status: ${status}). Benchmark results remain available in uploaded artifacts.`);
             }
 
       - name: Check for regressions


### PR DESCRIPTION
Closes #623
Relates to #603
Updates #138

## Summary
- add explicit workflow permissions for PR comment publishing in the performance benchmark workflow
- make the PR comment publish step non-fatal when GitHub denies comment access
- preserve benchmark failure semantics so actual regressions still fail the workflow

## Validation
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/performance.yml"); puts "YAML_OK"'`

## Evidence
- workflow diff in `.github/workflows/performance.yml`
- failing post-merge run from PR #622 showed benchmark execution succeeded and the workflow failed only on `Comment on PR with results` with `403 Resource not accessible by integration`

## Residual Risk
- PR comment publication may still be skipped in restricted contexts, but it will no longer mask the real benchmark result.
